### PR TITLE
docs: align architecture, operations, and project status with the recovered system (#20)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,275 +1,122 @@
-# CONTRIBUTING.md
+# Contributing to Hola
 
-Welcome to the Hola project! This guide will help you understand how to work with our monorepo structure using Yarn workspaces.
+Welcome! Hola is a TypeScript monorepo managed with **Bun workspaces**. This
+guide covers the development setup, commands, and conventions.
 
-## Project Structure
+For the system design see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md); for
+running a deployment see [docs/OPERATIONS.md](docs/OPERATIONS.md).
 
-This project is organized as a monorepo using Yarn workspaces with the following main components:
+## Project structure
 
-- **server**: Node.js/TypeScript API server
-- **client**: Node.js/TypeScript CLI application
-
-## Setting Up Development Environment
-
-1. Clone the repository:
-   ```bash
-   git clone https://github.com/try-hola/hola.git
-   cd hola
-   ```
-
-2. Install dependencies for all workspaces:
-   ```bash
-   yarn install
-   ```
-
-## Yarn Workspace Commands
-
-### Working with Workspaces
-
-List all workspaces:
-```bash
-yarn workspaces info
+```
+packages/
+├── web/       # Vite + React SPA dashboard
+├── server/    # Bun HTTP API (owns deployment state, Docker + Traefik)
+├── shared/    # API route constants, shared types, Compose validator
+├── cli/       # React + Ink CLI (over the SDK)
+├── sdk/       # Typed API client
+└── compose/   # Production single-host Docker Compose stack
 ```
 
-Run a command in a specific workspace:
-```bash
-yarn workspace <workspace-name> <command>
-```
+## Setting up
 
-For example:
-```bash
-yarn workspace server start
-yarn workspace client dev
-```
-
-### Common Development Tasks
-
-#### Starting the Development Server
+Prerequisites: **Bun** matching `.bun-version` (1.3.14).
 
 ```bash
-# Start the server in development mode
-yarn workspace server dev
-
-# Start the client in development mode
-yarn workspace client dev
+git clone https://github.com/try-hola/hola.git
+cd hola
+bun install
 ```
 
-#### Building the Project
+## Common commands
+
+All commands run from the repo root unless noted. Root scripts fan out across
+workspaces.
 
 ```bash
-# Build all workspaces
-yarn workspaces run build
+# Run web + server in watch mode
+bun run dev
+#   web:    http://localhost:5173
+#   server: http://localhost:3001 (base path /api)
 
-# Build a specific workspace
-yarn workspace server build
+# Run one side
+bun run dev:web
+bun run dev:server
+
+# Quality gates (run all before opening a PR)
+bun run typecheck     # tsc --noEmit across packages
+bun run lint          # eslint across packages
+bun run test          # server (bun test) + web (vitest)
+bun run build         # build all packages
 ```
 
-#### Running Tests
-
-Run all tests:
-```bash
-bun test
-```
-
-Run tests for a specific workspace:
-```bash
-bun run --filter './packages/*' test
-# or specifically
-cd packages/server && bun test
-cd packages/web && bun test
-```
-
-Run tests from the workspace root:
-```bash
-# Web tests (using Vitest)
-bun run test:web
-
-# Server tests (using Bun's built-in test runner)
-cd packages/server && bun test
-
-# Run tests in watch mode
-cd packages/web && bun test:watch
-```
-
-Run specific test files or patterns:
-```bash
-# Run a specific test file
-bun test packages/server/src/__tests__/health/infrastructure.test.ts
-
-# Run tests in a specific domain
-bun test packages/server/src/__tests__/auth/
-bun test packages/web/src/__tests__/hooks/
-```
-
-#### Linting
+Run a command in a single package with `bun --cwd`:
 
 ```bash
-# Lint all workspaces
-bun run lint
-
-# Lint a specific workspace
-cd packages/server && bun run lint
-cd packages/web && bun run lint
+bun --cwd packages/server test
+bun --cwd packages/web run build
 ```
 
-## Development Workflow
+> Note: run the test suites via `bun run test` (or the per-package scripts
+> below). A bare `bun test` from the repo root would try to collect the web
+> package's jsdom/Vitest tests under Bun's runner and fail.
 
-1. Create a new branch for your feature or bugfix:
-   ```bash
-   git checkout -b feature/your-feature-name
-   ```
+### Testing
 
-2. Make your changes, following our code organization principles:
-   - Keep related functionality in the same module
-   - Use TypeScript types and interfaces extensively
-   - Write tests for new functionality
+```bash
+bun run test:server                       # server suite (Bun) — hermetic, mock services
+bun run test:web                          # web suite (Vitest)
+bun --cwd packages/server test path/to/file.test.ts   # a single server file
 
-3. Run tests to ensure your changes don't break existing functionality:
-   ```bash
-   bun test
-   # or for a specific workspace
-   cd packages/server && bun test
-   cd packages/web && bun test
-   ```
-
-4. Lint your code:
-   ```bash
-   bun run lint
-   ```
-
-5. Commit your changes with a descriptive commit message
-
-6. Push your branch and create a pull request
-
-## Testing Guidelines
-
-We organize tests by functional domains rather than implementation structure. Tests are grouped into logical feature areas for better maintainability and discoverability.
-
-### Test Organization
-
-**Server Tests** (`packages/server/src/__tests__/`):
-- `health/` - Health endpoints, infrastructure, and observability
-- `auth/` - Authentication, authorization, and security
-- `system/` - System monitoring, status, and performance
-- `docker/` - Docker service integration and health reporting
-- `jobs/` - Job management, tracking, and structured logging
-- `bundles/` - Bundle cache, OCI integration, and catalog management
-- `drafts/` - Draft lifecycle and validation
-- `deployments/` - Deployment management and actions
-- `dev-sessions/` - Development session management
-- `sse/` - Server-Sent Events and real-time features
-- `utils/` - Test utilities and shared helpers
-
-**Web Tests** (`packages/web/src/__tests__/`):
-- `hooks/` - React hooks and custom API hooks
-- `components/` - React component unit tests  
-- `pages/` - Page component integration tests
-- `api/` - API client and integration tests
-- `sse/` - SSE client-side functionality and real-time features
-- `utils/` - Test utilities, mocks, and fixtures
-
-### Test Patterns
-
-Follow these established patterns:
-1. Import dependencies and setup mocks first
-2. Import modules under test after mocking  
-3. Define test fixtures and setup in beforeEach()
-4. Write specific test cases with clear, descriptive assertions
-5. Use functional test names that describe behavior, not implementation details
-6. Group related tests in describe blocks by feature or scenario
-
-## Code Review with CodeRabbit
-
-This repository uses CodeRabbit AI for automated code reviews. CodeRabbit provides context-aware code analysis, automated reviews on pull requests with actionable feedback, and integrates with 40+ linters and security tools.
-
-### What CodeRabbit Provides
-
-- **Assertive Review Profile**: Thorough reviews focusing on critical issues
-- **TypeScript Focus**: Specialized attention to type safety and API contracts
-- **Monorepo Awareness**: Package-specific review instructions
-- **Security Scanning**: GitLeaks for secrets detection
-- **Code Quality Tools**: ESLint, Hadolint (Docker), YAML/Markdown linting
-- **Knowledge Base**: Learns from our coding guidelines in `.github/copilot-instructions.md`
-
-### Package-Specific Reviews
-
-CodeRabbit provides tailored feedback for each package:
-
-- **`packages/web/`**: React patterns, hooks, performance, accessibility
-- **`packages/server/`**: API implementation, security, Bun patterns
-- **`packages/shared/`**: Type definitions, breaking changes, contracts
-- **`packages/cli/`**: CLI usability, error handling
-- **`packages/sdk/`**: API client implementation, documentation
-- **Tests**: Focus on fakes over mocks, isolation, edge cases
-
-### Working with CodeRabbit
-
-**In Pull Requests**, CodeRabbit automatically reviews all pull requests and provides:
-
-1. **High-level Summary**: What changed and why it matters
-2. **File-by-file Walkthrough**: Detailed breakdown of each change
-3. **Architecture Diagrams**: Visual flow of system changes
-4. **Inline Comments**: Specific feedback on code sections
-
-**Interacting with CodeRabbit** - You can chat with CodeRabbit in PR comments:
-
-```
-@coderabbitai Can you explain this function?
-@coderabbitai How does this change affect the API contract?
-@coderabbitai Generate unit tests for this component
-@coderabbitai Create documentation for this endpoint
+# Real-Docker integration + end-to-end smoke (requires a Docker daemon)
+bun --cwd packages/server run test:integration
 ```
 
-**Review Commands**:
-- `@coderabbitai summary` - Generate/update PR summary
-- `@coderabbitai review` - Trigger a new review
-- `@coderabbitai help` - Show available commands
+Tests are organized by domain under `packages/server/src/__tests__/`
+(`auth/`, `deployments/`, `drafts/`, `jobs/`, `routing/`, `contract/`,
+`smoke/`, `integration/`, …). Integration tests are named `*.it.ts` and are
+**not** collected by the default suite — they run only via the
+`test:integration` script and skip explicitly when Docker is unavailable. See
+[`packages/server/README-TESTING.md`](packages/server/README-TESTING.md) for the
+test tiers and the in-process server harness.
 
-### Best Practices for CodeRabbit
+When writing real-service tests, reuse the helpers in
+`packages/server/src/__tests__/helpers/` (e.g. `makeRealSystem`,
+`setupTestEnvironment`) rather than standing up servers or temp dirs by hand.
 
-**For Code Authors**:
-1. **Use Descriptive PR Titles**: CodeRabbit can auto-generate titles with `@coderabbitai` placeholder
-2. **Link Issues**: CodeRabbit verifies changes address linked issues
-3. **Small, Focused PRs**: Better reviews with clear scope
-4. **Draft PRs**: Use drafts for work-in-progress (reviews are skipped)
+## Development workflow
 
-**For Reviewers**:
-1. **Review CodeRabbit's Analysis**: Start with the high-level summary
-2. **Check Inline Comments**: Address or resolve AI feedback
-3. **Use Chat Feature**: Ask CodeRabbit questions about complex changes
-4. **Provide Feedback**: Teach CodeRabbit your team's preferences
+1. Branch: `git checkout -b feat/short-description` (or `fix/…`, `chore/…`,
+   `docs/…`).
+2. Make focused changes; keep related functionality together and prefer the
+   shared types in `@hola/shared` so the API contract stays consistent across
+   server, web, SDK, and CLI.
+3. Run the full gate: `bun run typecheck && bun run lint && bun run test && bun run build`.
+   Linting and type errors must be clean before committing — zero tolerance.
+4. Commit with a descriptive, conventional-style message
+   (`feat(server): …`, `fix(web): …`, `chore(tests): …`).
+5. Push and open a pull request with a clear summary and any verification notes.
 
-**Teaching CodeRabbit**: When CodeRabbit's suggestions don't match your preferences, reply to its comment with your preference. CodeRabbit learns and applies this to future reviews.
+## Conventions
 
-### Troubleshooting CodeRabbit
+- **TypeScript everywhere**, `moduleResolution: bundler` for Vite/Bun
+  compatibility.
+- **Comments explain _why_**, not _what_. Match the density and style of the
+  surrounding code.
+- **Shared contract first** — when changing a server endpoint, update the
+  `@hola/shared` types in the same change.
+- The server exposes OpenAPI at `/api/openapi.json` with interactive docs at
+  `/docs`; keep endpoint docs in sync when adding routes.
 
-**CodeRabbit Not Reviewing**:
-1. Check repository access in [CodeRabbit settings](https://app.coderabbit.ai/settings/repositories)
-2. Verify PR is not a draft (if `auto_review.drafts: false`)
-3. Ensure PR has changes in included file patterns
+## Code review
 
-**Bot PRs**: CodeRabbit is configured to review pull requests from bots (including GitHub Actions, Dependabot, etc.). If you want to exclude specific bots, add their usernames to the `ignore_usernames` array in `.coderabbit.yaml`.
+Automated CodeRabbit reviews are currently **disabled** (`.coderabbit.yaml`). If
+re-enabled, it auto-reviews PRs and can be summoned on demand with an
+`@coderabbitai review` comment. Review configuration lives in `.coderabbit.yaml`.
 
-**Configuration Updates**: To modify CodeRabbit's behavior, edit `.coderabbit.yaml` in the repository root. Changes take effect on the next PR.
+## Getting help
 
-## Documentation Standards
+- Check existing docs and code for patterns.
+- Open an issue for larger discussions or design questions.
 
-- Document public API endpoints in the OpenAPI spec at `/server/public/docs/openapi.yaml`
-- Add JSDoc comments to functions and classes
-- When adding comments, explain _why_ something is done rather than _what_ is being done
-- Keep README.md files updated in each workspace
-
-## Getting Help
-
-If you have any questions or need help, please:
-- Check the existing documentation
-- Look at existing code for examples
-- Ask CodeRabbit questions in PR comments using `@coderabbitai`
-- Open an issue for larger discussions
-
-For CodeRabbit-specific support:
-- **Documentation**: [docs.coderabbit.ai](https://docs.coderabbit.ai/)
-- **Discord**: [CodeRabbit Community](https://discord.gg/GsXnASn26c)
-- **Issues**: Create GitHub issues for configuration problems
-
-Thank you for contributing to the Hola project!
+Thank you for contributing to Hola!

--- a/README.md
+++ b/README.md
@@ -10,26 +10,39 @@ This repository is a TypeScript-first monorepo powered by Bun workspaces contain
 - **SDK**: TypeScript client library for server API
 - **Compose**: Docker Compose stack for local deployment
 
-**Current Status**: 🚀 Core server implementation complete with deployment management, job tracking, and real-time updates.
+**Current Status**: Hola runs the supported workflow end to end — catalog →
+draft → validate → finalize → deploy → manage — through real Docker Compose
+orchestration and Traefik routing, with state that survives restarts. Some
+features remain on the roadmap (see [What Hola Does](#what-hola-does)).
 
 Available documentation:
-- UX specification: [`docs/UX_SPEC.md`](docs/UX_SPEC.md)
-- Implementation review: [`docs/HOLA_REVIEW.md`](docs/HOLA_REVIEW.md)
+- Architecture overview: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)
+- Operations guide (install, deploy, recover): [`docs/OPERATIONS.md`](docs/OPERATIONS.md)
+- Authentication ADR: [`docs/adr/0001-authentication.md`](docs/adr/0001-authentication.md)
+- Production stack: [`packages/compose/README.md`](packages/compose/README.md)
 - Contributing guide: [`CONTRIBUTING.md`](CONTRIBUTING.md)
+- UX specification (pre-recovery, historical): [`docs/UX_SPEC.md`](docs/UX_SPEC.md)
+- Implementation review (pre-recovery, historical): [`docs/HOLA_REVIEW.md`](docs/HOLA_REVIEW.md)
 
 ## What Hola Does
 
-Hola streamlines self‑hosted app deployments for home lab hobbyists, tinkerers, and power users. The dashboard provides:
+Hola streamlines self‑hosted app deployments for home lab hobbyists, tinkerers, and power users.
+
+**Implemented today:**
 - App catalog browsing with search and details
-- A guided install wizard with:
-  - Environment variables editing
-  - Optional Docker Compose override upload
-  - Additional file uploads for config/secrets
-  - Advanced options (ports, volumes)
-- Deployment lifecycle controls: start/stop/restart/update/uninstall
-- Health, logs, and status views
+- A guided install wizard: environment-variable editing, optional Docker Compose
+  override + additional config/secret file uploads, with strict Compose
+  validation and preflight checks
+- Deployment lifecycle controls: start / stop / restart / delete, plus rollback
+- Traefik-based routing for deployed apps (no host-port publishing)
+- Health, logs (live job/log streaming), and status views
+- Durable state: drafts, deployments, releases, and routing survive restarts
+- Control-plane authentication via an admin API key (see the auth ADR)
+
+**Roadmap (not yet implemented):**
 - Notifications for updates/errors/backups
-- Backups and restores
+- Scheduled backups and UI-driven restores
+- Application SSO via an external identity provider (Traefik forward-auth)
 
 Non-goals (see full PRD for details):
 - Not a hosted SaaS; focuses on local/self-hosted environments
@@ -46,7 +59,7 @@ Non-goals (see full PRD for details):
 │   ├── cli/       # Command-line interface
 │   ├── sdk/       # TypeScript client library
 │   └── compose/   # Docker Compose stack
-├── docs/          # UX spec and implementation review
+├── docs/          # architecture, operations, ADRs (+ historical UX spec/review)
 ├── .bun-version   # Bun version pin
 ├── package.json   # Bun workspaces root
 └── tsconfig.json  # TS project references
@@ -125,9 +138,12 @@ bun run lint
 
 Run tests:
 ```bash
-bun test                    # All tests
-bun run test:web           # Web tests only
-bun run test:server        # Server tests only
+bun run test                # Server (Bun) + web (Vitest) suites
+bun run test:web            # Web tests only
+bun run test:server         # Server tests only
+
+# Real-Docker integration + end-to-end smoke (requires a Docker daemon)
+bun --cwd packages/server run test:integration
 ```
 
 Build:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,136 @@
+# Hola Architecture
+
+This document describes how Hola is built and how a request flows through the
+system as it is implemented today. For day-2 operations (install, backup,
+restart recovery, troubleshooting) see [OPERATIONS.md](OPERATIONS.md). For the
+authentication decision record see
+[adr/0001-authentication.md](adr/0001-authentication.md).
+
+> Status legend used throughout Hola docs:
+> **Implemented** — works today · **Optional** — supported integration, off by
+> default · **Roadmap** — planned, not built yet.
+
+## Components
+
+Hola is a Bun monorepo. Each package has a single responsibility and shares one
+typed API contract.
+
+| Package | Role |
+| --- | --- |
+| `@hola/web` | React + Vite SPA dashboard: catalog, install wizard, deployments, jobs/logs, settings. |
+| `@hola/server` | Bun HTTP API. Owns deployment state and orchestrates Docker Compose + Traefik routing. |
+| `@hola/shared` | Single source of truth for API route constants and TypeScript models; also the reusable Compose validator (`@hola/shared/compose-validate`). |
+| `@hola/sdk` | Typed client for the API (scripts/integrations). |
+| `@hola/cli` | React + Ink CLI over the SDK for common workflows. |
+| `@hola/compose` | The production single-host Docker Compose stack (Traefik + web + server). Not a code library. |
+
+The web, SDK, and CLI never talk to Docker or storage directly — they call the
+server's HTTP API and consume the shared response types, so all three see the
+same behavior and the same structured errors.
+
+## Request topology (production stack)
+
+```
+browser ──TLS──▶ Traefik ──▶ web (nginx: SPA + /api proxy) ──▶ server ──┬─▶ Docker engine (deploys apps)
+                    │                                                     └─▶ /data/runtime/traefik/*.yml
+                    └────────────────── routes deployed apps ◀────────────────────┘ (file provider)
+```
+
+- **Single origin.** The `web` container serves the SPA and reverse-proxies
+  `/api` (including SSE log streams) to the server, so the browser talks to one
+  origin — no CORS, one `HOLA_DOMAIN` to configure.
+- **Traefik** terminates TLS, routes `HOLA_DOMAIN` → web, and reads the
+  server-emitted dynamic config (file provider) to route each deployed app at
+  `<app>.<HOLA_BASE_DOMAIN>`.
+- **Ingress is Traefik-only.** Apps are reachable through Traefik routing, not
+  by publishing host ports. There is no host-port registry; the Compose
+  validator rejects `ports:` exposure (use `expose:` for container-internal
+  ports).
+
+## Server services
+
+The server is composed of single-responsibility services selected per
+environment in `packages/server/src/services/simple-factory.ts`
+(`test` → mocks, `development` → real services + mock Docker, `production` →
+all real). Each has a `Real*` and `Mock*` implementation behind one interface.
+
+| Service | Responsibility |
+| --- | --- |
+| Storage | File persistence rooted at `HOLA_DATA_DIR` (atomic writes). |
+| Database | Bun SQLite (`hola.db`) for jobs and durable records. |
+| Catalog | App catalog (OCI-backed) — list/detail/versions. |
+| Draft | Draft lifecycle: create, configure, validate, preflight, finalize. |
+| Validation | Strict Compose schema/semantic validation + preflight checks. |
+| Deployment | Owns deployment/release state; coordinates jobs, routing, Docker. |
+| Job | Bounded-concurrency job queue with an executor for real Compose work. |
+| Routing | Generates Traefik rules, detects host conflicts, emits dynamic config. |
+| Docker | Wraps the host `docker compose` CLI (up/down/ps/restart/logs). |
+| Logging | File logger + in-process pub/sub for log streaming. |
+| Auth | Control-plane API-key auth (see ADR 0001). |
+
+## Deployment lifecycle
+
+An app goes from catalog to running through one path, exercised end-to-end by
+the smoke tests (`packages/server/src/__tests__/smoke`) and, against a real
+daemon, by the integration tests (`__tests__/integration/*.it.ts`):
+
+```
+catalog ─▶ draft ─▶ configure ─▶ validate ─▶ preflight ─▶ finalize
+                                                              │
+                                                              ▼
+                              deployment create ─▶ job (Compose up) ─▶ running
+                                                              │
+                                                routing activated (Traefik rule emitted)
+```
+
+1. **Draft** — created from a catalog app; the user edits env, optionally
+   uploads a Compose override / extra files.
+2. **Validate** — strict Compose validation (`@hola/shared/compose-validate`):
+   YAML parse, service shape (name, image/build, env form), undefined
+   volume/network/secret references, and host-port rejection. Issues are
+   returned as structured `ValidationIssue`s (`code`, `severity`, `path`).
+   Malformed YAML is rejected at ingestion with `400`; semantic issues surface
+   through `/validate` for inline display.
+3. **Preflight** — environment checks (Docker reachable, disk, images, routing
+   conflict) returned as pass/warn/fail.
+4. **Finalize** — produces an immutable spec + checksum; refuses to finalize an
+   invalid draft.
+5. **Deployment create** — builds a release from the finalized draft and starts
+   a job that runs `docker compose up`. On success the deployment is `running`
+   and lifecycle `active`; on failure it lands in a truthful `error` state
+   without corrupting the record.
+6. **Routing** — the deployment's release is given a Traefik router/service
+   written to `/data/runtime/traefik/dynamic.yml`; the app joins the external
+   `hola` network so Traefik can reach it.
+
+Lifecycle actions (start/stop/restart/delete) and rollback run as jobs through
+the same Deployment service, so list, detail, and history always read one
+consistent state source.
+
+## Data layout
+
+All durable state lives under `HOLA_DATA_DIR` (the `hola-data` volume at `/data`
+in the stack). See [OPERATIONS.md](OPERATIONS.md#data-layout) for the full tree.
+Key locations:
+
+- `drafts/<id>/` — draft record, uploaded files, finalized manifest.
+- `deployments/<id>/` — deployment record, releases, materialized
+  `runtime/docker-compose.yml`.
+- `runtime/traefik/{routing-map.json,dynamic.yml}` — canonical routing state and
+  the Traefik file-provider config.
+- `data/hola.db` — SQLite (jobs, durable records).
+- `config/admin-api-key` — generated admin key (first-boot bootstrap).
+- `logs/` — server logs.
+
+State is rehydrated from this tree on startup, which is what makes restart
+recovery work: recreating the services over the same data dir restores
+deployments, releases, and routing.
+
+## Authentication
+
+Control-plane auth is an admin API key (ADR 0001): enabled by default in
+production, disabled in development/test. Clients send
+`Authorization: Bearer <key>` or `X-API-Key: <key>`; the CLI/SDK read `HOLA_TOKEN`.
+Public endpoints (health/readiness/metrics) are exempt; invalid credentials →
+`401`, insufficient capability → `403`. Application SSO via an external IdP +
+Traefik forward-auth is **roadmap** (ADR 0001 pt.2).

--- a/docs/HOLA_REVIEW.md
+++ b/docs/HOLA_REVIEW.md
@@ -1,5 +1,10 @@
 # Hola Repository Review: PRD Alignment and Technical Assessment
 
+> **Historical document.** This review predates the production-recovery epic and
+> its phase-based framing no longer reflects the current system. For accurate,
+> current docs see [ARCHITECTURE.md](ARCHITECTURE.md) and
+> [OPERATIONS.md](OPERATIONS.md). Kept for context.
+
 **Review Date**: January 2025  
 **Scope**: Complete codebase analysis comparing actual implementation against PRD requirements  
 **Purpose**: Identify deviations, complexity issues, and ambiguity areas for improved AI agent assistance

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,0 +1,159 @@
+# Hola Operations Guide
+
+How to install, operate, and recover a single-host Hola deployment. For the
+system design see [ARCHITECTURE.md](ARCHITECTURE.md); for authentication see
+[adr/0001-authentication.md](adr/0001-authentication.md).
+
+> Status legend: **Implemented** · **Optional** · **Roadmap**.
+
+## Install
+
+The production stack lives in `packages/compose` and is the canonical install
+path. Its [README](../packages/compose/README.md) is the authoritative,
+step-by-step reference (prerequisites, TLS, upgrade, troubleshooting); this
+section summarizes the workflow.
+
+```bash
+cd packages/compose
+cp .env.example .env          # set HOLA_DOMAIN, HOLA_BASE_DOMAIN, LETSENCRYPT_EMAIL, ...
+./scripts/install.sh          # prepares .env/acme and runs `docker compose up -d --build`
+```
+
+Prerequisites: a host with **Docker** + the **Docker Compose v2** plugin, and
+DNS (or `/etc/hosts`) pointing your domains at the host.
+
+### Authenticate
+
+Auth is **on by default in production**. If you did not set `HOLA_API_KEY` in
+`.env`, the server generates one on first boot and writes it into the data
+volume:
+
+```bash
+docker compose exec server cat /data/config/admin-api-key
+```
+
+Send it as `Authorization: Bearer <key>` (or `X-API-Key: <key>`); for the CLI/SDK
+set `HOLA_TOKEN`. Development and test run with auth disabled. See ADR 0001.
+
+## Deploy an app
+
+Through the web dashboard (or the SDK/CLI against the API), an app moves through:
+
+```
+catalog → draft → configure → validate → preflight → finalize →
+deployment create → job (Compose up) → running → routed via Traefik
+```
+
+The deployment becomes reachable at `<app>.<HOLA_BASE_DOMAIN>` once its Traefik
+router is emitted. Lifecycle actions — **start / stop / restart / delete** and
+**rollback** — run as jobs; their state is reflected consistently across the
+deployment's list, detail, and history views. See the
+[deployment lifecycle](ARCHITECTURE.md#deployment-lifecycle) for the full path.
+
+### Routing generation
+
+When an app is deployed, the server writes a Traefik router/service for it into
+`/data/runtime/traefik/dynamic.yml` (and records canonical state in
+`routing-map.json`). Traefik watches that file and picks up the route
+automatically. For Traefik to reach the app, the app's Compose services join the
+external `hola` network under the service name Hola expects. Ingress is
+Traefik-only — apps do not publish host ports.
+
+## Data layout
+
+Everything durable lives under `HOLA_DATA_DIR` — the `hola-data` named volume
+mounted at `/data` in the stack:
+
+```
+/data/
+├── config/
+│   └── admin-api-key            # generated admin key (first-boot bootstrap)
+├── data/
+│   └── hola.db                  # SQLite: jobs, durable records
+├── drafts/<draftId>/
+│   ├── draft.json               # mutable draft record
+│   ├── files/                   # uploaded blobs (compose override, extra files)
+│   └── finalized/manifest.json  # immutable finalized spec
+├── deployments/<deploymentId>/
+│   ├── deployment.json          # deployment record
+│   ├── releases/<releaseId>/    # per-release manifest + rendered compose
+│   └── runtime/docker-compose.yml  # materialized active project
+├── runtime/traefik/
+│   ├── routing-map.json         # canonical routing state
+│   └── dynamic.yml              # Traefik file-provider config
+├── logs/                        # server logs
+└── cache/bundles/               # pulled OCI catalog bundles
+```
+
+This tree is the single thing to back up.
+
+## Restart recovery
+
+Hola is stateless in memory: all deployment, release, routing, and job state is
+persisted under `/data` and **rehydrated on startup**. Restarting the server (or
+the whole stack) restores deployments, their releases, the active-release
+pointer, and Traefik routing from disk — running apps keep running, and the
+dashboard reflects their true state after the restart.
+
+```bash
+cd packages/compose
+docker compose -f docker-compose.yml restart server   # or: down && up
+```
+
+Recovery is verified end-to-end by the smoke and integration tests
+(`__tests__/smoke`, `__tests__/integration/smoke-workflow.it.ts`), which recreate
+the services over the same data dir and assert the deployment, release, and
+routing survive.
+
+## Logs
+
+- **Server / stack logs:** `./scripts/logs.sh` or
+  `docker compose logs -f traefik server web`.
+- **Per-deployment job logs** stream through the API/dashboard (SSE) and are
+  also written under `/data`.
+
+## Backup & restore
+
+Everything durable is in the `hola-data` volume (plus keep a copy of `.env` and
+`traefik/acme/acme.json`). See the
+[compose README](../packages/compose/README.md#backup--restore) for the exact
+`tar` commands.
+
+```bash
+# Backup
+docker run --rm -v hola-data:/data -v "$PWD":/backup alpine \
+  tar czf /backup/hola-data-$(date +%F).tgz -C /data .
+```
+
+> Scheduled/automatic backups and restore orchestration through the UI are
+> **roadmap**; today backup/restore is the manual volume snapshot above.
+
+## Upgrade
+
+```bash
+git pull
+cd packages/compose
+docker compose -f docker-compose.yml up -d --build
+```
+
+State in the `hola-data` volume is preserved across upgrades.
+
+## Troubleshooting
+
+The [compose README](../packages/compose/README.md#troubleshooting) has the full
+list. Common cases:
+
+- **502 from the UI** — the `server` container isn't healthy yet;
+  `docker compose logs server`.
+- **No TLS cert** — domains must be public and resolve to the host (Let's Encrypt
+  HTTP-01).
+- **Deployed app not routable** — confirm its Compose joined the `hola` network
+  and that `/data/runtime/traefik/dynamic.yml` contains its router.
+- **Validate config** — `docker compose config` validates the merged `.env`.
+
+## Security note
+
+The server mounts `/var/run/docker.sock` to run `docker compose` for
+deployments. **This grants control of the host's Docker engine (effectively root
+on the host).** Run Hola only on a host you trust, keep the admin API key secret,
+and never expose the API without auth.

--- a/docs/UX_SPEC.md
+++ b/docs/UX_SPEC.md
@@ -1,4 +1,10 @@
 # Hola Website UX Spec
+
+> **Historical / aspirational.** This UX spec (including marketing-site scope and
+> any phase or OrbStack references) predates the production-recovery epic and
+> does not all reflect the implemented product. For the current system see
+> [ARCHITECTURE.md](ARCHITECTURE.md) and [OPERATIONS.md](OPERATIONS.md).
+
 Scope: Marketing site (M1–M6) and Product SPA (S1–S10)
 Deliverables: Low-fidelity ASCII wireframes + structured descriptions and acceptance criteria
 Design direction: Dark-first high-contrast theme, accessible tokens. Link out to GitHub docs for MVP.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -28,6 +28,5 @@ console.log(deployments.items.map(d => d.name));
 - Jobs: get and stream logs, list by deployment/status
 - Validation: compose validation
 - Bundles: import/register
-- Dev sessions (feature-flagged): CRUD, actions, status, logs
 
 All responses and inputs are fully typed using `@hola/shared` models.


### PR DESCRIPTION
Closes #20. The final recovery-epic (#21) item — documentation reconciliation.

## Added
- **`docs/ARCHITECTURE.md`** — components, production request topology, server services, the deployment lifecycle (catalog→draft→validate→preflight→finalize→deploy→route), data layout, and authentication. Uses an **implemented / optional / roadmap** status legend.
- **`docs/OPERATIONS.md`** — canonical install (points to the compose stack), deploy + lifecycle, routing generation, the `/data` layout, **restart recovery**, logs, backup/restore, upgrade, troubleshooting, and the Docker-socket security note.

## Fixed
- **`CONTRIBUTING.md`** — full **Yarn → Bun** rewrite: correct package names (web/server/cli/sdk/shared/compose), real commands, the `bun run test` vs bare `bun test` caveat, the test tiers (incl. `*.it.ts` gating), removed the stale `dev-sessions/` reference, and trimmed the long CodeRabbit section (auto-review is now disabled).
- **`README.md`** — replaced the "core implementation complete" claim with an accurate status; split features into **implemented vs roadmap** (notifications, scheduled backups/restores, app SSO → roadmap); fixed the test command; linked the new architecture/operations/ADR/compose docs.
- **`packages/sdk/README.md`** — removed the stale "Dev sessions (feature-flagged)" capability (those endpoints were removed).
- **`docs/HOLA_REVIEW.md`, `docs/UX_SPEC.md`** — marked **historical/pre-recovery** so their phase/marketing/OrbStack framing isn't read as current.

## Acceptance criteria
- A new contributor can run dev and tests from current commands ✓ (CONTRIBUTING/README use real Bun commands)
- An operator can install → authenticate → deploy → inspect logs → restart → recover from the docs ✓ (OPERATIONS + compose README)
- Docs match the production Compose stack and current API surface ✓
- No document claims mocked/unfinished capabilities are complete ✓ (status legend; backups/notifications/SSO marked roadmap)
- Stale Yarn / port-registry / dev-API / phase / OrbStack content removed or marked historical ✓ (verified no live `/api/dev/*` or port registry remain)

## Verification
- `bun run typecheck` / `bun run lint` / `bun run build` → green
- Referenced doc paths all exist (link sanity check)

Once merged, all of #13/#17/#18/#19/#20 are complete and tracking epic **#21** can close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)