### PR TITLE
fix(compose): default scripts to the production stack; make dev opt-in

### DIFF
--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -32,14 +32,15 @@ browser ──TLS──▶ Traefik ──▶ web (nginx: SPA + /api proxy) ─�
 ```bash
 cd packages/compose
 cp .env.example .env          # set HOLA_DOMAIN, HOLA_BASE_DOMAIN, LETSENCRYPT_EMAIL, ...
-./scripts/install.sh          # prepares .env/acme and runs `docker compose up -d --build`
+./scripts/install.sh          # prepares .env/acme and runs `up.sh --build` (production)
 # or manually:
 docker compose -f docker-compose.yml up -d --build
 ```
 
-`./scripts/install.sh` only includes the dev override when you run the dev scripts; for a
-production deploy use the explicit `-f docker-compose.yml` form above (or `scripts/up.sh` after
-removing the override).
+`./scripts/install.sh` defaults to the **production** stack and builds the images on first run.
+The dev overlay (`docker-compose.dev.yml`) is opt-in via `HOLA_DEV=1`, and because it is named
+`*.dev.yml` (not `*.override.yml`) `docker compose` never auto-merges it — so a fresh-host install
+is always production.
 
 ### Retrieve the admin API key
 Auth is **on by default in production**. If you did not set `HOLA_API_KEY` in `.env`, the server
@@ -57,7 +58,8 @@ Send it as `Authorization: Bearer <key>` (or `X-API-Key: <key>`) from the CLI/SD
 ```bash
 cd packages/compose
 cp .env.example .env
-./scripts/up.sh               # auto-includes docker-compose.override.yml
+HOLA_DEV=1 ./scripts/up.sh    # opt into the dev overlay (docker-compose.dev.yml)
+# or: bun run dev
 ```
 
 Dev runs the monorepo with Bun dev servers (hot reload) over **HTTP only** (no TLS/LE). The web
@@ -124,7 +126,7 @@ covered by the integration test in issue #19.
 
 ## Files
 - `docker-compose.yml` — production stack (build, socket, data volume, Traefik file provider).
-- `docker-compose.override.yml` — local dev (Bun dev servers, HTTP only).
+- `docker-compose.dev.yml` — opt-in local dev overlay (Bun dev servers, HTTP only); `HOLA_DEV=1`.
 - `../server/Dockerfile`, `../web/Dockerfile`, `../web/nginx.conf` — images.
 - `.env.example` — domains, ports, auth.
 - `scripts/` — install/up/down/logs/status helpers.

--- a/packages/compose/docker-compose.dev.yml
+++ b/packages/compose/docker-compose.dev.yml
@@ -1,4 +1,8 @@
-# Local development overrides (auto-merged by docker compose).
+# Local development overlay — OPT-IN, layered on top of docker-compose.yml.
+#
+# Named *.dev.yml (not *.override.yml) so `docker compose` never auto-merges it;
+# production stays the default. Enable it with `HOLA_DEV=1 ./scripts/up.sh` or
+# `docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d`.
 #
 # Runs the monorepo with Bun dev servers (hot reload), HTTP only (no TLS/LE),
 # and a single dev domain. Web (Vite, :5173) serves the SPA and proxies /api to

--- a/packages/compose/docker-compose.yml
+++ b/packages/compose/docker-compose.yml
@@ -5,7 +5,11 @@
 # its file provider, so deployed apps become routable at <app>.<HOLA_BASE_DOMAIN>.
 #
 #   cp .env.example .env   # then edit
-#   ./scripts/install.sh   # or: docker compose up -d --build
+#   ./scripts/install.sh   # or: docker compose -f docker-compose.yml up -d --build
+#
+# This is the PRODUCTION stack. For local development use the dev override:
+#   HOLA_DEV=1 ./scripts/up.sh
+#   # or: docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d
 
 services:
   traefik:

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "install:stack": "./scripts/install.sh",
     "up": "./scripts/up.sh",
+    "dev": "HOLA_DEV=1 ./scripts/up.sh",
     "down": "./scripts/down.sh",
     "restart": "./scripts/down.sh && ./scripts/up.sh",
     "logs": "./scripts/logs.sh",

--- a/packages/compose/scripts/_common.sh
+++ b/packages/compose/scripts/_common.sh
@@ -7,11 +7,23 @@ export COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME:-hola}
 
 COMPOSE_FILE="$ROOT_DIR/docker-compose.yml"
 ENV_FILE="$ROOT_DIR/.env"
-OVERRIDE_FILE="$ROOT_DIR/docker-compose.override.yml"
+DEV_FILE="$ROOT_DIR/docker-compose.dev.yml"
+
+# Default to the PRODUCTION stack. The dev override (Bun dev servers, HTTP only,
+# auth disabled) is opt-in via HOLA_DEV=1, so a fresh-host install is correct.
+# The dev file is named *.dev.yml (not *.override.yml) so `docker compose` never
+# auto-merges it — production stays the default even for a bare `docker compose`.
 COMPOSE_FILES=("-f" "$COMPOSE_FILE")
-if [[ -f "$OVERRIDE_FILE" ]]; then
-  COMPOSE_FILES+=("-f" "$OVERRIDE_FILE")
+HOLA_MODE="production"
+if [[ "${HOLA_DEV:-}" == "1" || "${HOLA_DEV:-}" == "true" ]]; then
+  if [[ -f "$DEV_FILE" ]]; then
+    COMPOSE_FILES+=("-f" "$DEV_FILE")
+    HOLA_MODE="development"
+  else
+    echo "[compose] HOLA_DEV set but $DEV_FILE not found; using production stack" >&2
+  fi
 fi
+export HOLA_MODE
 
 if [[ ! -f "$ENV_FILE" ]]; then
   echo "[compose] No .env found, using defaults from .env.example" >&2

--- a/packages/compose/scripts/install.sh
+++ b/packages/compose/scripts/install.sh
@@ -31,16 +31,19 @@ if [[ ! -f "$ROOT_DIR/traefik/acme/acme.json" ]]; then
   chmod 600 "$ROOT_DIR/traefik/acme/acme.json"
 fi
 
-# Provide hosts hint
-if ! grep -q "app.local.hola" /etc/hosts 2>/dev/null; then
-  cat <<'HOSTS_HINT'
-[install] Hint: Add these to /etc/hosts for local domains:
+# Dev-only hosts hint (production uses real, resolvable domains).
+if [[ "${HOLA_DEV:-}" == "1" || "${HOLA_DEV:-}" == "true" ]]; then
+  if ! grep -q "app.local.hola" /etc/hosts 2>/dev/null; then
+    cat <<'HOSTS_HINT'
+[install] Hint: Add these to /etc/hosts for local dev domains:
   127.0.0.1 app.local.hola traefik.local.hola
 HOSTS_HINT
+  fi
 fi
 
-# Bring up the stack (will automatically include docker-compose.override.yml if present)
-"$SCRIPT_DIR/up.sh"
+# Build images and bring up the stack. Defaults to the PRODUCTION stack; set
+# HOLA_DEV=1 to run the local dev override (Bun dev servers, HTTP only) instead.
+"$SCRIPT_DIR/up.sh" --build
 
 cat <<'NEXT'
 [install] Done. If auth is enabled and you did not set HOLA_API_KEY, retrieve the

--- a/packages/compose/scripts/up.sh
+++ b/packages/compose/scripts/up.sh
@@ -4,11 +4,12 @@ source "$(dirname "$0")/_common.sh"
 
 mkdir -p "$ROOT_DIR/logs" "$ROOT_DIR/data"
 
-echo "[compose] Starting stack using files: ${COMPOSE_FILES[*]}"
+# Extra args are forwarded to `up` (e.g. `--build` for a first-run/production build).
+echo "[compose] Starting ${HOLA_MODE} stack using files: ${COMPOSE_FILES[*]}"
 if [[ -f "$ENV_FILE" ]]; then
-  docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" up -d
+  docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" up -d "$@"
 else
-  docker compose "${COMPOSE_FILES[@]}" up -d
+  docker compose "${COMPOSE_FILES[@]}" up -d "$@"
 fi
 
 echo "[compose] Stack is up. Services:"


### PR DESCRIPTION
Fixes a fresh-VM install footgun surfaced while planning a real server deploy.

## Problem
`./scripts/install.sh` brought up the **dev** stack, not production: the local override was committed as `docker-compose.override.yml`, which both the helper scripts (`_common.sh`) **and a bare `docker compose up`** auto-merge — so a fresh host ran Bun dev servers over HTTP with **auth disabled**.

## Fix
- **Rename** `docker-compose.override.yml` → `docker-compose.dev.yml` so Docker Compose never auto-merges it; production is the default even for `docker compose up`.
- `_common.sh` includes the dev overlay **only when `HOLA_DEV=1`** (default: production) and exports `HOLA_MODE` for clear logging.
- `up.sh` forwards extra args (e.g. `--build`) and logs the active mode.
- `install.sh` now runs `up.sh --build` so a fresh host **builds the production images on first run**, and only prints the `/etc/hosts` dev hint under `HOLA_DEV`.
- Add a `dev` script (`HOLA_DEV=1 ./scripts/up.sh`); update the compose README, the stack header comment, and the dev-file header to document the opt-in overlay.

## Result
A fresh VM: `cp .env.example .env` → edit → `./scripts/install.sh` brings up the **production** stack (Traefik TLS + web + server), builds from source, and prints how to fetch the admin API key. Local dev is `HOLA_DEV=1 ./scripts/up.sh` (or `bun run dev`).

## Verification
- `_common.sh` selects **production** by default and the dev overlay only with `HOLA_DEV=1` (confirmed).
- `docker compose config` validates both the production file and the production+dev merge.
- `bun run lint` / `typecheck` / `build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)