### PR TITLE
fix(web): healthcheck via 127.0.0.1 so the container reports healthy

### DIFF
--- a/packages/web/Dockerfile
+++ b/packages/web/Dockerfile
@@ -13,5 +13,8 @@ FROM nginx:1.27-alpine
 COPY packages/web/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /app/packages/web/dist /usr/share/nginx/html
 EXPOSE 80
+# Use 127.0.0.1 (not localhost): in the alpine image `localhost` can resolve to
+# IPv6 ::1, where nginx (listening on IPv4 0.0.0.0:80) does not answer, which
+# would mark the container unhealthy even though it serves correctly.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD wget -qO- http://localhost/ >/dev/null 2>&1 || exit 1
+  CMD wget -qO- http://127.0.0.1/ >/dev/null 2>&1 || exit 1


### PR DESCRIPTION
Found while verifying the fresh-VM production install (bringing the stack up from freshly built images).

## Problem
The web image `HEALTHCHECK` hit `http://localhost/`. In the `nginx:1.27-alpine` image `localhost` can resolve to IPv6 `::1`, but nginx listens on IPv4 `0.0.0.0:80` and doesn't answer on `::1` — so `wget` gets "connection refused" and the container is marked **unhealthy**, even though it serves the SPA and proxies `/api` correctly. This would affect a real VM too.

## Fix
Use `127.0.0.1` in the healthcheck.

## Verification
With the production images running, `hola-web` showed `unhealthy` while `wget http://127.0.0.1/...` from inside the container returned the SPA and proxied the API. After rebuilding with this fix the container transitions to **healthy** (confirmed locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)