### PR TITLE
feat(server): auth provisioner foundation + native-oidc (#90)

### DIFF
--- a/packages/server/src/__tests__/contract/real-services-contract.test.ts
+++ b/packages/server/src/__tests__/contract/real-services-contract.test.ts
@@ -21,6 +21,7 @@ import { join } from 'path';
 import { fileURLToPath } from 'url';
 
 import { RealDeploymentService } from '../../services/core/deployment';
+import { MockProvisionerService } from '../../services/core/provisioner';
 import { RealDraftService } from '../../services/core/draft';
 import { RealStorageService } from '../../services/core/storage';
 import { RealRoutingService } from '../../services/core/routing';
@@ -63,7 +64,7 @@ function makeSystem(dataRoot: string) {
   const systemMonitoring = new MockSystemMonitoringService();
   const validation = new RealValidationService(docker, systemMonitoring, storage, routing);
   const drafts = new RealDraftService(storage, makeCatalog(), validation);
-  const deployments = new RealDeploymentService(storage, jobs, docker, drafts, routing, logging);
+  const deployments = new RealDeploymentService(storage, jobs, docker, drafts, routing, logging, new MockProvisionerService());
   return { storage, database, jobs, routing, docker, validation, drafts, deployments };
 }
 

--- a/packages/server/src/__tests__/deployments/auth-provisioning.test.ts
+++ b/packages/server/src/__tests__/deployments/auth-provisioning.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Auth provisioning lifecycle tests (epic #89, PR1).
+ *
+ * Verifies that when a catalog app declares a `native-oidc` auth block, the
+ * deploy lifecycle provisions an OIDC client, injects the returned env into the
+ * materialized compose (ingress service), persists the provisioned ref, reuses
+ * it on re-deploy, tears it down on delete (but not on stop), and fails the
+ * deploy cleanly when provisioning fails. Uses a spy provisioner — no network.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { parse } from 'yaml';
+
+import { RealDeploymentService } from '../../services/core/deployment';
+import { RealDraftService } from '../../services/core/draft';
+import { RealStorageService } from '../../services/core/storage';
+import { RealRoutingService } from '../../services/core/routing';
+import { RealDatabaseService } from '../../services/core/database';
+import { RealLoggingService } from '../../services/core/logging';
+import { RealJobService } from '../../services/core/jobs';
+import { MockDockerService, type DockerService } from '../../services/core/docker';
+import { ProvisioningError } from '../../middleware/error-mapping';
+import type {
+  ProvisionerService,
+  ProvisionInput,
+  ProvisionResult,
+  DeprovisionInput,
+} from '../../services/core/provisioner';
+import type { AppAuthConfig } from '@hola/shared';
+
+type CatalogArg = ConstructorParameters<typeof RealDraftService>[1];
+type ValidationArg = ConstructorParameters<typeof RealDraftService>[2];
+
+const OIDC_AUTH: AppAuthConfig = {
+  mode: 'native-oidc',
+  oidc: {
+    redirectPath: '/user/oauth2/authentik/callback',
+    scopes: ['openid', 'profile', 'email'],
+    env: {
+      issuer: 'GITEA_OIDC_ISSUER',
+      clientId: 'GITEA_OIDC_CLIENT_ID',
+      clientSecret: 'GITEA_OIDC_CLIENT_SECRET',
+      redirectUri: 'GITEA_OIDC_REDIRECT',
+    },
+  },
+};
+
+function makeCatalog(auth?: AppAuthConfig): CatalogArg {
+  return {
+    getApp: async (appId: string) => ({ id: appId, name: 'Gitea', icon: '🍵' }),
+    getVersionDetail: async () => ({
+      defaultEnv: [],
+      defaults: { ports: [{ host: 3000, container: 3000, protocol: 'tcp' as const }], volumes: [] },
+      auth,
+    }),
+  } as unknown as CatalogArg;
+}
+
+function makeValidation(): ValidationArg {
+  return {
+    validateDraft: async () => ({ ok: true, errors: [], warnings: [] }),
+    preflightCheck: async () => ({ ok: true, checks: [] }),
+  } as unknown as ValidationArg;
+}
+
+const COMPOSE = 'services:\n  gitea:\n    image: gitea/gitea:1.21.0\n';
+
+/** Records every provision/deprovision call; can be told to fail the next provision. */
+class SpyProvisioner implements ProvisionerService {
+  provisions: ProvisionInput[] = [];
+  deprovisions: DeprovisionInput[] = [];
+  failNext = false;
+
+  async healthCheck() {
+    return { healthy: true, lastCheck: new Date() };
+  }
+
+  async provision(input: ProvisionInput): Promise<ProvisionResult> {
+    this.provisions.push(input);
+    if (this.failNext) throw new ProvisioningError('simulated provisioning failure');
+    if (input.mode === 'native-oidc' && input.oidc) {
+      const names = input.oidc.env;
+      return {
+        env: {
+          [names.issuer]: 'https://auth.example.com/application/o/gitea-x/',
+          [names.clientId]: 'cid-123',
+          [names.clientSecret]: 'csecret-456',
+          [names.redirectUri]: `https://${input.host}${input.oidc.redirectPath}`,
+        },
+        ref: input.existingRef ?? { mode: 'native-oidc', providerPk: 42, applicationSlug: 'gitea-x', clientId: 'cid-123' },
+      };
+    }
+    return { env: {}, ref: { mode: input.mode } };
+  }
+
+  async deprovision(input: DeprovisionInput): Promise<void> {
+    this.deprovisions.push(input);
+  }
+}
+
+async function waitForJob(jobs: RealJobService, id: string, timeoutMs = 5000) {
+  const start = Date.now();
+  for (;;) {
+    const job = await jobs.getJob(id);
+    if (job && (job.status === 'completed' || job.status === 'failed')) return job;
+    if (Date.now() - start > timeoutMs) throw new Error(`Job ${id} did not finish (last status: ${job?.status})`);
+    await new Promise(r => setTimeout(r, 10));
+  }
+}
+
+describe('Auth provisioning lifecycle', () => {
+  let dataRoot: string;
+
+  beforeEach(async () => {
+    dataRoot = await mkdtemp(join(tmpdir(), 'hola-auth-'));
+  });
+
+  afterEach(async () => {
+    await rm(dataRoot, { recursive: true, force: true });
+  });
+
+  function makeSystem(opts: { auth?: AppAuthConfig; provisioner?: ProvisionerService; docker?: DockerService } = {}) {
+    const storage = new RealStorageService({ holaDir: dataRoot });
+    const database = new RealDatabaseService(storage);
+    const logging = new RealLoggingService(storage);
+    const jobs = new RealJobService(database, logging);
+    const routing = new RealRoutingService(storage, { baseDomain: 'local.hola' });
+    const drafts = new RealDraftService(storage, makeCatalog(opts.auth), makeValidation());
+    const provisioner = opts.provisioner ?? new SpyProvisioner();
+    const docker = opts.docker ?? new MockDockerService();
+    const deployments = new RealDeploymentService(storage, jobs, docker, drafts, routing, logging, provisioner);
+    return { storage, jobs, drafts, deployments, provisioner };
+  }
+
+  async function finalizedDraft(drafts: RealDraftService): Promise<string> {
+    const { draftId } = await drafts.createDraft({ appId: 'gitea', version: '1.0.0' });
+    await drafts.updateDraft(draftId, { composeOverride: COMPOSE });
+    await drafts.finalizeDraft(draftId);
+    return draftId;
+  }
+
+  async function readMaterializedEnv(storage: RealStorageService, deploymentId: string): Promise<Record<string, unknown>> {
+    const raw = await storage.readFileAsString(`deployments/${deploymentId}/runtime/docker-compose.yml`);
+    const doc = parse(raw) as { services?: Record<string, { environment?: Record<string, unknown> }> };
+    return doc.services?.gitea?.environment ?? {};
+  }
+
+  test('native-oidc: provisions, injects env into the ingress service, persists the ref', async () => {
+    const sys = makeSystem({ auth: OIDC_AUTH });
+    const spy = sys.provisioner as SpyProvisioner;
+
+    const created = await sys.deployments.createFromDraft({ draftId: await finalizedDraft(sys.drafts), name: 'gitea' });
+    const job = await waitForJob(sys.jobs, created.jobId!);
+    expect(job.status).toBe('completed');
+
+    // Provisioner was called once with the app's host + oidc mapping.
+    expect(spy.provisions).toHaveLength(1);
+    expect(spy.provisions[0].mode).toBe('native-oidc');
+    expect(spy.provisions[0].host).toBe('gitea.local.hola');
+    expect(spy.provisions[0].existingRef).toBeUndefined();
+
+    // Env was injected onto the ingress service under the app's expected names.
+    const env = await readMaterializedEnv(sys.storage, created.deploymentId);
+    expect(env.GITEA_OIDC_CLIENT_ID).toBe('cid-123');
+    expect(env.GITEA_OIDC_CLIENT_SECRET).toBe('csecret-456');
+    expect(env.GITEA_OIDC_REDIRECT).toBe('https://gitea.local.hola/user/oauth2/authentik/callback');
+    expect(env.GITEA_OIDC_ISSUER).toBe('https://auth.example.com/application/o/gitea-x/');
+
+    // The provisioned ref is persisted on the deployment metadata.
+    const meta = JSON.parse(await sys.storage.readFileAsString(`deployments/${created.deploymentId}/metadata.json`));
+    expect(meta.metadata.auth.mode).toBe('native-oidc');
+    expect(meta.metadata.auth.ref.providerPk).toBe(42);
+  });
+
+  test('no auth block: deploys normally with no provisioning and no injected env', async () => {
+    const sys = makeSystem({ auth: undefined });
+    const spy = sys.provisioner as SpyProvisioner;
+
+    const created = await sys.deployments.createFromDraft({ draftId: await finalizedDraft(sys.drafts), name: 'gitea' });
+    expect((await waitForJob(sys.jobs, created.jobId!)).status).toBe('completed');
+
+    expect(spy.provisions).toHaveLength(0);
+    expect(await readMaterializedEnv(sys.storage, created.deploymentId)).toEqual({});
+  });
+
+  test('re-deploy reuses the existing ref (idempotent, keyed on deploymentId)', async () => {
+    const sys = makeSystem({ auth: OIDC_AUTH });
+    const spy = sys.provisioner as SpyProvisioner;
+
+    const created = await sys.deployments.createFromDraft({ draftId: await finalizedDraft(sys.drafts), name: 'gitea' });
+    await waitForJob(sys.jobs, created.jobId!);
+
+    // A restart re-runs the deploy path and must reuse the same client.
+    const restart = await sys.deployments.executeAction(created.deploymentId, { action: 'restart' });
+    await waitForJob(sys.jobs, restart.jobId!);
+
+    expect(spy.provisions).toHaveLength(2);
+    expect(spy.provisions[1].existingRef?.providerPk).toBe(42);
+  });
+
+  test('deprovision runs on delete but not on stop', async () => {
+    const sys = makeSystem({ auth: OIDC_AUTH });
+    const spy = sys.provisioner as SpyProvisioner;
+
+    const created = await sys.deployments.createFromDraft({ draftId: await finalizedDraft(sys.drafts), name: 'gitea' });
+    await waitForJob(sys.jobs, created.jobId!);
+
+    // Stop does NOT tear down the auth client.
+    const stop = await sys.deployments.executeAction(created.deploymentId, { action: 'stop' });
+    await waitForJob(sys.jobs, stop.jobId!);
+    expect(spy.deprovisions).toHaveLength(0);
+
+    // Delete DOES, with the persisted ref.
+    await sys.deployments.deleteDeployment(created.deploymentId);
+    expect(spy.deprovisions).toHaveLength(1);
+    expect(spy.deprovisions[0].ref?.providerPk).toBe(42);
+  });
+
+  test('provisioning failure fails the deploy before any container starts', async () => {
+    const spy = new SpyProvisioner();
+    spy.failNext = true;
+    const sys = makeSystem({ auth: OIDC_AUTH, provisioner: spy });
+
+    const created = await sys.deployments.createFromDraft({ draftId: await finalizedDraft(sys.drafts), name: 'gitea' });
+    const job = await waitForJob(sys.jobs, created.jobId!);
+
+    expect(job.status).toBe('failed');
+    expect((await sys.deployments.getDeployment(created.deploymentId)).status).toBe('error');
+    // No compose was materialized (provisioning threw first).
+    expect(await sys.storage.fileExists(`deployments/${created.deploymentId}/runtime/docker-compose.yml`)).toBe(false);
+  });
+
+  test('delete tolerates a deprovision failure (orphan logged, delete proceeds)', async () => {
+    const failingDeprovision = new (class extends SpyProvisioner {
+      override async deprovision(input: DeprovisionInput): Promise<void> {
+        await super.deprovision(input);
+        throw new ProvisioningError('simulated deprovision failure');
+      }
+    })();
+    const sys = makeSystem({ auth: OIDC_AUTH, provisioner: failingDeprovision });
+
+    const created = await sys.deployments.createFromDraft({ draftId: await finalizedDraft(sys.drafts), name: 'gitea' });
+    await waitForJob(sys.jobs, created.jobId!);
+
+    await sys.deployments.deleteDeployment(created.deploymentId);
+    // Deletion completed despite the deprovision error.
+    expect(failingDeprovision.deprovisions).toHaveLength(1);
+    await expect(sys.deployments.getDeployment(created.deploymentId)).rejects.toThrow();
+  });
+});

--- a/packages/server/src/__tests__/deployments/lifecycle.test.ts
+++ b/packages/server/src/__tests__/deployments/lifecycle.test.ts
@@ -14,6 +14,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 
 import { RealDeploymentService } from '../../services/core/deployment';
+import { MockProvisionerService } from '../../services/core/provisioner';
 import { RealDraftService } from '../../services/core/draft';
 import { RealStorageService } from '../../services/core/storage';
 import { RealRoutingService } from '../../services/core/routing';
@@ -72,7 +73,7 @@ describe('Deployment lifecycle (real orchestration wiring)', () => {
     const jobs = new RealJobService(database, logging);
     const routing = new RealRoutingService(storage, { baseDomain: 'local.hola' });
     const drafts = new RealDraftService(storage, makeCatalog(), makeValidation());
-    const deployments = new RealDeploymentService(storage, jobs, docker, drafts, routing, logging);
+    const deployments = new RealDeploymentService(storage, jobs, docker, drafts, routing, logging, new MockProvisionerService());
     return { storage, jobs, logging, drafts, deployments };
   }
 

--- a/packages/server/src/__tests__/deployments/persistence.test.ts
+++ b/packages/server/src/__tests__/deployments/persistence.test.ts
@@ -16,6 +16,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 
 import { RealDeploymentService } from '../../services/core/deployment';
+import { MockProvisionerService } from '../../services/core/provisioner';
 import { RealDraftService } from '../../services/core/draft';
 import { RealStorageService } from '../../services/core/storage';
 import { RealRoutingService } from '../../services/core/routing';
@@ -90,7 +91,7 @@ describe('Deployment persistence (real service)', () => {
     const storage = new RealStorageService({ holaDir: dataRoot });
     const drafts = new RealDraftService(storage, makeCatalog(), makeValidation());
     const routing = new RealRoutingService(storage, { baseDomain: 'local.hola' });
-    const deployments = new RealDeploymentService(storage, makeJobs(), noDocker, drafts, routing, noLogging);
+    const deployments = new RealDeploymentService(storage, makeJobs(), noDocker, drafts, routing, noLogging, new MockProvisionerService());
     return { storage, drafts, routing, deployments };
   }
 

--- a/packages/server/src/__tests__/helpers/real-system.ts
+++ b/packages/server/src/__tests__/helpers/real-system.ts
@@ -19,7 +19,9 @@ import { RealJobService } from '../../services/core/jobs';
 import { RealValidationService } from '../../services/core/validation';
 import { MockDockerService } from '../../services/core/docker';
 import { MockSystemMonitoringService } from '../../services/core/system-monitoring';
+import { MockProvisionerService } from '../../services/core/provisioner';
 import type { DockerService } from '../../services/core/docker';
+import type { ProvisionerService } from '../../services/core/provisioner';
 
 type CatalogArg = ConstructorParameters<typeof RealDraftService>[1];
 
@@ -50,11 +52,16 @@ export interface RealSystem {
   docker: DockerService;
   validation: RealValidationService;
   drafts: RealDraftService;
+  provisioner: ProvisionerService;
   deployments: RealDeploymentService;
 }
 
 /** Build a full real-service system rooted at `dataRoot`, with the given Docker engine. */
-export function makeRealSystem(dataRoot: string, docker: DockerService = new MockDockerService()): RealSystem {
+export function makeRealSystem(
+  dataRoot: string,
+  docker: DockerService = new MockDockerService(),
+  provisioner: ProvisionerService = new MockProvisionerService()
+): RealSystem {
   const storage = new RealStorageService({ holaDir: dataRoot });
   const database = new RealDatabaseService(storage);
   const logging = new RealLoggingService(storage);
@@ -63,8 +70,8 @@ export function makeRealSystem(dataRoot: string, docker: DockerService = new Moc
   const systemMonitoring = new MockSystemMonitoringService();
   const validation = new RealValidationService(docker, systemMonitoring, storage, routing);
   const drafts = new RealDraftService(storage, makeStubCatalog(), validation);
-  const deployments = new RealDeploymentService(storage, jobs, docker, drafts, routing, logging);
-  return { storage, database, jobs, routing, docker, validation, drafts, deployments };
+  const deployments = new RealDeploymentService(storage, jobs, docker, drafts, routing, logging, provisioner);
+  return { storage, database, jobs, routing, docker, validation, drafts, provisioner, deployments };
 }
 
 /** Poll a job to a terminal state. */

--- a/packages/server/src/__tests__/integration/catalog-deploy.it.ts
+++ b/packages/server/src/__tests__/integration/catalog-deploy.it.ts
@@ -21,6 +21,7 @@ import { join } from 'path';
 import { fileURLToPath } from 'url';
 
 import { RealDeploymentService } from '../../services/core/deployment';
+import { MockProvisionerService } from '../../services/core/provisioner';
 import { RealDraftService } from '../../services/core/draft';
 import { RealStorageService } from '../../services/core/storage';
 import { RealRoutingService } from '../../services/core/routing';
@@ -156,7 +157,7 @@ describe.skipIf(!dockerOk)('Catalog → deploy (real daemon)', () => {
       const jobs = new RealJobService(database, logging);
       const routing = new RealRoutingService(storage, { baseDomain: 'local.hola' });
       const drafts = new RealDraftService(storage, makeCatalog(compose), makeValidation());
-      const deployments = new RealDeploymentService(storage, jobs, docker, drafts, routing, logging);
+      const deployments = new RealDeploymentService(storage, jobs, docker, drafts, routing, logging, new MockProvisionerService());
 
       // Catalog-seeded draft: NO updateDraft of composeOverride — it must arrive
       // from getVersionDetail via createDraft (the #82 change).

--- a/packages/server/src/__tests__/integration/docker-orchestration.it.ts
+++ b/packages/server/src/__tests__/integration/docker-orchestration.it.ts
@@ -27,6 +27,7 @@ import { join } from 'path';
 import { fileURLToPath } from 'url';
 
 import { RealDeploymentService } from '../../services/core/deployment';
+import { MockProvisionerService } from '../../services/core/provisioner';
 import { RealDraftService } from '../../services/core/draft';
 import { RealStorageService } from '../../services/core/storage';
 import { RealRoutingService } from '../../services/core/routing';
@@ -178,7 +179,7 @@ describe.skipIf(!dockerOk)('Docker/Compose orchestration (real daemon)', () => {
     const jobs = new RealJobService(database, logging);
     const routing = new RealRoutingService(storage, { baseDomain: 'local.hola' });
     const drafts = new RealDraftService(storage, makeCatalog(), makeValidation());
-    const deployments = new RealDeploymentService(storage, jobs, docker, drafts, routing, logging);
+    const deployments = new RealDeploymentService(storage, jobs, docker, drafts, routing, logging, new MockProvisionerService());
     return { storage, jobs, logging, drafts, deployments };
   }
 

--- a/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
+++ b/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Authentik provisioner contract tests (epic #89, PR1).
+ *
+ * Exercises RealAuthentikProvisionerService against a mocked `fetch`, asserting
+ * it speaks the documented Authentik REST endpoints: resolves the default flows,
+ * creates an OAuth2 provider with Hola-generated client_id/secret and a strict
+ * redirect URI, links an application, returns env under the app's expected names,
+ * and tears both down on deprovision. No live Authentik.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { RealAuthentikProvisionerService } from '../../services/core/provisioner';
+import type { AuthConfig } from '../../config/auth';
+
+const CONFIG: AuthConfig = {
+  mode: 'authentik',
+  authentikUrl: 'http://authentik-server:9000',
+  authentikPublicUrl: 'https://auth.example.com',
+  authentikApiToken: 'test-token',
+  fetchTimeoutMs: 5000,
+};
+
+interface RecordedCall {
+  method: string;
+  path: string;
+  body?: unknown;
+  authorization?: string;
+}
+
+let calls: RecordedCall[] = [];
+let originalFetch: typeof globalThis.fetch;
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+}
+
+/** Install a fetch that answers the Authentik endpoints the provisioner calls. */
+function installFetch(handler?: (call: RecordedCall) => Response | undefined) {
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = new URL(typeof input === 'string' ? input : input.toString());
+    const method = (init?.method ?? 'GET').toUpperCase();
+    const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+    const authorization = (init?.headers as Record<string, string> | undefined)?.Authorization;
+    const call: RecordedCall = { method, path: url.pathname + url.search, body, authorization };
+    calls.push(call);
+
+    const override = handler?.(call);
+    if (override) return override;
+
+    // Default happy-path responses.
+    if (method === 'GET' && url.pathname.startsWith('/api/v3/flows/instances/')) {
+      return json({ pk: `flow-${url.pathname.split('/').slice(-2, -1)[0]}` });
+    }
+    if (method === 'GET' && url.pathname.startsWith('/api/v3/propertymappings/provider/scope/')) {
+      return json({ results: [{ pk: `scope-${url.searchParams.get('scope_name')}` }] });
+    }
+    if (method === 'POST' && url.pathname === '/api/v3/providers/oauth2/') {
+      return json({ pk: 42, client_id: body.client_id, client_secret: body.client_secret }, 201);
+    }
+    if (method === 'POST' && url.pathname === '/api/v3/core/applications/') {
+      return json({ pk: 7, slug: body.slug }, 201);
+    }
+    if (method === 'DELETE') {
+      return new Response(null, { status: 204 });
+    }
+    return new Response('unexpected', { status: 500 });
+  }) as typeof globalThis.fetch;
+}
+
+const OIDC_INPUT = {
+  deploymentId: 'dep-abcdef0123456789',
+  appName: 'gitea',
+  mode: 'native-oidc' as const,
+  host: 'gitea.example.com',
+  oidc: {
+    redirectPath: '/user/oauth2/authentik/callback',
+    scopes: ['openid', 'profile', 'email'],
+    env: {
+      issuer: 'GITEA_OIDC_ISSUER',
+      clientId: 'GITEA_OIDC_CLIENT_ID',
+      clientSecret: 'GITEA_OIDC_CLIENT_SECRET',
+      redirectUri: 'GITEA_OIDC_REDIRECT',
+    },
+  },
+};
+
+describe('RealAuthentikProvisionerService (REST contract)', () => {
+  beforeEach(() => {
+    calls = [];
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test('native-oidc provision creates a provider + application and returns mapped env', async () => {
+    installFetch();
+    const svc = new RealAuthentikProvisionerService(CONFIG);
+
+    const result = await svc.provision(OIDC_INPUT);
+
+    // The provider POST carried Hola-generated credentials and a strict redirect URI.
+    const providerCall = calls.find(c => c.method === 'POST' && c.path === '/api/v3/providers/oauth2/')!;
+    expect(providerCall).toBeDefined();
+    expect(providerCall.authorization).toBe('Bearer test-token');
+    const pbody = providerCall.body as Record<string, unknown>;
+    expect(pbody.client_type).toBe('confidential');
+    expect(typeof pbody.client_id).toBe('string');
+    expect(typeof pbody.client_secret).toBe('string');
+    expect(pbody.redirect_uris).toEqual([
+      { matching_mode: 'strict', url: 'https://gitea.example.com/user/oauth2/authentik/callback' },
+    ]);
+    expect(pbody.authorization_flow).toBeTruthy();
+    expect(pbody.invalidation_flow).toBeTruthy();
+
+    // An application was linked to the provider pk.
+    const appCall = calls.find(c => c.method === 'POST' && c.path === '/api/v3/core/applications/')!;
+    expect(appCall).toBeDefined();
+    expect((appCall.body as Record<string, unknown>).provider).toBe(42);
+
+    // Returned env is keyed by the app's expected names and matches the generated creds.
+    expect(result.env.GITEA_OIDC_CLIENT_ID).toBe(pbody.client_id);
+    expect(result.env.GITEA_OIDC_CLIENT_SECRET).toBe(pbody.client_secret);
+    expect(result.env.GITEA_OIDC_REDIRECT).toBe('https://gitea.example.com/user/oauth2/authentik/callback');
+    expect(result.env.GITEA_OIDC_ISSUER).toBe(`https://auth.example.com/application/o/${result.ref.applicationSlug}/`);
+
+    // The ref carries what teardown needs.
+    expect(result.ref.mode).toBe('native-oidc');
+    expect(result.ref.providerPk).toBe(42);
+    expect(result.ref.applicationSlug).toBeTruthy();
+  });
+
+  test('rolls back the provider if application creation fails', async () => {
+    installFetch(call => {
+      if (call.method === 'POST' && call.path === '/api/v3/core/applications/') {
+        return new Response('boom', { status: 400 });
+      }
+      return undefined;
+    });
+    const svc = new RealAuthentikProvisionerService(CONFIG);
+
+    await expect(svc.provision(OIDC_INPUT)).rejects.toThrow();
+    // The orphaned provider was deleted.
+    expect(calls.some(c => c.method === 'DELETE' && c.path === '/api/v3/providers/oauth2/42/')).toBe(true);
+  });
+
+  test('deprovision deletes the application then the provider', async () => {
+    installFetch();
+    const svc = new RealAuthentikProvisionerService(CONFIG);
+
+    await svc.deprovision({
+      deploymentId: 'dep-abcdef0123456789',
+      ref: { mode: 'native-oidc', providerPk: 42, applicationSlug: 'gitea-dep-abcd' },
+    });
+
+    const deletes = calls.filter(c => c.method === 'DELETE').map(c => c.path);
+    expect(deletes).toContain('/api/v3/core/applications/gitea-dep-abcd/');
+    expect(deletes).toContain('/api/v3/providers/oauth2/42/');
+  });
+
+  test('deprovision tolerates an already-deleted resource (404)', async () => {
+    installFetch(call => (call.method === 'DELETE' ? new Response('gone', { status: 404 }) : undefined));
+    const svc = new RealAuthentikProvisionerService(CONFIG);
+
+    await expect(
+      svc.deprovision({ deploymentId: 'x', ref: { mode: 'native-oidc', providerPk: 99, applicationSlug: 'gone' } })
+    ).resolves.toBeUndefined();
+  });
+
+  test('forward-auth and native-ldap are not implemented yet', async () => {
+    installFetch();
+    const svc = new RealAuthentikProvisionerService(CONFIG);
+    await expect(svc.provision({ ...OIDC_INPUT, mode: 'forward-auth', oidc: undefined })).rejects.toThrow(/not implemented/);
+    await expect(svc.provision({ ...OIDC_INPUT, mode: 'native-ldap', oidc: undefined })).rejects.toThrow(/not implemented/);
+  });
+});

--- a/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
+++ b/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
@@ -120,8 +120,8 @@ describe('RealAuthentikProvisionerService (REST contract)', () => {
     expect((appCall.body as Record<string, unknown>).provider).toBe(42);
 
     // Returned env is keyed by the app's expected names and matches the generated creds.
-    expect(result.env.GITEA_OIDC_CLIENT_ID).toBe(pbody.client_id);
-    expect(result.env.GITEA_OIDC_CLIENT_SECRET).toBe(pbody.client_secret);
+    expect(result.env.GITEA_OIDC_CLIENT_ID).toBe(pbody.client_id as string);
+    expect(result.env.GITEA_OIDC_CLIENT_SECRET).toBe(pbody.client_secret as string);
     expect(result.env.GITEA_OIDC_REDIRECT).toBe('https://gitea.example.com/user/oauth2/authentik/callback');
     expect(result.env.GITEA_OIDC_ISSUER).toBe(`https://auth.example.com/application/o/${result.ref.applicationSlug}/`);
 

--- a/packages/server/src/__tests__/provisioner/manifest-auth.test.ts
+++ b/packages/server/src/__tests__/provisioner/manifest-auth.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Unit tests for coerceManifestAuth (epic #89, PR1).
+ *
+ * The catalog drops unknown manifest fields, so the `auth` block is coerced
+ * defensively: well-formed blocks pass through, malformed ones degrade to
+ * undefined (treated as no-auth) rather than throwing — a sloppy manifest must
+ * never break catalog browsing or half-provision an app.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { coerceManifestAuth } from '../../services/core/manifest-auth';
+
+describe('coerceManifestAuth', () => {
+  test('returns undefined for missing/non-object input', () => {
+    expect(coerceManifestAuth(undefined)).toBeUndefined();
+    expect(coerceManifestAuth(null)).toBeUndefined();
+    expect(coerceManifestAuth('native-oidc')).toBeUndefined();
+    expect(coerceManifestAuth([])).toBeUndefined();
+  });
+
+  test('returns undefined for an unknown mode', () => {
+    expect(coerceManifestAuth({ mode: 'magic' })).toBeUndefined();
+  });
+
+  test('coerces mode: none', () => {
+    expect(coerceManifestAuth({ mode: 'none' })).toEqual({ mode: 'none' });
+  });
+
+  test('coerces a complete native-oidc block', () => {
+    const result = coerceManifestAuth({
+      mode: 'native-oidc',
+      oidc: {
+        redirectPath: '/cb',
+        scopes: ['openid', 'email'],
+        env: { issuer: 'ISS', clientId: 'CID', clientSecret: 'SEC', redirectUri: 'RU' },
+      },
+      fallback: 'forward-auth',
+    });
+    expect(result).toEqual({
+      mode: 'native-oidc',
+      oidc: {
+        redirectPath: '/cb',
+        scopes: ['openid', 'email'],
+        env: { issuer: 'ISS', clientId: 'CID', clientSecret: 'SEC', redirectUri: 'RU' },
+      },
+      fallback: 'forward-auth',
+    });
+  });
+
+  test('native-oidc with an incomplete env mapping degrades to undefined', () => {
+    expect(
+      coerceManifestAuth({
+        mode: 'native-oidc',
+        oidc: { redirectPath: '/cb', scopes: ['openid'], env: { issuer: 'ISS', clientId: 'CID' } },
+      })
+    ).toBeUndefined();
+  });
+
+  test('native-oidc missing the oidc block degrades to undefined', () => {
+    expect(coerceManifestAuth({ mode: 'native-oidc' })).toBeUndefined();
+  });
+
+  test('coerces native-ldap and forward-auth blocks', () => {
+    expect(
+      coerceManifestAuth({
+        mode: 'native-ldap',
+        ldap: { env: { host: 'H', port: 'P', bindDn: 'B', bindPassword: 'PW', baseDn: 'BD' } },
+      })
+    ).toEqual({
+      mode: 'native-ldap',
+      ldap: { env: { host: 'H', port: 'P', bindDn: 'B', bindPassword: 'PW', baseDn: 'BD' } },
+    });
+
+    expect(coerceManifestAuth({ mode: 'forward-auth' })).toEqual({ mode: 'forward-auth', forwardAuth: {} });
+    expect(coerceManifestAuth({ mode: 'forward-auth', forwardAuth: { allowedGroups: ['admins'] } })).toEqual({
+      mode: 'forward-auth',
+      forwardAuth: { allowedGroups: ['admins'] },
+    });
+  });
+});

--- a/packages/server/src/config/auth.ts
+++ b/packages/server/src/config/auth.ts
@@ -1,0 +1,53 @@
+// Auth / SSO platform configuration (MVP pt2).
+//
+// Hola provisions per-app auth artifacts (OIDC clients, forward-auth providers,
+// LDAP bind accounts) against an auth platform when a catalog app declares an
+// `auth` block. Authentik is the default platform; the lightweight Authelia+LLDAP
+// alternative is tracked in try-hola/hola#88 and would implement the same
+// ProvisionerService contract behind a different `mode`.
+//
+// When `mode` is `none` the factory wires a no-op MockProvisionerService, so apps
+// that declare `auth` simply deploy without auth wiring (and a warning is logged).
+
+export type AuthBackendMode = 'none' | 'authentik';
+
+export interface AuthConfig {
+  /** Which auth platform Hola provisions against. */
+  mode: AuthBackendMode;
+  /**
+   * Internal base URL the server uses to reach Authentik's API
+   * (e.g. `http://authentik-server:9000`). No trailing slash.
+   */
+  authentikUrl?: string;
+  /**
+   * Browser-facing base URL of Authentik used to build OIDC issuer URLs
+   * (e.g. `https://auth.example.com`). No trailing slash. Falls back to
+   * `authentikUrl` when unset.
+   */
+  authentikPublicUrl?: string;
+  /** Long-lived API token (Bearer) the provisioner authenticates with. */
+  authentikApiToken?: string;
+  /** Network timeout for Authentik API calls. */
+  fetchTimeoutMs: number;
+}
+
+function stripTrailingSlash(url: string | undefined): string | undefined {
+  if (!url) return undefined;
+  return url.replace(/\/+$/, '');
+}
+
+export const defaultAuthConfig: AuthConfig = {
+  mode: (process.env.HOLA_AUTH_MODE as AuthBackendMode) || 'none',
+  authentikUrl: stripTrailingSlash(process.env.HOLA_AUTHENTIK_URL),
+  authentikPublicUrl:
+    stripTrailingSlash(process.env.HOLA_AUTHENTIK_PUBLIC_URL) ||
+    stripTrailingSlash(process.env.HOLA_AUTHENTIK_URL),
+  authentikApiToken: process.env.HOLA_AUTHENTIK_API_TOKEN || undefined,
+  fetchTimeoutMs: Number(process.env.HOLA_AUTHENTIK_FETCH_TIMEOUT_MS) || 5000,
+};
+
+export function loadAuthConfig(): AuthConfig {
+  return { ...defaultAuthConfig };
+}
+
+export const authConfig = loadAuthConfig();

--- a/packages/server/src/middleware/error-mapping.ts
+++ b/packages/server/src/middleware/error-mapping.ts
@@ -103,6 +103,22 @@ export class TimeoutError extends Error implements ApiError {
   }
 }
 
+/**
+ * Raised when provisioning auth artifacts against the auth platform (Authentik)
+ * fails. 502 because the failure originates upstream, not in the client request.
+ */
+export class ProvisioningError extends Error implements ApiError {
+  code = 'PROVISIONING_ERROR';
+  status = 502;
+  details?: unknown;
+
+  constructor(message: string, details?: unknown) {
+    super(message);
+    this.name = 'ProvisioningError';
+    this.details = details;
+  }
+}
+
 export class RateLimitError extends Error implements ApiError {
   code = 'RATE_LIMIT_EXCEEDED';
   status = 429;

--- a/packages/server/src/services/core/catalog.ts
+++ b/packages/server/src/services/core/catalog.ts
@@ -11,6 +11,7 @@ import type {
   CatalogApp,
   CatalogAppVersion,
 } from '@hola/shared';
+import { coerceManifestAuth } from './manifest-auth';
 
 // Shape of remote catalog JSON (minimal for now)
 type RemoteCatalog = {
@@ -139,6 +140,7 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
           ports?: Array<{ host?: unknown; container: unknown; protocol?: unknown }>;
           volumes?: Array<{ hostPath?: unknown; containerPath: unknown; readOnly?: unknown }>;
         };
+        auth?: unknown;
       };
 
       const manifest: Manifest = JSON.parse(raw) as unknown as Manifest;
@@ -184,7 +186,12 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
       // Merge compose and manifest defaults (manifest takes precedence)
       const merged = mergeDefaults(composeDefaults, manifestDefaults, manifestEnv);
 
-      return { ...merged, composeOverride } satisfies GetCatalogAppVersionDetailResponse;
+      // Coerce the optional auth block (drives SSO provisioning at deploy time).
+      // Unknown manifest fields are dropped here unless explicitly carried — so
+      // the auth block must be coerced or it silently vanishes downstream.
+      const auth = coerceManifestAuth(manifest.auth);
+
+      return { ...merged, composeOverride, auth } satisfies GetCatalogAppVersionDetailResponse;
     } catch (error) {
       this.logger.warn('Failed to read or parse bundle manifest; deferring to mocks', { appId, version, error: error instanceof Error ? error.message : String(error) });
       throw new Error('MANIFEST_UNAVAILABLE', { cause: error });

--- a/packages/server/src/services/core/compose-network.ts
+++ b/packages/server/src/services/core/compose-network.ts
@@ -77,3 +77,53 @@ export function attachToHolaNetwork(composeYaml: string, opts: AttachOptions): s
 
   return stringify(doc);
 }
+
+/**
+ * Return the Compose YAML with the given environment merged into the ingress
+ * service's `environment` block (as a map). Used to inject provisioned auth
+ * settings (OIDC client id/secret/issuer/redirect) so the app picks them up on
+ * first boot. Injected values take precedence over the app's declared defaults.
+ *
+ * Throws if the YAML is not a parseable Compose document, or if no env was
+ * actually injected when some was requested — callers must NOT swallow this, so
+ * a failure fails the deploy rather than silently shipping an app without auth.
+ */
+export function injectEnvironment(
+  composeYaml: string,
+  env: Record<string, string>,
+  opts: { ingressService?: string }
+): string {
+  const keys = Object.keys(env);
+  if (keys.length === 0) return composeYaml;
+
+  const doc = (parse(composeYaml) ?? {}) as ComposeDoc;
+  const services = doc.services;
+  if (!services || typeof services !== 'object' || Object.keys(services).length === 0) {
+    throw new Error('cannot inject environment: compose document has no services');
+  }
+
+  const names = Object.keys(services);
+  const ingress = opts.ingressService && services[opts.ingressService] ? opts.ingressService : names[0];
+  const service = services[ingress];
+
+  // Normalize an existing `environment` (which may be a `KEY=value` array) to a map.
+  const existing = service.environment;
+  const envMap: Record<string, string> = {};
+  if (Array.isArray(existing)) {
+    for (const entry of existing) {
+      if (typeof entry !== 'string') continue;
+      const eq = entry.indexOf('=');
+      if (eq === -1) envMap[entry] = '';
+      else envMap[entry.slice(0, eq)] = entry.slice(eq + 1);
+    }
+  } else if (existing && typeof existing === 'object') {
+    for (const [k, v] of Object.entries(existing as Record<string, unknown>)) {
+      envMap[k] = v == null ? '' : String(v);
+    }
+  }
+
+  for (const k of keys) envMap[k] = env[k];
+  service.environment = envMap;
+
+  return stringify(doc);
+}

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -40,10 +40,11 @@ import type { HealthCheckable, ServiceHealth } from './types';
 import type { StorageService } from './storage';
 import type { JobService, JobContext } from './jobs';
 import type { DockerService } from './docker';
-import type { DraftService, FinalizedArtifacts } from './draft';
+import type { DraftService, FinalizedArtifacts, FinalizedManifest } from './draft';
 import type { RoutingService } from './routing';
 import type { LoggingService } from './logging';
-import { attachToHolaNetwork } from './compose-network';
+import type { ProvisionerService } from './provisioner';
+import { attachToHolaNetwork, injectEnvironment } from './compose-network';
 
 /** Promote a new release built from a finalized draft onto an existing deployment. */
 export interface PromoteRequest {
@@ -305,6 +306,15 @@ abstract class InMemoryDeploymentService implements DeploymentService {
     void deploymentId;
   }
 
+  /**
+   * Tear down provisioned auth artifacts when a deployment is deleted. Default
+   * no-op (mock). Called with the live deployment record (so its metadata.auth
+   * ref is available) before storage is removed.
+   */
+  protected async onDeprovision(deployment: EnhancedDeploymentDetail): Promise<void> {
+    void deployment;
+  }
+
   /** Load the finalized artifacts for a draft. Default null (mock has no draft store). */
   protected async loadFinalizedArtifacts(draftId: string): Promise<FinalizedArtifacts | null> {
     void draftId;
@@ -513,7 +523,9 @@ abstract class InMemoryDeploymentService implements DeploymentService {
 
   async deleteDeployment(deploymentId: string): Promise<void> {
     await this.ensureLoaded();
-    this.requireDeployment(deploymentId);
+    // Capture the live record up front so its provisioned-auth ref is available
+    // for teardown before in-memory/storage state is removed.
+    const deployment = this.requireDeployment(deploymentId);
 
     this.logger.info('Deleting deployment', { deploymentId });
 
@@ -522,6 +534,17 @@ abstract class InMemoryDeploymentService implements DeploymentService {
       await this.executeAction(deploymentId, { action: 'stop' });
     } catch (error) {
       this.logger.warn('Failed to stop deployment before deletion', {
+        deploymentId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
+    // Tear down auth artifacts (OIDC client, etc.). Must never block deletion:
+    // a failure leaves an orphan that is logged for manual cleanup.
+    try {
+      await this.onDeprovision(deployment);
+    } catch (error) {
+      this.logger.warn('Failed to deprovision auth artifacts; continuing with delete', {
         deploymentId,
         error: error instanceof Error ? error.message : String(error),
       });
@@ -683,7 +706,8 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     private dockerService: DockerService,
     private draftService: DraftService,
     private routingService: RoutingService,
-    private loggingService: LoggingService
+    private loggingService: LoggingService,
+    private provisioner: ProvisionerService
   ) {
     super(jobService);
     // Perform real Compose lifecycle work when a deployment job runs.
@@ -701,7 +725,10 @@ export class RealDeploymentService extends InMemoryDeploymentService {
   }
 
   /** Write the active release's compose file into the deployment runtime dir. */
-  private async materializeCompose(deployment: EnhancedDeploymentDetail): Promise<string> {
+  private async materializeCompose(
+    deployment: EnhancedDeploymentDetail,
+    injectedEnv: Record<string, string> = {}
+  ): Promise<string> {
     const releaseId = deployment.currentReleaseId;
     if (!releaseId) {
       throw new Error('No active release to deploy');
@@ -725,8 +752,63 @@ export class RealDeploymentService extends InMemoryDeploymentService {
       });
     }
 
-    await this.storageService.writeFile(`deployments/${deployment.id}/runtime/docker-compose.yml`, content);
+    // Inject provisioned auth env into the ingress service. NOT swallowed: a
+    // failure here must fail the deploy rather than silently ship an app whose
+    // auth was never wired (a security-relevant bypass).
+    const hasSecret = Object.keys(injectedEnv).length > 0;
+    if (hasSecret) {
+      content = injectEnvironment(content, injectedEnv, { ingressService: deployment.app });
+    }
+
+    // The runtime compose may hold a client secret in cleartext; restrict it.
+    await this.storageService.writeFile(
+      `deployments/${deployment.id}/runtime/docker-compose.yml`,
+      content,
+      hasSecret ? 0o600 : undefined
+    );
     return this.runtimeDir(deployment.id);
+  }
+
+  /**
+   * Provision auth artifacts (if the active release's manifest declares an
+   * `auth` block) before the app starts, and return the env to inject. Idempotent:
+   * reuses any ref already persisted on the deployment (keyed on deploymentId), so
+   * restart/rollback/start-after-stop never create duplicate clients. Throws on
+   * provisioning failure so the lifecycle job fails before any container starts.
+   */
+  private async provisionAuthEnv(deployment: EnhancedDeploymentDetail): Promise<Record<string, string>> {
+    const releaseId = deployment.currentReleaseId;
+    if (!releaseId) return {};
+    const manifestPath = `deployments/${deployment.id}/releases/${releaseId}/manifest.json`;
+    if (!(await this.storageService.fileExists(manifestPath))) return {};
+
+    let auth: FinalizedManifest['auth'];
+    try {
+      const manifest = JSON.parse(await this.storageService.readFileAsString(manifestPath)) as FinalizedManifest;
+      auth = manifest.auth;
+    } catch {
+      return {};
+    }
+    if (!auth || auth.mode === 'none') return {};
+
+    const rule = this.routingRuleFor(deployment);
+    const result = await this.provisioner.provision({
+      deploymentId: deployment.id,
+      appName: deployment.app,
+      mode: auth.mode,
+      host: rule.host,
+      existingRef: deployment.metadata.auth?.ref,
+      oidc: auth.oidc,
+      ldap: auth.ldap,
+      forwardAuth: auth.forwardAuth,
+    });
+
+    // Persist the provisioned ref so re-deploy reuses it and delete can tear it down.
+    deployment.metadata.auth = { mode: auth.mode, ref: result.ref };
+    this.deployments.set(deployment.id, deployment);
+    await this.persistDeployment(deployment);
+
+    return result.env;
   }
 
   private jobTypeToAction(type: Job['type']): string {
@@ -772,14 +854,16 @@ export class RealDeploymentService extends InMemoryDeploymentService {
         nextStatus = 'stopped';
         nextLifecycle = 'stopped';
       } else if (action === 'restart') {
-        const res = await this.dockerService.composeRestart(await this.materializeCompose(deployment), projectName);
+        const env = await this.provisionAuthEnv(deployment);
+        const res = await this.dockerService.composeRestart(await this.materializeCompose(deployment, env), projectName);
         output = res.output;
         if (!res.success) throw new Error(res.output);
         nextStatus = 'running';
         nextLifecycle = 'active';
       } else {
         // deploy / start / rollback -> compose up
-        const res = await this.dockerService.composeUp(await this.materializeCompose(deployment), projectName);
+        const env = await this.provisionAuthEnv(deployment);
+        const res = await this.dockerService.composeUp(await this.materializeCompose(deployment, env), projectName);
         output = res.output;
         if (!res.success) throw new Error(res.output);
         nextStatus = 'running';
@@ -901,6 +985,12 @@ export class RealDeploymentService extends InMemoryDeploymentService {
 
   protected override async onDeploymentRemoved(deploymentId: string): Promise<void> {
     await this.routingService.deactivateRoute(deploymentId);
+  }
+
+  protected override async onDeprovision(deployment: EnhancedDeploymentDetail): Promise<void> {
+    const auth = deployment.metadata.auth;
+    if (!auth) return;
+    await this.provisioner.deprovision({ deploymentId: deployment.id, ref: auth.ref });
   }
 
   protected override async loadFinalizedArtifacts(draftId: string): Promise<FinalizedArtifacts | null> {

--- a/packages/server/src/services/core/draft.ts
+++ b/packages/server/src/services/core/draft.ts
@@ -19,7 +19,8 @@ import type {
   EnhancedPreflightResponse,
   FinalizeDraftResponse,
   AppEnvVar,
-  DraftDefaults
+  DraftDefaults,
+  AppAuthConfig
 } from '@hola/shared';
 
 import { createHash } from 'crypto';
@@ -52,6 +53,9 @@ export interface FinalizedManifest {
   appEnv: AppEnvVar[];
   ports: Array<{ host?: number; container: number; protocol: 'tcp' | 'udp' }>;
   composeOverride: string;
+  // App auth capability carried from the catalog manifest so the deploy
+  // lifecycle can provision SSO without re-reading the bundle.
+  auth?: AppAuthConfig;
   files: FinalizedManifestFile[];
   checksum: string;
   finalizedAt: string;
@@ -313,6 +317,7 @@ export class RealDraftService implements DraftService {
         appEnv: defaults.env,
         ports: defaults.defaults.ports,
         composeOverride,
+        auth: defaults.auth,
         files: [],
       };
 
@@ -562,6 +567,7 @@ export class RealDraftService implements DraftService {
         appEnv: draft.appEnv,
         ports: draft.ports,
         composeOverride: draft.composeOverride ?? '',
+        auth: draft.auth,
         files: specFiles,
       };
 
@@ -639,13 +645,14 @@ export class RealDraftService implements DraftService {
     };
   }
 
-  async getDraftDefaults(appId: string, version?: string): Promise<{ env: AppEnvVar[]; defaults: DraftDefaults; composeOverride: string }> {
+  async getDraftDefaults(appId: string, version?: string): Promise<{ env: AppEnvVar[]; defaults: DraftDefaults; composeOverride: string; auth?: AppAuthConfig }> {
     try {
       const versionDetail = await this.catalogService.getVersionDetail(appId, version || 'latest');
       return {
         env: versionDetail.defaultEnv,
         defaults: versionDetail.defaults,
         composeOverride: versionDetail.composeOverride ?? '',
+        auth: versionDetail.auth,
       };
     } catch (error) {
       this.logger.warn('Failed to get app defaults, using fallback', { appId, version, error: error instanceof Error ? error.message : String(error) });

--- a/packages/server/src/services/core/manifest-auth.ts
+++ b/packages/server/src/services/core/manifest-auth.ts
@@ -1,0 +1,82 @@
+// Defensive coercion for a catalog bundle manifest's optional `auth` block into
+// a typed AppAuthConfig. Mirrors the narrow-shape coercion used for env/ports in
+// catalog.ts: anything malformed degrades to `undefined` (treated as no-auth)
+// rather than throwing, so a sloppy manifest never breaks catalog browsing.
+
+import type { AppAuthConfig, AuthMode } from '@hola/shared';
+
+const AUTH_MODES: readonly AuthMode[] = ['none', 'native-oidc', 'native-ldap', 'forward-auth'];
+
+function asRecord(v: unknown): Record<string, unknown> | undefined {
+  return v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : undefined;
+}
+
+function asString(v: unknown): string | undefined {
+  return typeof v === 'string' && v.length > 0 ? v : undefined;
+}
+
+function asStringArray(v: unknown): string[] | undefined {
+  if (!Array.isArray(v)) return undefined;
+  const out = v.filter((x): x is string => typeof x === 'string');
+  return out.length > 0 ? out : undefined;
+}
+
+/** Require every named env mapping to be a non-empty string; else undefined. */
+function coerceEnvMap<K extends string>(v: unknown, keys: readonly K[]): Record<K, string> | undefined {
+  const rec = asRecord(v);
+  if (!rec) return undefined;
+  const out = {} as Record<K, string>;
+  for (const k of keys) {
+    const val = asString(rec[k]);
+    if (!val) return undefined;
+    out[k] = val;
+  }
+  return out;
+}
+
+/**
+ * Coerce an unknown manifest `auth` value into AppAuthConfig.
+ * Returns undefined when absent or unusable (caller treats as `none`).
+ * For a mode that requires sub-config (oidc/ldap), a missing/invalid sub-block
+ * yields undefined so we never half-provision against a bad manifest.
+ */
+export function coerceManifestAuth(value: unknown): AppAuthConfig | undefined {
+  const rec = asRecord(value);
+  if (!rec) return undefined;
+
+  const mode = rec.mode;
+  if (typeof mode !== 'string' || !AUTH_MODES.includes(mode as AuthMode)) return undefined;
+  const m = mode as AuthMode;
+
+  if (m === 'none') return { mode: 'none' };
+
+  const result: AppAuthConfig = { mode: m };
+
+  if (m === 'native-oidc') {
+    const oidc = asRecord(rec.oidc);
+    const redirectPath = asString(oidc?.redirectPath);
+    const scopes = asStringArray(oidc?.scopes);
+    const env = coerceEnvMap(oidc?.env, ['issuer', 'clientId', 'clientSecret', 'redirectUri'] as const);
+    if (!redirectPath || !scopes || !env) return undefined;
+    result.oidc = { redirectPath, scopes, env };
+  }
+
+  if (m === 'native-ldap') {
+    const ldap = asRecord(rec.ldap);
+    const env = coerceEnvMap(ldap?.env, ['host', 'port', 'bindDn', 'bindPassword', 'baseDn'] as const);
+    if (!env) return undefined;
+    result.ldap = { env };
+  }
+
+  if (m === 'forward-auth') {
+    const fa = asRecord(rec.forwardAuth);
+    const allowedGroups = asStringArray(fa?.allowedGroups);
+    result.forwardAuth = allowedGroups ? { allowedGroups } : {};
+  }
+
+  if (asString(rec.fallback) === 'forward-auth') {
+    result.fallback = 'forward-auth';
+  }
+
+  return result;
+}

--- a/packages/server/src/services/core/provisioner.ts
+++ b/packages/server/src/services/core/provisioner.ts
@@ -1,0 +1,324 @@
+/**
+ * ProvisionerService — auth/SSO provisioning for deployed apps (MVP pt2).
+ *
+ * When a catalog app declares an `auth` block, Hola provisions the matching auth
+ * artifacts on the operator's auth platform at deploy time and injects the
+ * resulting settings into the app's environment, so SSO "just works" on first
+ * boot — with no human in the auth UI. On uninstall the artifacts are torn down.
+ *
+ * The interface is platform-agnostic so the lightweight Authelia+LLDAP backend
+ * (try-hola/hola#88) can implement the same contract later. The first backend is
+ * Authentik, and PR1 fully implements only `native-oidc`; `forward-auth` and
+ * `native-ldap` are part of the contract but throw "not implemented" until PR3/PR4.
+ *
+ * Provisioning is idempotent and keyed on `deploymentId` (stable across releases):
+ * a re-deploy/rollback reuses the same OIDC client rather than creating a new one.
+ */
+
+import { randomBytes, randomUUID } from 'crypto';
+import { getLogger } from '../../lib/logger';
+import { ProvisioningError } from '../../middleware/error-mapping';
+import type { AuthConfig } from '../../config/auth';
+import type { AuthMode, ProvisionedAuthRef } from '@hola/shared';
+import type { ServiceHealth, HealthCheckable } from './types';
+
+export interface ProvisionInput {
+  /** Stable key for the deployment — NEVER releaseId (rollback keeps the same client). */
+  deploymentId: string;
+  appName: string;
+  mode: AuthMode;
+  /** The app's external host (`{appName}.{baseDomain}`), used to build redirect/issuer URLs. */
+  host: string;
+  /** Existing provisioned ref (from deployment metadata) for idempotent re-provision. */
+  existingRef?: ProvisionedAuthRef;
+  oidc?: {
+    redirectPath: string;
+    scopes: string[];
+    /** The app's expected env-var NAMES for each OIDC setting. */
+    env: { issuer: string; clientId: string; clientSecret: string; redirectUri: string };
+  };
+  ldap?: {
+    env: { host: string; port: string; bindDn: string; bindPassword: string; baseDn: string };
+  };
+  forwardAuth?: { allowedGroups?: string[] };
+}
+
+export interface ProvisionResult {
+  /** Environment to inject, keyed by the app's expected var NAMES. */
+  env: Record<string, string>;
+  /** Opaque handle to persist for idempotent re-provision and teardown. */
+  ref: ProvisionedAuthRef;
+  /** forward-auth only (PR3): Traefik middleware descriptor for the router. */
+  middleware?: {
+    name: string;
+    forwardAuth: { address: string; trustForwardHeader: boolean; authResponseHeaders: string[] };
+  };
+}
+
+export interface DeprovisionInput {
+  deploymentId: string;
+  ref?: ProvisionedAuthRef;
+}
+
+export interface ProvisionerService extends HealthCheckable {
+  provision(input: ProvisionInput): Promise<ProvisionResult>;
+  deprovision(input: DeprovisionInput): Promise<void>;
+  healthCheck(): Promise<ServiceHealth>;
+}
+
+// ---------------------------------------------------------------------------
+// Authentik REST backend
+// ---------------------------------------------------------------------------
+
+const AUTHZ_FLOW_SLUG = 'default-provider-authorization-implicit-consent';
+const INVALIDATION_FLOW_SLUG = 'default-provider-invalidation';
+
+/** Sanitize a string into an Authentik slug (lowercase, alnum + hyphen). */
+function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 50);
+}
+
+export class RealAuthentikProvisionerService implements ProvisionerService {
+  private logger = getLogger().child({ service: 'RealAuthentikProvisionerService' });
+
+  constructor(private config: AuthConfig) {}
+
+  async healthCheck(): Promise<ServiceHealth> {
+    try {
+      await this.api('GET', '/api/v3/admin/version/');
+      return { healthy: true, lastCheck: new Date() };
+    } catch (error) {
+      return { healthy: false, lastCheck: new Date(), error: error instanceof Error ? error.message : String(error) };
+    }
+  }
+
+  async provision(input: ProvisionInput): Promise<ProvisionResult> {
+    switch (input.mode) {
+      case 'native-oidc':
+        return this.provisionOidc(input);
+      case 'forward-auth':
+      case 'native-ldap':
+        throw new ProvisioningError(`auth mode '${input.mode}' is not implemented yet`);
+      case 'none':
+        return { env: {}, ref: { mode: 'none' } };
+      default:
+        throw new ProvisioningError(`unknown auth mode '${String(input.mode)}'`);
+    }
+  }
+
+  async deprovision(input: DeprovisionInput): Promise<void> {
+    const ref = input.ref;
+    if (!ref || ref.mode !== 'native-oidc') return;
+    // Delete the application first (it points at the provider), then the provider.
+    if (ref.applicationSlug) {
+      await this.apiDeleteIgnoreMissing(`/api/v3/core/applications/${encodeURIComponent(ref.applicationSlug)}/`);
+    }
+    if (ref.providerPk != null) {
+      await this.apiDeleteIgnoreMissing(`/api/v3/providers/oauth2/${ref.providerPk}/`);
+    }
+    this.logger.info('Deprovisioned OIDC client', { deploymentId: input.deploymentId, providerPk: ref.providerPk });
+  }
+
+  // ---- native-oidc -------------------------------------------------------
+
+  private async provisionOidc(input: ProvisionInput): Promise<ProvisionResult> {
+    const oidc = input.oidc;
+    if (!oidc) throw new ProvisioningError('native-oidc requires an oidc config block');
+
+    const redirectUri = `https://${input.host}${oidc.redirectPath}`;
+    const slug = slugify(`hola-${input.appName}-${input.deploymentId.slice(0, 8)}`);
+
+    // Idempotent re-provision: reuse the existing client, refresh its redirect URI.
+    const existing = input.existingRef;
+    if (existing && existing.mode === 'native-oidc' && existing.providerPk != null) {
+      const provider = await this.api<AuthentikOAuth2Provider>('GET', `/api/v3/providers/oauth2/${existing.providerPk}/`);
+      await this.api('PATCH', `/api/v3/providers/oauth2/${existing.providerPk}/`, {
+        redirect_uris: [{ matching_mode: 'strict', url: redirectUri }],
+      });
+      this.logger.info('Reused existing OIDC client', { deploymentId: input.deploymentId, providerPk: existing.providerPk });
+      return {
+        env: this.oidcEnv(oidc.env, provider.client_id, provider.client_secret, redirectUri, existing.applicationSlug ?? slug),
+        ref: existing,
+      };
+    }
+
+    // Fresh provision: pre-generate credentials so injection needs no read-back.
+    const clientId = randomUUID();
+    const clientSecret = randomBytes(32).toString('hex');
+
+    const [authFlow, invalidationFlow, propertyMappings] = await Promise.all([
+      this.resolveFlowPk(AUTHZ_FLOW_SLUG),
+      this.resolveFlowPk(INVALIDATION_FLOW_SLUG),
+      this.resolveScopeMappingPks(oidc.scopes),
+    ]);
+
+    const provider = await this.api<AuthentikOAuth2Provider>('POST', '/api/v3/providers/oauth2/', {
+      name: `hola-${input.appName}-${input.deploymentId.slice(0, 8)}`,
+      authorization_flow: authFlow,
+      invalidation_flow: invalidationFlow,
+      client_type: 'confidential',
+      client_id: clientId,
+      client_secret: clientSecret,
+      redirect_uris: [{ matching_mode: 'strict', url: redirectUri }],
+      property_mappings: propertyMappings,
+      sub_mode: 'hashed_user_id',
+    });
+
+    // Create the application; roll back the provider if that fails so we never
+    // leave a half-provisioned orphan.
+    try {
+      await this.api('POST', '/api/v3/core/applications/', {
+        name: `${input.appName} (${input.deploymentId.slice(0, 8)})`,
+        slug,
+        provider: provider.pk,
+        meta_launch_url: `https://${input.host}/`,
+      });
+    } catch (error) {
+      await this.apiDeleteIgnoreMissing(`/api/v3/providers/oauth2/${provider.pk}/`);
+      throw new ProvisioningError('failed to create Authentik application', error);
+    }
+
+    this.logger.info('Provisioned OIDC client', { deploymentId: input.deploymentId, providerPk: provider.pk, slug });
+
+    return {
+      env: this.oidcEnv(oidc.env, clientId, clientSecret, redirectUri, slug),
+      ref: { mode: 'native-oidc', providerPk: provider.pk, applicationSlug: slug, clientId },
+    };
+  }
+
+  private oidcEnv(
+    names: { issuer: string; clientId: string; clientSecret: string; redirectUri: string },
+    clientId: string,
+    clientSecret: string,
+    redirectUri: string,
+    slug: string
+  ): Record<string, string> {
+    const base = this.config.authentikPublicUrl || this.config.authentikUrl || '';
+    return {
+      [names.issuer]: `${base}/application/o/${slug}/`,
+      [names.clientId]: clientId,
+      [names.clientSecret]: clientSecret,
+      [names.redirectUri]: redirectUri,
+    };
+  }
+
+  private async resolveFlowPk(slug: string): Promise<string> {
+    const flow = await this.api<{ pk: string }>('GET', `/api/v3/flows/instances/${encodeURIComponent(slug)}/`);
+    return flow.pk;
+  }
+
+  /** Best-effort: collect scope-mapping pks for the requested scope names. */
+  private async resolveScopeMappingPks(scopes: string[]): Promise<string[]> {
+    const pks: string[] = [];
+    for (const scope of scopes) {
+      try {
+        const res = await this.api<{ results: Array<{ pk: string }> }>(
+          'GET',
+          `/api/v3/propertymappings/provider/scope/?scope_name=${encodeURIComponent(scope)}`
+        );
+        if (res.results?.[0]?.pk) pks.push(res.results[0].pk);
+      } catch (error) {
+        this.logger.warn('Could not resolve OIDC scope mapping; continuing', {
+          scope,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+    return pks;
+  }
+
+  // ---- HTTP --------------------------------------------------------------
+
+  private async api<T = unknown>(method: string, path: string, body?: unknown): Promise<T> {
+    if (!this.config.authentikUrl) throw new ProvisioningError('HOLA_AUTHENTIK_URL is not configured');
+    if (!this.config.authentikApiToken) throw new ProvisioningError('HOLA_AUTHENTIK_API_TOKEN is not configured');
+
+    const controller = new AbortController();
+    const tid = setTimeout(() => controller.abort(), this.config.fetchTimeoutMs);
+    try {
+      const res = await fetch(`${this.config.authentikUrl}${path}`, {
+        method,
+        headers: {
+          Authorization: `Bearer ${this.config.authentikApiToken}`,
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+        signal: controller.signal,
+      });
+      if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        throw new ProvisioningError(`Authentik ${method} ${path} failed: ${res.status}`, { status: res.status, body: text });
+      }
+      if (res.status === 204) return undefined as T;
+      const text = await res.text();
+      return (text ? JSON.parse(text) : undefined) as T;
+    } catch (error) {
+      if (error instanceof ProvisioningError) throw error;
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw new ProvisioningError(`Authentik ${method} ${path} timed out`);
+      }
+      throw new ProvisioningError(`Authentik ${method} ${path} error: ${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+      clearTimeout(tid);
+    }
+  }
+
+  /** DELETE that tolerates an already-absent resource (404) — for teardown. */
+  private async apiDeleteIgnoreMissing(path: string): Promise<void> {
+    try {
+      await this.api('DELETE', path);
+    } catch (error) {
+      const status = error instanceof ProvisioningError ? (error.details as { status?: number })?.status : undefined;
+      if (status === 404) return;
+      throw error;
+    }
+  }
+}
+
+interface AuthentikOAuth2Provider {
+  pk: number;
+  client_id: string;
+  client_secret: string;
+}
+
+// ---------------------------------------------------------------------------
+// Mock backend — no network. Used in test/dev and when HOLA_AUTH_MODE=none.
+// ---------------------------------------------------------------------------
+
+export class MockProvisionerService implements ProvisionerService {
+  private logger = getLogger().child({ service: 'MockProvisionerService' });
+
+  async healthCheck(): Promise<ServiceHealth> {
+    return { healthy: true, lastCheck: new Date() };
+  }
+
+  async provision(input: ProvisionInput): Promise<ProvisionResult> {
+    if (input.mode === 'native-oidc' && input.oidc) {
+      const slug = slugify(`hola-${input.appName}-${input.deploymentId.slice(0, 8)}`);
+      const clientId = input.existingRef?.clientId ?? `mock-client-${input.deploymentId.slice(0, 8)}`;
+      const clientSecret = `mock-secret-${input.deploymentId.slice(0, 8)}`;
+      const redirectUri = `https://${input.host}${input.oidc.redirectPath}`;
+      const names = input.oidc.env;
+      return {
+        env: {
+          [names.issuer]: `https://auth.mock/application/o/${slug}/`,
+          [names.clientId]: clientId,
+          [names.clientSecret]: clientSecret,
+          [names.redirectUri]: redirectUri,
+        },
+        ref: input.existingRef ?? { mode: 'native-oidc', providerPk: 1, applicationSlug: slug, clientId },
+      };
+    }
+    // none / unimplemented modes: no-op so a deploy proceeds without auth wiring.
+    return { env: {}, ref: { mode: input.mode } };
+  }
+
+  async deprovision(input: DeprovisionInput): Promise<void> {
+    this.logger.debug('Mock deprovision', { deploymentId: input.deploymentId, mode: input.ref?.mode });
+  }
+}

--- a/packages/server/src/services/core/storage.ts
+++ b/packages/server/src/services/core/storage.ts
@@ -35,7 +35,8 @@ export interface StorageService extends HealthCheckable {
   deleteDir(path: string, recursive?: boolean): Promise<void>;
   
   // File operations
-  writeFile(path: string, content: string | Buffer): Promise<void>;
+  // `mode` (e.g. 0o600) restricts permissions for files holding secrets.
+  writeFile(path: string, content: string | Buffer, mode?: number): Promise<void>;
   readFile(path: string): Promise<Buffer>;
   readFileAsString(path: string, encoding?: BufferEncoding): Promise<string>;
   deleteFile(path: string): Promise<void>;
@@ -170,7 +171,7 @@ export class RealStorageService implements StorageService {
   }
 
   // File operations
-  async writeFile(path: string, content: string | Buffer): Promise<void> {
+  async writeFile(path: string, content: string | Buffer, mode?: number): Promise<void> {
     path = this.resolveStoragePath(path);
 
     try {
@@ -179,13 +180,20 @@ export class RealStorageService implements StorageService {
       }
 
       if (this.config.atomicWrites) {
-        await this.writeFileAtomic(path, content);
+        await this.writeFileAtomic(path, content, mode);
       } else {
-        await fs.writeFile(path, content);
+        await fs.writeFile(path, content, mode !== undefined ? { mode } : undefined);
       }
 
-      this.logger.debug('File written', { 
-        path, 
+      // Atomic writes set the mode on the temp file before rename; for the
+      // non-atomic path the option above covers it. Re-assert for existing files
+      // (writeFile's mode is ignored when the file already exists).
+      if (mode !== undefined) {
+        await fs.chmod(path, mode);
+      }
+
+      this.logger.debug('File written', {
+        path,
         size: Buffer.isBuffer(content) ? content.length : content.length,
         atomic: this.config.atomicWrites,
       });
@@ -195,11 +203,11 @@ export class RealStorageService implements StorageService {
     }
   }
 
-  private async writeFileAtomic(path: string, content: string | Buffer): Promise<void> {
+  private async writeFileAtomic(path: string, content: string | Buffer, mode?: number): Promise<void> {
     const tempPath = `${path}.tmp.${randomUUID()}`;
-    
+
     try {
-      await fs.writeFile(tempPath, content);
+      await fs.writeFile(tempPath, content, mode !== undefined ? { mode } : undefined);
       await fs.rename(tempPath, path);
     } catch (error) {
       // Clean up temp file on failure
@@ -338,10 +346,10 @@ export class MockStorageService implements StorageService {
     this.logger.debug('Mock directory deleted', { path, recursive });
   }
 
-  async writeFile(path: string, content: string | Buffer): Promise<void> {
+  async writeFile(path: string, content: string | Buffer, mode?: number): Promise<void> {
     const buffer = Buffer.isBuffer(content) ? content : Buffer.from(content);
     this.files.set(path, buffer);
-    this.logger.debug('Mock file written', { path, size: buffer.length });
+    this.logger.debug('Mock file written', { path, size: buffer.length, mode });
   }
 
   async readFile(path: string): Promise<Buffer> {

--- a/packages/server/src/services/simple-factory.ts
+++ b/packages/server/src/services/simple-factory.ts
@@ -23,6 +23,8 @@ import { RealDraftService, MockDraftService, type DraftService } from './core/dr
 import { RealValidationService, MockValidationService, type ValidationService } from './core/validation';
 import { RealRoutingService, MockRoutingService, type RoutingService } from './core/routing';
 import { RealDeploymentService, MockDeploymentService, type DeploymentService } from './core/deployment';
+import { RealAuthentikProvisionerService, MockProvisionerService, type ProvisionerService } from './core/provisioner';
+import { authConfig } from '../config/auth';
 
 /**
  * Service collection interface
@@ -42,6 +44,7 @@ export interface Services {
   drafts: DraftService;
   validation: ValidationService;
   routing: RoutingService;
+  provisioner: ProvisionerService;
   deployments: DeploymentService;
 }
 
@@ -80,10 +83,11 @@ export function createServices(env: ServiceEnvironment): Services {
       drafts: new MockDraftService(),
       validation: new MockValidationService(),
       routing: new MockRoutingService(),
+      provisioner: new MockProvisionerService(),
       deployments: new MockDeploymentService(jobs),
     };
   }
-  
+
   if (env === 'development') {
     // Mixed services for development: real services where possible, mocks for external dependencies
     const storage = new RealStorageService();
@@ -109,6 +113,9 @@ export function createServices(env: ServiceEnvironment): Services {
     // Shared draft service: the deployment service builds releases from its finalized artifacts.
     const drafts = new RealDraftService(storage, catalog, validation);
 
+    // Mock provisioner in development for safety (no calls to a real auth platform).
+    const provisioner = new MockProvisionerService();
+
     return {
       storage,
       config: new RealConfigService(storage),
@@ -124,10 +131,11 @@ export function createServices(env: ServiceEnvironment): Services {
       drafts,
       validation,
       routing,
-      deployments: new RealDeploymentService(storage, jobs, docker, drafts, routing, logging),
+      provisioner,
+      deployments: new RealDeploymentService(storage, jobs, docker, drafts, routing, logging, provisioner),
     };
   }
-  
+
   // All real services for production
   const storage = new RealStorageService();
   const database = new RealDatabaseService(storage);
@@ -156,6 +164,12 @@ export function createServices(env: ServiceEnvironment): Services {
   // Shared draft service: the deployment service builds releases from its finalized artifacts.
   const drafts = new RealDraftService(storage, catalog, validation);
 
+  // Provision auth artifacts against the configured platform; no-op when disabled.
+  const provisioner: ProvisionerService =
+    authConfig.mode === 'authentik'
+      ? new RealAuthentikProvisionerService(authConfig)
+      : new MockProvisionerService();
+
   return {
     storage,
     config: new RealConfigService(storage),
@@ -171,7 +185,8 @@ export function createServices(env: ServiceEnvironment): Services {
     drafts,
     validation,
     routing,
-    deployments: new RealDeploymentService(storage, jobs, docker, drafts, routing, logging),
+    provisioner,
+    deployments: new RealDeploymentService(storage, jobs, docker, drafts, routing, logging, provisioner),
   };
 }
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -255,6 +255,51 @@ export type GetCatalogAppVersionDetailResponse = {
   // composeOverride so it can be deployed without the user pasting compose.
   // Optional: clients that only need env/port defaults can ignore it.
   composeOverride?: string;
+  // How the app integrates with auth/SSO, declared in its bundle manifest.
+  // Drives provisioning at deploy time (see AppAuthConfig). Optional: apps
+  // that don't declare it behave as `none` (no auth wiring).
+  auth?: AppAuthConfig;
+};
+
+// ------------------------------------------------------
+// Auth / SSO
+// ------------------------------------------------------
+// How a catalog app integrates with the operator's auth platform. The platform
+// (Authentik today; Authelia+LLDAP tracked in try-hola/hola#88) is chosen by the
+// operator; this declares only the app's *capability* so Hola can resolve
+// capability × platform at deploy time.
+export type AuthMode = 'none' | 'native-oidc' | 'native-ldap' | 'forward-auth';
+
+export type AppAuthConfig = {
+  mode: AuthMode;
+  // For `native-oidc`: the env-var NAMES this app expects its OIDC settings in,
+  // plus the callback path and requested scopes. Hola provisions an OIDC client
+  // and injects the values under these names at deploy time.
+  oidc?: {
+    redirectPath: string;
+    scopes: string[];
+    env: { issuer: string; clientId: string; clientSecret: string; redirectUri: string };
+  };
+  // For `native-ldap`: the env-var NAMES this app expects its LDAP bind settings in.
+  ldap?: {
+    env: { host: string; port: string; bindDn: string; bindPassword: string; baseDn: string };
+  };
+  // For `forward-auth`: optional access restriction by group.
+  forwardAuth?: { allowedGroups?: string[] };
+  // Optionally gate a `native-oidc`/no-auth app behind proxy login too.
+  fallback?: 'forward-auth';
+};
+
+// Opaque handle to the auth artifacts provisioned for a deployment, persisted on
+// its metadata so they can be reused (idempotent re-deploy) and torn down on delete.
+// Keyed on deploymentId (stable across releases), never releaseId.
+export type ProvisionedAuthRef = {
+  mode: AuthMode;
+  clientId?: string;
+  providerPk?: number;
+  applicationSlug?: string;
+  outpostPk?: number;
+  bindAccountPk?: number;
 };
 
 // ------------------------------------------------------
@@ -268,6 +313,9 @@ export type Draft = {
   appEnv: AppEnvVar[];
   ports: Array<{ host?: number; container: number; protocol: 'tcp' | 'udp' }>;
   composeOverride?: string;
+  // App auth capability seeded from the catalog bundle manifest (read-only; not
+  // user-editable). Carried through finalize so the deploy lifecycle can provision.
+  auth?: AppAuthConfig;
   files: Array<{ uploadId: string; name: string; size: number; kind: 'composeOverride' | 'additionalFile' | 'env' | 'secret' }>;
 };
 
@@ -716,6 +764,9 @@ export type EnhancedDeploymentDetail = DeploymentDetail & {
     owner?: string;
     tags?: string[];
     notes?: string;
+    // Auth artifacts provisioned for this deployment (if any), so they can be
+    // reused on re-deploy and torn down on delete. Keyed on deploymentId.
+    auth?: { mode: AuthMode; ref: ProvisionedAuthRef };
   };
 };
 


### PR DESCRIPTION
Closes #90. Part of the auth/SSO epic #89.

Introduces a platform-agnostic **`ProvisionerService`** that wires SSO into the deploy lifecycle, with **Authentik** as the first backend and **`native-oidc` fully implemented end-to-end**. `forward-auth` and `native-ldap` are part of the interface contract but throw "not implemented" until PR3/PR4. The interface is deliberately platform-agnostic so the Authelia+LLDAP alternative (#88) can implement the same contract later.

## What's here
- **`ProvisionerService`** (`services/core/provisioner.ts`): interface + `RealAuthentikProvisionerService` (pre-generates `client_id`/`client_secret`, creates an OAuth2 provider + application, returns env keyed by the app's expected var names, `DELETE`s on teardown) + `MockProvisionerService`. New `ProvisioningError` (502).
- **`config/auth.ts`**: `HOLA_AUTH_MODE` (`none|authentik`), `HOLA_AUTHENTIK_URL`, `HOLA_AUTHENTIK_PUBLIC_URL`, `HOLA_AUTHENTIK_API_TOKEN`. The factory wires the real backend only when `mode=authentik`; otherwise a no-op mock (so apps declaring `auth` still deploy, just without wiring).
- **Per-app `auth` block**: `AuthMode`/`AppAuthConfig` shared types, defensively coerced from the bundle manifest (`manifest-auth.ts`) and threaded catalog → draft → finalized → staged manifest. The provisioned ref is persisted on deployment metadata.
- **Lifecycle wiring** (`deployment.ts`):
  - Provision **before** `docker compose up`, inside the async `runLifecycleJob` — **idempotent, keyed on `deploymentId`** so restart/rollback/start-after-stop reuse the same client.
  - Inject credentials into the **materialized compose** ingress service (`compose-network.ts: injectEnvironment`) as a **non-swallowed** step — a failure fails the deploy rather than silently shipping an app with auth bypassed.
  - `0600` on the runtime compose (holds a secret in cleartext).
  - **Deprovision only on delete**, never on stop; failures log an orphan warning and never block deletion.

## Design notes
- Provisioning lives in `runLifecycleJob` (the async job), **not** `createFromDraft`, so it co-locates with compose materialization and re-runs on every start/restart/rollback.
- The ref is keyed on `deploymentId` (stable across releases), never `releaseId` — a rollback must not orphan/duplicate clients.

## Tests
- `deployments/auth-provisioning.test.ts`: env injection into the ingress service, ref persistence, idempotent re-deploy reuse, deprovision-on-delete (and **not** on stop), provisioning-failure → job error with no compose materialized, delete tolerating a deprovision failure.
- `provisioner/authentik-contract.test.ts`: REST contract over a mocked `fetch` — provider+application creation with pre-generated creds and a strict redirect URI, provider rollback on app-create failure, ordered teardown, 404 tolerance, not-implemented modes.
- `provisioner/manifest-auth.test.ts`: defensive coercion.
- Full suite green (208 server tests), lint, typecheck, build all pass.

## Not in this PR
- Deploying/bootstrapping Authentik itself (PR2 #91) — this PR is developed/tested against a mock and a manually-run Authentik.
- `forward-auth` (#92) and `native-ldap` (#93).
- The `auth.oidc` block on Gitea's manifest in `try-hola/apps` (companion change, follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)