### PR TITLE
feat(server): DraftService persistence and finalize artifact staging (#11)

### DIFF
--- a/packages/server/src/__tests__/drafts/persistence.test.ts
+++ b/packages/server/src/__tests__/drafts/persistence.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Draft Persistence Tests (real service)
+ *
+ * Verifies that RealDraftService is durable: drafts, edits, and uploaded files
+ * survive a simulated process restart (a fresh service instance pointed at the
+ * same data root), and that finalized artifacts are staged deterministically
+ * with stable, idempotent checksums. Uses a temporary data root so the suite
+ * passes without a writable home directory.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { RealDraftService } from '../../services/core/draft';
+import { RealStorageService } from '../../services/core/storage';
+
+type CatalogArg = ConstructorParameters<typeof RealDraftService>[1];
+type ValidationArg = ConstructorParameters<typeof RealDraftService>[2];
+
+function makeCatalog(): CatalogArg {
+  return {
+    getApp: async (appId: string) => ({ id: appId, name: 'Test App', icon: '📦' }),
+    getVersionDetail: async () => ({
+      defaultEnv: [{ key: 'APP_PORT', value: '8080', isSecret: false, description: 'port' }],
+      defaults: {
+        ports: [{ host: 8080, container: 80, protocol: 'tcp' as const }],
+        volumes: [{ hostPath: './data', containerPath: '/data', readOnly: false }],
+      },
+    }),
+  } as unknown as CatalogArg;
+}
+
+function makeValidation(ok = true): ValidationArg {
+  return {
+    validateDraft: async () => ({ ok, errors: [], warnings: [] }),
+    preflightCheck: async () => ({ ok: true, checks: [] }),
+  } as unknown as ValidationArg;
+}
+
+describe('Draft persistence (real service)', () => {
+  let dataRoot: string;
+  let storage: RealStorageService;
+
+  beforeEach(async () => {
+    dataRoot = await mkdtemp(join(tmpdir(), 'hola-draft-'));
+    storage = new RealStorageService({ holaDir: dataRoot });
+  });
+
+  afterEach(async () => {
+    await rm(dataRoot, { recursive: true, force: true });
+  });
+
+  /** A fresh service instance over the same storage simulates a restart. */
+  const newService = () => new RealDraftService(storage, makeCatalog(), makeValidation());
+
+  test('a created draft survives a restart', async () => {
+    const a = newService();
+    const { draftId } = await a.createDraft({ appId: 'nextcloud', version: '1.0.0' });
+
+    const b = newService();
+    const draft = await b.getDraft(draftId);
+    expect(draft.draftId).toBe(draftId);
+    expect(draft.appId).toBe('nextcloud');
+    expect(draft.version).toBe('1.0.0');
+  });
+
+  test('updates survive a restart', async () => {
+    const a = newService();
+    const { draftId } = await a.createDraft({ appId: 'nextcloud' });
+    await a.updateDraft(draftId, {
+      systemOverrides: { DOMAIN: 'example.com' },
+      appEnv: [{ key: 'SECRET', value: 'hunter2', isSecret: true }],
+    });
+
+    const b = newService();
+    const draft = await b.getDraft(draftId);
+    expect(draft.systemOverrides.DOMAIN).toBe('example.com');
+    expect(draft.appEnv.find(e => e.key === 'SECRET')?.value).toBe('hunter2');
+  });
+
+  test('uploaded files survive a restart and remain associated', async () => {
+    const a = newService();
+    const { draftId } = await a.createDraft({ appId: 'nextcloud' });
+    const upload = await a.uploadFile(draftId, {
+      name: 'docker-compose.override.yml',
+      content: Buffer.from('services: {}\n'),
+      kind: 'composeOverride',
+    });
+
+    const b = newService();
+    const draft = await b.getDraft(draftId);
+    expect(draft.files).toHaveLength(1);
+    expect(draft.files[0].uploadId).toBe(upload.uploadId);
+    expect(draft.files[0].name).toBe('docker-compose.override.yml');
+  });
+
+  test('deleting a draft removes it from durable storage', async () => {
+    const a = newService();
+    const { draftId } = await a.createDraft({ appId: 'nextcloud' });
+    await a.deleteDraft(draftId);
+
+    const b = newService();
+    await expect(b.getDraft(draftId)).rejects.toThrow(/not found/i);
+  });
+
+  test('finalization stages artifacts with a stable, idempotent checksum', async () => {
+    const a = newService();
+    const { draftId } = await a.createDraft({ appId: 'nextcloud' });
+    await a.updateDraft(draftId, { composeOverride: 'services:\n  app:\n    image: nextcloud\n' });
+    await a.uploadFile(draftId, {
+      name: 'config.json',
+      content: Buffer.from('{"k":"v"}'),
+      kind: 'additionalFile',
+      path: '/app/config.json',
+    });
+
+    const first = await a.finalizeDraft(draftId);
+    expect(first.checksum).toMatch(/^[0-9a-f]{64}$/);
+
+    // Idempotent: re-finalizing identical input yields the identical checksum.
+    const second = await a.finalizeDraft(draftId);
+    expect(second.checksum).toBe(first.checksum);
+
+    // Deterministic across instances (a "restart").
+    const b = newService();
+    const third = await b.finalizeDraft(draftId);
+    expect(third.checksum).toBe(first.checksum);
+
+    // Staged artifacts exist and the persisted record is marked finalized.
+    expect(await storage.fileExists(`drafts/${draftId}/finalized/manifest.json`)).toBe(true);
+    expect(await storage.fileExists(`drafts/${draftId}/finalized/compose-override.yml`)).toBe(true);
+
+    const record = JSON.parse(await storage.readFileAsString(`drafts/${draftId}/draft.json`));
+    expect(record.status).toBe('finalized');
+    expect(record.checksum).toBe(first.checksum);
+
+    const manifest = JSON.parse(await storage.readFileAsString(`drafts/${draftId}/finalized/manifest.json`));
+    expect(manifest.checksum).toBe(first.checksum);
+    expect(manifest.files).toHaveLength(1);
+    expect(manifest.files[0].sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(manifest.files[0].path).toBe('/app/config.json');
+  });
+
+  test('changing input between finalizations changes the checksum', async () => {
+    const a = newService();
+    const { draftId } = await a.createDraft({ appId: 'nextcloud' });
+    const before = await a.finalizeDraft(draftId);
+
+    await a.updateDraft(draftId, { composeOverride: 'services:\n  app:\n    image: changed\n' });
+    const after = await a.finalizeDraft(draftId);
+
+    expect(after.checksum).not.toBe(before.checksum);
+  });
+});

--- a/packages/server/src/services/core/draft.ts
+++ b/packages/server/src/services/core/draft.ts
@@ -22,10 +22,31 @@ import type {
   DraftDefaults
 } from '@hola/shared';
 
+import { createHash } from 'crypto';
+
 import { getLogger } from '../../lib/logger';
 import type { HealthCheckable, ServiceHealth } from './types';
 import type { StorageService } from './storage';
 import type { CatalogService } from './catalog';
+
+/**
+ * Deterministic JSON serialization with recursively sorted object keys, so a
+ * given draft specification always produces the same string (and thus the same
+ * checksum) regardless of property insertion order.
+ */
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`;
+  }
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, v]) => v !== undefined)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([k, v]) => `${JSON.stringify(k)}:${stableStringify(v)}`);
+    return `{${entries.join(',')}}`;
+  }
+  return JSON.stringify(value ?? null);
+}
 
 // Temporary interface - will be replaced when ValidationService is properly integrated
 interface ValidationService {
@@ -55,10 +76,38 @@ export interface DraftService extends HealthCheckable {
   getDraftDefaults(appId: string, version?: string): Promise<{ env: AppEnvVar[]; defaults: DraftDefaults }>;
 }
 
+/**
+ * Lifecycle status of a persisted draft.
+ * `draft` = still mutable; `finalized` = artifacts staged for deployment.
+ */
+type DraftLifecycleStatus = 'draft' | 'finalized';
+
+/**
+ * On-disk draft record. Wraps the public `Draft` (the wire contract) with
+ * persistence metadata that is not part of the API shape. Stored at
+ * `drafts/<draftId>/draft.json`. File blob content lives separately under
+ * `drafts/<draftId>/files/` and is cached in memory on demand.
+ */
+interface DraftRecord {
+  draft: Draft;
+  status: DraftLifecycleStatus;
+  createdAt: string;
+  updatedAt: string;
+  finalizedAt?: string;
+  checksum?: string;
+  /** Per-upload content checksums, keyed by uploadId (used for stable finalize). */
+  fileChecksums: Record<string, string>;
+  /** Per-upload target deployment paths, keyed by uploadId (not part of the wire Draft). */
+  filePaths: Record<string, string>;
+}
+
 export class RealDraftService implements DraftService {
   private logger = getLogger().child({ service: 'DraftService' });
-  private drafts = new Map<string, Draft>();
-  private draftFiles = new Map<string, Map<string, DraftFile & { content?: Buffer }>>();
+  private drafts = new Map<string, DraftRecord>();
+  /** Lazily-populated blob content cache: draftId -> uploadId -> content. */
+  private fileContents = new Map<string, Map<string, Buffer>>();
+  /** One-time rehydration guard so we load persisted state at most once. */
+  private loadPromise: Promise<void> | null = null;
 
   constructor(
     private storageService: StorageService,
@@ -70,7 +119,7 @@ export class RealDraftService implements DraftService {
     try {
       // Check if we can access storage
       await this.storageService.ensureDir('drafts');
-      
+
       return {
         healthy: true,
         lastCheck: new Date(),
@@ -84,17 +133,120 @@ export class RealDraftService implements DraftService {
     }
   }
 
+  // ---- persistence helpers -------------------------------------------------
+
+  /** Rehydrate persisted drafts from storage exactly once. */
+  private async ensureLoaded(): Promise<void> {
+    if (!this.loadPromise) {
+      this.loadPromise = this.loadFromStorage();
+    }
+    return this.loadPromise;
+  }
+
+  private async loadFromStorage(): Promise<void> {
+    if (!(await this.storageService.fileExists('drafts'))) {
+      return;
+    }
+
+    let ids: string[];
+    try {
+      ids = await this.storageService.listDir('drafts');
+    } catch {
+      return; // No drafts directory yet
+    }
+
+    for (const draftId of ids) {
+      const recordPath = `drafts/${draftId}/draft.json`;
+      if (!(await this.storageService.fileExists(recordPath))) {
+        continue;
+      }
+      try {
+        const raw = await this.storageService.readFileAsString(recordPath);
+        const record = JSON.parse(raw) as DraftRecord;
+        // Backfill optional sidecar maps for forward compatibility with older records.
+        if (!record.fileChecksums) {
+          record.fileChecksums = {};
+        }
+        if (!record.filePaths) {
+          record.filePaths = {};
+        }
+        this.drafts.set(draftId, record);
+      } catch (error) {
+        this.logger.warn('Failed to rehydrate draft; skipping', {
+          draftId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    this.logger.info('Rehydrated drafts from storage', { count: this.drafts.size });
+  }
+
+  private async persistRecord(record: DraftRecord): Promise<void> {
+    await this.storageService.writeFile(
+      `drafts/${record.draft.draftId}/draft.json`,
+      JSON.stringify(record, null, 2)
+    );
+  }
+
+  private requireRecord(draftId: string): DraftRecord {
+    const record = this.drafts.get(draftId);
+    if (!record) {
+      throw new Error(`Draft not found: ${draftId}`);
+    }
+    return record;
+  }
+
+  private blobPath(draftId: string, uploadId: string, name: string): string {
+    return `drafts/${draftId}/files/${uploadId}-${name}`;
+  }
+
+  /**
+   * Build the `Map<uploadId, DraftFile & { content }>` expected by the
+   * validation service, loading blob content from disk into the cache as needed.
+   */
+  private async buildFilesMap(draftId: string): Promise<Map<string, DraftFile & { content?: Buffer }>> {
+    const record = this.requireRecord(draftId);
+    let cache = this.fileContents.get(draftId);
+    if (!cache) {
+      cache = new Map();
+      this.fileContents.set(draftId, cache);
+    }
+
+    const result = new Map<string, DraftFile & { content?: Buffer }>();
+    for (const file of record.draft.files) {
+      let content = cache.get(file.uploadId);
+      if (!content) {
+        const path = this.blobPath(draftId, file.uploadId, file.name);
+        if (await this.storageService.fileExists(path)) {
+          content = await this.storageService.readFile(path);
+          cache.set(file.uploadId, content);
+        }
+      }
+      result.set(file.uploadId, { ...file, content });
+    }
+    return result;
+  }
+
+  private static sha256(content: string | Buffer): string {
+    const data = typeof content === 'string' ? new TextEncoder().encode(content) : content;
+    return createHash('sha256').update(data).digest('hex');
+  }
+
+  // ---- CRUD ----------------------------------------------------------------
+
   async createDraft(request: CreateDraftRequest): Promise<CreateDraftResponse> {
+    await this.ensureLoaded();
     const draftId = crypto.randomUUID();
     this.logger.info('Creating draft', { draftId, appId: request.appId, version: request.version });
 
     try {
       // Get app info from catalog
       const app = await this.catalogService.getApp(request.appId);
-      
+
       // Get default environment and configuration
       const defaults = await this.getDraftDefaults(request.appId, request.version);
-      
+
       // Create initial draft
       const draft: Draft = {
         draftId,
@@ -107,12 +259,21 @@ export class RealDraftService implements DraftService {
         files: [],
       };
 
-      // Store draft
-      this.drafts.set(draftId, draft);
-      this.draftFiles.set(draftId, new Map());
+      const now = new Date().toISOString();
+      const record: DraftRecord = {
+        draft,
+        status: 'draft',
+        createdAt: now,
+        updatedAt: now,
+        fileChecksums: {},
+        filePaths: {},
+      };
 
-      // Ensure storage directory exists
+      // Store draft (in memory + durable)
+      this.drafts.set(draftId, record);
+      this.fileContents.set(draftId, new Map());
       await this.storageService.ensureDir(`drafts/${draftId}`);
+      await this.persistRecord(record);
 
       const response: CreateDraftResponse = {
         draftId,
@@ -132,79 +293,45 @@ export class RealDraftService implements DraftService {
       this.logger.info('Draft created successfully', { draftId, appId: request.appId });
       return response;
     } catch (error) {
-      this.logger.error('Failed to create draft', error as Error, { draftId, request });
+      this.logger.error('Failed to create draft', error as Error, { draftId, appId: request.appId });
       throw error;
     }
   }
 
   async getDraft(draftId: string): Promise<GetDraftResponse> {
-    const draft = this.drafts.get(draftId);
-    if (!draft) {
-      throw new Error(`Draft not found: ${draftId}`);
-    }
-
-    const files = Array.from(this.draftFiles.get(draftId)?.values() || []).map(file => ({
-      uploadId: file.uploadId,
-      name: file.name,
-      size: file.size,
-      kind: file.kind,
-    }));
-
-    return {
-      ...draft,
-      files,
-    };
+    await this.ensureLoaded();
+    const record = this.requireRecord(draftId);
+    return { ...record.draft };
   }
 
   async updateDraft(draftId: string, patch: PatchDraftRequest): Promise<PatchDraftResponse> {
-    const draft = this.drafts.get(draftId);
-    if (!draft) {
-      throw new Error(`Draft not found: ${draftId}`);
-    }
+    await this.ensureLoaded();
+    const record = this.requireRecord(draftId);
 
-    this.logger.info('Updating draft', { draftId, patch });
+    // Avoid logging secret env values; log which fields changed instead.
+    this.logger.info('Updating draft', { draftId, fields: Object.keys(patch) });
 
-    // Apply patch
-    const updatedDraft: Draft = {
-      ...draft,
-      ...patch,
-    };
-
-    this.drafts.set(draftId, updatedDraft);
-
-    // Persist to storage
-    await this.storageService.writeFile(
-      `drafts/${draftId}/draft.json`,
-      JSON.stringify(updatedDraft, null, 2)
-    );
-
-    const files = Array.from(this.draftFiles.get(draftId)?.values() || []).map(file => ({
-      uploadId: file.uploadId,
-      name: file.name,
-      size: file.size,
-      kind: file.kind,
-    }));
+    // Apply patch (preserve file metadata managed by upload/delete).
+    record.draft = { ...record.draft, ...patch };
+    record.updatedAt = new Date().toISOString();
+    this.drafts.set(draftId, record);
+    await this.persistRecord(record);
 
     return {
       ok: true,
-      draft: {
-        ...updatedDraft,
-        files,
-      },
+      draft: { ...record.draft },
     };
   }
 
   async deleteDraft(draftId: string): Promise<void> {
-    const draft = this.drafts.get(draftId);
-    if (!draft) {
-      throw new Error(`Draft not found: ${draftId}`);
-    }
+    await this.ensureLoaded();
+    this.requireRecord(draftId);
 
     this.logger.info('Deleting draft', { draftId });
 
     // Remove from memory
     this.drafts.delete(draftId);
-    this.draftFiles.delete(draftId);
+    this.fileContents.delete(draftId);
 
     // Remove from storage
     try {
@@ -215,38 +342,37 @@ export class RealDraftService implements DraftService {
   }
 
   async uploadFile(
-    draftId: string, 
+    draftId: string,
     file: { name: string; content: Buffer; kind: DraftFile['kind']; path?: string }
   ): Promise<UploadDraftFileResponse> {
-    const draft = this.drafts.get(draftId);
-    if (!draft) {
-      throw new Error(`Draft not found: ${draftId}`);
-    }
+    await this.ensureLoaded();
+    const record = this.requireRecord(draftId);
 
     const uploadId = crypto.randomUUID();
     this.logger.info('Uploading file to draft', { draftId, uploadId, fileName: file.name, kind: file.kind, size: file.content.length });
 
-    // Create file record
-    const draftFile: DraftFile & { content: Buffer } = {
-      uploadId,
-      name: file.name,
-      size: file.content.length,
-      kind: file.kind,
-      path: file.path,
-      content: file.content,
-    };
+    // Persist blob first so durable state never references a missing file.
+    await this.storageService.writeFile(this.blobPath(draftId, uploadId, file.name), file.content);
 
-    // Store in memory
-    let files = this.draftFiles.get(draftId);
-    if (!files) {
-      files = new Map();
-      this.draftFiles.set(draftId, files);
+    // Update file metadata on the record and cache the content.
+    record.draft.files = [
+      ...record.draft.files,
+      { uploadId, name: file.name, size: file.content.length, kind: file.kind },
+    ];
+    record.fileChecksums[uploadId] = RealDraftService.sha256(file.content);
+    if (file.path) {
+      record.filePaths[uploadId] = file.path;
     }
-    files.set(uploadId, draftFile);
+    record.updatedAt = new Date().toISOString();
 
-    // Store to disk
-    const filePath = `drafts/${draftId}/files/${uploadId}-${file.name}`;
-    await this.storageService.writeFile(filePath, file.content);
+    let cache = this.fileContents.get(draftId);
+    if (!cache) {
+      cache = new Map();
+      this.fileContents.set(draftId, cache);
+    }
+    cache.set(uploadId, file.content);
+
+    await this.persistRecord(record);
 
     return {
       uploadId,
@@ -257,26 +383,27 @@ export class RealDraftService implements DraftService {
   }
 
   async deleteFile(draftId: string, uploadId: string): Promise<DeleteDraftFileResponse> {
-    const draft = this.drafts.get(draftId);
-    if (!draft) {
-      throw new Error(`Draft not found: ${draftId}`);
-    }
+    await this.ensureLoaded();
+    const record = this.requireRecord(draftId);
 
-    const files = this.draftFiles.get(draftId);
-    const file = files?.get(uploadId);
+    const file = record.draft.files.find(f => f.uploadId === uploadId);
     if (!file) {
       throw new Error(`File not found: ${uploadId}`);
     }
 
     this.logger.info('Deleting file from draft', { draftId, uploadId, fileName: file.name });
 
-    // Remove from memory
-    files?.delete(uploadId);
+    // Remove metadata + cached content
+    record.draft.files = record.draft.files.filter(f => f.uploadId !== uploadId);
+    delete record.fileChecksums[uploadId];
+    delete record.filePaths[uploadId];
+    record.updatedAt = new Date().toISOString();
+    this.fileContents.get(draftId)?.delete(uploadId);
+    await this.persistRecord(record);
 
-    // Remove from storage
+    // Remove the blob from storage
     try {
-      const filePath = `drafts/${draftId}/files/${uploadId}-${file.name}`;
-      await this.storageService.deleteFile(filePath);
+      await this.storageService.deleteFile(this.blobPath(draftId, uploadId, file.name));
     } catch (error) {
       this.logger.warn('Failed to delete file from storage', { draftId, uploadId, error: error instanceof Error ? error.message : String(error) });
     }
@@ -285,16 +412,14 @@ export class RealDraftService implements DraftService {
   }
 
   async validateDraft(draftId: string): Promise<ValidateDraftResponse> {
-    const draft = this.drafts.get(draftId);
-    if (!draft) {
-      throw new Error(`Draft not found: ${draftId}`);
-    }
+    await this.ensureLoaded();
+    const record = this.requireRecord(draftId);
 
     this.logger.info('Validating draft', { draftId });
 
     try {
       // Use validation service for comprehensive checks
-      const report = await this.validationService.validateDraft(draft, this.draftFiles.get(draftId));
+      const report = await this.validationService.validateDraft(record.draft, await this.buildFilesMap(draftId));
 
       return {
         ok: report.ok,
@@ -312,16 +437,14 @@ export class RealDraftService implements DraftService {
   }
 
   async preflightCheck(draftId: string): Promise<EnhancedPreflightResponse> {
-    const draft = this.drafts.get(draftId);
-    if (!draft) {
-      throw new Error(`Draft not found: ${draftId}`);
-    }
+    await this.ensureLoaded();
+    const record = this.requireRecord(draftId);
 
     this.logger.info('Running preflight check', { draftId });
 
     try {
       // Use validation service for preflight checks
-      return await this.validationService.preflightCheck(draft, this.draftFiles.get(draftId));
+      return await this.validationService.preflightCheck(record.draft, await this.buildFilesMap(draftId));
     } catch (error) {
       this.logger.error('Preflight check failed', error as Error, { draftId });
       return {
@@ -337,10 +460,8 @@ export class RealDraftService implements DraftService {
   }
 
   async finalizeDraft(draftId: string): Promise<FinalizeDraftResponse> {
-    const draft = this.drafts.get(draftId);
-    if (!draft) {
-      throw new Error(`Draft not found: ${draftId}`);
-    }
+    await this.ensureLoaded();
+    const record = this.requireRecord(draftId);
 
     this.logger.info('Finalizing draft', { draftId });
 
@@ -351,38 +472,73 @@ export class RealDraftService implements DraftService {
         throw new Error(`Draft validation failed: ${validation.errors.map(e => e.message).join(', ')}`);
       }
 
-      // Generate deployment spec
-      const files = this.draftFiles.get(draftId);
-      const spec = {
+      const draft = record.draft;
+      const filesMap = await this.buildFilesMap(draftId);
+
+      // Deterministic spec: sorted files, no timestamps. This is the checksum input,
+      // so repeated finalization of unchanged input yields an identical checksum.
+      const specFiles = draft.files
+        .map(f => ({
+          uploadId: f.uploadId,
+          name: f.name,
+          kind: f.kind,
+          path: record.filePaths[f.uploadId],
+          sha256: record.fileChecksums[f.uploadId],
+        }))
+        .sort((a, b) => a.uploadId.localeCompare(b.uploadId));
+
+      const canonicalSpec = {
         draftId,
         appId: draft.appId,
         version: draft.version,
         systemOverrides: draft.systemOverrides,
         appEnv: draft.appEnv,
         ports: draft.ports,
-        composeOverride: draft.composeOverride,
-        files: Array.from(files?.values() || []).map(f => ({
-          uploadId: f.uploadId,
-          name: f.name,
-          kind: f.kind,
-          path: f.path,
-        })),
-        finalizedAt: new Date().toISOString(),
+        composeOverride: draft.composeOverride ?? '',
+        files: specFiles,
       };
 
-      // Generate checksum
-      const checksum = await this.generateChecksum(spec);
+      const checksum = RealDraftService.sha256(stableStringify(canonicalSpec));
+      const finalizedAt = new Date().toISOString();
 
-      // Store finalized spec
+      // Stage deterministic artifacts consumable by DeploymentService (#14).
+      const finalizedDir = `drafts/${draftId}/finalized`;
+      await this.storageService.ensureDir(finalizedDir);
+
+      if (canonicalSpec.composeOverride) {
+        await this.storageService.writeFile(
+          `${finalizedDir}/compose-override.yml`,
+          canonicalSpec.composeOverride
+        );
+      }
+
+      for (const file of draft.files) {
+        const content = filesMap.get(file.uploadId)?.content;
+        if (content) {
+          await this.storageService.writeFile(
+            `${finalizedDir}/files/${file.uploadId}-${file.name}`,
+            content
+          );
+        }
+      }
+
+      const manifest = { ...canonicalSpec, checksum, finalizedAt };
       await this.storageService.writeFile(
-        `drafts/${draftId}/finalized.json`,
-        JSON.stringify(spec, null, 2)
+        `${finalizedDir}/manifest.json`,
+        JSON.stringify(manifest, null, 2)
       );
+
+      // Record finalized status durably.
+      record.status = 'finalized';
+      record.finalizedAt = finalizedAt;
+      record.checksum = checksum;
+      record.updatedAt = finalizedAt;
+      await this.persistRecord(record);
 
       this.logger.info('Draft finalized successfully', { draftId, checksum });
 
       return {
-        spec,
+        spec: manifest,
         checksum,
       };
     } catch (error) {
@@ -412,15 +568,6 @@ export class RealDraftService implements DraftService {
         },
       };
     }
-  }
-
-  private async generateChecksum(spec: unknown): Promise<string> {
-    const content = JSON.stringify(spec);
-    const encoder = new TextEncoder();
-    const data = encoder.encode(content);
-    const hashBuffer = await crypto.subtle.digest('SHA-256', data);
-    const hashArray = Array.from(new Uint8Array(hashBuffer));
-    return hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
   }
 }
 


### PR DESCRIPTION
## Summary
Makes `RealDraftService` durable and stages deterministic finalized artifacts for deployment creation. Resolves #11 (step 3 of the recovery epic #21). Unblocks #14 (durable releases) and #54 (CLI deploy).

## Problem
Draft state was authoritative in memory and only partially written to disk: `createDraft` never persisted (only `ensureDir`), uploads wrote the blob but no metadata, and nothing rehydrated on startup — so a restart lost drafts even though some files lingered on disk.

## Changes
- **Durable record:** persist a `DraftRecord` (the wire `Draft` plus `status`/timestamps and per-upload checksum & target-path sidecars) to `drafts/<id>/draft.json` on every mutation, using the configurable data root (`HOLA_DATA_DIR` / storage `holaDir`) — no hard-coded `~/.hola`. Writes are atomic (storage temp+rename).
- **Rehydration:** lazily reload all drafts from storage on first access (one-time, guarded); load blob content from disk on demand for validation/preflight/finalize.
- **Files:** `uploadFile`/`deleteFile` update durable metadata and blobs together; content is cached in memory.
- **Deterministic finalize:** stage a `finalized/` layout — `manifest.json` (per-file sha256 + spec), the compose override, and copied upload blobs. The checksum is computed over a **stable, timestamp-free** canonical spec, so re-finalizing unchanged input yields the **identical** checksum and never duplicates artifacts (idempotent). Artifacts are consumable by `DeploymentService` in #14.
- **Secrets:** redact secret env values from logs (log changed field names, not patch contents). On-disk encryption-at-rest remains future work.

## Acceptance criteria (from #11)
- [x] Create/update a draft, restart, retrieve identical state.
- [x] Uploaded files survive restart and stay associated with the draft.
- [x] Finalization produces stable artifacts and checksums consumable by `DeploymentService`.
- [x] Repeated finalization does not corrupt or duplicate artifacts.
- [x] Real-service tests use a temporary data root and pass without a writable home directory.

## Verification
- New `src/__tests__/drafts/persistence.test.ts` constructs `RealDraftService` over a temp data root and simulates a restart with a fresh instance: create/update/upload survive; delete clears durable state; finalize checksum is stable, idempotent, deterministic across instances, and changes when input changes.
- Full gate green: lint, typecheck, and builds across all packages; **server tests 129 pass / 0 fail**.

## Notes
- The wire `Draft` contract is unchanged; persistence metadata (status, checksums, paths) lives in the on-disk record, not the API shape.
- `MockDraftService` (test mode) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)