### PR TITLE
architecture(auth): control-plane API-key auth + ADR (#53, MVP pt.1)

### DIFF
--- a/docs/adr/0001-authentication.md
+++ b/docs/adr/0001-authentication.md
@@ -1,0 +1,63 @@
+# ADR 0001: Authentication architecture
+
+- **Status:** Accepted (June 2026)
+- **Context:** Recovery epic #21, issue #53. Supersedes the PRD's earlier "Authentik + OIDC + API keys" sketch where it implied all of it ships at once.
+
+## Context
+
+Hola exposes a control plane (web UI, CLI, API) that manages deployments on a single host, and
+it deploys applications (e.g. Gitea) that are reached through a consolidated **Traefik** front
+door. There are therefore two distinct authentication surfaces:
+
+1. **Control-plane auth** — who may call the Hola API / use the web UI / use the CLI to create and
+   manage deployments.
+2. **Application SSO** — a single login, external to each deployed app, that protects every app
+   behind the Traefik front door (log in once, reach Gitea and everything deployed after it).
+
+Before this decision the production server enabled auth but registered an **empty** API-key
+provider — auth was "on" with zero usable credentials, so no one could authenticate. The web,
+CLI, and shared `AUTH_API` routes were unimplemented.
+
+## Decision
+
+Authentication is delivered in **two phases**.
+
+### MVP pt.1 — control-plane auth (this issue)
+- **API keys** secure the control plane. A single **admin** API key grants full capability (`*`).
+- **First-admin bootstrap:** the admin key comes from `HOLA_API_KEY` if set; otherwise, in
+  production, the server generates a random key on first boot and persists it to
+  `<data-root>/config/admin-api-key` (mode `0600`), logging the file **location** (not the secret)
+  so the operator can retrieve it (`cat <data-root>/config/admin-api-key`). The same key is read
+  back on subsequent boots.
+- **Enforcement** (already present in `middleware/auth.ts`, gated by `featureFlags.useAuth`, which
+  is **on by default in production**):
+  - Public endpoints (no auth): `/healthz`, `/readyz`, `/metrics`, `/api/system/health`,
+    `/api/system/status`, `/api/echo`.
+  - Absent or invalid credentials → **401**.
+  - Authenticated but missing the required capability → **403**.
+  - Mutating routes (`POST`/`PATCH`/`DELETE` on deployments, drafts, settings, …) require a
+    write/manage capability; reads require none.
+- **Clients:** CLI/SDK send the key via `Authorization: Bearer <key>` or `X-API-Key` (env
+  `HOLA_TOKEN`/`HOLA_API_KEY`). The web app, in pt.1, runs against an auth-disabled dev server or a
+  reverse-proxy-injected key; a first-class browser login is pt.2.
+- `GET /api/auth/me` returns the current principal so clients can confirm identity.
+
+### MVP pt.2 — consolidated application SSO (future)
+- An identity provider (Authentik or equivalent) fronts deployed apps via **Traefik forward-auth**,
+  giving single sign-on across every deployed application.
+- The Hola web UI adopts the same browser session/OIDC flow; API keys remain for CLI/service access.
+- Capability/role mapping is sourced from the IdP (groups → capabilities).
+
+## Trust boundaries
+- Traefik terminates TLS and is the only ingress; the Hola API and deployed apps are not exposed on
+  host ports.
+- The admin API key is a bearer secret: treat the data root and logs as sensitive. Encryption at
+  rest for the key store is future work.
+- Test and development run with auth disabled (`featureFlags.useAuth = false`) and a synthetic
+  system principal, so local development and the in-process test suite need no credentials.
+
+## Consequences
+- A fresh production deployment has a documented, usable way to establish the first administrator.
+- The `AUTH_API` surface is trimmed to the implemented `me` endpoint; session endpoints
+  (`login`/`logout`/`refresh`) are deferred to pt.2 rather than left as dead routes.
+- No production mode ships with auth enabled but no usable credential.

--- a/packages/server/src/__tests__/auth/api-key.test.ts
+++ b/packages/server/src/__tests__/auth/api-key.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Admin API key + control-plane auth tests (issue #53, MVP pt.1).
+ *
+ * Verifies the first-admin bootstrap (env or generated+persisted key) and the
+ * API-key enforcement semantics the auth middleware maps to 401/403.
+ */
+
+import { describe, test, expect, afterEach } from 'bun:test';
+import { mkdtemp, rm, readFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { resolveAdminApiKey, createAdminApiKeyProvider, adminApiKeyPath } from '../../services/auth/api-key-config';
+import { RealAuthService, type Principal } from '../../services/auth/auth-service';
+
+describe('Admin API key bootstrap', () => {
+  const savedKey = process.env.HOLA_API_KEY;
+  const savedDir = process.env.HOLA_DATA_DIR;
+  let tmp: string | undefined;
+
+  afterEach(async () => {
+    if (savedKey === undefined) delete process.env.HOLA_API_KEY; else process.env.HOLA_API_KEY = savedKey;
+    if (savedDir === undefined) delete process.env.HOLA_DATA_DIR; else process.env.HOLA_DATA_DIR = savedDir;
+    if (tmp) { await rm(tmp, { recursive: true, force: true }); tmp = undefined; }
+  });
+
+  test('uses HOLA_API_KEY when set', () => {
+    process.env.HOLA_API_KEY = 'env-provided-key';
+    expect(resolveAdminApiKey()).toBe('env-provided-key');
+  });
+
+  test('generates and persists a key on first boot, stable across reboots', async () => {
+    delete process.env.HOLA_API_KEY;
+    tmp = await mkdtemp(join(tmpdir(), 'hola-auth-'));
+    process.env.HOLA_DATA_DIR = tmp;
+
+    const key = resolveAdminApiKey();
+    expect(key).toMatch(/^[0-9a-f]{48}$/);
+
+    // Persisted to the data root...
+    expect((await readFile(adminApiKeyPath(), 'utf8')).trim()).toBe(key);
+    // ...and read back identically on the next boot.
+    expect(resolveAdminApiKey()).toBe(key);
+  });
+});
+
+describe('API-key auth enforcement', () => {
+  test('valid admin key authenticates with full capability', async () => {
+    const auth = new RealAuthService(true);
+    auth.registerProvider(createAdminApiKeyProvider('secret-admin-key'));
+
+    const ok = await auth.authenticate('secret-admin-key');
+    expect(ok.success).toBe(true);
+    expect(ok.principal?.id).toBe('admin');
+    expect(auth.hasCapability(ok.principal!, 'write:deployments')).toBe(true);
+    expect(auth.hasCapability(ok.principal!, 'manage:system')).toBe(true);
+  });
+
+  test('invalid or absent credentials fail when auth is enabled (401 semantics)', async () => {
+    const auth = new RealAuthService(true);
+    auth.registerProvider(createAdminApiKeyProvider('the-key'));
+
+    expect((await auth.authenticate('wrong-key')).success).toBe(false);
+    expect((await auth.authenticate('')).success).toBe(false);
+  });
+
+  test('insufficient capability is denied (403 semantics)', () => {
+    const auth = new RealAuthService(true);
+    auth.registerProvider(createAdminApiKeyProvider('the-key'));
+
+    const readonly: Principal = {
+      id: 'viewer', type: 'user', name: 'Viewer', roles: ['viewer'], capabilities: ['read:deployments'],
+    };
+    expect(auth.hasCapability(readonly, 'read:deployments')).toBe(true);
+    expect(auth.hasCapability(readonly, 'write:deployments')).toBe(false);
+  });
+
+  test('disabled auth allows all (dev/test) with a system principal', async () => {
+    const auth = new RealAuthService(false);
+    const res = await auth.authenticate('');
+    expect(res.success).toBe(true);
+    expect(res.principal?.capabilities).toContain('*');
+  });
+});

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,5 +1,7 @@
 import {
   API,
+  AUTH_API,
+  type GetAuthMeResponse,
   type HealthResponse,
   type HelloResponse,
   type GetMeResponse,
@@ -58,7 +60,7 @@ import { createSSEStream, createSSEHeaders } from './utils/sse';
 import { mapErrorToResponse } from './middleware/error-mapping';
 
 // Phase 3: Authentication imports
-import { createAuthMiddleware } from './middleware/auth';
+import { createAuthMiddleware, getPrincipal } from './middleware/auth';
 
 // Import enhanced mock data
 import {
@@ -303,6 +305,17 @@ async function route(url: URL, req: Request): Promise<Response> {
   if (pathname === API.me && req.method === 'GET') {
     const me = getIdentity(req);
     if (!me) return json({ error: { code: 'UNAUTHENTICATED', message: 'No identity' } }, { status: 401 });
+    return json(me);
+  }
+
+  // Current authenticated principal (resolved by the auth middleware).
+  if (pathname === AUTH_API.me && req.method === 'GET') {
+    const principal = getPrincipal(req);
+    if (principal) {
+      return json(principal as GetAuthMeResponse);
+    }
+    const me = getIdentity(req);
+    if (!me) return json({ error: { code: 'UNAUTHORIZED', message: 'Authentication required' } }, { status: 401 });
     return json(me);
   }
 

--- a/packages/server/src/services/auth/api-key-config.ts
+++ b/packages/server/src/services/auth/api-key-config.ts
@@ -1,0 +1,66 @@
+/**
+ * Admin API key bootstrap (issue #53, MVP pt.1).
+ *
+ * Resolves the control-plane admin API key from `HOLA_API_KEY`, or generates and
+ * persists one under the data root on first boot so a fresh production deployment
+ * always has a usable administrator credential (no "auth enabled, zero keys" gap).
+ */
+
+import { randomBytes } from 'crypto';
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { dirname, join } from 'path';
+
+import { getHolaDataDir } from '../../config/paths';
+import { getLogger } from '../../lib/logger';
+import { ApiKeyAuthProvider, type Principal } from './auth-service';
+
+const ADMIN_KEY_PATH = ['config', 'admin-api-key'];
+
+/** Path of the persisted admin key file under the configured data root. */
+export function adminApiKeyPath(): string {
+  return join(getHolaDataDir(), ...ADMIN_KEY_PATH);
+}
+
+/**
+ * Resolve the admin API key: `HOLA_API_KEY` if set, otherwise a persisted key,
+ * generating and persisting a new one (mode 0600) on first boot.
+ */
+export function resolveAdminApiKey(): string {
+  const logger = getLogger().child({ service: 'AuthConfig' });
+
+  const fromEnv = process.env.HOLA_API_KEY?.trim();
+  if (fromEnv) {
+    return fromEnv;
+  }
+
+  const path = adminApiKeyPath();
+  if (existsSync(path)) {
+    const existing = readFileSync(path, 'utf8').trim();
+    if (existing) {
+      return existing;
+    }
+  }
+
+  const generated = randomBytes(24).toString('hex');
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, generated, { mode: 0o600 });
+    // Log the location, not the secret. The operator retrieves it from the file.
+    logger.warn('Generated a new admin API key for first-time setup', { path });
+  } catch (error) {
+    logger.error('Failed to persist admin API key; using an ephemeral key for this run', error as Error);
+  }
+  return generated;
+}
+
+/** Build an API-key provider that authorizes the admin key with full capabilities. */
+export function createAdminApiKeyProvider(apiKey: string): ApiKeyAuthProvider {
+  const admin: Partial<Principal> = {
+    id: 'admin',
+    type: 'user',
+    name: 'Administrator',
+    roles: ['admin'],
+    capabilities: ['*'],
+  };
+  return new ApiKeyAuthProvider({ [apiKey]: admin });
+}

--- a/packages/server/src/services/simple-factory.ts
+++ b/packages/server/src/services/simple-factory.ts
@@ -11,7 +11,8 @@ import { RealStorageService, MockStorageService, type StorageService } from './c
 import { RealConfigService, MockConfigService, type ConfigService } from './core/config';
 import { RealDatabaseService, MockDatabaseService, type DatabaseService } from './core/database';
 import { RealDatabaseConfigService, type DatabaseConfigService } from './core/database-config';
-import { RealAuthService, MockAuthService, ApiKeyAuthProvider, type AuthService } from './auth/auth-service';
+import { RealAuthService, MockAuthService, type AuthService } from './auth/auth-service';
+import { resolveAdminApiKey, createAdminApiKeyProvider } from './auth/api-key-config';
 import { RealDockerService, MockDockerService, type DockerService } from './core/docker';
 import { RealSystemMonitoringService, MockSystemMonitoringService, type SystemMonitoringService } from './core/system-monitoring';
 import { RealLoggingService, MockLoggingService, type LoggingService } from './core/logging';
@@ -143,8 +144,8 @@ export function createServices(env: ServiceEnvironment): Services {
   const catalog = new RealCatalogService();
   
   // Set up auth provider for real auth service
-  const apiKeyProvider = new ApiKeyAuthProvider();
-  authService.registerProvider(apiKeyProvider);
+  // Register the admin API-key provider with a usable credential (env or generated+persisted).
+  authService.registerProvider(createAdminApiKeyProvider(resolveAdminApiKey()));
   
   // Shared routing service owns Traefik rule generation/validation/emission.
   const routing = new RealRoutingService(storage);

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -156,27 +156,12 @@ export const CAPABILITIES = {
 
 export type Capability = typeof CAPABILITIES[keyof typeof CAPABILITIES];
 
-// Auth API endpoints
+// Auth API endpoints.
+// pt.1 (control-plane API keys) implements `me`. Session/SSO endpoints
+// (login/logout/refresh) arrive with application SSO in MVP pt.2 (ADR 0001).
 export const AUTH_API = {
-  login: '/api/auth/login',
-  logout: '/api/auth/logout',
-  refresh: '/api/auth/refresh',
   me: '/api/auth/me',
 } as const;
-
-// Auth request/response types
-export type LoginRequest = {
-  // API key login
-  apiKey?: string;
-  // Future: username/password, OAuth, etc.
-};
-
-export type LoginResponse = {
-  success: boolean;
-  token?: string;
-  principal?: Principal;
-  error?: string;
-};
 
 export type GetAuthMeResponse = Principal;
 


### PR DESCRIPTION
## Summary
Decides and implements the **first phase** of Hola's authentication and closes the production gap where auth was enabled with **zero usable credentials**. Resolves #53 (MVP pt.1). Per our re-alignment, auth is two-phase: **control-plane API keys now**, **consolidated application SSO (Authentik forward-auth) in pt.2**.

## The decision (ADR 0001)
`docs/adr/0001-authentication.md` records two surfaces — control-plane auth (who manages Hola) and application SSO (one login in front of every deployed app via Traefik forward-auth) — and ships them in two phases. Trust boundaries, first-admin bootstrap, and the public-endpoint/capability model are documented.

## Changes
- **First-admin bootstrap** (`services/auth/api-key-config.ts`): `resolveAdminApiKey()` uses `HOLA_API_KEY` if set, otherwise generates a random key on first boot, persists it to `<data-root>/config/admin-api-key` (mode `0600`), and logs its **location** (not the secret). `createAdminApiKeyProvider()` maps it to an `admin` principal with full capability (`*`).
- **Factory:** production now registers the configured admin provider instead of an empty one — a fresh deployment has a usable administrator credential.
- **`GET /api/auth/me`:** returns the current principal resolved by the auth middleware (so clients can confirm identity).
- **Trimmed `AUTH_API`:** keeps the implemented `me`; drops the unimplemented `login`/`logout`/`refresh` routes and `Login*` types (session/SSO endpoints belong to pt.2) — they were referenced nowhere.

Enforcement already existed in `middleware/auth.ts` (401 on absent/invalid credentials, 403 on insufficient capability, gated by `featureFlags.useAuth` which is **on by default in production**); this PR makes it actually usable.

## Acceptance criteria (from #53)
- [x] A fresh production deployment has a documented way to establish the first administrator.
- [x] Valid identities can access permitted APIs (admin key → full capability).
- [x] Invalid/absent credentials receive consistent **401**; insufficient capability receives **403**.
- [x] No production mode ships with auth enabled but zero usable credentials/providers.
- [x] Unused shared auth endpoints are implemented (`me`) or removed (`login`/`logout`/`refresh`).

## Verification
- New `__tests__/auth/api-key.test.ts`: bootstrap (env + generate/persist/stable across reboot) and enforcement semantics (valid admin key → full capability; invalid/absent → 401; insufficient capability → 403; disabled → system principal).
- Full gate green across all packages; **server tests 140 pass / 0 fail**.

## Scope notes (pt.2 / other issues)
- **Web browser login** is part of consolidated SSO → **pt.2**. The web app continues to run against the auth-disabled dev server in development.
- **CLI token wiring** (sending `HOLA_TOKEN`/API key end-to-end) is finished with the CLI workflow in **#54**; the SDK already supports the auth header.
- The production stack that turns auth on with these credentials is **#55**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added authentication system with admin API key support and automatic bootstrap mechanism for initial setup
  * Introduced `/api/auth/me` endpoint to retrieve current authenticated principal and capabilities

* **Bug Fixes**
  * Enforced proper HTTP 401/403 error responses for unauthorized and insufficient privilege requests

* **Documentation**
  * Added architecture decision record documenting two-phase authentication strategy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->