### PR TITLE
feat(server): durable deployment promotion, release history, and rollback (#14)

### DIFF
--- a/packages/server/src/__tests__/deployments/persistence.test.ts
+++ b/packages/server/src/__tests__/deployments/persistence.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Deployment Persistence Tests (real service)
+ *
+ * Verifies that RealDeploymentService is durable and that promotion/rollback are
+ * atomic: releases are built from finalized draft artifacts (#11), deployments,
+ * releases, and the active-release pointer survive a simulated restart (a fresh
+ * service over the same data root), rollback atomically switches the active
+ * release, a failed promotion leaves the previous release active, and unknown /
+ * unfinalized inputs fail with typed errors. Uses a temporary data root so the
+ * suite passes without a writable home directory.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { RealDeploymentService } from '../../services/core/deployment';
+import { RealDraftService } from '../../services/core/draft';
+import { RealStorageService } from '../../services/core/storage';
+import { NotFoundError, ConflictError } from '../../middleware/error-mapping';
+import type { DockerService } from '../../services/core/docker';
+
+type CatalogArg = ConstructorParameters<typeof RealDraftService>[1];
+type ValidationArg = ConstructorParameters<typeof RealDraftService>[2];
+type JobArg = ConstructorParameters<typeof RealDeploymentService>[1];
+
+function makeCatalog(): CatalogArg {
+  return {
+    getApp: async (appId: string) => ({ id: appId, name: 'Test App', icon: '📦' }),
+    getVersionDetail: async () => ({
+      defaultEnv: [{ key: 'APP_PORT', value: '3000', isSecret: false, description: 'port' }],
+      defaults: {
+        ports: [{ host: 3000, container: 3000, protocol: 'tcp' as const }],
+        volumes: [{ hostPath: './data', containerPath: '/data', readOnly: false }],
+      },
+    }),
+  } as unknown as CatalogArg;
+}
+
+function makeValidation(): ValidationArg {
+  return {
+    validateDraft: async () => ({ ok: true, errors: [], warnings: [] }),
+    preflightCheck: async () => ({ ok: true, checks: [] }),
+  } as unknown as ValidationArg;
+}
+
+/** Minimal in-memory job service (avoids MockJobService's progress timers). */
+function makeJobs(): JobArg {
+  const jobs: Array<{ id: string; type: string; status: string; startedAt: string; deploymentId?: string }> = [];
+  return {
+    createJob: async (p: { type: string; deploymentId?: string }) => {
+      const job = { id: crypto.randomUUID(), type: p.type, status: 'queued', startedAt: new Date().toISOString(), deploymentId: p.deploymentId };
+      jobs.push(job);
+      return job;
+    },
+    listJobs: async (f?: { deploymentId?: string }) => jobs.filter(j => !f?.deploymentId || j.deploymentId === f.deploymentId),
+    cancelJob: async () => {},
+    getJob: async () => null,
+    onJobUpdate: () => ({ unsubscribe() {} }),
+    healthCheck: async () => ({ healthy: true, lastCheck: new Date() }),
+  } as unknown as JobArg;
+}
+
+const noDocker = {} as unknown as DockerService;
+
+describe('Deployment persistence (real service)', () => {
+  let dataRoot: string;
+
+  beforeEach(async () => {
+    dataRoot = await mkdtemp(join(tmpdir(), 'hola-deploy-'));
+  });
+
+  afterEach(async () => {
+    await rm(dataRoot, { recursive: true, force: true });
+  });
+
+  /** A fresh service set over the same data root simulates a restart. */
+  function makeSystem() {
+    const storage = new RealStorageService({ holaDir: dataRoot });
+    const drafts = new RealDraftService(storage, makeCatalog(), makeValidation());
+    const deployments = new RealDeploymentService(storage, makeJobs(), noDocker, drafts);
+    return { storage, drafts, deployments };
+  }
+
+  async function finalizedDraft(drafts: RealDraftService, compose?: string): Promise<string> {
+    const { draftId } = await drafts.createDraft({ appId: 'gitea', version: '1.0.0' });
+    if (compose) {
+      await drafts.updateDraft(draftId, { composeOverride: compose });
+    }
+    await drafts.finalizeDraft(draftId);
+    return draftId;
+  }
+
+  test('promotes a finalized draft into a deployment with a persisted active release', async () => {
+    const { storage, drafts, deployments } = makeSystem();
+    const draftId = await finalizedDraft(drafts, 'services:\n  gitea:\n    image: gitea/gitea\n');
+
+    const created = await deployments.createFromDraft({ draftId, name: 'gitea', options: { autoStart: false } });
+    expect(created.releaseId).toBeDefined();
+
+    // Built from the manifest (app/version), not fabricated.
+    const detail = await deployments.getDeployment(created.deploymentId);
+    expect(detail.app).toBe('gitea');
+    expect(detail.version).toBe('1.0.0');
+
+    // Durable: immutable release dir, staged compose, and the current pointer.
+    expect(await storage.fileExists(`deployments/${created.deploymentId}/releases/${created.releaseId}/metadata.json`)).toBe(true);
+    expect(await storage.fileExists(`deployments/${created.deploymentId}/releases/${created.releaseId}/compose-override.yml`)).toBe(true);
+    expect(await storage.readFileAsString(`deployments/${created.deploymentId}/current`)).toBe(created.releaseId);
+
+    const releases = await deployments.getReleases(created.deploymentId);
+    expect(releases).toHaveLength(1);
+    expect(releases[0].status).toBe('active');
+  });
+
+  test('deployment, releases, and active pointer survive a restart', async () => {
+    const a = makeSystem();
+    const draftId = await finalizedDraft(a.drafts);
+    const created = await a.deployments.createFromDraft({ draftId, name: 'gitea', options: { autoStart: false } });
+
+    // Restart.
+    const b = makeSystem();
+    const list = await b.deployments.listDeployments({ page: 1, limit: 100 });
+    expect(list.items.some(d => d.id === created.deploymentId)).toBe(true);
+
+    const detail = await b.deployments.getDeployment(created.deploymentId);
+    expect(detail.id).toBe(created.deploymentId);
+
+    const releases = await b.deployments.getReleases(created.deploymentId);
+    expect(releases.find(r => r.id === created.releaseId)?.status).toBe('active');
+  });
+
+  test('re-deploy then rollback atomically switches the active release and survives restart', async () => {
+    const a = makeSystem();
+    const draftA = await finalizedDraft(a.drafts, 'services:\n  gitea:\n    image: gitea:a\n');
+    const dep = await a.deployments.createFromDraft({ draftId: draftA, name: 'gitea', options: { autoStart: false } });
+    const release1 = dep.releaseId;
+
+    // Promote a second release onto the same deployment.
+    const draftB = await finalizedDraft(a.drafts, 'services:\n  gitea:\n    image: gitea:b\n');
+    const promoted = await a.deployments.promote(dep.deploymentId, { draftId: draftB, options: { autoStart: false } });
+    const release2 = promoted.releaseId;
+
+    expect(await a.storage.readFileAsString(`deployments/${dep.deploymentId}/current`)).toBe(release2);
+    let releases = await a.deployments.getReleases(dep.deploymentId);
+    expect(releases.find(r => r.id === release2)?.status).toBe('active');
+    expect(releases.find(r => r.id === release1)?.status).toBe('stopped');
+
+    // Roll back to the first release.
+    const rollback = await a.deployments.rollback(dep.deploymentId, { targetReleaseId: release1 });
+    expect(rollback.targetReleaseId).toBe(release1);
+    expect(rollback.previousReleaseId).toBe(release2);
+    expect(await a.storage.readFileAsString(`deployments/${dep.deploymentId}/current`)).toBe(release1);
+
+    releases = await a.deployments.getReleases(dep.deploymentId);
+    expect(releases.find(r => r.id === release1)?.status).toBe('active');
+    expect(releases.find(r => r.id === release2)?.status).toBe('stopped');
+
+    // Restart: the rolled-back pointer is rehydrated.
+    const b = makeSystem();
+    const after = await b.deployments.getReleases(dep.deploymentId);
+    expect(after.find(r => r.id === release1)?.status).toBe('active');
+    expect(await b.storage.readFileAsString(`deployments/${dep.deploymentId}/current`)).toBe(release1);
+  });
+
+  test('default rollback (no target) returns to the previous release', async () => {
+    const { drafts, deployments } = makeSystem();
+    const dep = await deployments.createFromDraft({ draftId: await finalizedDraft(drafts), options: { autoStart: false } });
+    const release1 = dep.releaseId;
+    const promoted = await deployments.promote(dep.deploymentId, { draftId: await finalizedDraft(drafts), options: { autoStart: false } });
+
+    const rollback = await deployments.rollback(dep.deploymentId, {});
+    expect(rollback.targetReleaseId).toBe(release1);
+    expect(rollback.previousReleaseId).toBe(promoted.releaseId);
+  });
+
+  test('a failed promotion leaves the previous release active', async () => {
+    const { storage, drafts, deployments } = makeSystem();
+    const dep = await deployments.createFromDraft({ draftId: await finalizedDraft(drafts), options: { autoStart: false } });
+    const release1 = dep.releaseId;
+
+    // Promote from a draft that was never finalized -> should throw before any switch.
+    const { draftId: unfinalized } = await drafts.createDraft({ appId: 'gitea' });
+    await expect(deployments.promote(dep.deploymentId, { draftId: unfinalized })).rejects.toBeInstanceOf(ConflictError);
+
+    // The active release and pointer are unchanged.
+    expect(await storage.readFileAsString(`deployments/${dep.deploymentId}/current`)).toBe(release1);
+    const releases = await deployments.getReleases(dep.deploymentId);
+    expect(releases).toHaveLength(1);
+    expect(releases[0].status).toBe('active');
+  });
+
+  test('unknown/stale releases and unfinalized drafts fail with typed errors', async () => {
+    const { drafts, deployments } = makeSystem();
+    const dep = await deployments.createFromDraft({ draftId: await finalizedDraft(drafts), options: { autoStart: false } });
+
+    await expect(deployments.getRelease(dep.deploymentId, 'bogus')).rejects.toBeInstanceOf(NotFoundError);
+    await expect(deployments.rollback(dep.deploymentId, { targetReleaseId: 'bogus' })).rejects.toBeInstanceOf(NotFoundError);
+
+    // Only the current release exists -> nothing to roll back to.
+    await expect(deployments.rollback(dep.deploymentId, {})).rejects.toBeInstanceOf(ConflictError);
+
+    // Creating from a non-finalized draft fails and leaves no deployment behind.
+    const { draftId: unfinalized } = await drafts.createDraft({ appId: 'gitea' });
+    await expect(deployments.createFromDraft({ draftId: unfinalized })).rejects.toBeInstanceOf(ConflictError);
+
+    const list = await deployments.listDeployments({ page: 1, limit: 100 });
+    expect(list.items).toHaveLength(1); // only the one valid deployment
+  });
+});

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -40,10 +40,20 @@ import type { HealthCheckable, ServiceHealth } from './types';
 import type { StorageService } from './storage';
 import type { JobService } from './jobs';
 import type { DockerService } from './docker';
+import type { DraftService, FinalizedArtifacts } from './draft';
+
+/** Promote a new release built from a finalized draft onto an existing deployment. */
+export interface PromoteRequest {
+  draftId: string;
+  reason?: string;
+  options?: { autoStart?: boolean };
+}
 
 export interface DeploymentService extends HealthCheckable {
   // Deployment lifecycle
   createFromDraft(request: CreateDeploymentFromDraftRequest): Promise<CreateDeploymentFromDraftResponse>;
+  /** Stage a new release from a finalized draft onto an existing deployment and activate it. */
+  promote(deploymentId: string, request: PromoteRequest): Promise<CreateDeploymentFromDraftResponse>;
 
   // Deployment management
   listDeployments(request: GetDeploymentsRequest): Promise<GetDeploymentsResponse>;
@@ -197,6 +207,8 @@ abstract class InMemoryDeploymentService implements DeploymentService {
   protected logger = getLogger().child({ service: 'DeploymentService' });
   protected deployments = new Map<string, EnhancedDeploymentDetail>();
   protected releases = new Map<string, Release>();
+  /** One-time rehydration guard so persisted state loads at most once. */
+  private loadPromise: Promise<void> | null = null;
 
   constructor(protected jobService: JobService) {}
 
@@ -216,6 +228,75 @@ abstract class InMemoryDeploymentService implements DeploymentService {
     void deploymentId;
   }
 
+  /** Rehydrate persisted deployments/releases from storage exactly once. */
+  protected async ensureLoaded(): Promise<void> {
+    if (!this.loadPromise) {
+      this.loadPromise = this.loadFromStorage();
+    }
+    return this.loadPromise;
+  }
+
+  /** Default: nothing to load (mock keeps its constructor seed). */
+  protected async loadFromStorage(): Promise<void> {}
+
+  /**
+   * Build the release (and resolved app/version) for a deployment from a draft.
+   * Default is a synthetic in-memory release; the real service overrides this to
+   * build from the finalized artifacts produced by DraftService (#11).
+   */
+  protected async buildReleaseFromDraft(
+    artifacts: FinalizedArtifacts | null,
+    request: { draftId?: string },
+    deploymentId: string,
+    releaseId: string
+  ): Promise<{ app: string; version?: string; release: Release }> {
+    void artifacts;
+    const now = new Date().toISOString();
+    return {
+      app: 'Unknown App',
+      version: undefined,
+      release: {
+        id: releaseId,
+        deploymentId,
+        draftId: request.draftId ?? '',
+        status: 'creating',
+        createdAt: now,
+        images: [],
+        ports: [],
+        filesChecksums: {},
+      },
+    };
+  }
+
+  /** Copy immutable release artifacts to durable storage. Default no-op (mock). */
+  protected async stageReleaseArtifacts(
+    artifacts: FinalizedArtifacts | null,
+    deploymentId: string,
+    release: Release
+  ): Promise<void> {
+    void artifacts;
+    void deploymentId;
+    void release;
+  }
+
+  /** Atomically record the active-release pointer. Default no-op (mock). */
+  protected async writeCurrentPointer(deploymentId: string, releaseId: string): Promise<void> {
+    void deploymentId;
+    void releaseId;
+  }
+
+  /** Routing-activation seam for Traefik config (issue #16). Default no-op. */
+  protected async onActiveReleaseChanged(deploymentId: string, releaseId: string): Promise<void> {
+    void deploymentId;
+    void releaseId;
+  }
+
+  /** Load the finalized artifacts for a draft. Default null (mock has no draft store). */
+  protected async loadFinalizedArtifacts(draftId: string): Promise<FinalizedArtifacts | null> {
+    void draftId;
+    return null;
+  }
+
   /** Look up a deployment or throw a typed 404. */
   protected requireDeployment(deploymentId: string): EnhancedDeploymentDetail {
     const deployment = this.deployments.get(deploymentId);
@@ -225,7 +306,63 @@ abstract class InMemoryDeploymentService implements DeploymentService {
     return deployment;
   }
 
+  private countReleases(deploymentId: string): number {
+    let n = 0;
+    for (const r of this.releases.values()) {
+      if (r.deploymentId === deploymentId) n++;
+    }
+    return n;
+  }
+
+  /**
+   * Atomically make `releaseId` the active release of a deployment: demote the
+   * previously-active release, activate the target, update the deployment's
+   * release pointers, and write the durable `current` pointer last. A failure
+   * before the pointer write leaves the previous active release intact.
+   */
+  protected async promoteRelease(deploymentId: string, releaseId: string): Promise<void> {
+    const deployment = this.requireDeployment(deploymentId);
+    const release = this.releases.get(releaseId);
+    if (!release || release.deploymentId !== deploymentId) {
+      throw new NotFoundError(`Release not found: ${releaseId}`);
+    }
+
+    const now = new Date().toISOString();
+    const previousReleaseId = deployment.currentReleaseId;
+
+    // Demote the previously-active release.
+    if (previousReleaseId && previousReleaseId !== releaseId) {
+      const prev = this.releases.get(previousReleaseId);
+      if (prev) {
+        prev.status = 'stopped';
+        this.releases.set(prev.id, prev);
+        await this.persistRelease(prev);
+      }
+    }
+
+    // Activate the target release.
+    release.status = 'active';
+    release.deployedAt = now;
+    this.releases.set(releaseId, release);
+    await this.persistRelease(release);
+
+    // Update deployment pointers.
+    if (previousReleaseId !== releaseId) {
+      deployment.previousReleaseId = previousReleaseId;
+    }
+    deployment.currentReleaseId = releaseId;
+    deployment.rollbackAvailable = this.countReleases(deploymentId) > 1;
+    deployment.lastUpdated = now;
+    this.deployments.set(deploymentId, deployment);
+    await this.persistDeployment(deployment);
+
+    // Durable active-release switch (authoritative on rehydration), then routing.
+    await this.writeCurrentPointer(deploymentId, releaseId);
+    await this.onActiveReleaseChanged(deploymentId, releaseId);
+  }
+
   async createFromDraft(request: CreateDeploymentFromDraftRequest): Promise<CreateDeploymentFromDraftResponse> {
+    await this.ensureLoaded();
     const deploymentId = crypto.randomUUID();
     const releaseId = crypto.randomUUID();
     const now = new Date().toISOString();
@@ -238,20 +375,25 @@ abstract class InMemoryDeploymentService implements DeploymentService {
     });
 
     try {
+      // Build the release from the finalized draft FIRST so an unfinalized draft
+      // fails before any deployment directory or record is created (no partial state).
+      const artifacts = await this.loadFinalizedArtifacts(request.draftId);
+      const { app, version, release } = await this.buildReleaseFromDraft(artifacts, request, deploymentId, releaseId);
+
       await this.ensureLayout(deploymentId);
 
       const deployment: EnhancedDeploymentDetail = {
         id: deploymentId,
         name: request.name || `deployment-${deploymentId.slice(0, 8)}`,
-        app: 'Unknown App', // Will be updated from draft
+        app,
         icon: '📦',
         status: 'installing',
         lifecycleState: 'releasing',
-        currentReleaseId: releaseId,
         draftId: request.draftId,
         rollbackAvailable: false,
         resources: { cpu: '0%', memory: '0MB' },
         ports: [],
+        version,
         lastUpdated: now,
         metadata: {
           createdAt: now,
@@ -260,34 +402,16 @@ abstract class InMemoryDeploymentService implements DeploymentService {
         },
       };
       this.deployments.set(deploymentId, deployment);
-
-      const release: Release = {
-        id: releaseId,
-        deploymentId,
-        draftId: request.draftId,
-        status: 'creating',
-        createdAt: now,
-        images: [],
-        ports: [],
-        filesChecksums: {},
-      };
       this.releases.set(releaseId, release);
 
-      await this.persistDeployment(deployment);
+      await this.stageReleaseArtifacts(artifacts, deploymentId, release);
       await this.persistRelease(release);
+      await this.persistDeployment(deployment);
 
-      let jobId: string | undefined;
+      // Atomically activate the first release.
+      await this.promoteRelease(deploymentId, releaseId);
 
-      // Optionally start deployment immediately
-      if (request.options?.autoStart !== false) {
-        const job = await this.jobService.createJob({
-          type: 'start',
-          deploymentId,
-          payload: { releaseId, action: 'deploy' },
-        });
-        jobId = job.id;
-        this.logger.info('Deployment job created', { deploymentId, releaseId, jobId });
-      }
+      const jobId = await this.maybeStartJob(deploymentId, releaseId, request.options?.autoStart);
 
       return { deploymentId, releaseId, jobId };
     } catch (error) {
@@ -299,17 +423,57 @@ abstract class InMemoryDeploymentService implements DeploymentService {
     }
   }
 
+  async promote(deploymentId: string, request: PromoteRequest): Promise<CreateDeploymentFromDraftResponse> {
+    await this.ensureLoaded();
+    this.requireDeployment(deploymentId);
+    const releaseId = crypto.randomUUID();
+
+    this.logger.info('Promoting new release onto deployment', { deploymentId, releaseId, draftId: request.draftId });
+
+    const artifacts = await this.loadFinalizedArtifacts(request.draftId);
+    const { release } = await this.buildReleaseFromDraft(artifacts, request, deploymentId, releaseId);
+    this.releases.set(releaseId, release);
+
+    await this.ensureLayout(deploymentId);
+    await this.stageReleaseArtifacts(artifacts, deploymentId, release);
+    await this.persistRelease(release);
+
+    // Atomically switch the active release to the new one.
+    await this.promoteRelease(deploymentId, releaseId);
+
+    const jobId = await this.maybeStartJob(deploymentId, releaseId, request.options?.autoStart);
+
+    return { deploymentId, releaseId, jobId };
+  }
+
+  /** Create a start job for a (re)deployment unless autoStart was disabled. */
+  private async maybeStartJob(deploymentId: string, releaseId: string, autoStart?: boolean): Promise<string | undefined> {
+    if (autoStart === false) {
+      return undefined;
+    }
+    const job = await this.jobService.createJob({
+      type: 'start',
+      deploymentId,
+      payload: { releaseId, action: 'deploy' },
+    });
+    this.logger.info('Deployment job created', { deploymentId, releaseId, jobId: job.id });
+    return job.id;
+  }
+
   async listDeployments(request: GetDeploymentsRequest): Promise<GetDeploymentsResponse> {
+    await this.ensureLoaded();
     this.logger.info('Listing deployments', { request });
     return filterAndPaginateDeployments(Array.from(this.deployments.values()), request);
   }
 
   async getDeployment(deploymentId: string): Promise<GetDeploymentResponse> {
+    await this.ensureLoaded();
     this.logger.info('Getting deployment', { deploymentId });
     return toDetailResponse(this.requireDeployment(deploymentId));
   }
 
   async updateDeployment(deploymentId: string, request: PatchDeploymentRequest): Promise<PatchDeploymentResponse> {
+    await this.ensureLoaded();
     const deployment = this.requireDeployment(deploymentId);
 
     this.logger.info('Updating deployment', { deploymentId, request });
@@ -331,6 +495,7 @@ abstract class InMemoryDeploymentService implements DeploymentService {
   }
 
   async deleteDeployment(deploymentId: string): Promise<void> {
+    await this.ensureLoaded();
     this.requireDeployment(deploymentId);
 
     this.logger.info('Deleting deployment', { deploymentId });
@@ -364,6 +529,7 @@ abstract class InMemoryDeploymentService implements DeploymentService {
   }
 
   async executeAction(deploymentId: string, request: PostDeploymentActionRequest): Promise<PostDeploymentActionResponse> {
+    await this.ensureLoaded();
     const deployment = this.requireDeployment(deploymentId);
 
     this.logger.info('Executing deployment action', { deploymentId, action: request.action });
@@ -387,28 +553,31 @@ abstract class InMemoryDeploymentService implements DeploymentService {
   }
 
   async rollback(deploymentId: string, request: RollbackRequest): Promise<RollbackResponse> {
+    await this.ensureLoaded();
     const deployment = this.requireDeployment(deploymentId);
 
     this.logger.info('Rolling back deployment', { deploymentId, targetReleaseId: request.targetReleaseId });
 
     let targetReleaseId = request.targetReleaseId;
     if (!targetReleaseId) {
-      // Find the previous successful release (second most recent active release).
-      const releases = Array.from(this.releases.values())
-        .filter(r => r.deploymentId === deploymentId && r.status === 'active')
+      // Default to the most recent release other than the one currently active.
+      const candidates = Array.from(this.releases.values())
+        .filter(r => r.deploymentId === deploymentId && r.id !== deployment.currentReleaseId)
         .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
 
-      if (releases.length < 2) {
+      if (candidates.length === 0) {
         throw new ConflictError('No previous release available for rollback');
       }
 
-      targetReleaseId = releases[1].id; // Second most recent
+      targetReleaseId = candidates[0].id;
     }
 
     const targetRelease = this.releases.get(targetReleaseId);
     if (!targetRelease || targetRelease.deploymentId !== deploymentId) {
       throw new NotFoundError(`Target release not found: ${targetReleaseId}`);
     }
+
+    const previousReleaseId = deployment.currentReleaseId || '';
 
     const job = await this.jobService.createJob({
       type: 'start',
@@ -420,7 +589,9 @@ abstract class InMemoryDeploymentService implements DeploymentService {
       },
     });
 
-    const previousReleaseId = deployment.currentReleaseId || '';
+    // Atomically activate the target release (switches the durable current pointer).
+    await this.promoteRelease(deploymentId, targetReleaseId);
+
     deployment.status = 'installing';
     deployment.lifecycleState = 'releasing';
     deployment.lastUpdated = new Date().toISOString();
@@ -438,6 +609,7 @@ abstract class InMemoryDeploymentService implements DeploymentService {
     deploymentId: string,
     options?: { page?: number; limit?: number }
   ): Promise<GetDeploymentHistoryResponse> {
+    await this.ensureLoaded();
     this.logger.info('Getting deployment history', { deploymentId, options });
     this.requireDeployment(deploymentId); // 404 for unknown deployments, consistent with other routes
     const jobs = await this.jobService.listJobs({ deploymentId });
@@ -445,12 +617,14 @@ abstract class InMemoryDeploymentService implements DeploymentService {
   }
 
   async getReleases(deploymentId: string): Promise<Release[]> {
+    await this.ensureLoaded();
     return Array.from(this.releases.values())
       .filter(r => r.deploymentId === deploymentId)
       .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
   }
 
   async getRelease(deploymentId: string, releaseId: string): Promise<Release> {
+    await this.ensureLoaded();
     const release = this.releases.get(releaseId);
     if (!release || release.deploymentId !== deploymentId) {
       throw new NotFoundError(`Release not found: ${releaseId}`);
@@ -488,7 +662,8 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     private storageService: StorageService,
     jobService: JobService,
     // Reserved for orchestration wiring (issue #15); not yet used directly here.
-    private dockerService: DockerService
+    private dockerService: DockerService,
+    private draftService: DraftService
   ) {
     super(jobService);
     void this.dockerService;
@@ -508,12 +683,129 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     }
   }
 
+  /** Rehydrate deployments, releases, and the active-release pointer from storage. */
+  protected override async loadFromStorage(): Promise<void> {
+    if (!(await this.storageService.fileExists('deployments'))) {
+      return;
+    }
+
+    let ids: string[];
+    try {
+      ids = await this.storageService.listDir('deployments');
+    } catch {
+      return;
+    }
+
+    for (const deploymentId of ids) {
+      const metaPath = `deployments/${deploymentId}/metadata.json`;
+      if (!(await this.storageService.fileExists(metaPath))) {
+        continue;
+      }
+      try {
+        const deployment = JSON.parse(await this.storageService.readFileAsString(metaPath)) as EnhancedDeploymentDetail;
+
+        // Load every release for this deployment.
+        const releasesDir = `deployments/${deploymentId}/releases`;
+        if (await this.storageService.fileExists(releasesDir)) {
+          for (const releaseId of await this.storageService.listDir(releasesDir)) {
+            const relPath = `${releasesDir}/${releaseId}/metadata.json`;
+            if (await this.storageService.fileExists(relPath)) {
+              const release = JSON.parse(await this.storageService.readFileAsString(relPath)) as Release;
+              this.releases.set(release.id, release);
+            }
+          }
+        }
+
+        // The `current` pointer is authoritative for the active release.
+        const pointerPath = `deployments/${deploymentId}/current`;
+        if (await this.storageService.fileExists(pointerPath)) {
+          deployment.currentReleaseId = (await this.storageService.readFileAsString(pointerPath)).trim();
+        }
+
+        this.deployments.set(deploymentId, deployment);
+      } catch (error) {
+        this.logger.warn('Failed to rehydrate deployment; skipping', {
+          deploymentId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    this.logger.info('Rehydrated deployments from storage', { count: this.deployments.size });
+  }
+
+  protected override async loadFinalizedArtifacts(draftId: string): Promise<FinalizedArtifacts | null> {
+    // Throws ConflictError if the draft was never finalized.
+    return this.draftService.getFinalizedArtifacts(draftId);
+  }
+
+  protected override async buildReleaseFromDraft(
+    artifacts: FinalizedArtifacts | null,
+    request: { draftId?: string },
+    deploymentId: string,
+    releaseId: string
+  ): Promise<{ app: string; version?: string; release: Release }> {
+    const now = new Date().toISOString();
+    const manifest = artifacts?.manifest;
+
+    const filesChecksums: Record<string, string> = {};
+    for (const f of manifest?.files ?? []) {
+      filesChecksums[f.path || f.name] = f.sha256;
+    }
+
+    const release: Release = {
+      id: releaseId,
+      deploymentId,
+      draftId: request.draftId ?? manifest?.draftId ?? '',
+      status: 'creating',
+      createdAt: now,
+      images: [],
+      ports: (manifest?.ports ?? []).map(p => ({ host: p.host, container: p.container, protocol: p.protocol })),
+      filesChecksums,
+      metadata: manifest ? { checksum: manifest.checksum } : undefined,
+    };
+
+    return {
+      app: manifest?.appId ?? 'Unknown App',
+      version: manifest?.version,
+      release,
+    };
+  }
+
   protected override async ensureLayout(deploymentId: string): Promise<void> {
     const layout = await this.getDirectoryLayout(deploymentId);
     await this.storageService.ensureDir(layout.deploymentPath);
     await this.storageService.ensureDir(layout.draftsPath);
     await this.storageService.ensureDir(layout.releasesPath);
     await this.storageService.ensureDir(layout.logsPath);
+  }
+
+  /** Copy the finalized artifacts into the immutable release directory. */
+  protected override async stageReleaseArtifacts(
+    artifacts: FinalizedArtifacts | null,
+    deploymentId: string,
+    release: Release
+  ): Promise<void> {
+    if (!artifacts) {
+      return;
+    }
+    const releaseDir = `deployments/${deploymentId}/releases/${release.id}`;
+    if (artifacts.composeOverride) {
+      await this.storageService.writeFile(`${releaseDir}/compose-override.yml`, artifacts.composeOverride);
+    }
+    for (const file of artifacts.files) {
+      await this.storageService.writeFile(`${releaseDir}/files/${file.uploadId}-${file.name}`, file.content);
+    }
+    // Persist the source manifest alongside the release for traceability.
+    await this.storageService.writeFile(
+      `${releaseDir}/manifest.json`,
+      JSON.stringify(artifacts.manifest, null, 2)
+    );
+  }
+
+  /** Atomically switch the active-release pointer (storage writes are temp+rename). */
+  protected override async writeCurrentPointer(deploymentId: string, releaseId: string): Promise<void> {
+    await this.storageService.writeFile(`deployments/${deploymentId}/current`, releaseId);
   }
 
   protected override async persistDeployment(deployment: EnhancedDeploymentDetail): Promise<void> {

--- a/packages/server/src/services/core/draft.ts
+++ b/packages/server/src/services/core/draft.ts
@@ -25,9 +25,43 @@ import type {
 import { createHash } from 'crypto';
 
 import { getLogger } from '../../lib/logger';
+import { NotFoundError, ConflictError } from '../../middleware/error-mapping';
 import type { HealthCheckable, ServiceHealth } from './types';
 import type { StorageService } from './storage';
 import type { CatalogService } from './catalog';
+
+/**
+ * Shape of `drafts/<id>/finalized/manifest.json` produced by `finalizeDraft`.
+ * This is the deterministic, deployment-ready specification consumed by
+ * `DeploymentService` when building a release.
+ */
+export interface FinalizedManifestFile {
+  uploadId: string;
+  name: string;
+  kind: DraftFile['kind'];
+  path?: string;
+  sha256: string;
+}
+
+export interface FinalizedManifest {
+  draftId: string;
+  appId: string;
+  version?: string;
+  systemOverrides: Record<string, string>;
+  appEnv: AppEnvVar[];
+  ports: Array<{ host?: number; container: number; protocol: 'tcp' | 'udp' }>;
+  composeOverride: string;
+  files: FinalizedManifestFile[];
+  checksum: string;
+  finalizedAt: string;
+}
+
+/** Finalized manifest plus the staged file/compose contents it references. */
+export interface FinalizedArtifacts {
+  manifest: FinalizedManifest;
+  composeOverride?: string;
+  files: Array<{ uploadId: string; name: string; kind: DraftFile['kind']; path?: string; content: Buffer }>;
+}
 
 /**
  * Deterministic JSON serialization with recursively sorted object keys, so a
@@ -71,7 +105,9 @@ export interface DraftService extends HealthCheckable {
   
   // Finalization
   finalizeDraft(draftId: string): Promise<FinalizeDraftResponse>;
-  
+  /** Read the staged finalized artifacts for a finalized draft (for deployment creation). */
+  getFinalizedArtifacts(draftId: string): Promise<FinalizedArtifacts>;
+
   // Internal helpers
   getDraftDefaults(appId: string, version?: string): Promise<{ env: AppEnvVar[]; defaults: DraftDefaults }>;
 }
@@ -547,6 +583,31 @@ export class RealDraftService implements DraftService {
     }
   }
 
+  async getFinalizedArtifacts(draftId: string): Promise<FinalizedArtifacts> {
+    await this.ensureLoaded();
+    const manifestPath = `drafts/${draftId}/finalized/manifest.json`;
+    if (!(await this.storageService.fileExists(manifestPath))) {
+      throw new ConflictError(`Draft is not finalized: ${draftId}`);
+    }
+
+    const manifest = JSON.parse(await this.storageService.readFileAsString(manifestPath)) as FinalizedManifest;
+
+    const files: FinalizedArtifacts['files'] = [];
+    for (const f of manifest.files) {
+      const blobPath = `drafts/${draftId}/finalized/files/${f.uploadId}-${f.name}`;
+      const content = (await this.storageService.fileExists(blobPath))
+        ? await this.storageService.readFile(blobPath)
+        : Buffer.alloc(0);
+      files.push({ uploadId: f.uploadId, name: f.name, kind: f.kind, path: f.path, content });
+    }
+
+    return {
+      manifest,
+      composeOverride: manifest.composeOverride || undefined,
+      files,
+    };
+  }
+
   async getDraftDefaults(appId: string, version?: string): Promise<{ env: AppEnvVar[]; defaults: DraftDefaults }> {
     try {
       const versionDetail = await this.catalogService.getVersionDetail(appId, version || 'latest');
@@ -697,6 +758,25 @@ export class MockDraftService implements DraftService {
     const draft = this.drafts.get(draftId);
     if (!draft) throw new Error(`Draft not found: ${draftId}`);
     return { spec: { draftId: draft.draftId, appId: draft.appId, finalizedAt: new Date().toISOString() }, checksum: crypto.randomUUID() };
+  }
+
+  async getFinalizedArtifacts(draftId: string): Promise<FinalizedArtifacts> {
+    this.logger.info('Mock: Getting finalized artifacts', { draftId });
+    const draft = this.drafts.get(draftId);
+    if (!draft) throw new NotFoundError(`Draft not found: ${draftId}`);
+    const manifest: FinalizedManifest = {
+      draftId,
+      appId: draft.appId,
+      version: draft.version,
+      systemOverrides: draft.systemOverrides,
+      appEnv: draft.appEnv,
+      ports: draft.ports,
+      composeOverride: draft.composeOverride ?? '',
+      files: [],
+      checksum: 'mock-checksum',
+      finalizedAt: new Date().toISOString(),
+    };
+    return { manifest, composeOverride: manifest.composeOverride || undefined, files: [] };
   }
 
   async getDraftDefaults(appId: string, version?: string): Promise<{ env: AppEnvVar[]; defaults: DraftDefaults }> {

--- a/packages/server/src/services/simple-factory.ts
+++ b/packages/server/src/services/simple-factory.ts
@@ -98,7 +98,10 @@ export function createServices(env: ServiceEnvironment): Services {
     
     // Create shared validation service instance to avoid duplication
     const validation = new RealValidationService(docker, systemMonitoring, storage);
-    
+
+    // Shared draft service: the deployment service builds releases from its finalized artifacts.
+    const drafts = new RealDraftService(storage, catalog, validation);
+
     return {
       storage,
       config: new RealConfigService(storage),
@@ -111,9 +114,9 @@ export function createServices(env: ServiceEnvironment): Services {
       jobs,
       catalog,
       bundles: new RealBundleService(storage.resolveHolaPath('cache', 'bundles')),
-      drafts: new RealDraftService(storage, catalog, validation),
+      drafts,
       validation,
-      deployments: new RealDeploymentService(storage, jobs, docker),
+      deployments: new RealDeploymentService(storage, jobs, docker, drafts),
     };
   }
   
@@ -136,9 +139,12 @@ export function createServices(env: ServiceEnvironment): Services {
   const apiKeyProvider = new ApiKeyAuthProvider();
   authService.registerProvider(apiKeyProvider);
   
-  // Create shared validation service instance to avoid duplication  
+  // Create shared validation service instance to avoid duplication
   const validation = new RealValidationService(docker, systemMonitoring, storage);
-  
+
+  // Shared draft service: the deployment service builds releases from its finalized artifacts.
+  const drafts = new RealDraftService(storage, catalog, validation);
+
   return {
     storage,
     config: new RealConfigService(storage),
@@ -151,9 +157,9 @@ export function createServices(env: ServiceEnvironment): Services {
     jobs,
     catalog,
     bundles: new RealBundleService(storage.resolveHolaPath('cache', 'bundles')),
-    drafts: new RealDraftService(storage, catalog, validation),
+    drafts,
     validation,
-    deployments: new RealDeploymentService(storage, jobs, docker),
+    deployments: new RealDeploymentService(storage, jobs, docker, drafts),
   };
 }
 


### PR DESCRIPTION
## Summary
Makes `DeploymentService` durable and promotion/rollback **atomic**, building releases from the finalized draft artifacts staged by #11. Resolves #14 (step 4 of the recovery epic #21). Unblocks #15, #18, #19, #54, #55; coordinates with #16.

## Problem
After #56 the deployment service was the single source of truth in memory, but it **didn't rehydrate on restart** (deployments vanished), `createFromDraft` **fabricated** releases instead of using the finalized draft, there were **no immutable release dirs or `current` pointer**, and **rollback never actually switched the active release**.

## Changes
- **Read finalized artifacts:** `DraftService.getFinalizedArtifacts(draftId)` returns the manifest + staged blobs (`ConflictError` if not finalized), so the deployment service builds releases without coupling to the draft layout.
- **Rehydration:** a one-time `ensureLoaded()` guard on the base service (called by every public method); `RealDeploymentService.loadFromStorage()` scans `deployments/`, loads metadata + releases, and treats the `current` pointer file as **authoritative** for the active release. Deployments/releases now survive a restart.
- **Atomic promotion:** a `promoteRelease()` primitive demotes the prior active release, activates the target, updates `currentReleaseId`/`previousReleaseId`/`rollbackAvailable`, and writes the durable `current` pointer **last**. `createFromDraft` builds the release from the manifest (app/version/ports/filesChecksums) and stages an **immutable release dir** (compose override, files, manifest); an unfinalized draft fails **before** any deployment dir is created (no partial state).
- **Re-deploy primitive:** new `promote(deploymentId, { draftId })` stages a new release onto an existing deployment (the operation #15 will wire to a route/action).
- **Durable rollback:** atomically switches the `current` pointer to a valid prior release and returns state-derived ids; unknown/foreign release → 404, nothing to roll back to → 409.
- **Routing seam:** `onActiveReleaseChanged()` hook for Traefik activation (#16) — no Traefik emission here. Real Docker lifecycle stays in #15.
- **Factory:** wires the shared `RealDraftService` into `RealDeploymentService`.

## Acceptance criteria (from #14)
- [x] A finalized draft promotes into a deployment with a persisted **active** release.
- [x] The deployment is consistent across list/detail/history.
- [x] State and history survive a server restart.
- [x] A failed promotion leaves the previous release active.
- [x] Rollback atomically activates a valid prior release and updates history.
- [x] Unknown/stale release ids produce consistent 404/409 responses.

## Verification
- New `src/__tests__/deployments/persistence.test.ts` (real service, temp data root): promote-from-finalized-draft, restart survival, re-deploy + atomic rollback (+ restart), default rollback, failed-promotion-leaves-previous-active, and typed 404/409.
- Full gate green: lint, typecheck, builds across all packages; **server tests 135 pass / 0 fail**.

## Notes
- Wire `Draft`/deployment API contracts are unchanged; `promote` is a new service method (no new HTTP route in #14 — routes + Docker lifecycle are #15).
- History stays job-based (JobService is DB-persisted); rehydration is what makes detail/history work after restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)