### PR TITLE
feat(server): attach deployed apps to the Traefik network for routing

### DIFF
--- a/examples/bundles/gitea/README.md
+++ b/examples/bundles/gitea/README.md
@@ -9,7 +9,7 @@ With the Hola stack running (see `packages/compose`) and `HOLA_TOKEN` set to you
 ```bash
 export HOLA_API_URL=https://app.<your-domain>   # or http://localhost:3001 against a local server
 export HOLA_TOKEN=<admin-api-key>               # docker compose exec server cat /data/config/admin-api-key
-hola bundle deploy --path examples/bundles/gitea --app-id gitea
+hola bundle deploy --path examples/bundles/gitea --app-id gitea --port 3000
 ```
 
 The CLI imports the compose, validates and finalizes a draft, creates the deployment, and watches

--- a/packages/cli/src/commands/bundle/deploy.ts
+++ b/packages/cli/src/commands/bundle/deploy.ts
@@ -14,6 +14,7 @@ export interface BundleDeployOptions {
   path?: string;
   appId?: string;
   version?: string;
+  port?: number | string;
   traefik?: boolean;
   noStream?: boolean;
   json?: boolean;
@@ -80,7 +81,12 @@ export async function runBundleDeploy(
 
     out(`Creating draft for ${appId}@${version}`);
     const draft = (await sdk.drafts.create({ appId, version })) as CreateDraftResponse;
-    await sdk.drafts.update(draft.draftId, { composeOverride, ...(appEnv.length ? { appEnv } : {}) });
+    const port = opts.port !== undefined ? Number(opts.port) : undefined;
+    await sdk.drafts.update(draft.draftId, {
+      composeOverride,
+      ...(appEnv.length ? { appEnv } : {}),
+      ...(port && Number.isFinite(port) ? { ports: [{ container: port, protocol: 'tcp' }] } : {}),
+    });
 
     out('Validating…');
     const report = (await sdk.drafts.validate(draft.draftId)) as {

--- a/packages/cli/src/index.tsx
+++ b/packages/cli/src/index.tsx
@@ -29,6 +29,7 @@ prog
   .option('--path, -p', 'Bundle directory', '.')
   .option('--app-id', 'App ID (defaults to the bundle directory name)')
   .option('--version', 'Version', 'latest')
+  .option('--port', 'Ingress container port Traefik routes to (e.g. 3000 for Gitea)')
   .option('--traefik', 'Require Traefik mode', false)
   .option('--strict', 'Fail on validation warnings', false)
   .option('--no-stream', 'Do not watch the deployment job', false)

--- a/packages/server/src/__tests__/deployments/lifecycle.test.ts
+++ b/packages/server/src/__tests__/deployments/lifecycle.test.ts
@@ -94,8 +94,11 @@ describe('Deployment lifecycle (real orchestration wiring)', () => {
     const detail = await deployments.getDeployment(created.deploymentId);
     expect(detail.status).toBe('running');
 
-    // The compose file was materialized for the Compose project.
-    expect(await makeSystem().storage.fileExists(`deployments/${created.deploymentId}/runtime/docker-compose.yml`)).toBe(true);
+    // The compose file was materialized and attached to the Traefik network.
+    const materialized = await makeSystem().storage.readFileAsString(`deployments/${created.deploymentId}/runtime/docker-compose.yml`);
+    expect(materialized).toContain('hola');
+    expect(materialized).toContain('aliases');
+    expect(materialized).toContain('external: true');
   });
 
   test('stop action runs Compose down and converges to stopped', async () => {

--- a/packages/server/src/__tests__/routing/compose-network.test.ts
+++ b/packages/server/src/__tests__/routing/compose-network.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Compose network attachment tests (#15/#16 routing last-mile).
+ *
+ * The ingress service of a deployed app must join the external Traefik network
+ * with an alias equal to the routing service name, so Traefik can reach it.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { parse } from 'yaml';
+
+import { attachToHolaNetwork } from '../../services/core/compose-network';
+
+describe('attachToHolaNetwork', () => {
+  test('attaches a single-service app to the hola network with the alias and keeps default', () => {
+    const input = 'services:\n  gitea:\n    image: gitea/gitea\n';
+    const out = parse(attachToHolaNetwork(input, { alias: 'gitea-abc123', ingressService: 'gitea' }));
+
+    expect(out.networks.hola).toEqual({ external: true });
+    expect(out.services.gitea.networks.hola).toEqual({ aliases: ['gitea-abc123'] });
+    // No declared networks -> preserve implicit default connectivity.
+    expect(out.services.gitea.networks.default).toEqual({});
+  });
+
+  test('exposes the named ingress service in a multi-service app, not the first', () => {
+    const input = [
+      'services:',
+      '  db:',
+      '    image: postgres',
+      '  gitea:',
+      '    image: gitea/gitea',
+      '',
+    ].join('\n');
+    const out = parse(attachToHolaNetwork(input, { alias: 'gitea-xyz', ingressService: 'gitea' }));
+
+    expect(out.services.gitea.networks.hola).toEqual({ aliases: ['gitea-xyz'] });
+    expect(out.services.db.networks).toBeUndefined(); // db not exposed
+  });
+
+  test('preserves an explicitly declared network and adds hola', () => {
+    const input = 'services:\n  app:\n    image: app\n    networks:\n      - backend\nnetworks:\n  backend: {}\n';
+    const out = parse(attachToHolaNetwork(input, { alias: 'app-1' }));
+
+    expect(out.services.app.networks.backend).toEqual({});
+    expect(out.services.app.networks.hola).toEqual({ aliases: ['app-1'] });
+    // Did not force the default network onto a service that declared its own.
+    expect(out.services.app.networks.default).toBeUndefined();
+  });
+
+  test('falls back to the first service when the named ingress is absent', () => {
+    const input = 'services:\n  web:\n    image: web\n';
+    const out = parse(attachToHolaNetwork(input, { alias: 'a-1', ingressService: 'missing' }));
+    expect(out.services.web.networks.hola).toEqual({ aliases: ['a-1'] });
+  });
+
+  test('returns the input unchanged when there are no services', () => {
+    const input = 'networks:\n  x: {}\n';
+    expect(attachToHolaNetwork(input, { alias: 'a-1' })).toBe(input);
+  });
+});

--- a/packages/server/src/services/core/compose-network.ts
+++ b/packages/server/src/services/core/compose-network.ts
@@ -1,0 +1,79 @@
+/**
+ * Attach a deployed app's Compose project to the shared Traefik network so the
+ * proxy can route to it (the routing last-mile for #15/#16).
+ *
+ * The Hola server emits Traefik config that targets `http://<serviceName>:<port>`
+ * (issue #16). For Traefik to resolve that, the app's ingress service must join
+ * the external `hola` network with a network alias equal to `<serviceName>`.
+ * This rewrites the user's Compose accordingly, preserving inter-service
+ * connectivity (the default network) when the service did not declare networks.
+ */
+
+import { parse, stringify } from 'yaml';
+
+export interface AttachOptions {
+  /** Network alias Traefik resolves (the routing service name). */
+  alias: string;
+  /** Preferred ingress service name (falls back to the first service). */
+  ingressService?: string;
+  /** External network name Traefik shares (default `hola`). */
+  networkName?: string;
+}
+
+interface ComposeService {
+  networks?: string[] | Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+interface ComposeDoc {
+  services?: Record<string, ComposeService>;
+  networks?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+function toNetworkMap(networks: ComposeService['networks']): Record<string, unknown> {
+  if (!networks) return {};
+  if (Array.isArray(networks)) {
+    const map: Record<string, unknown> = {};
+    for (const name of networks) map[name] = {};
+    return map;
+  }
+  return { ...networks };
+}
+
+/**
+ * Return the Compose YAML with the ingress service attached to the external
+ * routing network under `alias`. Throws if the YAML is not a parseable Compose
+ * document; callers may fall back to the original content.
+ */
+export function attachToHolaNetwork(composeYaml: string, opts: AttachOptions): string {
+  const network = opts.networkName ?? 'hola';
+  const doc = (parse(composeYaml) ?? {}) as ComposeDoc;
+
+  const services = doc.services;
+  if (!services || typeof services !== 'object' || Object.keys(services).length === 0) {
+    return composeYaml; // no services to expose
+  }
+
+  const names = Object.keys(services);
+  const ingress = opts.ingressService && services[opts.ingressService] ? opts.ingressService : names[0];
+
+  // Declare the external network shared with Traefik.
+  doc.networks = doc.networks ?? {};
+  if (!doc.networks[network]) {
+    doc.networks[network] = { external: true };
+  }
+
+  // Attach the ingress service to the network with the routing alias.
+  const service = services[ingress];
+  const hadNetworks = service.networks !== undefined;
+  const serviceNetworks = toNetworkMap(service.networks);
+  serviceNetworks[network] = { aliases: [opts.alias] };
+  // Preserve implicit default connectivity for services that declared no networks.
+  if (!hadNetworks) {
+    serviceNetworks.default = {};
+  }
+  service.networks = serviceNetworks;
+
+  return stringify(doc);
+}

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -43,6 +43,7 @@ import type { DockerService } from './docker';
 import type { DraftService, FinalizedArtifacts } from './draft';
 import type { RoutingService } from './routing';
 import type { LoggingService } from './logging';
+import { attachToHolaNetwork } from './compose-network';
 
 /** Promote a new release built from a finalized draft onto an existing deployment. */
 export interface PromoteRequest {
@@ -709,7 +710,21 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     if (!(await this.storageService.fileExists(src))) {
       throw new Error('Active release has no compose file');
     }
-    const content = await this.storageService.readFileAsString(src);
+    const raw = await this.storageService.readFileAsString(src);
+
+    // Attach the ingress service to the Traefik network so the emitted routing
+    // config can reach it (the alias must match the routing service name).
+    let content = raw;
+    try {
+      const alias = this.routingService.generateRule({ deploymentId: deployment.id, appName: deployment.app }).serviceName;
+      content = attachToHolaNetwork(raw, { alias, ingressService: deployment.app });
+    } catch (error) {
+      this.logger.warn('Could not attach app to Traefik network; deploying compose as-is', {
+        deploymentId: deployment.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
     await this.storageService.writeFile(`deployments/${deployment.id}/runtime/docker-compose.yml`, content);
     return this.runtimeDir(deployment.id);
   }


### PR DESCRIPTION
## Summary
Closes the routing **last-mile** so a deployed app is actually **reachable** through Traefik, not just running. This is the final gap between "Gitea deploys" and "Gitea works in a browser".

## The gap
The server emits Traefik dynamic config targeting `http://<serviceName>:<port>` (#16). For Traefik to resolve that, the app's container must be on the external `hola` network **with a network alias = `<serviceName>`**, and the routing must target the app's real ingress port. Until now the materialized compose ran the app as-is — on its own project network, with its own service name — so Traefik couldn't reach it.

## Changes
- **`compose-network.ts`** — `attachToHolaNetwork()` rewrites the materialized compose to declare the external `hola` network and attach the **ingress service** (named after the app, else the first service) with the routing **alias**. It preserves implicit default connectivity when the service declared no networks, and respects explicitly declared networks otherwise.
- **`deployment.ts`** — `materializeCompose()` applies the attachment, deriving the alias from `RoutingService` so it matches the emitted config exactly; falls back to the raw compose if the YAML can't be parsed.
- **CLI** — `hola bundle deploy --port <n>` sets the draft ingress port so the emitted Traefik service targets the right container port (e.g. **3000** for Gitea). The Gitea example now uses `--port 3000`.

## Verification
- New `compose-network.test.ts`: single/multi-service, explicitly-declared networks, ingress fallback, and no-services cases.
- `lifecycle.test.ts` now asserts the materialized compose is network-attached (`hola` / `external: true` / `aliases`).
- Full gate green; **server 145 / CLI 5 tests pass**.

## Result
With the stack (#55) running and `hola bundle deploy --path examples/bundles/gitea --port 3000`, Gitea is deployed as a real Compose project, attached to the `hola` network with the alias Traefik expects, and routed at `gitea.<HOLA_BASE_DOMAIN>`. End-to-end proof on a real Docker host is the conditional integration test **#19** (this dev container has no daemon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)