### PR TITLE
feat(server): seed a catalog draft's compose from the bundle (#82)

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -8,7 +8,7 @@
     "start": "bun run src/server.ts",
     "build": "bun build src/server.ts --outdir=dist --target=bun --sourcemap",
     "test": "bun test",
-    "test:integration": "bun test ./src/__tests__/integration/docker-orchestration.it.ts ./src/__tests__/integration/smoke-workflow.it.ts",
+    "test:integration": "bun test ./src/__tests__/integration/docker-orchestration.it.ts ./src/__tests__/integration/smoke-workflow.it.ts ./src/__tests__/integration/catalog-deploy.it.ts",
     "typecheck": "tsc --noEmit",
     "lint": "bunx --bun eslint ."
   },

--- a/packages/server/src/__tests__/bundles/catalog-compose-override.test.ts
+++ b/packages/server/src/__tests__/bundles/catalog-compose-override.test.ts
@@ -1,0 +1,96 @@
+/**
+ * RealCatalogService surfaces the bundle compose (#82)
+ *
+ * getVersionDetail() pulls the bundle and reads manifest.json + compose.yaml from
+ * the local bundle dir. This test verifies it returns the raw compose.yaml as
+ * composeOverride (so a catalog-created draft can be deployed without the user
+ * pasting compose). It runs against the MockBundleService (NODE_ENV=test, no
+ * ORAS/GHCR): the remote catalog is served from a `data:` URL and the bundle is
+ * pre-staged at the mock bundle path.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtemp, rm, mkdir, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { catalogConfig } from '../../config/catalog';
+import { resetServices } from '../../services/simple-factory';
+import { RealCatalogService } from '../../services/core/catalog';
+
+const APP_ID = 'fixtureapp';
+const VERSION = '1.0.0';
+
+const COMPOSE = `services:
+  fixtureapp:
+    image: nginx:1.27
+    restart: unless-stopped
+    volumes:
+      - fixtureapp-data:/data
+volumes:
+  fixtureapp-data:
+`;
+
+const MANIFEST = JSON.stringify({
+  name: APP_ID,
+  defaultEnv: [{ key: 'APP_ENV', value: 'production', isSecret: false }],
+  defaults: {
+    ports: [{ container: 80, protocol: 'tcp' }],
+    volumes: [{ containerPath: '/data' }],
+  },
+});
+
+function dataUrlCatalog(): string {
+  const catalog = {
+    apps: [
+      { id: APP_ID, name: 'Fixture App', versions: [{ version: VERSION, refs: { oci: `ghcr.io/try-hola/${APP_ID}:${VERSION}` } }] },
+    ],
+  };
+  return 'data:application/json,' + encodeURIComponent(JSON.stringify(catalog));
+}
+
+describe('RealCatalogService composeOverride (#82)', () => {
+  let dataRoot: string;
+  let prevDataDir: string | undefined;
+  let prevNodeEnv: string | undefined;
+  let prevCatalogUrl: string | undefined;
+
+  beforeEach(async () => {
+    prevDataDir = process.env.HOLA_DATA_DIR;
+    prevNodeEnv = process.env.NODE_ENV;
+    prevCatalogUrl = catalogConfig.catalogUrl;
+
+    dataRoot = await mkdtemp(join(tmpdir(), 'hola-catalog-'));
+    process.env.HOLA_DATA_DIR = dataRoot;
+    process.env.NODE_ENV = 'test'; // → MockBundleService (no ORAS/allowlist)
+    resetServices();
+
+    // Stage the bundle where MockBundleService.ensurePulled returns it:
+    // <HOLA_DATA_DIR>/mock-bundles/<appId>/<version>/{compose.yaml,manifest.json}
+    const bundleDir = join(dataRoot, 'mock-bundles', APP_ID, VERSION);
+    await mkdir(bundleDir, { recursive: true });
+    await writeFile(join(bundleDir, 'compose.yaml'), COMPOSE);
+    await writeFile(join(bundleDir, 'manifest.json'), MANIFEST);
+
+    Object.assign(catalogConfig, { catalogUrl: dataUrlCatalog() });
+  });
+
+  afterEach(async () => {
+    Object.assign(catalogConfig, { catalogUrl: prevCatalogUrl });
+    if (prevDataDir === undefined) delete process.env.HOLA_DATA_DIR;
+    else process.env.HOLA_DATA_DIR = prevDataDir;
+    if (prevNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = prevNodeEnv;
+    resetServices();
+    await rm(dataRoot, { recursive: true, force: true });
+  });
+
+  test('returns the bundle compose.yaml as composeOverride', async () => {
+    const svc = new RealCatalogService();
+    const detail = await svc.getVersionDetail(APP_ID, VERSION);
+
+    expect(detail.composeOverride).toBe(COMPOSE);
+    // Defaults are still merged from manifest/compose as before.
+    expect(detail.defaults.ports.some(p => p.container === 80)).toBe(true);
+  });
+});

--- a/packages/server/src/__tests__/drafts/catalog-compose.test.ts
+++ b/packages/server/src/__tests__/drafts/catalog-compose.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Catalog → draft compose wiring (#82)
+ *
+ * A draft created from a catalog app must seed its composeOverride from the
+ * bundle's compose.yaml (surfaced via CatalogService.getVersionDetail), so the
+ * app can be deployed without the user pasting compose. These tests exercise the
+ * real wiring (RealDraftService + MockCatalogService → mock-data) without Docker
+ * or ORAS — MockCatalogService returns the same composeOverride a real bundle would.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { RealDraftService } from '../../services/core/draft';
+import { MockCatalogService } from '../../services/core/catalog';
+import { RealStorageService } from '../../services/core/storage';
+import { getCatalogAppVersionDetail } from '../../mock-data/catalog';
+
+type CatalogArg = ConstructorParameters<typeof RealDraftService>[1];
+type ValidationArg = ConstructorParameters<typeof RealDraftService>[2];
+
+// createDraft doesn't call the validation service (it uses the module-level
+// assertComposeParses guard), so a minimal stub suffices.
+function makeValidation(): ValidationArg {
+  return {
+    validateDraft: async () => ({ ok: true, errors: [], warnings: [] }),
+    preflightCheck: async () => ({ ok: true, checks: [] }),
+  } as unknown as ValidationArg;
+}
+
+describe('Catalog → draft compose (#82)', () => {
+  let dataRoot: string;
+  let drafts: RealDraftService;
+
+  beforeEach(async () => {
+    dataRoot = await mkdtemp(join(tmpdir(), 'hola-draft-'));
+    const storage = new RealStorageService({ holaDir: dataRoot });
+    drafts = new RealDraftService(storage, new MockCatalogService() as unknown as CatalogArg, makeValidation());
+  });
+
+  afterEach(async () => {
+    await rm(dataRoot, { recursive: true, force: true });
+  });
+
+  test('seeds composeOverride from the catalog bundle', async () => {
+    const expected = getCatalogAppVersionDetail('nextcloud', '28.0.2')?.composeOverride;
+    expect(expected).toBeTruthy();
+
+    const { draftId } = await drafts.createDraft({ appId: 'nextcloud', version: '28.0.2' });
+    const draft = await drafts.getDraft(draftId);
+
+    expect(draft.composeOverride).toBe(expected!);
+    expect(draft.composeOverride).toContain('nextcloud:30-apache');
+  });
+
+  test('the seeded compose flows through finalize into the manifest', async () => {
+    const { draftId } = await drafts.createDraft({ appId: 'nextcloud', version: '28.0.2' });
+    const finalized = await drafts.finalizeDraft(draftId);
+    expect(finalized.checksum).toBeTruthy();
+
+    // The finalized release artifacts carry the bundle compose forward.
+    const artifacts = await drafts.getFinalizedArtifacts(draftId);
+    expect(artifacts?.composeOverride).toContain('nextcloud:30-apache');
+  });
+
+  test('falls back to empty composeOverride when the bundle has none', async () => {
+    // homeassistant has catalog defaults but no composeOverride in mock-data.
+    const detail = getCatalogAppVersionDetail('homeassistant', '2024.1.5');
+    expect(detail?.composeOverride).toBeUndefined();
+
+    const { draftId } = await drafts.createDraft({ appId: 'homeassistant', version: '2024.1.5' });
+    const draft = await drafts.getDraft(draftId);
+    expect(draft.composeOverride).toBe('');
+  });
+});

--- a/packages/server/src/__tests__/integration/catalog-deploy.it.ts
+++ b/packages/server/src/__tests__/integration/catalog-deploy.it.ts
@@ -1,0 +1,193 @@
+/**
+ * Catalog → deploy, end-to-end (#82, real daemon)
+ *
+ * Proves a draft whose composeOverride is *seeded from the catalog bundle* (not
+ * pasted by the user via updateDraft) deploys and is routable. This exercises the
+ * #82 change in RealDraftService.createDraft: getVersionDetail().composeOverride
+ * flows into draft.composeOverride → finalize → release → Compose up → Traefik
+ * route — without ORAS/GHCR (the catalog is stubbed to return the fixture compose,
+ * exactly what RealCatalogService would surface from a real bundle).
+ *
+ * Gated on a reachable Docker daemon (run via `bun test:integration`); mirrors the
+ * setup/cleanup discipline of docker-orchestration.it.ts.
+ */
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach } from 'bun:test';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { mkdtemp, rm, readFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { fileURLToPath } from 'url';
+
+import { RealDeploymentService } from '../../services/core/deployment';
+import { RealDraftService } from '../../services/core/draft';
+import { RealStorageService } from '../../services/core/storage';
+import { RealRoutingService } from '../../services/core/routing';
+import { RealDatabaseService } from '../../services/core/database';
+import { RealLoggingService } from '../../services/core/logging';
+import { RealJobService } from '../../services/core/jobs';
+import { RealDockerService } from '../../services/core/docker';
+
+const execAsync = promisify(exec);
+
+type CatalogArg = ConstructorParameters<typeof RealDraftService>[1];
+type ValidationArg = ConstructorParameters<typeof RealDraftService>[2];
+
+const FIXTURE_COMPOSE_PATH = join(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '..',
+  'fixtures',
+  'integration',
+  'docker-compose.yaml'
+);
+
+/**
+ * Catalog stub standing in for RealCatalogService: getVersionDetail surfaces the
+ * bundle compose as composeOverride plus the ingress port, exactly as the real
+ * service does after reading compose.yaml/manifest.json from a pulled bundle.
+ */
+function makeCatalog(composeOverride: string): CatalogArg {
+  return {
+    getApp: async (appId: string) => ({ id: appId, name: 'Fixture', icon: '🧪' }),
+    getVersionDetail: async () => ({
+      defaultEnv: [],
+      defaults: { ports: [{ container: 8080, protocol: 'tcp' as const }], volumes: [] },
+      composeOverride,
+    }),
+  } as unknown as CatalogArg;
+}
+
+function makeValidation(): ValidationArg {
+  return {
+    validateDraft: async () => ({ ok: true, errors: [], warnings: [] }),
+    preflightCheck: async () => ({ ok: true, checks: [] }),
+  } as unknown as ValidationArg;
+}
+
+async function sh(cmd: string): Promise<{ stdout: string; stderr: string; ok: boolean }> {
+  try {
+    const { stdout, stderr } = await execAsync(cmd, { timeout: 60_000 });
+    return { stdout, stderr, ok: true };
+  } catch (error) {
+    const e = error as { stdout?: string; stderr?: string; message?: string };
+    return { stdout: e.stdout ?? '', stderr: e.stderr ?? e.message ?? '', ok: false };
+  }
+}
+
+async function detectDocker(): Promise<boolean> {
+  const res = await sh('docker version --format "{{.Server.Version}}"');
+  return res.ok && res.stdout.trim().length > 0;
+}
+
+const dockerOk = await detectDocker();
+if (!dockerOk) {
+  console.warn('[#82] Docker unavailable — skipping catalog → deploy integration test');
+}
+
+async function waitForJob(jobs: RealJobService, id: string, timeoutMs = 120_000) {
+  const start = Date.now();
+  for (;;) {
+    const job = await jobs.getJob(id);
+    if (job && (job.status === 'completed' || job.status === 'failed')) return job;
+    if (Date.now() - start > timeoutMs) throw new Error(`Job ${id} did not finish (last status: ${job?.status})`);
+    await new Promise(r => setTimeout(r, 200));
+  }
+}
+
+async function containerId(project: string, service: string): Promise<string> {
+  const res = await sh(
+    `docker ps -aq --filter "label=com.docker.compose.project=${project}" --filter "label=com.docker.compose.service=${service}"`
+  );
+  return res.stdout.trim().split('\n').filter(Boolean)[0] ?? '';
+}
+
+describe.skipIf(!dockerOk)('Catalog → deploy (real daemon)', () => {
+  let dataRoot: string;
+  let createdHolaNetwork = false;
+  let projects: string[];
+  const allProjects: string[] = [];
+
+  beforeAll(async () => {
+    const inspectHola = await sh('docker network inspect hola');
+    if (!inspectHola.ok) {
+      const created = await sh('docker network create hola');
+      createdHolaNetwork = created.ok;
+    }
+  });
+
+  afterAll(async () => {
+    if (createdHolaNetwork) await sh('docker network rm hola');
+    for (const project of allProjects) {
+      const containers = await sh(`docker ps -aq --filter "label=com.docker.compose.project=${project}"`);
+      expect(containers.stdout.trim()).toBe('');
+      const nets = await sh(`docker network ls -q --filter "name=${project}_default"`);
+      expect(nets.stdout.trim()).toBe('');
+    }
+  });
+
+  beforeEach(async () => {
+    dataRoot = await mkdtemp(join(tmpdir(), 'hola-cat-it-'));
+    projects = [];
+  });
+
+  afterEach(async () => {
+    for (const project of projects) {
+      const ids = await sh(`docker ps -aq --filter "label=com.docker.compose.project=${project}"`);
+      const list = ids.stdout.trim().split('\n').filter(Boolean);
+      if (list.length) await sh(`docker rm -fv ${list.join(' ')}`);
+      const nets = await sh(`docker network ls -q --filter "name=${project}_default"`);
+      const netList = nets.stdout.trim().split('\n').filter(Boolean);
+      if (netList.length) await sh(`docker network rm ${netList.join(' ')}`);
+    }
+    await rm(dataRoot, { recursive: true, force: true });
+  });
+
+  const docker = new RealDockerService();
+
+  test(
+    'deploys a catalog-seeded draft (compose from getVersionDetail) and routes it via Traefik',
+    async () => {
+      const compose = await readFile(FIXTURE_COMPOSE_PATH, 'utf8');
+
+      const storage = new RealStorageService({ holaDir: dataRoot });
+      const database = new RealDatabaseService(storage);
+      const logging = new RealLoggingService(storage);
+      const jobs = new RealJobService(database, logging);
+      const routing = new RealRoutingService(storage, { baseDomain: 'local.hola' });
+      const drafts = new RealDraftService(storage, makeCatalog(compose), makeValidation());
+      const deployments = new RealDeploymentService(storage, jobs, docker, drafts, routing, logging);
+
+      // Catalog-seeded draft: NO updateDraft of composeOverride — it must arrive
+      // from getVersionDetail via createDraft (the #82 change).
+      const { draftId } = await drafts.createDraft({ appId: 'fixture', version: '1.0.0' });
+      const seeded = await drafts.getDraft(draftId);
+      expect(seeded.composeOverride).toBe(compose);
+      await drafts.finalizeDraft(draftId);
+
+      const created = await deployments.createFromDraft({ draftId, name: 'fixture' });
+      const shortId = created.deploymentId.slice(0, 12);
+      const project = `hola-${shortId}`;
+      projects.push(project);
+      allProjects.push(project);
+
+      const job = await waitForJob(jobs, created.jobId!);
+      expect(job.status).toBe('completed');
+      expect((await deployments.getDeployment(created.deploymentId)).status).toBe('running');
+
+      // No application host ports were published (Traefik-only ingress).
+      const materialized = await storage.readFileAsString(`deployments/${created.deploymentId}/runtime/docker-compose.yml`);
+      expect(materialized).not.toContain('ports:');
+
+      // The app is on the hola network with its routing alias, and the emitted
+      // Traefik dynamic config routes <app>.<domain> to it.
+      const cid = await containerId(project, 'fixture');
+      expect(cid).not.toBe('');
+      const expectedAlias = `fixture-${shortId}`;
+      const dynamic = await storage.readFileAsString('runtime/traefik/dynamic.yml');
+      expect(dynamic).toContain(expectedAlias);
+      expect(dynamic).toContain('fixture.local.hola');
+    },
+    180_000
+  );
+});

--- a/packages/server/src/mock-data/catalog.ts
+++ b/packages/server/src/mock-data/catalog.ts
@@ -212,6 +212,33 @@ export const appVersionsData: Record<string, CatalogAppVersion[]> = {
 };
 
 // App version details with environment variables and defaults
+// Representative bundle compose.yaml strings. Real catalog bundles carry a
+// compose.yaml (read by RealCatalogService.getVersionDetail and surfaced as
+// composeOverride); the mocks mirror that so a catalog-created draft gets a
+// non-empty composeOverride in the test/mock path too. Traefik-only ingress —
+// no host ports published.
+const NEXTCLOUD_COMPOSE = `services:
+  nextcloud:
+    image: nextcloud:30-apache
+    restart: unless-stopped
+    volumes:
+      - nextcloud:/var/www/html
+      - nextcloud-data:/var/www/html/data
+volumes:
+  nextcloud:
+  nextcloud-data:
+`;
+
+const GENERIC_COMPOSE = `services:
+  app:
+    image: nginx:1.27
+    restart: unless-stopped
+    volumes:
+      - app-data:/data
+volumes:
+  app-data:
+`;
+
 export const appVersionDetails: Record<string, GetCatalogAppVersionDetailResponse> = {
   nextcloud: {
     defaultEnv: [
@@ -231,6 +258,7 @@ export const appVersionDetails: Record<string, GetCatalogAppVersionDetailRespons
         { hostPath: './nextcloud-data', containerPath: '/var/www/html/data', readOnly: false }
       ],
     },
+    composeOverride: NEXTCLOUD_COMPOSE,
   },
   homeassistant: {
     defaultEnv: [
@@ -436,6 +464,7 @@ export function getCatalogAppVersionDetail(
         { hostPath: `./data`, containerPath: '/data', readOnly: false }
       ],
     },
+    composeOverride: GENERIC_COMPOSE,
   };
 }
 

--- a/packages/server/src/services/core/catalog.ts
+++ b/packages/server/src/services/core/catalog.ts
@@ -175,10 +175,16 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
       // Parse compose.yaml to get additional defaults
       const composeDefaults = parseComposeDefaults(info.localPath);
 
+      // Carry the raw compose.yaml through so a catalog-created draft can be
+      // deployed without the user pasting compose. Same file the parser reads;
+      // a missing/unreadable compose throws here and falls through to the same
+      // catch (MANIFEST_UNAVAILABLE) + draft-side fallback — no new failure mode.
+      const composeOverride = readFileSync(join(info.localPath, 'compose.yaml'), 'utf8');
+
       // Merge compose and manifest defaults (manifest takes precedence)
       const merged = mergeDefaults(composeDefaults, manifestDefaults, manifestEnv);
 
-      return merged satisfies GetCatalogAppVersionDetailResponse;
+      return { ...merged, composeOverride } satisfies GetCatalogAppVersionDetailResponse;
     } catch (error) {
       this.logger.warn('Failed to read or parse bundle manifest; deferring to mocks', { appId, version, error: error instanceof Error ? error.message : String(error) });
       throw new Error('MANIFEST_UNAVAILABLE', { cause: error });

--- a/packages/server/src/services/core/draft.ts
+++ b/packages/server/src/services/core/draft.ts
@@ -298,6 +298,12 @@ export class RealDraftService implements DraftService {
       // Get default environment and configuration
       const defaults = await this.getDraftDefaults(request.appId, request.version);
 
+      // Seed the draft's compose from the catalog bundle so it can be deployed
+      // without the user pasting compose. Guard it through the same parse check
+      // as user-supplied compose so a bad bundle fails fast.
+      const composeOverride = defaults.composeOverride ?? '';
+      assertComposeParses(composeOverride, 'catalog bundle');
+
       // Create initial draft
       const draft: Draft = {
         draftId,
@@ -306,7 +312,7 @@ export class RealDraftService implements DraftService {
         systemOverrides: {},
         appEnv: defaults.env,
         ports: defaults.defaults.ports,
-        composeOverride: '',
+        composeOverride,
         files: [],
       };
 
@@ -633,17 +639,18 @@ export class RealDraftService implements DraftService {
     };
   }
 
-  async getDraftDefaults(appId: string, version?: string): Promise<{ env: AppEnvVar[]; defaults: DraftDefaults }> {
+  async getDraftDefaults(appId: string, version?: string): Promise<{ env: AppEnvVar[]; defaults: DraftDefaults; composeOverride: string }> {
     try {
       const versionDetail = await this.catalogService.getVersionDetail(appId, version || 'latest');
       return {
         env: versionDetail.defaultEnv,
         defaults: versionDetail.defaults,
+        composeOverride: versionDetail.composeOverride ?? '',
       };
     } catch (error) {
       this.logger.warn('Failed to get app defaults, using fallback', { appId, version, error: error instanceof Error ? error.message : String(error) });
-      
-      // Fallback defaults
+
+      // Fallback defaults (no bundle compose available — the user supplies one)
       return {
         env: [
           { key: 'APP_PORT', value: '8080', isSecret: false, description: 'Application port' },
@@ -652,6 +659,7 @@ export class RealDraftService implements DraftService {
           ports: [{ host: 8080, container: 80, protocol: 'tcp' }],
           volumes: [{ hostPath: './data', containerPath: '/data', readOnly: false }],
         },
+        composeOverride: '',
       };
     }
   }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -251,6 +251,10 @@ export type DraftDefaults = {
 export type GetCatalogAppVersionDetailResponse = {
   defaultEnv: AppEnvVar[];
   defaults: DraftDefaults;
+  // The bundle's compose.yaml, used to seed a catalog-created draft's
+  // composeOverride so it can be deployed without the user pasting compose.
+  // Optional: clients that only need env/port defaults can ignore it.
+  composeOverride?: string;
 };
 
 // ------------------------------------------------------


### PR DESCRIPTION
Closes #82. Part of epic #84 (catalog → deploy). Builds on #81 (ORAS in the image) — independent code, but #81 is what lets the real bundle be pulled in production.

## Problem
A draft created from a catalog app had an **empty** `composeOverride`, so finalize/deploy had nothing to run — only the CLI's local-compose path worked. `RealCatalogService.getVersionDetail()` already pulled the bundle and had `compose.yaml` on disk, but read only manifest/defaults and **discarded the compose text**; `createDraft()` then set `composeOverride: ''`.

## Change
The full chain to deployment was already wired (`draft.composeOverride` → finalize → `artifacts.composeOverride` → `deployment.ts` writes `compose-override.yml` → materialize → route on `release.ports[0].container`). The only missing link was seeding the draft's compose:

- **`packages/shared/src/index.ts`** — add optional `composeOverride?: string` to `GetCatalogAppVersionDetailResponse` (clients that ignore it are unaffected).
- **`catalog.ts`** — `getVersionDetail()` returns the raw `compose.yaml` as `composeOverride`, read from the same bundle dir the defaults parser uses. Kept inside the existing `try`, so a missing/unreadable compose falls through to the same fallback — no new failure mode.
- **`draft.ts`** — `getDraftDefaults()`/`createDraft()` seed `draft.composeOverride` from the version detail and run the existing `assertComposeParses()` guard (a bad bundle compose fails fast with a 400).
- **`mock-data/catalog.ts`** — representative `composeOverride` for the mock catalog path (nextcloud + generic fallback), host-port-free.

## Tests
- `__tests__/drafts/catalog-compose.test.ts` — `createDraft` seeds `composeOverride`, it flows through finalize into the artifacts, and falls back to `''` when the bundle has none.
- `__tests__/bundles/catalog-compose-override.test.ts` — `RealCatalogService.getVersionDetail` returns the bundle `compose.yaml` (driven via a `data:` URL catalog + staged mock bundle; no ORAS/GHCR).
- `__tests__/integration/catalog-deploy.it.ts` (gated `*.it.ts`, real Docker) — deploys a **catalog-seeded** draft (compose from `getVersionDetail`, not `updateDraft`) and asserts it reaches `running` and that `runtime/traefik/dynamic.yml` routes `<app>.<domain>`. Added to `test:integration`.

## Verification (all green locally)
- `bun run lint` · `bun run typecheck` · `bun run test` (188 server + 123 web, no `.it.ts` collected) · `bun run build`.
- `bun --cwd packages/server test:integration` with Docker up → 3/3 pass (docker-orchestration + smoke-workflow + catalog-deploy); no stray `hola-*` containers/networks afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)