### PR TITLE
feat: one-line curl|sh installers for the server and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,18 +105,23 @@ Server (Bun):
 ## Install (production, single host)
 
 Run the server on a host with **Docker + Docker Compose v2 + git** (images build from
-source — no registry needed). Full details and operations in
-[`docs/OPERATIONS.md`](docs/OPERATIONS.md) and [`packages/compose/README.md`](packages/compose/README.md).
+source — no registry needed). One command:
 
 ```bash
-# On the server host
-git clone https://github.com/try-hola/hola.git
-cd hola/packages/compose
-cp .env.example .env          # set HOLA_DOMAIN, HOLA_BASE_DOMAIN, LETSENCRYPT_EMAIL
-./scripts/install.sh          # builds + runs the production stack (Traefik + web + server)
+curl -fsSL https://raw.githubusercontent.com/try-hola/hola/main/install.sh | sh
+```
 
-# Retrieve the generated admin API key (unless you set HOLA_API_KEY in .env)
-docker compose exec server cat /data/config/admin-api-key
+The installer clones Hola, prompts for your domain settings (or reads `HOLA_DOMAIN`,
+`HOLA_BASE_DOMAIN`, `LETSENCRYPT_EMAIL` from the environment), builds and starts the
+production stack (Traefik + web + server), and prints the generated admin API key.
+Re-running it upgrades an existing install. Full details and operations in
+[`docs/OPERATIONS.md`](docs/OPERATIONS.md) and [`packages/compose/README.md`](packages/compose/README.md).
+
+Non-interactive example:
+
+```bash
+HOLA_DOMAIN=app.example.com HOLA_BASE_DOMAIN=example.com LETSENCRYPT_EMAIL=you@example.com \
+  sh -c "$(curl -fsSL https://raw.githubusercontent.com/try-hola/hola/main/install.sh)"
 ```
 
 Point `HOLA_DOMAIN` (and app subdomains under `HOLA_BASE_DOMAIN`) at the host; Traefik
@@ -125,15 +130,14 @@ origin (`https://<HOLA_DOMAIN>`); the server port is not published directly.
 
 ### CLI on another machine
 
-The CLI talks to the server over the same API. Install it from the repo and point it at
-the server:
+Install the `hola` command with one line (downloads a prebuilt binary, or builds one with
+Bun if no release is published yet):
 
 ```bash
-git clone https://github.com/try-hola/hola.git && cd hola
-bun install && bun --cwd packages/cli build
+curl -fsSL https://raw.githubusercontent.com/try-hola/hola/main/cli-install.sh | sh
 export HOLA_API_URL=https://<HOLA_DOMAIN>     # the web origin (proxies /api to the server)
-export HOLA_TOKEN=<admin-api-key>             # from the server host, above
-./packages/cli/bin/hola --help
+export HOLA_TOKEN=<admin-api-key>             # printed by the server installer
+hola --help
 ```
 
 ## Getting Started

--- a/cli-install.sh
+++ b/cli-install.sh
@@ -1,0 +1,105 @@
+#!/bin/sh
+# Hola CLI installer.
+#
+#   curl -fsSL https://raw.githubusercontent.com/try-hola/hola/main/cli-install.sh | sh
+#
+# Installs the `hola` command. Prefers a prebuilt binary from the latest GitHub
+# release for your platform; if none is available it builds one from source with
+# Bun (installing Bun if needed). Until the CLI is published to npm this is the
+# supported install path.
+#
+# Environment overrides:
+#   HOLA_INSTALL_DIR    install directory   (default: $HOME/.local/bin)
+#   HOLA_REPO_SLUG      owner/repo          (default: try-hola/hola)
+#   HOLA_VERSION        release tag to pull (default: latest)
+set -eu
+
+REPO_SLUG="${HOLA_REPO_SLUG:-try-hola/hola}"
+INSTALL_DIR="${HOLA_INSTALL_DIR:-$HOME/.local/bin}"
+VERSION="${HOLA_VERSION:-latest}"
+BIN_NAME="hola"
+
+info() { printf '\033[1;36m[hola]\033[0m %s\n' "$1"; }
+warn() { printf '\033[1;33m[hola]\033[0m %s\n' "$1" >&2; }
+die()  { printf '\033[1;31m[hola] error:\033[0m %s\n' "$1" >&2; exit 1; }
+
+command -v curl >/dev/null 2>&1 || die "curl is required."
+
+# --- detect platform -------------------------------------------------------
+os="$(uname -s)"; arch="$(uname -m)"
+case "$os" in
+  Linux) os="linux" ;;
+  Darwin) os="darwin" ;;
+  *) die "unsupported OS: $os" ;;
+esac
+case "$arch" in
+  x86_64 | amd64) arch="x64" ;;
+  aarch64 | arm64) arch="arm64" ;;
+  *) die "unsupported architecture: $arch" ;;
+esac
+ASSET="hola-${os}-${arch}"
+
+mkdir -p "$INSTALL_DIR"
+TARGET="$INSTALL_DIR/$BIN_NAME"
+
+# --- try a prebuilt release binary -----------------------------------------
+if [ "$VERSION" = "latest" ]; then
+  API_URL="https://api.github.com/repos/${REPO_SLUG}/releases/latest"
+else
+  API_URL="https://api.github.com/repos/${REPO_SLUG}/releases/tags/${VERSION}"
+fi
+
+DL_URL="$(curl -fsSL "$API_URL" 2>/dev/null \
+  | grep -oE "https://[^\"]*/${ASSET}([\"[:space:]]|$)" \
+  | sed 's/[",[:space:]]*$//' \
+  | head -1 || true)"
+
+if [ -n "${DL_URL:-}" ]; then
+  info "Downloading prebuilt ${ASSET}"
+  tmp="$(mktemp)"
+  if curl -fSL "$DL_URL" -o "$tmp"; then
+    chmod +x "$tmp"
+    mv "$tmp" "$TARGET"
+  else
+    rm -f "$tmp"
+    die "failed to download $DL_URL"
+  fi
+else
+  # --- fall back to building from source ----------------------------------
+  warn "No prebuilt ${ASSET} found; building from source (requires git)."
+  command -v git >/dev/null 2>&1 || die "git is required to build from source."
+  if ! command -v bun >/dev/null 2>&1; then
+    info "Installing Bun..."
+    curl -fsSL https://bun.sh/install | bash
+    export BUN_INSTALL="${BUN_INSTALL:-$HOME/.bun}"
+    PATH="$BUN_INSTALL/bin:$PATH"
+  fi
+  command -v bun >/dev/null 2>&1 || die "Bun is not on PATH after install; open a new shell and retry."
+
+  src="$(mktemp -d)"
+  info "Cloning source into $src"
+  git clone --depth 1 "https://github.com/${REPO_SLUG}.git" "$src"
+  (
+    cd "$src"
+    bun install --frozen-lockfile
+    bun build packages/cli/src/index.tsx --compile \
+      --target="bun-${os}-${arch}" --external react-devtools-core \
+      --outfile "$TARGET"
+  )
+  rm -rf "$src"
+fi
+
+chmod +x "$TARGET"
+info "Installed $BIN_NAME to $TARGET"
+
+# --- PATH + usage hints ----------------------------------------------------
+case ":$PATH:" in
+  *":$INSTALL_DIR:"*) ;;
+  *) warn "$INSTALL_DIR is not on your PATH. Add it:"
+     warn "  export PATH=\"$INSTALL_DIR:\$PATH\"" ;;
+esac
+
+info "Point the CLI at your server:"
+info "  export HOLA_API_URL=https://<your-hola-domain>"
+info "  export HOLA_TOKEN=<admin-api-key>"
+info "Then: $BIN_NAME --help"

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -8,19 +8,31 @@ system design see [ARCHITECTURE.md](ARCHITECTURE.md); for authentication see
 
 ## Install
 
-The production stack lives in `packages/compose` and is the canonical install
-path. Its [README](../packages/compose/README.md) is the authoritative,
-step-by-step reference (prerequisites, TLS, upgrade, troubleshooting); this
-section summarizes the workflow.
+Prerequisites: a host with **Docker**, the **Docker Compose v2** plugin, and
+**git**, with DNS pointing your domains at the host.
+
+### One-line install (recommended)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/try-hola/hola/main/install.sh | sh
+```
+
+This clones Hola (to `$HOLA_HOME`, default `$HOME/hola`), prompts for the domain
+settings (or reads `HOLA_DOMAIN` / `HOLA_BASE_DOMAIN` / `LETSENCRYPT_EMAIL` from
+the environment), builds and starts the production stack, and prints the admin
+API key. Re-running upgrades an existing install.
+
+### Manual install
+
+The production stack lives in `packages/compose`; its
+[README](../packages/compose/README.md) is the authoritative, step-by-step
+reference (prerequisites, TLS, upgrade, troubleshooting).
 
 ```bash
 cd packages/compose
 cp .env.example .env          # set HOLA_DOMAIN, HOLA_BASE_DOMAIN, LETSENCRYPT_EMAIL, ...
-./scripts/install.sh          # prepares .env/acme and runs `docker compose up -d --build`
+./scripts/install.sh          # builds + runs the production stack
 ```
-
-Prerequisites: a host with **Docker** + the **Docker Compose v2** plugin, and
-DNS (or `/etc/hosts`) pointing your domains at the host.
 
 ### Authenticate
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,115 @@
+#!/bin/sh
+# Hola server installer.
+#
+#   curl -fsSL https://raw.githubusercontent.com/try-hola/hola/main/install.sh | sh
+#
+# Clones (or updates) Hola, configures the production Compose stack, builds and
+# starts it, then prints the admin API key. Re-running upgrades an existing
+# install. Config is taken from environment variables when set, otherwise the
+# script prompts (falling back to defaults when run non-interactively).
+#
+# Environment overrides:
+#   HOLA_HOME           install directory                 (default: $HOME/hola)
+#   HOLA_DOMAIN         UI/API domain                     (e.g. app.example.com)
+#   HOLA_BASE_DOMAIN    base domain for deployed apps     (e.g. example.com)
+#   LETSENCRYPT_EMAIL   email for Let's Encrypt           (e.g. you@example.com)
+#   HOLA_API_KEY        fixed admin key (else generated on first boot)
+#   HOLA_REPO           git URL    (default: https://github.com/try-hola/hola.git)
+#   HOLA_BRANCH         git branch (default: main)
+set -eu
+
+REPO="${HOLA_REPO:-https://github.com/try-hola/hola.git}"
+BRANCH="${HOLA_BRANCH:-main}"
+HOLA_HOME="${HOLA_HOME:-$HOME/hola}"
+
+info() { printf '\033[1;36m[hola]\033[0m %s\n' "$1"; }
+warn() { printf '\033[1;33m[hola]\033[0m %s\n' "$1" >&2; }
+die()  { printf '\033[1;31m[hola] error:\033[0m %s\n' "$1" >&2; exit 1; }
+
+# --- prerequisites ---------------------------------------------------------
+command -v git >/dev/null 2>&1 || die "git not found. Install git and re-run."
+command -v docker >/dev/null 2>&1 || die "Docker not found. See https://docs.docker.com/engine/install/"
+docker compose version >/dev/null 2>&1 || die "Docker Compose v2 plugin not found. Update Docker to include 'docker compose'."
+
+# --- fetch or update the repo ----------------------------------------------
+if [ -d "$HOLA_HOME/.git" ]; then
+  info "Updating existing checkout at $HOLA_HOME"
+  git -C "$HOLA_HOME" pull --ff-only
+else
+  info "Cloning Hola into $HOLA_HOME"
+  git clone --branch "$BRANCH" --depth 1 "$REPO" "$HOLA_HOME"
+fi
+
+COMPOSE_DIR="$HOLA_HOME/packages/compose"
+ENV_FILE="$COMPOSE_DIR/.env"
+[ -f "$COMPOSE_DIR/.env.example" ] || die "unexpected layout: $COMPOSE_DIR/.env.example missing"
+
+# --- configuration ---------------------------------------------------------
+# Prompt for a value: use an existing env override, else read from the terminal
+# (with a default), else fall back to the default when non-interactive.
+prompt() { # prompt <current-value> <label> <default>
+  cur="$1"; label="$2"; def="$3"
+  if [ -n "$cur" ]; then printf '%s' "$cur"; return; fi
+  if [ -r /dev/tty ]; then
+    printf '%s [%s]: ' "$label" "$def" >/dev/tty
+    read -r ans </dev/tty || ans=""
+    [ -n "$ans" ] && printf '%s' "$ans" || printf '%s' "$def"
+  else
+    printf '%s' "$def"
+  fi
+}
+
+# Replace KEY=... in the .env (values contain no '|', so it is a safe delimiter).
+set_env() { # set_env <key> <value>
+  key="$1"; val="$2"
+  if grep -q "^${key}=" "$ENV_FILE"; then
+    sed "s|^${key}=.*|${key}=${val}|" "$ENV_FILE" >"$ENV_FILE.tmp" && mv "$ENV_FILE.tmp" "$ENV_FILE"
+  else
+    printf '%s=%s\n' "$key" "$val" >>"$ENV_FILE"
+  fi
+}
+
+if [ -f "$ENV_FILE" ]; then
+  info "Using existing $ENV_FILE (delete it to reconfigure)"
+else
+  info "Configuring the stack. Press enter to accept defaults."
+  DOMAIN=$(prompt "${HOLA_DOMAIN:-}" "Hola UI/API domain (HOLA_DOMAIN)" "app.local.hola")
+  BASE_DOMAIN=$(prompt "${HOLA_BASE_DOMAIN:-}" "Base domain for deployed apps (HOLA_BASE_DOMAIN)" "local.hola")
+  LE_EMAIL=$(prompt "${LETSENCRYPT_EMAIL:-}" "Let's Encrypt email (LETSENCRYPT_EMAIL)" "admin@example.com")
+
+  cp "$COMPOSE_DIR/.env.example" "$ENV_FILE"
+  set_env HOLA_DOMAIN "$DOMAIN"
+  set_env HOLA_BASE_DOMAIN "$BASE_DOMAIN"
+  set_env LETSENCRYPT_EMAIL "$LE_EMAIL"
+  set_env HOLA_USE_AUTH "true"
+  [ -n "${HOLA_API_KEY:-}" ] && set_env HOLA_API_KEY "$HOLA_API_KEY"
+  info "Wrote $ENV_FILE"
+fi
+
+# --- build and start -------------------------------------------------------
+info "Building and starting the production stack (first run can take a few minutes)..."
+( cd "$COMPOSE_DIR" && ./scripts/install.sh )
+
+# --- admin key + next steps ------------------------------------------------
+info "Waiting for the admin API key to be provisioned..."
+KEY=""
+i=0
+while [ "$i" -lt 30 ]; do
+  KEY=$(cd "$COMPOSE_DIR" && docker compose --env-file .env exec -T server cat /data/config/admin-api-key 2>/dev/null || true)
+  [ -n "$KEY" ] && break
+  i=$((i + 1)); sleep 2
+done
+
+DOMAIN_OUT=$(grep '^HOLA_DOMAIN=' "$ENV_FILE" | cut -d= -f2-)
+printf '\n'
+info "Hola is up."
+info "  UI:        https://${DOMAIN_OUT}"
+if [ -n "$KEY" ]; then
+  info "  Admin key: ${KEY}"
+else
+  info "  Admin key: run 'docker compose --env-file .env exec server cat /data/config/admin-api-key' in $COMPOSE_DIR"
+fi
+info "  Install the CLI elsewhere:"
+info "    curl -fsSL https://raw.githubusercontent.com/try-hola/hola/main/cli-install.sh | sh"
+info "    export HOLA_API_URL=https://${DOMAIN_OUT} HOLA_TOKEN=<admin-key>"
+info "Manage the stack from $COMPOSE_DIR (./scripts/{logs,status,down}.sh)."

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -7,10 +7,24 @@ Developer-facing command-line interface built with React + Ink. The CLI talks to
 - Interfaces: Calls the Hola Server HTTP API using shared route constants and types from `@hola/shared` (and lightweight helpers in `src/lib/`).
 - Use Cases: Quick health checks, listing deployments, triggering actions, tailing logs, and validating drafts.
 
+## Install
+Install the standalone `hola` binary (downloads a prebuilt release binary, or builds one with Bun if no release is published yet):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/try-hola/hola/main/cli-install.sh | sh
+```
+
+Then point it at your server:
+```bash
+export HOLA_API_URL=https://<your-hola-domain>   # web origin; proxies /api to the server
+export HOLA_TOKEN=<admin-api-key>
+hola --help
+```
+
 ## Usage
 - From repo root: `bun --filter @hola/cli dev` (interactive dev)
 - Directly in package: `bun --cwd packages/cli dev`
-- Built binary entry: `packages/cli/bin/hola` (used by package publish/install flows)
+- Built standalone binary: `bun build packages/cli/src/index.tsx --compile --external react-devtools-core --outfile hola`
 
 Commands are organized under `src/commands/` (e.g., `bundle`, `deploy`). The CLI renders TUI screens via Ink components defined in `src/`.
 


### PR DESCRIPTION
Makes the single-host install turnkey instead of manual clone/edit/build.

## Server — `install.sh`
```bash
curl -fsSL https://raw.githubusercontent.com/try-hola/hola/main/install.sh | sh
```
Clones Hola, configures the production stack (prompts for `HOLA_DOMAIN`/`HOLA_BASE_DOMAIN`/`LETSENCRYPT_EMAIL` via the terminal, or reads them from the environment for non-interactive runs), builds + starts it, and prints the admin API key. Re-running upgrades.

## CLI — `cli-install.sh`
```bash
curl -fsSL https://raw.githubusercontent.com/try-hola/hola/main/cli-install.sh | sh
```
Installs the standalone `hola` binary: downloads a prebuilt release asset for the platform, or **falls back to building one with Bun** (`bun build --compile`, installing Bun if missing). Installs to `$HOME/.local/bin` by default.

## Docs
README, `docs/OPERATIONS.md`, and `packages/cli/README.md` now lead with the one-liners (manual steps retained).

## Note: companion CI workflow held back
A `.github/workflows/cli-release.yml` that cross-compiles `hola` for linux/macOS (x64+arm64) on a `cli-v*` tag and attaches the binaries to the Release **could not be pushed** — the `gh` token lacks the `workflow` OAuth scope. Until that's added (and a tag pushed), the CLI installer builds from source, which works today. See the PR discussion for how to add it.

## Verification
- Both scripts pass `sh -n`.
- **CLI installer end-to-end**: with no release present, it fell back to source, cloned, `bun install`, compiled, and installed a working `hola` (`hola, 0.1.0`).
- **Server installer** `.env` generation: domains/email substitute cleanly and the result passes `docker compose config`. (Full stack build/run was validated earlier this session.)
- Bun cross-compiles all four targets; `bun run lint`/`typecheck`/`build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)