### PR TITLE
chore(tests): end-to-end recovery smoke tests (#18)

### DIFF
--- a/packages/server/README-TESTING.md
+++ b/packages/server/README-TESTING.md
@@ -93,6 +93,31 @@ explicitly when an external dependency such as Docker is unavailable.
 NODE_ENV=test bun test
 ```
 
+### Test Tiers
+
+| Tier | Files | Services | Runs in default `bun test` / CI | Command |
+| --- | --- | --- | --- | --- |
+| Unit / integration | `*.test.ts` | mock | yes | `bun test` |
+| Contract | `__tests__/contract/*.test.ts` | mock (HTTP) + real (temp dir, mock Docker) | yes | `bun test` |
+| Smoke (mock + failure paths) | `__tests__/smoke/*.test.ts` | mock (HTTP) + real (temp dir, mock/failing Docker) | yes | `bun test` |
+| Smoke / orchestration (real Docker) | `__tests__/integration/*.it.ts` | real services + **real Docker** | **no** (gated) | `bun run test:integration` |
+
+`*.it.ts` files are never collected by the default `bun test` run — they only
+run via `bun run test:integration`, and each skips explicitly (`describe.skipIf`)
+when no Docker daemon is reachable, so the hermetic baseline stays green on
+daemonless hosts. Real-service tiers reuse `helpers/real-system.ts`
+(`makeRealSystem`, `finalizedFixtureDraft`, `waitForJob`) to wire the real
+services over a temporary `HOLA_DATA_DIR`; restart recovery is asserted by
+recreating that system over the same data dir.
+
+```bash
+# Hermetic baseline (unit, contract, smoke) — no Docker required
+bun test
+
+# Real-Docker orchestration + end-to-end smoke (workflow + restart recovery)
+bun run test:integration
+```
+
 ## Test Organization
 
 ### Directory Structure

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -8,7 +8,7 @@
     "start": "bun run src/server.ts",
     "build": "bun build src/server.ts --outdir=dist --target=bun --sourcemap",
     "test": "bun test",
-    "test:integration": "bun test ./src/__tests__/integration/docker-orchestration.it.ts",
+    "test:integration": "bun test ./src/__tests__/integration/docker-orchestration.it.ts ./src/__tests__/integration/smoke-workflow.it.ts",
     "typecheck": "tsc --noEmit",
     "lint": "bunx --bun eslint ."
   },

--- a/packages/server/src/__tests__/helpers/real-system.ts
+++ b/packages/server/src/__tests__/helpers/real-system.ts
@@ -1,0 +1,91 @@
+/**
+ * Shared wiring for tests that exercise the REAL services on an isolated temp
+ * data dir (no global singleton). Mirrors the production composition from
+ * simple-factory.ts but with a stub catalog (no network) and a caller-supplied
+ * Docker engine (mock by default, real for the Docker-gated integration suite).
+ */
+
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+import { fileURLToPath } from 'url';
+
+import { RealDeploymentService } from '../../services/core/deployment';
+import { RealDraftService } from '../../services/core/draft';
+import { RealStorageService } from '../../services/core/storage';
+import { RealRoutingService } from '../../services/core/routing';
+import { RealDatabaseService } from '../../services/core/database';
+import { RealLoggingService } from '../../services/core/logging';
+import { RealJobService } from '../../services/core/jobs';
+import { RealValidationService } from '../../services/core/validation';
+import { MockDockerService } from '../../services/core/docker';
+import { MockSystemMonitoringService } from '../../services/core/system-monitoring';
+import type { DockerService } from '../../services/core/docker';
+
+type CatalogArg = ConstructorParameters<typeof RealDraftService>[1];
+
+/** Stub catalog so draft creation needs no network. */
+export function makeStubCatalog(): CatalogArg {
+  return {
+    getApp: async (appId: string) => ({ id: appId, name: 'Fixture', icon: '🧪' }),
+    getVersionDetail: async () => ({
+      defaultEnv: [],
+      defaults: { ports: [{ container: 8080, protocol: 'tcp' as const }], volumes: [] },
+    }),
+  } as unknown as CatalogArg;
+}
+
+export const FIXTURE_COMPOSE_PATH = join(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '..',
+  'fixtures',
+  'integration',
+  'docker-compose.yaml',
+);
+
+export interface RealSystem {
+  storage: RealStorageService;
+  database: RealDatabaseService;
+  jobs: RealJobService;
+  routing: RealRoutingService;
+  docker: DockerService;
+  validation: RealValidationService;
+  drafts: RealDraftService;
+  deployments: RealDeploymentService;
+}
+
+/** Build a full real-service system rooted at `dataRoot`, with the given Docker engine. */
+export function makeRealSystem(dataRoot: string, docker: DockerService = new MockDockerService()): RealSystem {
+  const storage = new RealStorageService({ holaDir: dataRoot });
+  const database = new RealDatabaseService(storage);
+  const logging = new RealLoggingService(storage);
+  const jobs = new RealJobService(database, logging);
+  const routing = new RealRoutingService(storage, { baseDomain: 'local.hola' });
+  const systemMonitoring = new MockSystemMonitoringService();
+  const validation = new RealValidationService(docker, systemMonitoring, storage, routing);
+  const drafts = new RealDraftService(storage, makeStubCatalog(), validation);
+  const deployments = new RealDeploymentService(storage, jobs, docker, drafts, routing, logging);
+  return { storage, database, jobs, routing, docker, validation, drafts, deployments };
+}
+
+/** Poll a job to a terminal state. */
+export async function waitForJob(jobs: RealJobService, id: string, timeoutMs = 30_000) {
+  const start = Date.now();
+  for (;;) {
+    const job = await jobs.getJob(id);
+    if (job && (job.status === 'completed' || job.status === 'failed')) return job;
+    if (Date.now() - start > timeoutMs) throw new Error(`Job ${id} did not finish (last: ${job?.status})`);
+    await new Promise((r) => setTimeout(r, 50));
+  }
+}
+
+/** Create, configure with the busybox fixture compose, and finalize a draft. */
+export async function finalizedFixtureDraft(drafts: RealDraftService, appId = 'fixture'): Promise<string> {
+  const compose = await readFile(FIXTURE_COMPOSE_PATH, 'utf8');
+  const { draftId } = await drafts.createDraft({ appId, version: '1.0.0' });
+  await drafts.updateDraft(draftId, {
+    composeOverride: compose,
+    ports: [{ container: 8080, protocol: 'tcp' }],
+  });
+  await drafts.finalizeDraft(draftId);
+  return draftId;
+}

--- a/packages/server/src/__tests__/integration/smoke-workflow.it.ts
+++ b/packages/server/src/__tests__/integration/smoke-workflow.it.ts
@@ -1,0 +1,129 @@
+/**
+ * End-to-end recovery smoke test — real services + real Docker (#18).
+ *
+ * Drives the full supported workflow against the REAL deployment path and a
+ * REAL Docker daemon, then proves restart recovery: after recreating the
+ * services over the same data dir (a simulated server/stack restart), the
+ * deployment, its release, and its routing are still present and truthful.
+ *
+ * Gating: named `*.it.ts` so the default `bun test` never collects it; runs
+ * only via `bun run test:integration`, and skips explicitly when Docker is
+ * unavailable so the hermetic baseline stays green on daemonless hosts.
+ *
+ * Like docker-orchestration.it.ts, the deployed app's compose declares the
+ * shared `hola` network `external: true`, so this test creates that network
+ * before Compose up and removes it afterwards (only if it created it).
+ */
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach } from 'bun:test';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { RealDockerService } from '../../services/core/docker';
+import { makeRealSystem, finalizedFixtureDraft, waitForJob } from '../helpers/real-system';
+
+const execAsync = promisify(exec);
+
+async function sh(cmd: string): Promise<{ stdout: string; stderr: string; ok: boolean }> {
+  try {
+    const { stdout, stderr } = await execAsync(cmd, { timeout: 60_000 });
+    return { stdout, stderr, ok: true };
+  } catch (error) {
+    const e = error as { stdout?: string; stderr?: string; message?: string };
+    return { stdout: e.stdout ?? '', stderr: e.stderr ?? e.message ?? '', ok: false };
+  }
+}
+
+async function detectDocker(): Promise<boolean> {
+  const res = await sh('docker version --format "{{.Server.Version}}"');
+  return res.ok && res.stdout.trim().length > 0;
+}
+
+const dockerOk = await detectDocker();
+if (!dockerOk) {
+  console.warn('[#18] Docker unavailable — skipping end-to-end real-service smoke test');
+}
+
+describe.skipIf(!dockerOk)('Smoke: full workflow + restart recovery (real Docker)', () => {
+  const docker = new RealDockerService();
+  let dataRoot: string;
+  let createdNetwork = false;
+  const projects: string[] = [];
+
+  beforeAll(async () => {
+    // Ensure the external `hola` network exists; remember if we created it.
+    const existing = await sh('docker network ls -q --filter "name=^hola$"');
+    if (!existing.stdout.trim()) {
+      await sh('docker network create hola');
+      createdNetwork = true;
+    }
+  });
+
+  afterAll(async () => {
+    if (createdNetwork) await sh('docker network rm hola');
+  });
+
+  beforeEach(async () => {
+    dataRoot = await mkdtemp(join(tmpdir(), 'hola-smoke-it-'));
+  });
+
+  afterEach(async () => {
+    for (const project of projects.splice(0)) {
+      const ids = await sh(`docker ps -aq --filter "label=com.docker.compose.project=${project}"`);
+      const list = ids.stdout.trim().split('\n').filter(Boolean);
+      if (list.length) await sh(`docker rm -fv ${list.join(' ')}`);
+      const nets = await sh(`docker network ls -q --filter "name=${project}_default"`);
+      const netList = nets.stdout.trim().split('\n').filter(Boolean);
+      if (netList.length) await sh(`docker network rm ${netList.join(' ')}`);
+    }
+    await rm(dataRoot, { recursive: true, force: true });
+  });
+
+  test(
+    'catalog→draft→validate→finalize→deploy→running, consistent across surfaces, survives restart',
+    async () => {
+      const sys = makeRealSystem(dataRoot, docker);
+
+      // --- Install workflow through the real deployment path ----------------
+      const draftId = await finalizedFixtureDraft(sys.drafts);
+
+      // Validation passes for the supported fixture compose.
+      const report = await sys.drafts.validateDraft(draftId);
+      expect(report.ok).toBe(true);
+
+      const created = await sys.deployments.createFromDraft({ draftId, name: 'smoke' });
+      projects.push(`hola-${created.deploymentId.slice(0, 12)}`);
+      expect((await waitForJob(sys.jobs, created.jobId!, 120_000)).status).toBe('completed');
+
+      // Detail/list/history are consistent from one state source.
+      const detail = await sys.deployments.getDeployment(created.deploymentId);
+      expect(detail.status).toBe('running');
+      const list = await sys.deployments.listDeployments({ page: 1, limit: 100 });
+      expect(list.items.find((d) => d.id === created.deploymentId)?.status).toBe('running');
+      const history = await sys.deployments.getDeploymentHistory(created.deploymentId, { page: 1, limit: 100 });
+      expect(history.items.some((j) => j.id === created.jobId)).toBe(true);
+
+      // --- Restart recovery: rebuild services over the same data dir --------
+      const restarted = makeRealSystem(dataRoot, docker);
+      const afterRestart = await restarted.deployments.getDeployment(created.deploymentId);
+      expect(afterRestart.id).toBe(created.deploymentId);
+      expect(afterRestart.status).toBe('running');
+
+      // The release survived too.
+      const releases = await restarted.deployments.getReleases(created.deploymentId);
+      expect(releases.length).toBeGreaterThanOrEqual(1);
+
+      // Routing state is durable.
+      const map = await restarted.routing.getRoutingMap();
+      expect(Object.values(map).some((r) => r.deploymentId === created.deploymentId)).toBe(true);
+
+      // --- Clean up: stop the deployment ------------------------------------
+      const stop = await restarted.deployments.executeAction(created.deploymentId, { action: 'stop' });
+      expect((await waitForJob(restarted.jobs, stop.jobId!)).status).toBe('completed');
+    },
+    180_000,
+  );
+});

--- a/packages/server/src/__tests__/smoke/failure-paths.test.ts
+++ b/packages/server/src/__tests__/smoke/failure-paths.test.ts
@@ -1,0 +1,90 @@
+/**
+ * End-to-end recovery smoke test — failure paths (#18).
+ *
+ * Exercises representative workflow failures against the REAL services on an
+ * isolated temp data dir, asserting each produces an actionable error WITHOUT
+ * corrupting active state. Hermetic: no real Docker daemon (a stub engine
+ * simulates success/failure), no network (stub catalog).
+ *
+ * Coverage map for #18's required failure paths:
+ *  - invalid Compose          → here (finalize blocked by validation)
+ *  - routing conflict         → here (overlapping host rejected)
+ *  - failed deployment job    → here (failing Compose → truthful 'error' state)
+ *  - unauthorized mutation    → covered by auth/api-key.test.ts (401/403 semantics)
+ */
+
+import { describe, test, expect, afterEach } from 'bun:test';
+import { mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { MockDockerService } from '../../services/core/docker';
+import { makeRealSystem, finalizedFixtureDraft, waitForJob } from '../helpers/real-system';
+
+/** A Docker engine whose Compose up always fails, to drive a failed deploy job. */
+class FailingDockerService extends MockDockerService {
+  override async composeUp(): Promise<{ success: boolean; output: string }> {
+    return { success: false, output: 'simulated compose failure' };
+  }
+}
+
+describe('Smoke failure paths (real services)', () => {
+  let dataRoot: string;
+  afterEach(async () => {
+    if (dataRoot) await rm(dataRoot, { recursive: true, force: true });
+  });
+
+  test('invalid Compose blocks finalize with an actionable error', async () => {
+    dataRoot = await mkdtemp(join(tmpdir(), 'hola-smoke-'));
+    const { drafts } = makeRealSystem(dataRoot);
+
+    const { draftId } = await drafts.createDraft({ appId: 'fixture', version: '1.0.0' });
+    // Parseable YAML but semantically invalid (host port publishing).
+    await drafts.updateDraft(draftId, {
+      composeOverride: 'services:\n  web:\n    image: nginx:1.27\n    ports:\n      - "8080:80"\n',
+    });
+
+    // Validation reports the issue...
+    const report = await drafts.validateDraft(draftId);
+    expect(report.ok).toBe(false);
+    expect(report.errors.some((e) => e.code === 'HOST_PORT_NOT_ALLOWED')).toBe(true);
+
+    // ...and finalize refuses to produce an immutable spec from an invalid draft.
+    await expect(drafts.finalizeDraft(draftId)).rejects.toThrow();
+  });
+
+  test('a routing conflict is detected without disturbing the existing route', async () => {
+    dataRoot = await mkdtemp(join(tmpdir(), 'hola-smoke-'));
+    const { routing } = makeRealSystem(dataRoot);
+
+    const owner = routing.generateRule({ deploymentId: 'dep-owner', appName: 'grafana' });
+    await routing.activateRoute(owner);
+
+    const intruder = routing.generateRule({ deploymentId: 'dep-intruder', appName: 'grafana' });
+    expect((await routing.validateRule(intruder)).length).toBeGreaterThan(0);
+
+    // The original route is untouched and still owns the host.
+    const map = await routing.getRoutingMap();
+    expect(Object.values(map).some((r) => r.deploymentId === 'dep-owner')).toBe(true);
+  });
+
+  test('a failed deployment job lands in a truthful error state without corrupting the record', async () => {
+    dataRoot = await mkdtemp(join(tmpdir(), 'hola-smoke-'));
+    const sys = makeRealSystem(dataRoot, new FailingDockerService());
+
+    const draftId = await finalizedFixtureDraft(sys.drafts);
+    const created = await sys.deployments.createFromDraft({ draftId, name: 'will-fail' });
+    expect(created.jobId).toBeDefined();
+
+    // The job fails (Compose up returned failure)...
+    expect((await waitForJob(sys.jobs, created.jobId!)).status).toBe('failed');
+
+    // ...the deployment reports a truthful 'error' state, not a false 'running'...
+    const detail = await sys.deployments.getDeployment(created.deploymentId);
+    expect(detail.status).toBe('error');
+
+    // ...and the record is intact and still consistently listed.
+    const list = await sys.deployments.listDeployments({ page: 1, limit: 100 });
+    expect(list.items.some((d) => d.id === created.deploymentId)).toBe(true);
+  });
+});

--- a/packages/server/src/__tests__/smoke/workflow.test.ts
+++ b/packages/server/src/__tests__/smoke/workflow.test.ts
@@ -1,0 +1,165 @@
+/**
+ * End-to-end recovery smoke test — mock mode (#18).
+ *
+ * Drives the full supported product workflow through the public HTTP API with
+ * mock services (fast, hermetic, runs in the default `bun test`):
+ *
+ *   catalog → draft → configure → validate → preflight → finalize →
+ *   deployment create → list / detail / history
+ *
+ * The goal is a single high-signal path proving one app can be installed and
+ * remains consistently manageable across the list/detail/history surfaces from
+ * one state source — not a re-test of each unit. The conditional real-service
+ * variant (restart recovery + real Docker) lives in
+ * integration/smoke-workflow.it.ts.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import type {
+  GetCatalogAppsResponse,
+  CreateDraftResponse,
+  PatchDraftResponse,
+  ValidateDraftResponse,
+  EnhancedPreflightResponse,
+  FinalizeDraftResponse,
+  CreateDeploymentFromDraftResponse,
+  GetDeploymentsResponse,
+  GetDeploymentResponse,
+  GetDeploymentHistoryResponse,
+} from '@hola/shared';
+import { setupTestServer, teardownTestServer } from '../utils/bun-server';
+import { makeRequest } from '../utils/phase7-helpers';
+
+const baseURL = 'http://localhost:3001';
+
+describe('Smoke: full install workflow (mock mode)', () => {
+  beforeAll(async () => {
+    await setupTestServer(3001, { NODE_ENV: 'test' });
+  });
+
+  afterAll(async () => {
+    await teardownTestServer();
+  });
+
+  test('catalog → draft → validate → preflight → finalize → deploy → list/detail/history', async () => {
+    // 1. Catalog: pick an app to install.
+    const catalog = await makeRequest<GetCatalogAppsResponse>({
+      method: 'GET',
+      url: `${baseURL}/api/catalog/apps?page=1&limit=10`,
+    });
+    expect(catalog.success).toBe(true);
+    const appId = catalog.data!.items[0]?.id ?? 'nextcloud';
+
+    // 2. Draft: create from the catalog app.
+    const draft = await makeRequest<CreateDraftResponse>({
+      method: 'POST',
+      url: `${baseURL}/api/drafts`,
+      body: { appId, version: '1.0.0' },
+    });
+    expect(draft.success).toBe(true);
+    const draftId = draft.data!.draftId;
+
+    // 3. Configure: set an app env var.
+    const patch = await makeRequest<PatchDraftResponse>({
+      method: 'PATCH',
+      url: `${baseURL}/api/drafts/${draftId}`,
+      body: { appEnv: [{ key: 'LOG_LEVEL', value: 'info', isSecret: false }] },
+    });
+    expect(patch.success).toBe(true);
+    expect(patch.data!.ok).toBe(true);
+
+    // 4. Validate.
+    const validate = await makeRequest<ValidateDraftResponse>({
+      method: 'POST',
+      url: `${baseURL}/api/drafts/${draftId}/validate`,
+    });
+    expect(validate.success).toBe(true);
+    expect(validate.data!.ok).toBe(true);
+
+    // 5. Preflight.
+    const preflight = await makeRequest<EnhancedPreflightResponse>({
+      method: 'POST',
+      url: `${baseURL}/api/drafts/${draftId}/preflight`,
+    });
+    expect(preflight.success).toBe(true);
+    expect(preflight.data!.ok).toBe(true);
+
+    // 6. Finalize: immutable spec + checksum.
+    const finalize = await makeRequest<FinalizeDraftResponse>({
+      method: 'POST',
+      url: `${baseURL}/api/drafts/${draftId}/finalize`,
+    });
+    expect(finalize.success).toBe(true);
+    expect(typeof finalize.data!.checksum).toBe('string');
+    expect(finalize.data!.checksum.length).toBeGreaterThan(0);
+
+    // 7. Deployment: create from the finalized draft.
+    const deployment = await makeRequest<CreateDeploymentFromDraftResponse>({
+      method: 'POST',
+      url: `${baseURL}/api/deployments`,
+      body: { draftId, name: 'smoke-app' },
+    });
+    expect(deployment.success).toBe(true);
+    const deploymentId = deployment.data!.deploymentId;
+    expect(deploymentId).toBeDefined();
+    expect(deployment.data!.releaseId).toBeDefined();
+
+    // 8. Detail: the deployment is retrievable and named as requested.
+    const detail = await makeRequest<GetDeploymentResponse>({
+      method: 'GET',
+      url: `${baseURL}/api/deployments/${deploymentId}`,
+    });
+    expect(detail.success).toBe(true);
+    expect(detail.data!.id).toBe(deploymentId);
+    expect(detail.data!.name).toBe('smoke-app');
+
+    // 9. List: the same record is present with a consistent status (one source).
+    const list = await makeRequest<GetDeploymentsResponse>({
+      method: 'GET',
+      url: `${baseURL}/api/deployments?page=1&limit=100`,
+    });
+    expect(list.success).toBe(true);
+    const listed = list.data!.items.find((d) => d.id === deploymentId);
+    expect(listed).toBeDefined();
+    expect(listed!.status).toBe(detail.data!.status);
+
+    // 10. History: the deployment has at least its creation/release recorded.
+    const history = await makeRequest<GetDeploymentHistoryResponse>({
+      method: 'GET',
+      url: `${baseURL}/api/deployments/${deploymentId}/history`,
+    });
+    expect(history.success).toBe(true);
+    expect(history.data!.total).toBeGreaterThanOrEqual(1);
+  });
+
+  test('a created deployment can be stopped and the state is reflected consistently', async () => {
+    // Create via the same path, then exercise a lifecycle action end-to-end.
+    const draft = await makeRequest<CreateDraftResponse>({
+      method: 'POST',
+      url: `${baseURL}/api/drafts`,
+      body: { appId: 'nextcloud', version: '1.0.0' },
+    });
+    const draftId = draft.data!.draftId;
+    await makeRequest({ method: 'POST', url: `${baseURL}/api/drafts/${draftId}/finalize` });
+
+    const deployment = await makeRequest<CreateDeploymentFromDraftResponse>({
+      method: 'POST',
+      url: `${baseURL}/api/deployments`,
+      body: { draftId, name: 'smoke-stop' },
+    });
+    const deploymentId = deployment.data!.deploymentId;
+
+    const action = await makeRequest<{ ok: boolean; jobId?: string }>({
+      method: 'POST',
+      url: `${baseURL}/api/deployments/${deploymentId}/actions`,
+      body: { action: 'stop' },
+    });
+    expect(action.success).toBe(true);
+
+    const detail = await makeRequest<GetDeploymentResponse>({
+      method: 'GET',
+      url: `${baseURL}/api/deployments/${deploymentId}`,
+    });
+    expect(detail.data!.status).toBe('stopped');
+  });
+});


### PR DESCRIPTION
Closes #18. Third of the four remaining recovery-epic (#21) items (depends on #13/#15/#16, in main).

## What
High-signal smoke coverage of the full supported workflow + representative failure paths, in two tiers.

### Hermetic (runs in default `bun test` / CI)
- **`smoke/workflow.test.ts`** — drives `catalog → draft → configure → validate → preflight → finalize → deployment create → list/detail/history` through the public HTTP API (mock services). Asserts state consistency across list/detail/history from **one state source**, plus a stop action.
- **`smoke/failure-paths.test.ts`** — real services on a temp data dir, stub catalog, simulated Docker:
  - invalid Compose blocks `finalize` (actionable error);
  - routing conflict detected without disturbing the existing route;
  - failed deploy job → truthful `error` state, record not corrupted.
  - *(Unauthorized-mutation 401/403 semantics already covered by `auth/api-key.test.ts`.)*

### Real Docker (gated — `bun run test:integration`)
- **`integration/smoke-workflow.it.ts`** — full workflow against a real daemon, then **restart recovery**: recreating the services over the same data dir rehydrates the deployment, its release, and its routing. Skips explicitly when Docker is unavailable.

## Notes
- Shared real-service wiring extracted to `helpers/real-system.ts` (`makeRealSystem` / `finalizedFixtureDraft` / `waitForJob`).
- `test:integration` now runs **both** `.it.ts` files; `README-TESTING.md` documents the tiers.

## Acceptance criteria
- Happy path proves one app installs and stays manageable after restart ✓
- Created deployment visible consistently across list/detail/history ✓
- Failure cases produce actionable errors without corrupting active state ✓
- Suite documented; runs in CI at the appropriate tier (mock in CI, real gated) ✓

## Verification
- `bun --cwd packages/server test` → 184 pass / 0 fail / 26 files (no `.it.ts` collected)
- `bun run test:integration` → 2 pass against real Docker 29.5.3; **no resource leaks** (`docker ps -a`, `network ls`, `volume ls` clean)
- `bun run test:web` → 123 pass; `bun run typecheck` / `lint` / `build` → green

🤖 Generated with [Claude Code](https://claude.com/claude-code)