### PR TITLE
chore: disable CodeRabbit auto-review and PR status checks

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -15,8 +15,11 @@ reviews:
   high_level_summary_in_walkthrough: false
   
   # Auto-review settings
+  # Disabled: the org is credit-limited and CodeRabbit is not a required check
+  # (main is unprotected). Reviews can still be summoned on demand with an
+  # `@coderabbitai review` PR comment. Flip back to true to re-enable.
   auto_review:
-    enabled: true
+    enabled: false
     drafts: false  # Skip drafts to avoid noise
     
     # Include bot PRs by explicitly NOT ignoring common bot usernames
@@ -28,8 +31,9 @@ reviews:
   
   # Review features
   request_changes_workflow: false
-  review_status: true
-  commit_status: true
+  # Do not post the "CodeRabbit" review/commit status checks on PRs.
+  review_status: false
+  commit_status: false
   fail_commit_status: false
   collapse_walkthrough: false
   changed_files_summary: true


### PR DESCRIPTION
Disables CodeRabbit auto-reviews and stops it posting the review/commit status checks on PRs.

**Why:** the org is credit-limited (CodeRabbit has been returning a rate-limit notice instead of reviews), and `main` is unprotected so CodeRabbit was never a required check — it only added noise to the PR checks list.

**Effect:** no auto-reviews and no "CodeRabbit" status check. Reviews remain available on demand via an `@coderabbitai review` PR comment. Fully reversible — flip the flags back to re-enable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)