### PR TITLE
feat(server): install ORAS in the server image (#81)

### DIFF
--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -3,6 +3,35 @@
 FROM oven/bun:1 AS base
 WORKDIR /app
 
+# ORAS CLI — the server pulls catalog app bundles from GHCR via `oras pull`
+# (RealBundleService.ensurePulled). The oven/bun:1 base is Debian-based but ships
+# without oras/curl, so install a pinned, arch-correct release here. Placed before
+# the source COPY so this layer caches independently of application changes.
+#
+# Signing (cosign) is intentionally NOT installed: the default signaturePolicy is
+# 'optional', under which a missing cosign only warns (verifySignature degrades
+# gracefully). If signaturePolicy='required' is ever adopted, install cosign too.
+#
+# GHCR auth: try-hola/* app packages are public, so no credentials / `oras login`
+# are needed. Pulling private packages would require a GHCR token + `oras login`
+# at startup — out of scope here.
+ARG ORAS_VERSION=1.2.3
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends curl ca-certificates; \
+    rm -rf /var/lib/apt/lists/*; \
+    arch="$(dpkg --print-architecture)"; \
+    case "$arch" in \
+      amd64) oras_arch="amd64" ;; \
+      arm64) oras_arch="arm64" ;; \
+      *) echo "unsupported architecture: $arch" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL -o /tmp/oras.tar.gz \
+      "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_${oras_arch}.tar.gz"; \
+    tar -xzf /tmp/oras.tar.gz -C /usr/local/bin oras; \
+    rm -f /tmp/oras.tar.gz; \
+    oras version
+
 # Install workspace dependencies against the committed lockfile (reproducible).
 COPY . .
 RUN bun install --frozen-lockfile


### PR DESCRIPTION
Closes #81. Part of epic #84 (catalog → deploy).

## Problem
The server pulls catalog app bundles from GHCR by shelling out to the ORAS CLI (`RealBundleService.ensurePulled()` → `oras pull`, `packages/server/src/services/core/bundles.ts:68`). The `oven/bun:1` base image ships without `oras`, so every catalog-based deploy failed in production with `ORAS_PULL_FAILED` (`oras: command not found`).

## Change
`packages/server/Dockerfile`: install a pinned, arch-correct ORAS release at `/usr/local/bin/oras`.

- **Pinned** to `v1.2.3` via `ARG ORAS_VERSION`.
- **Multi-arch**: arch detected with `dpkg --print-architecture` (amd64/arm64) — robust under plain `docker build` and buildx alike (no reliance on `ARG TARGETARCH`).
- Installs `curl`/`ca-certificates`, then cleans apt lists.
- Placed **before** the source `COPY` so the layer caches independently of application changes.

## Deliberate non-goals (documented inline)
- **cosign not installed** — `signaturePolicy` defaults to `'optional'`, under which a missing cosign only warns (`bundles.ts:85-87`) and `verifySignature()` degrades gracefully. A comment notes cosign must be added if `'required'` is ever adopted.
- **GHCR auth** — assumes `try-hola/*` packages are **public** (no creds / no `oras login`). A comment notes private packages would need a GHCR token + `oras login` at startup.

> ⚠️ Heads-up for the auth decision: `ghcr.io/try-hola/oci-test` currently returns `unauthorized: authentication required` on anonymous pull, i.e. it's **private** today. For catalog pulls to work end-to-end without credentials, `try-hola/*` app packages need their GHCR visibility set to **public** — otherwise we follow up with the token path. This PR's binary install is correct either way.

## Verification
- `docker build -f packages/server/Dockerfile -t hola/server:test .` — green.
- `docker run --rm hola/server:test oras version` → `Version: 1.2.3`. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)