### PR TITLE
fix(compose): issue Let's Encrypt certs for deployed app routes

### DIFF
--- a/packages/compose/docker-compose.yml
+++ b/packages/compose/docker-compose.yml
@@ -25,6 +25,11 @@ services:
       - --providers.file.watch=true
       - --entrypoints.web.address=:80
       - --entrypoints.websecure.address=:443
+      # Default cert resolver for HTTPS so server-emitted app routes (Traefik
+      # file provider, which set `tls: {}` without a resolver) get Let's Encrypt
+      # certificates automatically — every deployed app at <app>.<base-domain>
+      # is served over valid TLS, not Traefik's self-signed default.
+      - --entrypoints.websecure.http.tls.certresolver=le
       # Global HTTP -> HTTPS redirect at the entrypoint (no per-service middleware).
       - --entrypoints.web.http.redirections.entrypoint.to=websecure
       - --entrypoints.web.http.redirections.entrypoint.scheme=https


### PR DESCRIPTION
Found while writing the Gitea deploy instructions.

## Problem
The Hola server emits each deployed app's Traefik route through the file provider with `entryPoints: ['websecure']` and `tls: {}` — but **no cert resolver**. Only the main web-UI router (a Docker label) requested a Let's Encrypt cert explicitly. So apps at `<app>.<HOLA_BASE_DOMAIN>` were served with Traefik's **self-signed default certificate** (browser warning), not a real cert.

## Fix
Add a default cert resolver to the HTTPS entrypoint:
```
--entrypoints.websecure.http.tls.certresolver=le
```
Traefik applies an entrypoint's default TLS config to any TLS router on that entrypoint that doesn't set its own resolver — so the web UI **and every server-emitted app route** now get Let's Encrypt certs automatically.

## Notes
- Requires app hostnames to be publicly resolvable to the host; a wildcard `*.<HOLA_BASE_DOMAIN>` A record covers all current and future apps.
- No effect on the HTTP-only dev overlay (it replaces the Traefik command).

## Verification
- `docker compose config` validates.
- Brought Traefik up standalone with the flag — it starts and stays running (Traefik exits immediately on an unknown flag, so a clean start confirms the flag is accepted), no command-line errors in logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)