### PR TITLE
feat(server): consume a remote catalog via HOLA_CATALOG_URL (#83)

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -49,6 +49,13 @@ set `HOLA_TOKEN`. Development and test run with auth disabled. See ADR 0001.
 
 ## Deploy an app
 
+The web dashboard browses a remote **catalog** of installable apps, set via
+`HOLA_CATALOG_URL` in `.env` (a fresh install defaults to the official
+`try-hola/apps` catalog; blank it to disable, or point it at your own
+`catalog.json`). With it set, `GET /api/catalog/apps` lists the apps and the web
+catalog renders them. See the catalog notes in the compose
+[README](../packages/compose/README.md#app-catalog).
+
 Through the web dashboard (or the SDK/CLI against the API), an app moves through:
 
 ```

--- a/packages/compose/.env.example
+++ b/packages/compose/.env.example
@@ -16,6 +16,13 @@ HOLA_DOMAIN=app.local.hola
 # Base domain that DEPLOYED apps are exposed under, e.g. gitea.local.hola.
 HOLA_BASE_DOMAIN=local.hola
 
+# --- App catalog ---
+# URL of the catalog.json the server browses for installable apps. Defaults to
+# the official try-hola catalog; point it at your own catalog.json to self-host,
+# or leave it blank to disable the catalog (the install wizard then needs a
+# pasted/uploaded compose).
+HOLA_CATALOG_URL=https://raw.githubusercontent.com/try-hola/apps/main/catalog.json
+
 # --- Authentication (see docs/adr/0001-authentication.md) ---
 # Auth is on by default in production. Set a fixed admin API key here, or leave
 # it blank to have the server generate one on first boot and write it to

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -108,6 +108,25 @@ The server mounts `/var/run/docker.sock` so it can run `docker compose` for depl
 grants control of the host's Docker engine** (effectively root on the host). Run Hola only on a
 host you trust, keep the admin API key secret, and do not expose the API without auth.
 
+## App catalog
+The install wizard browses a remote **catalog** of installable apps. The server fetches the
+catalog JSON from `HOLA_CATALOG_URL`, set in `.env`:
+
+```bash
+# the official catalog (the default in .env.example)
+HOLA_CATALOG_URL=https://raw.githubusercontent.com/try-hola/apps/main/catalog.json
+```
+
+- **Default (turnkey):** `.env.example` ships pointing at the official `try-hola/apps` catalog, so a
+  fresh install shows published apps (e.g. Gitea) out of the box.
+- **Self-host:** point `HOLA_CATALOG_URL` at your own `catalog.json` (same shape; see the
+  [apps repo](https://github.com/try-hola/apps)).
+- **Disable:** leave `HOLA_CATALOG_URL` blank — the catalog is empty and you install by
+  pasting/uploading a Compose file instead.
+
+Apps are pulled from GHCR (`ghcr.io/try-hola/*`) as OCI bundles; the bundle's `compose.yaml`
+becomes the deployment. Pulling requires the package to be **public** (or a registry token).
+
 ## Deploying apps & routing
 When you deploy an app through Hola, the server writes a Traefik router/service for it into
 `/data/runtime/traefik/dynamic.yml`, which Traefik picks up automatically. For Traefik to reach the
@@ -128,5 +147,5 @@ covered by the integration test in issue #19.
 - `docker-compose.yml` — production stack (build, socket, data volume, Traefik file provider).
 - `docker-compose.dev.yml` — opt-in local dev overlay (Bun dev servers, HTTP only); `HOLA_DEV=1`.
 - `../server/Dockerfile`, `../web/Dockerfile`, `../web/nginx.conf` — images.
-- `.env.example` — domains, ports, auth.
+- `.env.example` — domains, ports, auth, catalog URL.
 - `scripts/` — install/up/down/logs/status helpers.

--- a/packages/compose/docker-compose.yml
+++ b/packages/compose/docker-compose.yml
@@ -69,6 +69,9 @@ services:
       - HOLA_API_KEY=${HOLA_API_KEY:-}
       # Base domain that deployed apps are exposed under (e.g. gitea.${HOLA_BASE_DOMAIN}).
       - HOLA_BASE_DOMAIN=${HOLA_BASE_DOMAIN:-local.hola}
+      # Remote app catalog (JSON). The turnkey default lives in .env.example; blank
+      # disables the catalog. See README "App catalog".
+      - HOLA_CATALOG_URL=${HOLA_CATALOG_URL:-}
     volumes:
       # Orchestrate deployments by talking to the host Docker engine.
       # SECURITY: this grants control of the host's Docker - see README.

--- a/packages/server/src/__tests__/bundles/catalog-remote.test.ts
+++ b/packages/server/src/__tests__/bundles/catalog-remote.test.ts
@@ -1,0 +1,79 @@
+/**
+ * RealCatalogService consumes a remote catalog.json (#83)
+ *
+ * The server browses apps from a remote catalog set via HOLA_CATALOG_URL
+ * (catalogConfig.catalogUrl). This verifies listApps/getApp/getVersions resolve
+ * apps from a fetched catalog and that mapApp applies sensible defaults for
+ * sparse entries. Served from a `data:` URL — no network, no ORAS (bundle pulls
+ * only happen in getVersionDetail, which this does not exercise).
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+
+import { catalogConfig } from '../../config/catalog';
+import { RealCatalogService } from '../../services/core/catalog';
+
+// Two apps: gitea (full metadata) + "barebones" (only id+name, to exercise the
+// mapApp defaults: icon 📦, category "apps", empty tags).
+const CATALOG = {
+  apps: [
+    {
+      id: 'gitea',
+      name: 'Gitea',
+      description: 'Self-hosted Git service',
+      icon: '🍵',
+      category: 'apps',
+      tags: ['git'],
+      versions: [{ version: '1.0.0', refs: { oci: 'ghcr.io/try-hola/gitea:1.0.0' } }],
+    },
+    {
+      id: 'barebones',
+      name: 'Barebones',
+      versions: [{ version: '2.1.0', refs: { oci: 'ghcr.io/try-hola/barebones:2.1.0' } }],
+    },
+  ],
+};
+
+function dataUrl(obj: unknown): string {
+  return 'data:application/json,' + encodeURIComponent(JSON.stringify(obj));
+}
+
+describe('RealCatalogService remote catalog (#83)', () => {
+  let prevCatalogUrl: string | undefined;
+
+  beforeEach(() => {
+    prevCatalogUrl = catalogConfig.catalogUrl;
+    Object.assign(catalogConfig, { catalogUrl: dataUrl(CATALOG) });
+  });
+
+  afterEach(() => {
+    Object.assign(catalogConfig, { catalogUrl: prevCatalogUrl });
+  });
+
+  test('listApps returns the catalog apps, mapped with defaults', async () => {
+    const svc = new RealCatalogService();
+    const res = await svc.listApps({ page: 1, limit: 12 });
+
+    expect(res.total).toBe(2);
+    const gitea = res.items.find(a => a.id === 'gitea');
+    expect(gitea).toMatchObject({ name: 'Gitea', icon: '🍵', category: 'apps', tags: ['git'] });
+
+    // Sparse entry falls back to mapApp defaults.
+    const bare = res.items.find(a => a.id === 'barebones');
+    expect(bare).toMatchObject({ name: 'Barebones', icon: '📦', category: 'apps', tags: [] });
+    expect(bare?.description).toBe('');
+  });
+
+  test('getApp / getVersions resolve a catalog app', async () => {
+    const svc = new RealCatalogService();
+
+    const app = await svc.getApp('gitea');
+    expect(app.id).toBe('gitea');
+    expect(app.versions).toContain('1.0.0');
+
+    const versions = await svc.getVersions('gitea');
+    expect(versions.items.map(v => v.version)).toContain('1.0.0');
+
+    await expect(svc.getApp('does-not-exist')).rejects.toThrow('APP_NOT_FOUND');
+  });
+});


### PR DESCRIPTION
Closes #83. Completes epic #84 (catalog → deploy) together with #81 + #82 and try-hola/apps#2.

## Problem
The server already reads `HOLA_CATALOG_URL` (`config/catalog.ts:31`) and wires `RealCatalogService` through every catalog route (with a mock fallback), but the var was never passed through the compose stack, defaulted, or documented — so production shipped with an **inert (empty)** catalog.

## Change (config + docs + test; the service plumbing already existed)
- **`packages/compose/docker-compose.yml`** — pass `HOLA_CATALOG_URL=${HOLA_CATALOG_URL:-}` to the `server` service.
- **`packages/compose/.env.example`** — new `# --- App catalog ---` section defaulting to the official catalog `https://raw.githubusercontent.com/try-hola/apps/main/catalog.json`. `scripts/install.sh` copies `.env.example` → `.env`, so a fresh install is **turnkey** (apps appear out of the box); blank it to disable, or point at your own `catalog.json`.
- **Docs** — `packages/compose/README.md` "App catalog" section + a note in `docs/OPERATIONS.md`.
- **Test** — `__tests__/bundles/catalog-remote.test.ts`: `RealCatalogService` against a fixture catalog (`data:` URL) — `listApps` maps apps (incl. `mapApp` defaults for sparse entries) and `getApp`/`getVersions` resolve. Pure unit, no Docker/ORAS.

## Verification (all green)
- `docker compose config` shows `HOLA_CATALOG_URL` in the server env.
- `bun run lint` · `bun run typecheck` · `bun run test` (190 server + 123 web) · `bun run build`.
- Live: the official catalog is hosted and resolves — `curl https://raw.githubusercontent.com/try-hola/apps/main/catalog.json` lists Gitea (`ghcr.io/try-hola/gitea:1.0.0`), published by try-hola/apps#2.

## Note (manual, tracked)
For credential-free bundle pulls, `ghcr.io/try-hola/gitea` must be set to **public** (GHCR package settings) — otherwise the server needs a registry token (per #81). Flagged in try-hola/apps#3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)