### PR TITLE
feat(server): strict Compose schema and semantic validation (#13)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -73,6 +73,9 @@
     "packages/shared": {
       "name": "@hola/shared",
       "version": "0.1.0",
+      "dependencies": {
+        "yaml": "^2.9.0",
+      },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/bun": "^1.3.14",

--- a/packages/server/src/__tests__/validation/compose-validate.test.ts
+++ b/packages/server/src/__tests__/validation/compose-validate.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Strict Compose validation tests (#13).
+ *
+ * Exercises the pure validator in @hola/shared across the acceptance-criteria
+ * cases: malformed YAML, environment variants, undefined resources, unsupported
+ * host-port exposure, and valid multi-service bundles.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { validateComposeDocument } from '@hola/shared/compose-validate';
+import type { ValidationIssue } from '@hola/shared';
+
+const codes = (issues: ValidationIssue[]) => issues.map((i) => i.code);
+const errors = (issues: ValidationIssue[]) => issues.filter((i) => i.severity === 'error');
+
+describe('validateComposeDocument', () => {
+  test('malformed YAML yields a single INVALID_YAML error', () => {
+    const issues = validateComposeDocument('services: [unclosed');
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe('INVALID_YAML');
+    expect(issues[0].severity).toBe('error');
+    expect(issues[0].message).toMatch(/Invalid Compose YAML/);
+  });
+
+  test('empty document reports NO_SERVICES', () => {
+    expect(codes(validateComposeDocument(''))).toContain('NO_SERVICES');
+  });
+
+  test('document without services reports NO_SERVICES', () => {
+    expect(codes(validateComposeDocument('version: "3"\n'))).toContain('NO_SERVICES');
+  });
+
+  test('a valid single-service bundle passes clean', () => {
+    const yaml = `
+services:
+  web:
+    image: nginx:1.27
+    expose:
+      - "80"
+    environment:
+      - LOG_LEVEL=info
+`;
+    expect(validateComposeDocument(yaml)).toEqual([]);
+  });
+
+  test('a valid multi-service bundle with defined resources passes clean', () => {
+    const yaml = `
+services:
+  app:
+    image: ghcr.io/acme/app:1.2.3
+    environment:
+      APP_ENV: production
+    volumes:
+      - data:/var/lib/app
+      - ./config:/etc/app:ro
+    networks:
+      - backend
+    secrets:
+      - api_key
+  db:
+    image: postgres:16
+    volumes:
+      - db:/var/lib/postgresql/data
+    networks:
+      - backend
+volumes:
+  data:
+  db:
+networks:
+  backend:
+secrets:
+  api_key:
+    external: true
+`;
+    expect(validateComposeDocument(yaml)).toEqual([]);
+  });
+
+  describe('host-port rejection', () => {
+    test('short string form is rejected', () => {
+      const yaml = `
+services:
+  web:
+    image: nginx:1.27
+    ports:
+      - "8080:80"
+`;
+      const errs = errors(validateComposeDocument(yaml));
+      expect(errs).toHaveLength(1);
+      expect(errs[0].code).toBe('HOST_PORT_NOT_ALLOWED');
+      expect(errs[0].path).toBe('services.web.ports[0]');
+    });
+
+    test('host_ip form is rejected', () => {
+      const yaml = `
+services:
+  web:
+    image: nginx:1.27
+    ports:
+      - "127.0.0.1:8080:80"
+`;
+      expect(codes(validateComposeDocument(yaml))).toContain('HOST_PORT_NOT_ALLOWED');
+    });
+
+    test('long published form is rejected', () => {
+      const yaml = `
+services:
+  web:
+    image: nginx:1.27
+    ports:
+      - target: 80
+        published: 8080
+`;
+      expect(codes(validateComposeDocument(yaml))).toContain('HOST_PORT_NOT_ALLOWED');
+    });
+
+    test('expose (container-internal) is allowed', () => {
+      const yaml = `
+services:
+  web:
+    image: nginx:1.27
+    expose:
+      - "80"
+`;
+      expect(validateComposeDocument(yaml)).toEqual([]);
+    });
+  });
+
+  describe('service shape', () => {
+    test('image and build together conflict', () => {
+      const yaml = `
+services:
+  web:
+    image: nginx:1.27
+    build: ./web
+`;
+      expect(codes(validateComposeDocument(yaml))).toContain('IMAGE_AND_BUILD_CONFLICT');
+    });
+
+    test('neither image nor build is rejected', () => {
+      const yaml = `
+services:
+  web:
+    environment:
+      - A=b
+`;
+      expect(codes(validateComposeDocument(yaml))).toContain('MISSING_IMAGE_OR_BUILD');
+    });
+
+    test('build-only service is valid', () => {
+      const yaml = `
+services:
+  web:
+    build: ./web
+`;
+      expect(validateComposeDocument(yaml)).toEqual([]);
+    });
+
+    test('image without tag warns but does not error', () => {
+      const yaml = `
+services:
+  web:
+    image: nginx
+`;
+      const issues = validateComposeDocument(yaml);
+      expect(errors(issues)).toEqual([]);
+      expect(codes(issues)).toContain('IMAGE_MISSING_TAG');
+    });
+
+    test('invalid service name is rejected', () => {
+      const yaml = `
+services:
+  "bad name!":
+    image: nginx:1.27
+`;
+      expect(codes(validateComposeDocument(yaml))).toContain('INVALID_SERVICE_NAME');
+    });
+  });
+
+  describe('environment forms', () => {
+    test('object form is accepted', () => {
+      const yaml = `
+services:
+  web:
+    image: nginx:1.27
+    environment:
+      KEY: value
+`;
+      expect(validateComposeDocument(yaml)).toEqual([]);
+    });
+
+    test('duplicate keys in list form warn', () => {
+      const yaml = `
+services:
+  web:
+    image: nginx:1.27
+    environment:
+      - KEY=a
+      - KEY=b
+`;
+      expect(codes(validateComposeDocument(yaml))).toContain('DUPLICATE_ENV_KEY');
+    });
+
+    test('scalar environment is an invalid form', () => {
+      const yaml = `
+services:
+  web:
+    image: nginx:1.27
+    environment: "not-a-map"
+`;
+      expect(codes(validateComposeDocument(yaml))).toContain('INVALID_ENV_FORM');
+    });
+  });
+
+  describe('undefined resource references', () => {
+    test('undefined named volume is rejected', () => {
+      const yaml = `
+services:
+  web:
+    image: nginx:1.27
+    volumes:
+      - data:/var/lib/app
+`;
+      const errs = errors(validateComposeDocument(yaml));
+      expect(errs.map((e) => e.code)).toContain('UNDEFINED_VOLUME');
+    });
+
+    test('bind-mount paths do not require a top-level volume', () => {
+      const yaml = `
+services:
+  web:
+    image: nginx:1.27
+    volumes:
+      - ./config:/etc/app:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+`;
+      expect(validateComposeDocument(yaml)).toEqual([]);
+    });
+
+    test('undefined network is rejected', () => {
+      const yaml = `
+services:
+  web:
+    image: nginx:1.27
+    networks:
+      - missing
+`;
+      expect(codes(validateComposeDocument(yaml))).toContain('UNDEFINED_NETWORK');
+    });
+
+    test('undefined secret is rejected', () => {
+      const yaml = `
+services:
+  web:
+    image: nginx:1.27
+    secrets:
+      - missing
+`;
+      expect(codes(validateComposeDocument(yaml))).toContain('UNDEFINED_SECRET');
+    });
+  });
+
+  test('unsupported top-level key warns', () => {
+    const yaml = `
+bogus: true
+services:
+  web:
+    image: nginx:1.27
+`;
+    const issues = validateComposeDocument(yaml);
+    expect(errors(issues)).toEqual([]);
+    expect(codes(issues)).toContain('UNSUPPORTED_KEY');
+  });
+});

--- a/packages/server/src/__tests__/validation/draft-validation.test.ts
+++ b/packages/server/src/__tests__/validation/draft-validation.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Service-level validation tests (#13).
+ *
+ * Verifies that RealValidationService surfaces strict Compose issues through the
+ * shared ValidationReport shape, and that RealDraftService rejects unparseable
+ * compose overrides at ingestion with a 400-mapped ValidationError.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import type { Draft } from '@hola/shared';
+import { RealValidationService } from '../../services/core/validation';
+import { RealDraftService } from '../../services/core/draft';
+import { MockStorageService } from '../../services/core/storage';
+import { ValidationError } from '../../middleware/error-mapping';
+
+function makeValidationService(): RealValidationService {
+  // validateDraft only exercises env/port/compose checks — docker/system/routing
+  // dependencies are unused on this path, so minimal stubs are sufficient.
+  return new RealValidationService(
+    {} as never,
+    {} as never,
+    new MockStorageService(),
+  );
+}
+
+function draftWith(composeOverride: string): Draft {
+  return {
+    draftId: 'd1',
+    appId: 'fixture',
+    systemOverrides: {},
+    appEnv: [],
+    ports: [],
+    composeOverride,
+    files: [],
+  };
+}
+
+describe('RealValidationService.validateDraft', () => {
+  test('reports a host-port error with a prefixed field path', async () => {
+    const svc = makeValidationService();
+    const report = await svc.validateDraft(
+      draftWith(`
+services:
+  web:
+    image: nginx:1.27
+    ports:
+      - "8080:80"
+`),
+    );
+
+    expect(report.ok).toBe(false);
+    const hostPort = report.errors.find((e) => e.code === 'HOST_PORT_NOT_ALLOWED');
+    expect(hostPort).toBeDefined();
+    expect(hostPort!.severity).toBe('error');
+    expect(hostPort!.path).toBe('composeOverride.services.web.ports[0]');
+  });
+
+  test('a valid compose override passes clean', async () => {
+    const svc = makeValidationService();
+    const report = await svc.validateDraft(
+      draftWith(`
+services:
+  web:
+    image: nginx:1.27
+    expose:
+      - "80"
+`),
+    );
+
+    expect(report.ok).toBe(true);
+    expect(report.errors).toEqual([]);
+  });
+
+  test('warnings do not block (ok stays true)', async () => {
+    const svc = makeValidationService();
+    const report = await svc.validateDraft(
+      draftWith(`
+services:
+  web:
+    image: nginx
+`),
+    );
+
+    expect(report.ok).toBe(true);
+    expect(report.warnings.some((w) => w.code === 'IMAGE_MISSING_TAG')).toBe(true);
+  });
+});
+
+describe('RealDraftService compose-override ingestion guard', () => {
+  function makeDraftService(): RealDraftService {
+    const svc = new RealDraftService(new MockStorageService(), {} as never, {} as never);
+    // Seed a draft record directly so updateDraft has something to patch.
+    const record = {
+      draft: draftWith(''),
+      status: 'draft',
+      createdAt: 't',
+      updatedAt: 't',
+      fileChecksums: {},
+      filePaths: {},
+    };
+    (svc as unknown as { drafts: Map<string, unknown> }).drafts.set('d1', record);
+    return svc;
+  }
+
+  test('updateDraft rejects malformed YAML with a 400 ValidationError', async () => {
+    const svc = makeDraftService();
+    let thrown: unknown;
+    try {
+      await svc.updateDraft('d1', { composeOverride: 'services: [unclosed' });
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(ValidationError);
+    const err = thrown as ValidationError;
+    expect(err.status).toBe(400);
+    expect((err.details as { issues: Array<{ code: string }> }).issues[0].code).toBe('INVALID_YAML');
+  });
+
+  test('updateDraft accepts a parseable compose override', async () => {
+    const svc = makeDraftService();
+    const result = await svc.updateDraft('d1', {
+      composeOverride: 'services:\n  web:\n    image: nginx:1.27\n',
+    });
+    expect(result.ok).toBe(true);
+  });
+});

--- a/packages/server/src/services/core/draft.ts
+++ b/packages/server/src/services/core/draft.ts
@@ -25,7 +25,8 @@ import type {
 import { createHash } from 'crypto';
 
 import { getLogger } from '../../lib/logger';
-import { NotFoundError, ConflictError } from '../../middleware/error-mapping';
+import { NotFoundError, ConflictError, ValidationError } from '../../middleware/error-mapping';
+import { validateComposeDocument } from '@hola/shared/compose-validate';
 import type { HealthCheckable, ServiceHealth } from './types';
 import type { StorageService } from './storage';
 import type { CatalogService } from './catalog';
@@ -135,6 +136,20 @@ interface DraftRecord {
   fileChecksums: Record<string, string>;
   /** Per-upload target deployment paths, keyed by uploadId (not part of the wire Draft). */
   filePaths: Record<string, string>;
+}
+
+/**
+ * Reject a Compose override that cannot be parsed as YAML at ingestion time so
+ * malformed input fails fast with a 400. Semantic issues (undefined volumes,
+ * host ports, etc.) are NOT rejected here — they surface through the `/validate`
+ * endpoint so the wizard can display them inline while the user iterates.
+ */
+function assertComposeParses(content: string, source: string): void {
+  if (!content || !content.trim()) return;
+  const parseErrors = validateComposeDocument(content).filter((i) => i.code === 'INVALID_YAML');
+  if (parseErrors.length > 0) {
+    throw new ValidationError(`Invalid compose YAML in ${source}`, { issues: parseErrors });
+  }
 }
 
 export class RealDraftService implements DraftService {
@@ -347,6 +362,11 @@ export class RealDraftService implements DraftService {
     // Avoid logging secret env values; log which fields changed instead.
     this.logger.info('Updating draft', { draftId, fields: Object.keys(patch) });
 
+    // Fail fast on unparseable compose overrides set via PATCH (#13).
+    if (typeof patch.composeOverride === 'string') {
+      assertComposeParses(patch.composeOverride, 'composeOverride');
+    }
+
     // Apply patch (preserve file metadata managed by upload/delete).
     record.draft = { ...record.draft, ...patch };
     record.updatedAt = new Date().toISOString();
@@ -383,6 +403,11 @@ export class RealDraftService implements DraftService {
   ): Promise<UploadDraftFileResponse> {
     await this.ensureLoaded();
     const record = this.requireRecord(draftId);
+
+    // Fail fast on unparseable compose overrides (#13).
+    if (file.kind === 'composeOverride') {
+      assertComposeParses(file.content.toString('utf-8'), file.name);
+    }
 
     const uploadId = crypto.randomUUID();
     this.logger.info('Uploading file to draft', { draftId, uploadId, fileName: file.name, kind: file.kind, size: file.content.length });

--- a/packages/server/src/services/core/validation.ts
+++ b/packages/server/src/services/core/validation.ts
@@ -24,7 +24,20 @@ import type { SystemMonitoringService } from './system-monitoring';
 import type { RoutingService } from './routing';
 import type { StorageService } from './storage';
 import { parse as parseYAML } from 'yaml';
+import { validateComposeDocument } from '@hola/shared/compose-validate';
 import type { ComposeFile, ComposeService } from './compose-parser';
+
+/**
+ * Prefix Compose-internal field paths (e.g. `services.web.ports[0]`) with the
+ * source they came from within the draft (`composeOverride` or `files.<id>`),
+ * so clients can locate the offending input precisely.
+ */
+function remapComposePath(issues: ValidationIssue[], source: string): ValidationIssue[] {
+  return issues.map((issue) => {
+    const path = issue.path ? `${source}.${issue.path}` : source;
+    return { ...issue, path, field: path };
+  });
+}
 
 export interface ValidationService extends HealthCheckable {
   // Draft validation
@@ -72,54 +85,40 @@ export class RealValidationService implements ValidationService {
     const errors: ValidationIssue[] = [];
     const warnings: ValidationIssue[] = [];
 
+    const partition = (issues: ValidationIssue[]) => {
+      for (const issue of issues) {
+        if (issue.severity === 'error') errors.push(issue);
+        else warnings.push(issue);
+      }
+    };
+
     try {
       // Validate required fields
       if (!draft.appId) {
-        errors.push({ field: 'appId', message: 'Application ID is required' });
+        errors.push({ code: 'MISSING_APP_ID', severity: 'error', field: 'appId', path: 'appId', message: 'Application ID is required' });
       }
 
       // Validate environment variables
-      const envIssues = await this.validateEnvironment(draft.appEnv);
-      errors.push(...envIssues.filter(i => i.code === 'ERROR'));
-      warnings.push(...envIssues.filter(i => i.code === 'WARNING'));
+      partition(await this.validateEnvironment(draft.appEnv));
 
       // Validate ports
-      const portIssues = await this.validatePorts(draft.ports);
-      errors.push(...portIssues.filter(i => i.code === 'ERROR'));
-      warnings.push(...portIssues.filter(i => i.code === 'WARNING'));
+      partition(await this.validatePorts(draft.ports));
 
-      // Validate compose override if present
+      // Strict Compose schema + semantic validation of the override (#13).
       if (draft.composeOverride) {
-        try {
-          // Inline compose validation (simplified)
-          const composeData = parseYAML(draft.composeOverride) as ComposeFile;
-          if (!composeData.services || Object.keys(composeData.services).length === 0) {
-            warnings.push({ 
-              field: 'composeOverride', 
-              message: 'Compose file has no services defined' 
-            });
-          }
-        } catch (error) {
-          errors.push({ 
-            field: 'composeOverride', 
-            message: `Invalid compose override: ${error instanceof Error ? error.message : 'Unknown error'}` 
-          });
-        }
+        partition(
+          remapComposePath(validateComposeDocument(draft.composeOverride), 'composeOverride'),
+        );
       }
 
-      // Validate uploaded files
+      // Validate uploaded compose files with the same strict validator.
       if (files) {
         for (const [uploadId, file] of files) {
           if (file.kind === 'composeOverride' && file.content) {
-            try {
-              const composeContent = file.content.toString('utf-8');
-              parseYAML(composeContent) as ComposeFile;
-            } catch (error) {
-              errors.push({
-                field: `files.${uploadId}`,
-                message: `Invalid compose file: ${error instanceof Error ? error.message : 'Parse error'}`,
-              });
-            }
+            const composeContent = file.content.toString('utf-8');
+            partition(
+              remapComposePath(validateComposeDocument(composeContent), `files.${uploadId}`),
+            );
           }
         }
       }
@@ -133,7 +132,7 @@ export class RealValidationService implements ValidationService {
       this.logger.error('Draft validation failed', error as Error, { draftId: draft.draftId });
       return {
         ok: false,
-        errors: [{ message: error instanceof Error ? error.message : 'Validation failed' }],
+        errors: [{ code: 'VALIDATION_FAILED', severity: 'error', message: error instanceof Error ? error.message : 'Validation failed' }],
         warnings,
       };
     }
@@ -190,7 +189,7 @@ export class RealValidationService implements ValidationService {
       // Validate port definitions (no host-port reservation; ingress is Traefik-only).
       if (draft.ports.length > 0) {
         const portIssues = await this.validatePorts(draft.ports);
-        if (portIssues.some(i => i.code === 'ERROR')) {
+        if (portIssues.some(i => i.severity === 'error')) {
           checks.push({
             name: 'ports',
             type: 'ports',
@@ -218,7 +217,7 @@ export class RealValidationService implements ValidationService {
           detail: 'Environment variables are valid',
         });
       } else {
-        const hasErrors = envIssues.some(i => i.code === 'ERROR');
+        const hasErrors = envIssues.some(i => i.severity === 'error');
         checks.push({
           name: 'env',
           type: 'env',
@@ -306,34 +305,16 @@ export class RealValidationService implements ValidationService {
     const issues: ValidationIssue[] = [];
 
     for (const port of ports) {
-      const hostPort = port.host;
-      if (hostPort) {
-        // Check port range
-        if (hostPort < 1 || hostPort > 65535) {
-          issues.push({
-            field: 'ports',
-            message: `Port ${hostPort} is outside valid range (1-65535)`,
-            code: 'ERROR',
-          });
-          continue;
-        }
-
-        // Check for well-known ports
-        if (hostPort < 1024) {
-          issues.push({
-            field: 'ports',
-            message: `Port ${hostPort} is a privileged port and may require root access`,
-            code: 'WARNING',
-          });
-        }
-      }
-
-      // Validate container port
+      // Host-port publishing is unsupported (Traefik-only ingress); the strict
+      // Compose validator rejects `ports:` entries. Here we only sanity-check
+      // the container port range for declared port intents.
       if (port.container < 1 || port.container > 65535) {
         issues.push({
+          code: 'INVALID_PORT_RANGE',
+          severity: 'error',
           field: 'ports',
+          path: 'ports',
           message: `Container port ${port.container} is outside valid range (1-65535)`,
-          code: 'ERROR',
         });
       }
     }
@@ -351,8 +332,9 @@ export class RealValidationService implements ValidationService {
           // For now, just validate the image name format
           if (!image.includes(':')) {
             issues.push({
+              code: 'IMAGE_MISSING_TAG',
+              severity: 'warning',
               message: `Image '${image}' should include a tag (e.g., '${image}:latest')`,
-              code: 'WARNING',
             });
           }
         } catch {
@@ -361,8 +343,9 @@ export class RealValidationService implements ValidationService {
       }
     } catch (error) {
       issues.push({
+        code: 'IMAGE_MISSING_TAG',
+        severity: 'warning',
         message: `Could not validate images: ${error instanceof Error ? error.message : 'Unknown error'}`,
-        code: 'WARNING',
       });
     }
 
@@ -376,18 +359,22 @@ export class RealValidationService implements ValidationService {
       // Check for empty required variables
       if (!envVar.value && envVar.isSecret) {
         issues.push({
+          code: 'MISSING_SECRET_VALUE',
+          severity: 'error',
           field: `env.${envVar.key}`,
+          path: `env.${envVar.key}`,
           message: `Secret environment variable '${envVar.key}' is required but empty`,
-          code: 'ERROR',
         });
       }
 
       // Check for invalid characters in keys
       if (!envVar.key.match(/^[A-Z_][A-Z0-9_]*$/)) {
         issues.push({
+          code: 'INVALID_ENV_KEY',
+          severity: 'warning',
           field: `env.${envVar.key}`,
+          path: `env.${envVar.key}`,
           message: `Environment variable name '${envVar.key}' should use uppercase letters, numbers, and underscores`,
-          code: 'WARNING',
         });
       }
     }
@@ -401,15 +388,17 @@ export class RealValidationService implements ValidationService {
     if (limits) {
       if (limits.memoryBytes && limits.memoryBytes < 64 * 1024 * 1024) { // 64MB minimum
         issues.push({
+          code: 'LOW_MEMORY',
+          severity: 'warning',
           message: 'Memory limit is very low (< 64MB) and may cause container crashes',
-          code: 'WARNING',
         });
       }
 
       if (limits.cpuShares && limits.cpuShares < 256) {
         issues.push({
+          code: 'LOW_CPU',
+          severity: 'warning',
           message: 'CPU shares are very low and may impact performance',
-          code: 'WARNING',
         });
       }
     }
@@ -480,7 +469,7 @@ export class MockValidationService implements ValidationService {
       ok: true,
       errors: [],
       warnings: [
-        { field: 'ports', message: 'Mock validation - ports may conflict' },
+        { code: 'IMAGE_MISSING_TAG', severity: 'warning', field: 'ports', message: 'Mock validation - ports may conflict' },
       ],
     };
   }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -7,11 +7,18 @@
     ".": {
       "types": "./src/index.ts",
       "default": "./src/index.ts"
+    },
+    "./compose-validate": {
+      "types": "./src/compose-validate.ts",
+      "default": "./src/compose-validate.ts"
     }
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
     "lint": "bunx --bun eslint ."
+  },
+  "dependencies": {
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "typescript": "^6.0.3",

--- a/packages/shared/src/compose-validate.ts
+++ b/packages/shared/src/compose-validate.ts
@@ -1,0 +1,285 @@
+/**
+ * Strict Docker Compose schema + semantic validation (issue #13).
+ *
+ * Pure, dependency-light validator that turns a Compose document into a list of
+ * structured {@link ValidationIssue}s with stable codes, severity, and field
+ * paths. It is intentionally free of any server/service coupling so it can be
+ * reused by the server's ValidationService, and (optionally) by the SDK/CLI.
+ *
+ * Architecture note: Hola routes all application ingress through Traefik, so
+ * publishing host ports is unsupported. Any `ports:` entry is therefore an
+ * error (`HOST_PORT_NOT_ALLOWED`); use `expose:` for container-internal ports.
+ */
+
+import { parse as parseYAML } from 'yaml';
+import type { ValidationIssue, ValidationSeverity, ComposeIssueCode } from './index';
+
+// Loose structural shapes — we validate them, so they are deliberately permissive.
+interface RawService {
+  image?: unknown;
+  build?: unknown;
+  ports?: unknown;
+  expose?: unknown;
+  environment?: unknown;
+  volumes?: unknown;
+  networks?: unknown;
+  secrets?: unknown;
+  [key: string]: unknown;
+}
+
+interface RawCompose {
+  version?: unknown;
+  name?: unknown;
+  services?: unknown;
+  volumes?: unknown;
+  networks?: unknown;
+  secrets?: unknown;
+  configs?: unknown;
+  [key: string]: unknown;
+}
+
+const SUPPORTED_TOP_LEVEL_KEYS = new Set([
+  'version',
+  'name',
+  'services',
+  'volumes',
+  'networks',
+  'secrets',
+  'configs',
+]);
+
+// Compose service names: start alphanumeric, then alphanumerics, `_`, `.`, `-`.
+const SERVICE_NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9_.-]*$/;
+// Permissive image reference: optional registry[:port]/, path, optional :tag, optional @sha256:digest.
+const IMAGE_REF_RE =
+  /^([a-z0-9.-]+(:[0-9]+)?\/)?[a-z0-9][a-z0-9._/-]*(:[\w][\w.-]*)?(@sha256:[a-f0-9]{64})?$/i;
+// Env var keys: POSIX-ish (letter/underscore start).
+const ENV_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+function issue(
+  code: ComposeIssueCode,
+  severity: ValidationSeverity,
+  message: string,
+  path?: string,
+): ValidationIssue {
+  // `field` is kept in sync with `path` for back-compat with existing consumers.
+  return { code, severity, message, path, field: path };
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Names of top-level resources that count as "defined" (including external ones). */
+function definedNames(block: unknown): Set<string> {
+  const names = new Set<string>();
+  if (isPlainObject(block)) {
+    for (const key of Object.keys(block)) names.add(key);
+  }
+  return names;
+}
+
+function validateEnvironment(env: unknown, basePath: string, issues: ValidationIssue[]): void {
+  if (env === undefined || env === null) return;
+
+  if (Array.isArray(env)) {
+    const seen = new Set<string>();
+    env.forEach((entry, i) => {
+      if (typeof entry !== 'string') {
+        issues.push(
+          issue('INVALID_ENV_FORM', 'error', 'Environment entries must be "KEY=value" strings', `${basePath}[${i}]`),
+        );
+        return;
+      }
+      const key = entry.split('=', 1)[0];
+      if (!ENV_KEY_RE.test(key)) {
+        issues.push(
+          issue('INVALID_ENV_FORM', 'error', `Invalid environment variable name '${key}'`, `${basePath}[${i}]`),
+        );
+        return;
+      }
+      if (seen.has(key)) {
+        issues.push(issue('DUPLICATE_ENV_KEY', 'warning', `Duplicate environment key '${key}'`, `${basePath}[${i}]`));
+      }
+      seen.add(key);
+    });
+    return;
+  }
+
+  if (isPlainObject(env)) {
+    for (const key of Object.keys(env)) {
+      if (!ENV_KEY_RE.test(key)) {
+        issues.push(issue('INVALID_ENV_FORM', 'error', `Invalid environment variable name '${key}'`, `${basePath}.${key}`));
+      }
+    }
+    return;
+  }
+
+  issues.push(issue('INVALID_ENV_FORM', 'error', 'environment must be a list or a mapping', basePath));
+}
+
+function validateVolumes(
+  vols: unknown,
+  basePath: string,
+  defined: Set<string>,
+  issues: ValidationIssue[],
+): void {
+  if (!Array.isArray(vols)) return;
+  vols.forEach((entry, i) => {
+    const path = `${basePath}[${i}]`;
+    let source: string | undefined;
+    let isNamed = false;
+    if (typeof entry === 'string') {
+      source = entry.split(':')[0];
+      // A named volume has no path separators and is not relative/absolute.
+      isNamed = !!source && !source.includes('/') && !source.startsWith('.') && !source.startsWith('~');
+    } else if (isPlainObject(entry)) {
+      const type = entry.type;
+      source = typeof entry.source === 'string' ? entry.source : undefined;
+      isNamed = type === 'volume' && !!source;
+    }
+    if (isNamed && source && !defined.has(source)) {
+      issues.push(issue('UNDEFINED_VOLUME', 'error', `Volume '${source}' is not defined under top-level 'volumes'`, path));
+    }
+  });
+}
+
+function validateNetworks(
+  nets: unknown,
+  basePath: string,
+  defined: Set<string>,
+  issues: ValidationIssue[],
+): void {
+  if (nets === undefined || nets === null) return;
+  const refs: string[] = Array.isArray(nets)
+    ? nets.filter((n): n is string => typeof n === 'string')
+    : isPlainObject(nets)
+      ? Object.keys(nets)
+      : [];
+  refs.forEach((name) => {
+    if (name === 'default') return; // implicit network
+    if (!defined.has(name)) {
+      issues.push(issue('UNDEFINED_NETWORK', 'error', `Network '${name}' is not defined under top-level 'networks'`, basePath));
+    }
+  });
+}
+
+function validateSecrets(
+  secs: unknown,
+  basePath: string,
+  defined: Set<string>,
+  issues: ValidationIssue[],
+): void {
+  if (!Array.isArray(secs)) return;
+  secs.forEach((entry, i) => {
+    const name = typeof entry === 'string' ? entry : isPlainObject(entry) && typeof entry.source === 'string' ? entry.source : undefined;
+    if (name && !defined.has(name)) {
+      issues.push(issue('UNDEFINED_SECRET', 'error', `Secret '${name}' is not defined under top-level 'secrets'`, `${basePath}[${i}]`));
+    }
+  });
+}
+
+function validateImage(svc: RawService, name: string, issues: ValidationIssue[]): void {
+  const hasImage = typeof svc.image === 'string' && svc.image.trim().length > 0;
+  const hasBuild = svc.build !== undefined && svc.build !== null;
+
+  if (hasImage && hasBuild) {
+    issues.push(issue('IMAGE_AND_BUILD_CONFLICT', 'error', `Service '${name}' sets both 'image' and 'build'`, `services.${name}`));
+  } else if (!hasImage && !hasBuild) {
+    issues.push(issue('MISSING_IMAGE_OR_BUILD', 'error', `Service '${name}' must define 'image' or 'build'`, `services.${name}`));
+  }
+
+  if (hasImage) {
+    const ref = (svc.image as string).trim();
+    if (!IMAGE_REF_RE.test(ref)) {
+      issues.push(issue('INVALID_IMAGE_REF', 'error', `Invalid image reference '${ref}'`, `services.${name}.image`));
+    } else if (!ref.includes(':') && !ref.includes('@')) {
+      issues.push(issue('IMAGE_MISSING_TAG', 'warning', `Image '${ref}' has no tag; consider pinning a version`, `services.${name}.image`));
+    }
+  }
+}
+
+function validatePorts(svc: RawService, name: string, issues: ValidationIssue[]): void {
+  // Any `ports:` entry publishes to the host, which is unsupported (Traefik-only ingress).
+  if (!Array.isArray(svc.ports)) return;
+  svc.ports.forEach((_entry, i) => {
+    issues.push(
+      issue(
+        'HOST_PORT_NOT_ALLOWED',
+        'error',
+        `Host port publishing is not supported; ingress is handled by Traefik. Use 'expose' for container-internal ports.`,
+        `services.${name}.ports[${i}]`,
+      ),
+    );
+  });
+}
+
+/**
+ * Validate a parsed Compose object. Returns all issues found (errors + warnings).
+ */
+export function validateComposeObject(parsed: unknown): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+
+  if (!isPlainObject(parsed)) {
+    issues.push(issue('INVALID_YAML', 'error', 'Compose document must be a mapping at the top level'));
+    return issues;
+  }
+
+  const doc = parsed as RawCompose;
+
+  // Unsupported top-level keys → advisory warnings.
+  for (const key of Object.keys(doc)) {
+    if (!SUPPORTED_TOP_LEVEL_KEYS.has(key)) {
+      issues.push(issue('UNSUPPORTED_KEY', 'warning', `Unsupported top-level key '${key}'`, key));
+    }
+  }
+
+  if (!isPlainObject(doc.services) || Object.keys(doc.services).length === 0) {
+    issues.push(issue('NO_SERVICES', 'error', "Compose document must define at least one service under 'services'", 'services'));
+    return issues;
+  }
+
+  const volumeNames = definedNames(doc.volumes);
+  const networkNames = definedNames(doc.networks);
+  const secretNames = definedNames(doc.secrets);
+
+  for (const [name, rawSvc] of Object.entries(doc.services)) {
+    if (!SERVICE_NAME_RE.test(name)) {
+      issues.push(issue('INVALID_SERVICE_NAME', 'error', `Invalid service name '${name}'`, `services.${name}`));
+    }
+    if (!isPlainObject(rawSvc)) {
+      issues.push(issue('INVALID_SERVICE', 'error', `Service '${name}' must be a mapping`, `services.${name}`));
+      continue;
+    }
+    const svc = rawSvc as RawService;
+    validateImage(svc, name, issues);
+    validatePorts(svc, name, issues);
+    validateEnvironment(svc.environment, `services.${name}.environment`, issues);
+    validateVolumes(svc.volumes, `services.${name}.volumes`, volumeNames, issues);
+    validateNetworks(svc.networks, `services.${name}.networks`, networkNames, issues);
+    validateSecrets(svc.secrets, `services.${name}.secrets`, secretNames, issues);
+  }
+
+  return issues;
+}
+
+/**
+ * Parse and validate a Compose YAML document.
+ *
+ * @param yamlText raw Compose YAML
+ * @returns all validation issues; a YAML parse failure yields a single
+ *          `INVALID_YAML` error and no further checks are attempted.
+ */
+export function validateComposeDocument(yamlText: string): ValidationIssue[] {
+  let parsed: unknown;
+  try {
+    parsed = parseYAML(yamlText);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown parse error';
+    return [issue('INVALID_YAML', 'error', `Invalid Compose YAML: ${message}`)];
+  }
+  if (parsed === null || parsed === undefined) {
+    return [issue('NO_SERVICES', 'error', "Compose document is empty; define at least one service under 'services'", 'services')];
+  }
+  return validateComposeObject(parsed);
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -570,7 +570,57 @@ export * from './docs';
 // ------------------------------------------------------
 
 // Validation report for internal use
-export type ValidationIssue = { field?: string; message: string; code?: string };
+export type ValidationSeverity = 'error' | 'warning';
+
+/**
+ * Stable, machine-readable codes emitted by Compose schema/semantic validation.
+ * These are part of the API contract; clients may branch on them.
+ */
+export type ComposeIssueCode =
+  | 'INVALID_YAML'
+  | 'NO_SERVICES'
+  | 'UNSUPPORTED_KEY'
+  | 'INVALID_SERVICE'
+  | 'INVALID_SERVICE_NAME'
+  | 'IMAGE_AND_BUILD_CONFLICT'
+  | 'MISSING_IMAGE_OR_BUILD'
+  | 'INVALID_IMAGE_REF'
+  | 'IMAGE_MISSING_TAG'
+  | 'INVALID_ENV_FORM'
+  | 'DUPLICATE_ENV_KEY'
+  | 'UNDEFINED_VOLUME'
+  | 'UNDEFINED_NETWORK'
+  | 'UNDEFINED_SECRET'
+  | 'HOST_PORT_NOT_ALLOWED';
+
+/**
+ * Codes emitted by the broader ValidationService (drafts, env, resources).
+ * The trailing `(string & {})` keeps the type open for codes produced by
+ * other validators while preserving autocompletion for the known set.
+ */
+export type ValidationIssueCode =
+  | ComposeIssueCode
+  | 'MISSING_APP_ID'
+  | 'INVALID_PORT_RANGE'
+  | 'INVALID_ENV_KEY'
+  | 'MISSING_SECRET_VALUE'
+  | 'LOW_MEMORY'
+  | 'LOW_CPU'
+  | 'VALIDATION_FAILED'
+  | (string & {});
+
+export type ValidationIssue = {
+  /** Stable machine-readable code (e.g. 'HOST_PORT_NOT_ALLOWED'). */
+  code: ValidationIssueCode;
+  /** Whether this issue blocks (`error`) or is advisory (`warning`). */
+  severity: ValidationSeverity;
+  /** Human-readable description of the problem. */
+  message: string;
+  /** Precise dotted/bracketed path to the offending node, e.g. `services.web.ports[0]`. */
+  path?: string;
+  /** @deprecated Human-facing field label; prefer `path`. Retained for back-compat. */
+  field?: string;
+};
 export type ValidationReport = {
   ok: boolean;
   errors: ValidationIssue[];


### PR DESCRIPTION
Closes #13. First of the four remaining recovery-epic (#21) items.

## What
Strict Compose YAML + semantic validation, with structured issues (stable code, severity, field path). Host-port publishing is rejected (Traefik-only ingress); `expose` is allowed.

## How
- **New pure validator** `@hola/shared/compose-validate` (`validateComposeDocument`) — reusable by server/SDK/CLI, exposed via a package subpath export so `yaml` is **not** dragged into the web bundle.
  - Layers: parse → top-level shape (services required, unsupported-key warnings) → per-service (DNS-safe name, exactly one of image/build, image-ref format, env array/object form + duplicate keys) → cross-refs (undefined volume/network/secret) → host-port rejection.
- **Contract change** (`@hola/shared`): `ValidationIssue` now has required `code` + `severity` and optional dotted `path` (e.g. `services.web.ports[0]`); `field` retained for back-compat. `ComposeIssueCode`/`ValidationIssueCode` enumerate stable codes.
- **Server wiring**: `RealValidationService.validateDraft` delegates the compose path to the shared validator and partitions by `severity` (replacing the old `code==='ERROR'` overload). `RealDraftService` rejects **unparseable** overrides at ingestion (upload + PATCH) with a **400**; semantic issues continue to surface through `/validate` (200 + errors) for inline display.

## Acceptance criteria
- Malformed YAML → 400 with a specific parse issue ✓ (ingestion guard; `INVALID_YAML`)
- Invalid semantic constructs identify the offending field path ✓
- Valid supported Compose passes deterministically ✓
- Web/CLI receive the same shared response shape ✓ (shared `ValidationReport`/`ValidationIssue`)
- Tests cover malformed YAML, env variants, undefined resources, unsupported host-port exposure, valid multi-service bundles ✓

## Verification
- `bun --cwd packages/server test` → 172 pass / 0 fail / 22 files (no `.it.ts` collected)
- `bun run test:web` → 123 pass
- `bun run typecheck` / `bun run lint` / `bun run build` → green

🤖 Generated with [Claude Code](https://claude.com/claude-code)