### PR TITLE
ci: publish prebuilt CLI binaries on cli-v* tags

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -1,0 +1,53 @@
+name: CLI Release
+
+# Build standalone `hola` binaries and attach them to a GitHub Release.
+# Trigger by pushing a tag like `cli-v0.1.0`:
+#   git tag cli-v0.1.0 && git push origin cli-v0.1.0
+on:
+  push:
+    tags:
+      - 'cli-v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: .bun-version
+
+      - name: Install
+        run: bun install --frozen-lockfile
+
+      - name: Compile binaries (cross-target)
+        run: |
+          mkdir -p dist-bin
+          for t in linux-x64 linux-arm64 darwin-x64 darwin-arm64; do
+            echo "Building hola-$t"
+            bun build packages/cli/src/index.tsx --compile \
+              --target="bun-$t" --external react-devtools-core \
+              --outfile "dist-bin/hola-$t"
+          done
+          ls -lh dist-bin
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Create the release if it does not exist, then upload (clobbering) the binaries.
+          if ! gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            gh release create "$GITHUB_REF_NAME" \
+              --title "Hola CLI $GITHUB_REF_NAME" \
+              --notes "Standalone \`hola\` CLI binaries. Install with:
+          \`\`\`
+          curl -fsSL https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/main/cli-install.sh | sh
+          \`\`\`"
+          fi
+          gh release upload "$GITHUB_REF_NAME" dist-bin/hola-* --clobber


### PR DESCRIPTION
Follow-up to #78 (the installers). This is the companion workflow that was held back because pushing `.github/workflows/` needs the `workflow` OAuth scope.

On a `cli-v*` tag, it cross-compiles the standalone `hola` CLI for linux/macOS (x64+arm64) with Bun (`bun build --compile`) and attaches the binaries to the GitHub Release using the built-in `gh` (no third-party actions). This activates the **download path** in `cli-install.sh`.

## How to cut a release
```bash
git tag cli-v0.1.0
git push origin cli-v0.1.0
```
The workflow builds `hola-linux-x64`, `hola-linux-arm64`, `hola-darwin-x64`, `hola-darwin-arm64` and publishes them; `cli-install.sh` then downloads the right one instead of building from source.

## Verification
- Workflow YAML validated (job `release`, trigger `cli-v*`).
- Bun cross-compiles all four targets locally (confirmed in #78's testing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)