### PR TITLE
feat(server): post-deploy OIDC setup command for CLI-configured apps (#90)

### DIFF
--- a/packages/server/src/__tests__/deployments/auth-provisioning.test.ts
+++ b/packages/server/src/__tests__/deployments/auth-provisioning.test.ts
@@ -82,14 +82,15 @@ class SpyProvisioner implements ProvisionerService {
     this.provisions.push(input);
     if (this.failNext) throw new ProvisioningError('simulated provisioning failure');
     if (input.mode === 'native-oidc' && input.oidc) {
+      const redirectUri = `https://${input.host}${input.oidc.redirectPath}`;
+      const issuer = 'https://auth.example.com/application/o/gitea-x/';
       const names = input.oidc.env;
+      const env = names
+        ? { [names.issuer]: issuer, [names.clientId]: 'cid-123', [names.clientSecret]: 'csecret-456', [names.redirectUri]: redirectUri }
+        : {};
       return {
-        env: {
-          [names.issuer]: 'https://auth.example.com/application/o/gitea-x/',
-          [names.clientId]: 'cid-123',
-          [names.clientSecret]: 'csecret-456',
-          [names.redirectUri]: `https://${input.host}${input.oidc.redirectPath}`,
-        },
+        env,
+        credentials: { clientId: 'cid-123', clientSecret: 'csecret-456', issuer, redirectUri },
         ref: input.existingRef ?? { mode: 'native-oidc', providerPk: 42, applicationSlug: 'gitea-x', clientId: 'cid-123' },
       };
     }
@@ -249,5 +250,71 @@ describe('Auth provisioning lifecycle', () => {
     // Deletion completed despite the deprovision error.
     expect(failingDeprovision.deprovisions).toHaveLength(1);
     await expect(sys.deployments.getDeployment(created.deploymentId)).rejects.toThrow();
+  });
+
+  // --- Post-deploy setup command (e.g. Gitea `gitea admin auth add-oauth`) -----
+
+  const OIDC_SETUP_AUTH: AppAuthConfig = {
+    mode: 'native-oidc',
+    oidc: {
+      redirectPath: '/user/oauth2/authentik/callback',
+      scopes: ['openid', 'email'],
+      // No `env` — Gitea-style: configured by an in-container command instead.
+      setup: {
+        user: 'git',
+        check: ['gitea', 'admin', 'auth', 'list'],
+        checkMatch: 'authentik',
+        command: [
+          'gitea', 'admin', 'auth', 'add-oauth', '--name', 'authentik',
+          '--key', '{{clientId}}', '--secret', '{{clientSecret}}',
+          '--auto-discover-url', '{{issuer}}.well-known/openid-configuration',
+        ],
+      },
+    },
+  };
+
+  /** Docker mock that records composeExec calls and lets a test control the check output. */
+  class RecordingDocker extends MockDockerService {
+    execCalls: Array<{ service: string; command: string[]; user?: string }> = [];
+    checkOutput = '';
+    override async composeExec(_p: string, _n: string, service: string, command: string[], opts?: { user?: string }) {
+      this.execCalls.push({ service, command, user: opts?.user });
+      if (command.includes('list')) return { success: true, output: this.checkOutput };
+      return { success: true, output: '[mock] source created' };
+    }
+  }
+
+  test('post-deploy setup runs the OIDC command with substituted credentials (no env injected)', async () => {
+    const docker = new RecordingDocker();
+    const sys = makeSystem({ auth: OIDC_SETUP_AUTH, docker });
+
+    const created = await sys.deployments.createFromDraft({ draftId: await finalizedDraft(sys.drafts), name: 'gitea' });
+    expect((await waitForJob(sys.jobs, created.jobId!)).status).toBe('completed');
+
+    // The add-oauth command ran in the ingress service as the configured user,
+    // with placeholders substituted by the provisioned credentials.
+    const addCall = docker.execCalls.find(c => c.command.includes('add-oauth'));
+    expect(addCall).toBeDefined();
+    expect(addCall!.service).toBe('gitea');
+    expect(addCall!.user).toBe('git');
+    expect(addCall!.command).toContain('cid-123');
+    expect(addCall!.command).toContain('csecret-456');
+    expect(addCall!.command).toContain('https://auth.example.com/application/o/gitea-x/.well-known/openid-configuration');
+
+    // The app has no env mapping, so nothing was injected into the compose.
+    expect(await readMaterializedEnv(sys.storage, created.deploymentId)).toEqual({});
+  });
+
+  test('post-deploy setup is idempotent: skips the command when already configured', async () => {
+    const docker = new RecordingDocker();
+    docker.checkOutput = 'authentik   OAuth2   ...'; // `gitea admin auth list` already lists it
+    const sys = makeSystem({ auth: OIDC_SETUP_AUTH, docker });
+
+    const created = await sys.deployments.createFromDraft({ draftId: await finalizedDraft(sys.drafts), name: 'gitea' });
+    expect((await waitForJob(sys.jobs, created.jobId!)).status).toBe('completed');
+
+    // The guard matched, so only the check ran — no add-oauth.
+    expect(docker.execCalls.some(c => c.command.includes('add-oauth'))).toBe(false);
+    expect(docker.execCalls.some(c => c.command.includes('list'))).toBe(true);
   });
 });

--- a/packages/server/src/__tests__/provisioner/manifest-auth.test.ts
+++ b/packages/server/src/__tests__/provisioner/manifest-auth.test.ts
@@ -60,6 +60,31 @@ describe('coerceManifestAuth', () => {
     expect(coerceManifestAuth({ mode: 'native-oidc' })).toBeUndefined();
   });
 
+  test('native-oidc with a setup command and no env is valid', () => {
+    const result = coerceManifestAuth({
+      mode: 'native-oidc',
+      oidc: {
+        redirectPath: '/cb',
+        scopes: ['openid'],
+        setup: { user: 'git', check: ['gitea', 'admin', 'auth', 'list'], checkMatch: 'authentik', command: ['gitea', 'admin', 'auth', 'add-oauth', '--key', '{{clientId}}'] },
+      },
+    });
+    expect(result).toEqual({
+      mode: 'native-oidc',
+      oidc: {
+        redirectPath: '/cb',
+        scopes: ['openid'],
+        setup: { user: 'git', check: ['gitea', 'admin', 'auth', 'list'], checkMatch: 'authentik', command: ['gitea', 'admin', 'auth', 'add-oauth', '--key', '{{clientId}}'] },
+      },
+    });
+  });
+
+  test('native-oidc setup without a command argv degrades to undefined', () => {
+    expect(
+      coerceManifestAuth({ mode: 'native-oidc', oidc: { redirectPath: '/cb', scopes: ['openid'], setup: { check: ['x'] } } })
+    ).toBeUndefined();
+  });
+
   test('coerces native-ldap and forward-auth blocks', () => {
     expect(
       coerceManifestAuth({

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -43,8 +43,10 @@ import type { DockerService } from './docker';
 import type { DraftService, FinalizedArtifacts, FinalizedManifest } from './draft';
 import type { RoutingService } from './routing';
 import type { LoggingService } from './logging';
-import type { ProvisionerService } from './provisioner';
+import type { ProvisionerService, ProvisionResult } from './provisioner';
 import { attachToHolaNetwork, injectEnvironment } from './compose-network';
+
+type ProvisionCredentials = NonNullable<ProvisionResult['credentials']>;
 
 /** Promote a new release built from a finalized draft onto an existing deployment. */
 export interface PromoteRequest {
@@ -714,6 +716,10 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     this.jobService.setExecutor(ctx => this.runLifecycleJob(ctx));
   }
 
+  /** Post-deploy auth-setup retry tuning (overridable in tests to avoid real waits). */
+  authSetupMaxAttempts = 18;
+  authSetupIntervalMs = 5000;
+
   /** Deterministic Compose project name (aligns with the routing network name). */
   private projectName(deploymentId: string): string {
     return `hola-${deploymentId.slice(0, 12)}`;
@@ -769,27 +775,34 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     return this.runtimeDir(deployment.id);
   }
 
-  /**
-   * Provision auth artifacts (if the active release's manifest declares an
-   * `auth` block) before the app starts, and return the env to inject. Idempotent:
-   * reuses any ref already persisted on the deployment (keyed on deploymentId), so
-   * restart/rollback/start-after-stop never create duplicate clients. Throws on
-   * provisioning failure so the lifecycle job fails before any container starts.
-   */
-  private async provisionAuthEnv(deployment: EnhancedDeploymentDetail): Promise<Record<string, string>> {
+  /** Read the active release's declared auth config (if any). */
+  private async readActiveAuth(deployment: EnhancedDeploymentDetail): Promise<FinalizedManifest['auth']> {
     const releaseId = deployment.currentReleaseId;
-    if (!releaseId) return {};
+    if (!releaseId) return undefined;
     const manifestPath = `deployments/${deployment.id}/releases/${releaseId}/manifest.json`;
-    if (!(await this.storageService.fileExists(manifestPath))) return {};
-
-    let auth: FinalizedManifest['auth'];
+    if (!(await this.storageService.fileExists(manifestPath))) return undefined;
     try {
       const manifest = JSON.parse(await this.storageService.readFileAsString(manifestPath)) as FinalizedManifest;
-      auth = manifest.auth;
+      return manifest.auth;
     } catch {
-      return {};
+      return undefined;
     }
-    if (!auth || auth.mode === 'none') return {};
+  }
+
+  /**
+   * Provision auth artifacts (if the active release's manifest declares an
+   * `auth` block) before the app starts. Returns the env to inject plus the raw
+   * provisioned credentials + the auth config (for any post-deploy setup command),
+   * or null when there's nothing to do. Idempotent: reuses any ref already persisted
+   * on the deployment (keyed on deploymentId), so restart/rollback/start-after-stop
+   * never create duplicate clients. Throws on provisioning failure so the lifecycle
+   * job fails before any container starts.
+   */
+  private async provisionAuth(
+    deployment: EnhancedDeploymentDetail
+  ): Promise<{ env: Record<string, string>; credentials?: ProvisionCredentials; auth: NonNullable<FinalizedManifest['auth']> } | null> {
+    const auth = await this.readActiveAuth(deployment);
+    if (!auth || auth.mode === 'none') return null;
 
     const rule = this.routingRuleFor(deployment);
     const result = await this.provisioner.provision({
@@ -808,7 +821,61 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     this.deployments.set(deployment.id, deployment);
     await this.persistDeployment(deployment);
 
-    return result.env;
+    return { env: result.env, credentials: result.credentials, auth };
+  }
+
+  /**
+   * Run an app's post-deploy OIDC setup command (e.g. `gitea admin auth add-oauth`)
+   * inside its container, for apps that can't be configured by env alone. Idempotent
+   * via the manifest's check/checkMatch guard, and retried with backoff because the
+   * app may still be running first-boot migrations. Throws if it never succeeds, so a
+   * deploy that can't complete its auth wiring is surfaced rather than silently broken.
+   */
+  private async runPostDeploySetup(
+    deployment: EnhancedDeploymentDetail,
+    provisioned: { credentials?: ProvisionCredentials; auth: NonNullable<FinalizedManifest['auth']> },
+    projectName: string,
+    logBoth: (level: 'info' | 'warn' | 'error' | 'debug', message: string) => Promise<void>
+  ): Promise<void> {
+    const setup = provisioned.auth.oidc?.setup;
+    const creds = provisioned.credentials;
+    if (!setup || !creds) return;
+
+    const service = setup.service ?? deployment.app;
+    const dir = this.runtimeDir(deployment.id);
+    const subs: Record<string, string> = {
+      clientId: creds.clientId,
+      clientSecret: creds.clientSecret,
+      issuer: creds.issuer,
+      redirectUri: creds.redirectUri,
+      host: this.routingRuleFor(deployment).host,
+    };
+    const apply = (args: string[]) =>
+      args.map(a => a.replace(/\{\{(\w+)\}\}/g, (_, k) => subs[k] ?? `{{${k}}}`));
+
+    for (let attempt = 1; attempt <= this.authSetupMaxAttempts; attempt++) {
+      if (attempt > 1) await new Promise(r => setTimeout(r, this.authSetupIntervalMs));
+
+      if (setup.check) {
+        const chk = await this.dockerService.composeExec(dir, projectName, service, apply(setup.check), { user: setup.user });
+        if (!chk.success) {
+          await logBoth('info', `Auth setup: app not ready yet (attempt ${attempt}/${this.authSetupMaxAttempts})`);
+          continue; // app likely still starting; retry
+        }
+        if (setup.checkMatch && chk.output.includes(setup.checkMatch)) {
+          await logBoth('info', 'Auth setup: already configured, skipping');
+          return;
+        }
+      }
+
+      const cmd = await this.dockerService.composeExec(dir, projectName, service, apply(setup.command), { user: setup.user });
+      if (cmd.success) {
+        await logBoth('info', 'Auth setup: OIDC source configured');
+        return;
+      }
+      await logBoth('warn', `Auth setup command failed (attempt ${attempt}/${this.authSetupMaxAttempts})`);
+    }
+    throw new Error('post-deploy auth setup did not succeed after retries');
   }
 
   private jobTypeToAction(type: Job['type']): string {
@@ -854,18 +921,20 @@ export class RealDeploymentService extends InMemoryDeploymentService {
         nextStatus = 'stopped';
         nextLifecycle = 'stopped';
       } else if (action === 'restart') {
-        const env = await this.provisionAuthEnv(deployment);
-        const res = await this.dockerService.composeRestart(await this.materializeCompose(deployment, env), projectName);
+        const provisioned = await this.provisionAuth(deployment);
+        const res = await this.dockerService.composeRestart(await this.materializeCompose(deployment, provisioned?.env ?? {}), projectName);
         output = res.output;
         if (!res.success) throw new Error(res.output);
+        if (provisioned) await this.runPostDeploySetup(deployment, provisioned, projectName, logBoth);
         nextStatus = 'running';
         nextLifecycle = 'active';
       } else {
         // deploy / start / rollback -> compose up
-        const env = await this.provisionAuthEnv(deployment);
-        const res = await this.dockerService.composeUp(await this.materializeCompose(deployment, env), projectName);
+        const provisioned = await this.provisionAuth(deployment);
+        const res = await this.dockerService.composeUp(await this.materializeCompose(deployment, provisioned?.env ?? {}), projectName);
         output = res.output;
         if (!res.success) throw new Error(res.output);
+        if (provisioned) await this.runPostDeploySetup(deployment, provisioned, projectName, logBoth);
         nextStatus = 'running';
         nextLifecycle = 'active';
       }

--- a/packages/server/src/services/core/docker.ts
+++ b/packages/server/src/services/core/docker.ts
@@ -5,7 +5,7 @@
  * and log streaming capabilities with graceful degradation when Docker is unavailable.
  */
 
-import { exec } from 'child_process';
+import { exec, execFile } from 'child_process';
 import { promisify } from 'util';
 import { existsSync } from 'fs';
 import { join } from 'path';
@@ -13,6 +13,7 @@ import { getLogger } from '../../lib/logger';
 import type { ServiceHealth, HealthCheckable } from './types';
 
 const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 export interface DockerInfo {
   available: boolean;
@@ -57,7 +58,16 @@ export interface DockerService {
   composeDown(projectPath: string, projectName: string): Promise<{ success: boolean; output: string }>;
   composePs(projectPath: string, projectName: string): Promise<ComposeProject>;
   composeRestart(projectPath: string, projectName: string, serviceName?: string): Promise<{ success: boolean; output: string }>;
-  
+  /** Run a command inside a running compose service (no shell). Used for post-deploy
+   *  auth setup (e.g. `gitea admin auth add-oauth`). */
+  composeExec(
+    projectPath: string,
+    projectName: string,
+    service: string,
+    command: string[],
+    opts?: { user?: string }
+  ): Promise<{ success: boolean; output: string }>;
+
   // Log operations
   getContainerLogs(containerName: string, since?: string, tail?: number): Promise<DockerLogs>;
   streamContainerLogs(containerName: string, callback: (log: DockerLogs['entries'][0]) => void): Promise<{ stop: () => void }>;
@@ -284,6 +294,32 @@ export class RealDockerService implements DockerService, HealthCheckable {
     }
   }
 
+  async composeExec(
+    projectPath: string,
+    projectName: string,
+    service: string,
+    command: string[],
+    opts?: { user?: string }
+  ): Promise<{ success: boolean; output: string }> {
+    const composeFile = join(projectPath, 'docker-compose.yml');
+    // Build argv directly (no shell) so provisioned values can't be injected.
+    const args = ['compose', '-f', composeFile, '-p', projectName, 'exec', '-T'];
+    if (opts?.user) args.push('--user', opts.user);
+    args.push(service, ...command);
+    try {
+      const { stdout, stderr } = await execFileAsync('docker', args, { cwd: projectPath, timeout: 60000 });
+      const output = [stdout, stderr].filter(Boolean).join('\n');
+      this.logger.info('Compose exec succeeded', { projectName, service, output: output.substring(0, 1000) });
+      return { success: true, output };
+    } catch (error) {
+      // execFile rejects on non-zero exit; surface stdout+stderr+message for the caller.
+      const e = error as { stdout?: string; stderr?: string; message?: string };
+      const output = [e.stdout, e.stderr, e.message].filter(Boolean).join('\n');
+      this.logger.warn('Compose exec failed', { projectName, service, output: output.substring(0, 1000) });
+      return { success: false, output };
+    }
+  }
+
   async getContainerLogs(containerName: string, since?: string, tail?: number): Promise<DockerLogs> {
     try {
       this.logger.debug('Getting container logs', { containerName, since, tail });
@@ -495,6 +531,16 @@ export class MockDockerService implements DockerService {
   async composeRestart(projectPath: string, projectName: string): Promise<{ success: boolean; output: string }> {
     this.logger.debug('Mock compose restart', { projectPath, projectName });
     return { success: true, output: `[mock] Project ${projectName} restarted` };
+  }
+
+  async composeExec(
+    projectPath: string,
+    projectName: string,
+    service: string,
+    command: string[]
+  ): Promise<{ success: boolean; output: string }> {
+    this.logger.debug('Mock compose exec', { projectPath, projectName, service, command });
+    return { success: true, output: `[mock] exec ${service}: ${command.join(' ')}` };
   }
 
   async getContainerLogs(containerName: string): Promise<DockerLogs> {

--- a/packages/server/src/services/core/manifest-auth.ts
+++ b/packages/server/src/services/core/manifest-auth.ts
@@ -3,7 +3,7 @@
 // catalog.ts: anything malformed degrades to `undefined` (treated as no-auth)
 // rather than throwing, so a sloppy manifest never breaks catalog browsing.
 
-import type { AppAuthConfig, AuthMode } from '@hola/shared';
+import type { AppAuthConfig, AuthMode, OidcSetupCommand } from '@hola/shared';
 
 const AUTH_MODES: readonly AuthMode[] = ['none', 'native-oidc', 'native-ldap', 'forward-auth'];
 
@@ -34,6 +34,24 @@ function coerceEnvMap<K extends string>(v: unknown, keys: readonly K[]): Record<
   return out;
 }
 
+/** Coerce a post-deploy OIDC setup command. Requires a non-empty string[] command. */
+function coerceOidcSetup(value: unknown): OidcSetupCommand | undefined {
+  const rec = asRecord(value);
+  if (!rec) return undefined;
+  const command = asStringArray(rec.command);
+  if (!command) return undefined;
+  const setup: OidcSetupCommand = { command };
+  const service = asString(rec.service);
+  if (service) setup.service = service;
+  const user = asString(rec.user);
+  if (user) setup.user = user;
+  const check = asStringArray(rec.check);
+  if (check) setup.check = check;
+  const checkMatch = asString(rec.checkMatch);
+  if (checkMatch) setup.checkMatch = checkMatch;
+  return setup;
+}
+
 /**
  * Coerce an unknown manifest `auth` value into AppAuthConfig.
  * Returns undefined when absent or unusable (caller treats as `none`).
@@ -57,8 +75,10 @@ export function coerceManifestAuth(value: unknown): AppAuthConfig | undefined {
     const redirectPath = asString(oidc?.redirectPath);
     const scopes = asStringArray(oidc?.scopes);
     const env = coerceEnvMap(oidc?.env, ['issuer', 'clientId', 'clientSecret', 'redirectUri'] as const);
-    if (!redirectPath || !scopes || !env) return undefined;
-    result.oidc = { redirectPath, scopes, env };
+    const setup = coerceOidcSetup(oidc?.setup);
+    // Require redirectPath + scopes, and at least one wiring mechanism (env or setup).
+    if (!redirectPath || !scopes || (!env && !setup)) return undefined;
+    result.oidc = { redirectPath, scopes, ...(env ? { env } : {}), ...(setup ? { setup } : {}) };
   }
 
   if (m === 'native-ldap') {

--- a/packages/server/src/services/core/provisioner.ts
+++ b/packages/server/src/services/core/provisioner.ts
@@ -34,8 +34,9 @@ export interface ProvisionInput {
   oidc?: {
     redirectPath: string;
     scopes: string[];
-    /** The app's expected env-var NAMES for each OIDC setting. */
-    env: { issuer: string; clientId: string; clientSecret: string; redirectUri: string };
+    /** The app's expected env-var NAMES for each OIDC setting (optional — apps that
+     *  configure OIDC via a setup command rather than env omit this). */
+    env?: { issuer: string; clientId: string; clientSecret: string; redirectUri: string };
   };
   ldap?: {
     env: { host: string; port: string; bindDn: string; bindPassword: string; baseDn: string };
@@ -44,8 +45,11 @@ export interface ProvisionInput {
 }
 
 export interface ProvisionResult {
-  /** Environment to inject, keyed by the app's expected var NAMES. */
+  /** Environment to inject, keyed by the app's expected var NAMES (empty if the app
+   *  has no env mapping and is wired by a setup command instead). */
   env: Record<string, string>;
+  /** Raw provisioned OIDC values, for post-deploy setup-command substitution. */
+  credentials?: { clientId: string; clientSecret: string; issuer: string; redirectUri: string };
   /** Opaque handle to persist for idempotent re-provision and teardown. */
   ref: ProvisionedAuthRef;
   /** forward-auth only (PR3): Traefik middleware descriptor for the router. */
@@ -140,8 +144,10 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
         redirect_uris: [{ matching_mode: 'strict', url: redirectUri }],
       });
       this.logger.info('Reused existing OIDC client', { deploymentId: input.deploymentId, providerPk: existing.providerPk });
+      const reuseSlug = existing.applicationSlug ?? slug;
       return {
-        env: this.oidcEnv(oidc.env, provider.client_id, provider.client_secret, redirectUri, existing.applicationSlug ?? slug),
+        env: this.oidcEnv(oidc.env, provider.client_id, provider.client_secret, redirectUri, reuseSlug),
+        credentials: { clientId: provider.client_id, clientSecret: provider.client_secret, issuer: this.issuerUrl(reuseSlug), redirectUri },
         ref: existing,
       };
     }
@@ -186,20 +192,26 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
 
     return {
       env: this.oidcEnv(oidc.env, clientId, clientSecret, redirectUri, slug),
+      credentials: { clientId, clientSecret, issuer: this.issuerUrl(slug), redirectUri },
       ref: { mode: 'native-oidc', providerPk: provider.pk, applicationSlug: slug, clientId },
     };
   }
 
+  private issuerUrl(slug: string): string {
+    const base = this.config.authentikPublicUrl || this.config.authentikUrl || '';
+    return `${base}/application/o/${slug}/`;
+  }
+
   private oidcEnv(
-    names: { issuer: string; clientId: string; clientSecret: string; redirectUri: string },
+    names: { issuer: string; clientId: string; clientSecret: string; redirectUri: string } | undefined,
     clientId: string,
     clientSecret: string,
     redirectUri: string,
     slug: string
   ): Record<string, string> {
-    const base = this.config.authentikPublicUrl || this.config.authentikUrl || '';
+    if (!names) return {};
     return {
-      [names.issuer]: `${base}/application/o/${slug}/`,
+      [names.issuer]: this.issuerUrl(slug),
       [names.clientId]: clientId,
       [names.clientSecret]: clientSecret,
       [names.redirectUri]: redirectUri,
@@ -303,14 +315,14 @@ export class MockProvisionerService implements ProvisionerService {
       const clientId = input.existingRef?.clientId ?? `mock-client-${input.deploymentId.slice(0, 8)}`;
       const clientSecret = `mock-secret-${input.deploymentId.slice(0, 8)}`;
       const redirectUri = `https://${input.host}${input.oidc.redirectPath}`;
+      const issuer = `https://auth.mock/application/o/${slug}/`;
       const names = input.oidc.env;
+      const env = names
+        ? { [names.issuer]: issuer, [names.clientId]: clientId, [names.clientSecret]: clientSecret, [names.redirectUri]: redirectUri }
+        : {};
       return {
-        env: {
-          [names.issuer]: `https://auth.mock/application/o/${slug}/`,
-          [names.clientId]: clientId,
-          [names.clientSecret]: clientSecret,
-          [names.redirectUri]: redirectUri,
-        },
+        env,
+        credentials: { clientId, clientSecret, issuer, redirectUri },
         ref: input.existingRef ?? { mode: 'native-oidc', providerPk: 1, applicationSlug: slug, clientId },
       };
     }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -270,15 +270,36 @@ export type GetCatalogAppVersionDetailResponse = {
 // capability × platform at deploy time.
 export type AuthMode = 'none' | 'native-oidc' | 'native-ldap' | 'forward-auth';
 
+// A command run inside an app's container after deploy to finish OIDC wiring for
+// apps that can't be configured by env alone (e.g. Gitea stores its OAuth2 login
+// source in the DB and needs `gitea admin auth add-oauth`). Placeholders
+// {{clientId}} {{clientSecret}} {{issuer}} {{redirectUri}} {{host}} are substituted
+// with the provisioned values. `check`/`checkMatch` make it idempotent: if `check`
+// exits 0 and its stdout contains `checkMatch`, `command` is skipped.
+export type OidcSetupCommand = {
+  /** Compose service to exec in (defaults to the ingress service). */
+  service?: string;
+  /** Exec as this user (e.g. `git` for Gitea). */
+  user?: string;
+  /** Idempotency probe argv; if it succeeds and its output contains checkMatch, skip command. */
+  check?: string[];
+  checkMatch?: string;
+  /** The argv that configures the OIDC source (placeholders substituted). */
+  command: string[];
+};
+
 export type AppAuthConfig = {
   mode: AuthMode;
-  // For `native-oidc`: the env-var NAMES this app expects its OIDC settings in,
-  // plus the callback path and requested scopes. Hola provisions an OIDC client
-  // and injects the values under these names at deploy time.
+  // For `native-oidc`: how Hola wires the provisioned OIDC client into the app.
+  // `env` maps the issuer/client id/secret/redirect into the app's expected env-var
+  // NAMES (for env-configurable apps like Grafana). `setup` runs an in-container
+  // command for apps configured via CLI/DB (like Gitea). At least one is expected;
+  // an app may use both. `redirectPath` + `scopes` are always required.
   oidc?: {
     redirectPath: string;
     scopes: string[];
-    env: { issuer: string; clientId: string; clientSecret: string; redirectUri: string };
+    env?: { issuer: string; clientId: string; clientSecret: string; redirectUri: string };
+    setup?: OidcSetupCommand;
   };
   // For `native-ldap`: the env-var NAMES this app expects its LDAP bind settings in.
   ldap?: {


### PR DESCRIPTION
Part of epic #89; **completes the native-oidc story** begun in #94, on which this is **stacked** (base retargets to `main` once #94 merges).

## Why
Not every app can be wired for OIDC by environment variables. **Gitea** stores its OAuth2 login source in the **database** and requires `gitea admin auth add-oauth` — confirmed against current Gitea docs (env-based config is open proposal go-gitea/gitea#31995, unimplemented). PR1's env injection alone would provision the Authentik client but leave Gitea login non-functional. This PR adds a post-deploy command hook so `native-oidc` works end-to-end for such apps.

## What's here
- **shared**: `AppAuthConfig.oidc.env` is now **optional**; new `OidcSetupCommand` (`service`/`user`/`check`/`checkMatch`/`command`) with `{{clientId}} {{clientSecret}} {{issuer}} {{redirectUri}} {{host}}` placeholders. A native-oidc app must declare **at least one** of `env` or `setup`.
- **provisioner**: `ProvisionResult` now also returns raw **`credentials`** (for command substitution) alongside the mapped `env`; `env` is emitted only when the manifest declares an env mapping. (Env-native apps like Grafana use `env`; Gitea uses `setup`.)
- **docker**: new `composeExec` (builds argv directly — **no shell**, so provisioned secrets can't be injected) on Real + Mock.
- **deployment**: after a successful compose up/restart, run the setup command in the app's container with placeholder substitution, an **idempotency guard** (`check` + `checkMatch`), and **bounded retry-with-backoff** (the app may still be running first-boot migrations). Throws if it never succeeds — broken auth wiring is surfaced, not silent. Retry tuning is overridable in tests.

## Tests
- Setup command runs with substituted credentials in the ingress container as the configured user; no env injected when the app has no env mapping.
- Idempotent: when `gitea admin auth list` already shows the source, the command is skipped.
- Manifest coercion for `setup` (and rejection when `command` is missing).
- Full server suite (212), lint, build green.

## Follow-ups
- Companion `try-hola/apps` change: add the `auth.oidc.setup` block to Gitea's manifest + republish (separate repo).
- Known Gitea caveat (go-gitea/gitea#8356, old versions): a CLI-created source may need a one-time UI re-save; verify on the pinned image during the real end-to-end test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)