### PR TITLE
test(server): Docker/Compose orchestration integration test (#19)

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,49 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/aws-cli:1": {
+      "version": "1.1.4",
+      "resolved": "ghcr.io/devcontainers/features/aws-cli@sha256:1f93c8315b7a6d76982ebb2269f8b0d50413fc0f965c032edf4aee0caceb73ef",
+      "integrity": "sha256:1f93c8315b7a6d76982ebb2269f8b0d50413fc0f965c032edf4aee0caceb73ef"
+    },
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "version": "2.17.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:25b9f05705ffba7dbe503230ac76081419306f8c8bc88e0ce78c4ecd99a0c78c",
+      "integrity": "sha256:25b9f05705ffba7dbe503230ac76081419306f8c8bc88e0ce78c4ecd99a0c78c"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
+    },
+    "ghcr.io/eitsupi/devcontainer-features/jq-likes:2": {
+      "version": "2.1.1",
+      "resolved": "ghcr.io/eitsupi/devcontainer-features/jq-likes@sha256:6a8b044f9f424097ec6d212167836b26994a76a556cbcb202084be79fe8032bd",
+      "integrity": "sha256:6a8b044f9f424097ec6d212167836b26994a76a556cbcb202084be79fe8032bd"
+    },
+    "ghcr.io/get2knowio/devcontainer-features/ai-clis:2": {
+      "version": "2.0.6",
+      "resolved": "ghcr.io/get2knowio/devcontainer-features/ai-clis@sha256:c480d9b3ea88a09c969eeb7fcf7a6c74c5a4ca6b2c14ef01d7db5fc65ff4798b",
+      "integrity": "sha256:c480d9b3ea88a09c969eeb7fcf7a6c74c5a4ca6b2c14ef01d7db5fc65ff4798b"
+    },
+    "ghcr.io/get2knowio/devcontainer-features/github-actions-tools:2": {
+      "version": "2.0.2",
+      "resolved": "ghcr.io/get2knowio/devcontainer-features/github-actions-tools@sha256:63c152ec19fd3270976a89903ee93c4c8472be0fd3cbc6aef087257ab2630e06",
+      "integrity": "sha256:63c152ec19fd3270976a89903ee93c4c8472be0fd3cbc6aef087257ab2630e06"
+    },
+    "ghcr.io/get2knowio/devcontainer-features/modern-cli-tools:2": {
+      "version": "2.0.3",
+      "resolved": "ghcr.io/get2knowio/devcontainer-features/modern-cli-tools@sha256:d4cf41edcd17990728818792d5083fbccdf63e4fc05d2e5a867b997eafce8363",
+      "integrity": "sha256:d4cf41edcd17990728818792d5083fbccdf63e4fc05d2e5a867b997eafce8363"
+    },
+    "ghcr.io/get2knowio/devcontainer-features/node-dev-tools:2": {
+      "version": "2.0.2",
+      "resolved": "ghcr.io/get2knowio/devcontainer-features/node-dev-tools@sha256:bcdefb033ce24be39706fc5f92a0226f799aabcbe31a9b0edf619adae434d037",
+      "integrity": "sha256:bcdefb033ce24be39706fc5f92a0226f799aabcbe31a9b0edf619adae434d037"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,12 @@
   "name": "get2know.io devcontainer",
   "image": "ghcr.io/get2knowio/devcontainer:latest",
   "remoteUser": "vscode",
-  "features": {},
+  "features": {
+    // Docker-in-Docker so the Compose orchestration integration test (#19) can
+    // run a real daemon inside the dev container. Starts dockerd and adds the
+    // remote user to the docker group.
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+  },
 //   "postCreateCommand": "npm install",
   "customizations": {
     "vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,9 @@
     // Docker-in-Docker so the Compose orchestration integration test (#19) can
     // run a real daemon inside the dev container. Starts dockerd and adds the
     // remote user to the docker group.
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "moby": false
+    }
   },
 //   "postCreateCommand": "npm install",
   "customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,23 +1,36 @@
 {
-  "name": "get2know.io devcontainer",
-  "image": "ghcr.io/get2knowio/devcontainer:latest",
+  "name": "Node.js Agentic Development",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
   "remoteUser": "vscode",
   "features": {
-    // Docker-in-Docker so the Compose orchestration integration test (#19) can
-    // run a real daemon inside the dev container. Starts dockerd and adds the
-    // remote user to the docker group.
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "22"
+    },
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "version": "latest",
       "moby": false
-    }
+    },
+    "ghcr.io/devcontainers/features/aws-cli:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/eitsupi/devcontainer-features/jq-likes:2": {},
+    "ghcr.io/get2knowio/devcontainer-features/ai-clis:2": {
+      "omit": "codeRabbit,qmd"
+    },
+    "ghcr.io/get2knowio/devcontainer-features/modern-cli-tools:2": {},
+    "ghcr.io/get2knowio/devcontainer-features/node-dev-tools:2": {},
+    "ghcr.io/get2knowio/devcontainer-features/github-actions-tools:2": {}
   },
-//   "postCreateCommand": "npm install",
   "customizations": {
     "vscode": {
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "zsh"
+      },
       "extensions": [
         "ms-vscode.vscode-typescript-next",
         "esbenp.prettier-vscode",
         "dbaeumer.vscode-eslint"
       ]
     }
-  }
+  },
+  "postCreateCommand": "node --version && tsc --version"
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:web:watch": "cd packages/web && npx vitest",
     "test:server": "bun --cwd packages/server test",
     "test:server:watch": "bun --cwd packages/server test --watch",
+    "test:integration": "bun --cwd packages/server test:integration",
     "test:env:setup": "docker-compose -f packages/server/test-docker-compose.yml up -d",
     "test:env:teardown": "docker-compose -f packages/server/test-docker-compose.yml down -v",
     "test:env:integration": "bun run test:env:setup && bun run test && bun run test:env:teardown",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -8,6 +8,7 @@
     "start": "bun run src/server.ts",
     "build": "bun build src/server.ts --outdir=dist --target=bun --sourcemap",
     "test": "bun test",
+    "test:integration": "bun test ./src/__tests__/integration/docker-orchestration.it.ts",
     "typecheck": "tsc --noEmit",
     "lint": "bunx --bun eslint ."
   },

--- a/packages/server/src/__tests__/fixtures/integration/docker-compose.yaml
+++ b/packages/server/src/__tests__/fixtures/integration/docker-compose.yaml
@@ -1,0 +1,19 @@
+# Minimal fixture bundle for the Docker/Compose orchestration integration test (#19).
+#
+# Chosen for deterministic, fast, hermetic behaviour:
+#   - busybox (~4MB) so the first run pulls quickly;
+#   - emits a fixed `HOLA_FIXTURE_READY` line so the test can prove logs come from
+#     the real container rather than synthetic fallback data;
+#   - a real healthcheck (a sentinel file) so the container transitions to `healthy`;
+#   - NO `ports:` mapping — nothing is published to the host; the app is only
+#     reachable on the internal `hola` network, exactly as Hola requires.
+services:
+  fixture:
+    image: busybox:1.36
+    command: ["sh", "-c", "echo HOLA_FIXTURE_READY && touch /tmp/ready && sleep 3600"]
+    healthcheck:
+      test: ["CMD", "test", "-f", "/tmp/ready"]
+      interval: 2s
+      timeout: 2s
+      retries: 5
+      start_period: 1s

--- a/packages/server/src/__tests__/integration/docker-orchestration.it.ts
+++ b/packages/server/src/__tests__/integration/docker-orchestration.it.ts
@@ -1,0 +1,292 @@
+/**
+ * Docker/Compose orchestration integration test (issue #19).
+ *
+ * Drives a minimal fixture bundle through the supported deployment service APIs
+ * against a REAL Docker daemon and asserts on real Compose state: containers up,
+ * isolated `hola` network membership with the routing alias, NO published host
+ * ports, logs originating from the real container, plus restart / stop / rollback.
+ *
+ * Gating: this file is named `*.it.ts` so the default `bun test` run (which only
+ * collects `*.test.ts`) never picks it up — it runs only via `bun run
+ * test:integration`. Even then, the suite skips explicitly when Docker is
+ * unavailable, so the hermetic baseline stays green on hosts without a daemon.
+ *
+ * In production the shared `hola` network is created by the main Compose stack
+ * (packages/compose/docker-compose.yml → networks.default.name: hola). The
+ * deployed app's compose declares it `external: true` (see compose-network.ts),
+ * so this test must create that network itself before Compose up and remove it
+ * afterwards (only if it created it).
+ */
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach } from 'bun:test';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { mkdtemp, rm, readFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { fileURLToPath } from 'url';
+
+import { RealDeploymentService } from '../../services/core/deployment';
+import { RealDraftService } from '../../services/core/draft';
+import { RealStorageService } from '../../services/core/storage';
+import { RealRoutingService } from '../../services/core/routing';
+import { RealDatabaseService } from '../../services/core/database';
+import { RealLoggingService } from '../../services/core/logging';
+import { RealJobService } from '../../services/core/jobs';
+import { RealDockerService } from '../../services/core/docker';
+
+const execAsync = promisify(exec);
+
+type CatalogArg = ConstructorParameters<typeof RealDraftService>[1];
+type ValidationArg = ConstructorParameters<typeof RealDraftService>[2];
+
+function makeCatalog(): CatalogArg {
+  return {
+    getApp: async (appId: string) => ({ id: appId, name: 'Fixture', icon: '🧪' }),
+    getVersionDetail: async () => ({
+      defaultEnv: [],
+      defaults: { ports: [{ container: 8080, protocol: 'tcp' as const }], volumes: [] },
+    }),
+  } as unknown as CatalogArg;
+}
+
+function makeValidation(): ValidationArg {
+  return {
+    validateDraft: async () => ({ ok: true, errors: [], warnings: [] }),
+    preflightCheck: async () => ({ ok: true, checks: [] }),
+  } as unknown as ValidationArg;
+}
+
+const FIXTURE_COMPOSE_PATH = join(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '..',
+  'fixtures',
+  'integration',
+  'docker-compose.yaml'
+);
+
+/** Run a shell command, capturing output and never throwing (best-effort). */
+async function sh(cmd: string): Promise<{ stdout: string; stderr: string; ok: boolean }> {
+  try {
+    const { stdout, stderr } = await execAsync(cmd, { timeout: 60_000 });
+    return { stdout, stderr, ok: true };
+  } catch (error) {
+    const e = error as { stdout?: string; stderr?: string; message?: string };
+    return { stdout: e.stdout ?? '', stderr: e.stderr ?? e.message ?? '', ok: false };
+  }
+}
+
+/** True when a Docker engine (server) is reachable — mirrors RealDockerService.getDockerInfo. */
+async function detectDocker(): Promise<boolean> {
+  const res = await sh('docker version --format "{{.Server.Version}}"');
+  return res.ok && res.stdout.trim().length > 0;
+}
+
+const dockerOk = await detectDocker();
+if (!dockerOk) {
+  // Explicit, visible skip so an absent daemon never looks like a silent pass.
+  console.warn('[#19] Docker unavailable — skipping Docker/Compose orchestration integration test');
+}
+
+async function waitForJob(jobs: RealJobService, id: string, timeoutMs = 120_000) {
+  const start = Date.now();
+  for (;;) {
+    const job = await jobs.getJob(id);
+    if (job && (job.status === 'completed' || job.status === 'failed')) return job;
+    if (Date.now() - start > timeoutMs) throw new Error(`Job ${id} did not finish (last status: ${job?.status})`);
+    await new Promise(r => setTimeout(r, 200));
+  }
+}
+
+/** Resolve the single container id for a project's service via Compose labels. */
+async function containerId(project: string, service: string): Promise<string> {
+  const res = await sh(
+    `docker ps -aq --filter "label=com.docker.compose.project=${project}" --filter "label=com.docker.compose.service=${service}"`
+  );
+  return res.stdout.trim().split('\n').filter(Boolean)[0] ?? '';
+}
+
+async function inspect(cid: string, format: string): Promise<string> {
+  const res = await sh(`docker inspect -f '${format}' ${cid}`);
+  return res.stdout.trim();
+}
+
+async function waitForHealthy(cid: string, timeoutMs = 60_000): Promise<string> {
+  const start = Date.now();
+  for (;;) {
+    const status = await inspect(cid, '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}');
+    if (status === 'healthy') return status;
+    if (Date.now() - start > timeoutMs) return status;
+    await new Promise(r => setTimeout(r, 500));
+  }
+}
+
+describe.skipIf(!dockerOk)('Docker/Compose orchestration (real daemon)', () => {
+  let dataRoot: string;
+  let createdHolaNetwork = false;
+  /** Compose project names created during the current test, swept in afterEach. */
+  let projects: string[];
+  /** Every project created across the suite — the afterAll leak guard. */
+  const allProjects: string[] = [];
+
+  beforeAll(async () => {
+    // The deployed app's compose marks `hola` external; create it if absent.
+    const inspectHola = await sh('docker network inspect hola');
+    if (!inspectHola.ok) {
+      const created = await sh('docker network create hola');
+      createdHolaNetwork = created.ok;
+    }
+  });
+
+  afterAll(async () => {
+    if (createdHolaNetwork) {
+      await sh('docker network rm hola');
+    }
+    // Final leak guard: every project created by the suite must leave behind no
+    // containers and no project network (exact-match label/name filters).
+    for (const project of allProjects) {
+      const containers = await sh(`docker ps -aq --filter "label=com.docker.compose.project=${project}"`);
+      expect(containers.stdout.trim()).toBe('');
+      const nets = await sh(`docker network ls -q --filter "name=${project}_default"`);
+      expect(nets.stdout.trim()).toBe('');
+    }
+  });
+
+  beforeEach(async () => {
+    dataRoot = await mkdtemp(join(tmpdir(), 'hola-it-'));
+    projects = [];
+  });
+
+  afterEach(async () => {
+    // Reliable, compose-file-independent cleanup: remove every container of each
+    // project (with anonymous volumes) and the project's default network.
+    for (const project of projects) {
+      const ids = await sh(`docker ps -aq --filter "label=com.docker.compose.project=${project}"`);
+      const list = ids.stdout.trim().split('\n').filter(Boolean);
+      if (list.length) await sh(`docker rm -fv ${list.join(' ')}`);
+      const nets = await sh(`docker network ls -q --filter "name=${project}_default"`);
+      const netList = nets.stdout.trim().split('\n').filter(Boolean);
+      if (netList.length) await sh(`docker network rm ${netList.join(' ')}`);
+    }
+    await rm(dataRoot, { recursive: true, force: true });
+  });
+
+  function makeSystem() {
+    const storage = new RealStorageService({ holaDir: dataRoot });
+    const database = new RealDatabaseService(storage);
+    const logging = new RealLoggingService(storage);
+    const jobs = new RealJobService(database, logging);
+    const routing = new RealRoutingService(storage, { baseDomain: 'local.hola' });
+    const drafts = new RealDraftService(storage, makeCatalog(), makeValidation());
+    const deployments = new RealDeploymentService(storage, jobs, docker, drafts, routing, logging);
+    return { storage, jobs, logging, drafts, deployments };
+  }
+
+  const docker = new RealDockerService();
+
+  async function finalizedFixtureDraft(drafts: RealDraftService): Promise<string> {
+    const compose = await readFile(FIXTURE_COMPOSE_PATH, 'utf8');
+    const { draftId } = await drafts.createDraft({ appId: 'fixture', version: '1.0.0' });
+    await drafts.updateDraft(draftId, {
+      composeOverride: compose,
+      ports: [{ container: 8080, protocol: 'tcp' }],
+    });
+    await drafts.finalizeDraft(draftId);
+    return draftId;
+  }
+
+  test(
+    'deploy fixture: up, healthy, no host ports, isolated hola network, real logs, restart, stop, rollback',
+    async () => {
+      const { storage, jobs, drafts, deployments } = makeSystem();
+
+      // --- Create + start (Compose up) -------------------------------------
+      const created = await deployments.createFromDraft({
+        draftId: await finalizedFixtureDraft(drafts),
+        name: 'fixture',
+      });
+      const shortId = created.deploymentId.slice(0, 12);
+      const project = `hola-${shortId}`;
+      projects.push(project);
+      allProjects.push(project);
+
+      const job = await waitForJob(jobs, created.jobId!);
+      expect(job.status).toBe('completed');
+      expect((await deployments.getDeployment(created.deploymentId)).status).toBe('running');
+
+      // --- Compose ps reflects actual running state ------------------------
+      const runtimeDir = storage.resolveHolaPath('deployments', created.deploymentId, 'runtime');
+      const ps = await docker.composePs(runtimeDir, project);
+      const svc = ps.services.find(s => s.name === 'fixture');
+      expect(svc?.state).toBe('running');
+
+      // --- Real container health transitions to healthy --------------------
+      const cid = await containerId(project, 'fixture');
+      expect(cid).not.toBe('');
+      expect(await waitForHealthy(cid)).toBe('healthy');
+
+      // --- No application host ports are published -------------------------
+      const materialized = await storage.readFileAsString(`deployments/${created.deploymentId}/runtime/docker-compose.yml`);
+      expect(materialized).not.toContain('ports:');
+      const portsJson = await inspect(cid, '{{json .NetworkSettings.Ports}}');
+      const ports = JSON.parse(portsJson || '{}') as Record<string, unknown[] | null>;
+      const published = Object.values(ports).filter(v => Array.isArray(v) && v.length > 0);
+      expect(published).toHaveLength(0);
+
+      // --- Isolated network membership with the routing alias --------------
+      const expectedAlias = `fixture-${shortId}`;
+      const netsJson = await inspect(cid, '{{json .NetworkSettings.Networks}}');
+      const nets = JSON.parse(netsJson) as Record<string, { Aliases?: string[] }>;
+      expect(Object.keys(nets)).toContain('hola');
+      expect(nets.hola.Aliases ?? []).toContain(expectedAlias);
+
+      // Cross-check the emitted Traefik artifacts agree with the live alias.
+      const routingMap = await storage.readFileAsString('runtime/traefik/routing-map.json');
+      expect(routingMap).toContain(expectedAlias);
+      expect(routingMap).toContain('fixture.local.hola');
+      const dynamic = await storage.readFileAsString('runtime/traefik/dynamic.yml');
+      expect(dynamic).toContain(expectedAlias);
+      expect(dynamic).toContain('fixture.local.hola');
+
+      // --- Logs originate from the real fixture container ------------------
+      const logs = await docker.getContainerLogs(cid);
+      expect(logs.entries.some(e => e.message.includes('HOLA_FIXTURE_READY'))).toBe(true);
+
+      // --- Restart keeps it running ----------------------------------------
+      const restart = await deployments.executeAction(created.deploymentId, { action: 'restart' });
+      expect((await waitForJob(jobs, restart.jobId!)).status).toBe('completed');
+      const psAfterRestart = await docker.composePs(runtimeDir, project);
+      expect(psAfterRestart.services.find(s => s.name === 'fixture')?.state).toBe('running');
+
+      // --- Stop tears the containers down ----------------------------------
+      const stop = await deployments.executeAction(created.deploymentId, { action: 'stop' });
+      expect((await waitForJob(jobs, stop.jobId!)).status).toBe('completed');
+      expect((await deployments.getDeployment(created.deploymentId)).status).toBe('stopped');
+      const psAfterStop = await docker.composePs(runtimeDir, project);
+      expect(psAfterStop.services.filter(s => s.state === 'running')).toHaveLength(0);
+
+      // --- Promote a second release, then roll back to the first -----------
+      const firstReleaseId = (await deployments.getReleases(created.deploymentId))[0].id;
+      // Stage release 2 without starting it, so its job can't race the rollback's
+      // compose-up on the shared project.
+      await deployments.promote(created.deploymentId, {
+        draftId: await finalizedFixtureDraft(drafts),
+        options: { autoStart: false },
+      });
+      const releasesAfterPromote = await deployments.getReleases(created.deploymentId);
+      expect(releasesAfterPromote.length).toBe(2);
+      const currentAfterPromote = (await storage.readFileAsString(`deployments/${created.deploymentId}/current`)).trim();
+      expect(currentAfterPromote).not.toBe(firstReleaseId);
+
+      const rollback = await deployments.rollback(created.deploymentId, {});
+      expect(rollback.targetReleaseId).toBe(firstReleaseId);
+      expect((await waitForJob(jobs, rollback.jobId)).status).toBe('completed');
+      const currentAfterRollback = (await storage.readFileAsString(`deployments/${created.deploymentId}/current`)).trim();
+      expect(currentAfterRollback).toBe(firstReleaseId);
+      // Compose re-converges to running on the rolled-back release.
+      const psAfterRollback = await docker.composePs(runtimeDir, project);
+      expect(psAfterRollback.services.find(s => s.name === 'fixture')?.state).toBe('running');
+    },
+    180_000
+  );
+});


### PR DESCRIPTION
Closes #19. Step 8 of the recovery epic (#21).

## What

A **conditional** integration test that drives a minimal fixture bundle through the real deployment service APIs against an **actual Docker daemon**, proving the orchestration path the Gitea deploy depends on. Until now that path was only exercised with the success-simulating `MockDockerService`.

## Acceptance criteria → how it's covered

| AC | Coverage |
|----|----------|
| Run when Docker is available, skip explicitly otherwise | Top-level `detectDocker()` + `describe.skipIf(!dockerOk)`; prints a `[#19]` skip notice |
| No application host ports published | Asserts materialized compose has no `ports:` **and** `.NetworkSettings.Ports` publishes nothing |
| Lifecycle actions match real Compose state | `composePs` after up/restart shows `running`; after stop shows none; rollback re-converges to `running` |
| Logs from the fixture container, not fallback | `getContainerLogs` contains the fixture's deterministic `HOLA_FIXTURE_READY` line |
| No leftover containers/networks/volumes/runtime files | Per-test `docker rm -fv` + network sweep, temp data-root removed, and an `afterAll` leak-guard asserts emptiness |
| Project names can't collide across runs | Project name derives from the deployment UUID (`hola-<shortId>`) |

Also verifies **isolated `hola` network membership** with the routing alias and cross-checks the emitted Traefik artifacts (`routing-map.json`, `dynamic.yml`), plus **restart / stop / promote / rollback**.

## Gating (keeps the green baseline hermetic)

The file is named `*.it.ts`, so the default `bun test` (which only collects `*.test.ts`) never runs it. Run it explicitly:

```
bun run test:integration   # from repo root or packages/server
```

In production the shared `hola` network is created by the main stack (`packages/compose/docker-compose.yml`); the deployed app's compose marks it `external: true`, so the test creates that network when missing and removes it only if it created it.

## Fixture

`busybox` sentinel — deterministic log line, a real healthcheck (sentinel file), no listening/host ports, ~4MB.

## Verification

- `bun test` (server): **145 pass / 20 files** — unchanged; the `.it.ts` is not collected.
- `bun run test:integration` **without** Docker (this env/CI): suite **skips** explicitly, exit 0.
- `bun run lint`, root `bun run typecheck`, root `bun run build`: green.
- **With** Docker (real host): the full up/health/no-ports/network/logs/restart/stop/rollback flow runs and leaves nothing behind. ⚠️ This dev container has no Docker daemon, so the live run has **not** been executed here — it must be validated on a Docker host.

## Non-goals

Live Traefik routing/TLS/LE and HTTP reachability through the proxy (asserts emitted artifacts + network membership instead); contract tests (#17), smoke tests (#18), docs (#20). No production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added a new Docker/Compose integration test that verifies fixture deployment, container health, network routing/aliasing, absence of published host ports, and Traefik/routing artifacts. Also covers restart, stop, and rollback lifecycle behaviors.

* **Chores**
  * Added a `test:integration` script to run integration tests and introduced a Docker Compose fixture for deterministic orchestration.
  * Updated the development container setup to a newer Ubuntu-based image with Node.js tooling, Docker-in-Docker, and expanded CLI utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->