### PR TITLE
feat: native-ldap mode — per-app LDAP bind accounts via Authentik (#93)

### DIFF
--- a/packages/compose/.env.example
+++ b/packages/compose/.env.example
@@ -53,3 +53,10 @@ HOLA_AUTHENTIK_API_TOKEN=
 # Override only if you point Hola at an external Authentik.
 # HOLA_AUTHENTIK_URL=http://authentik-server:9000
 # HOLA_AUTHENTIK_PUBLIC_URL=https://auth.local.hola
+
+# LDAP (only for `native-ldap` apps). Base DN of the shared directory, and the
+# token of the LDAP outpost you create in Authentik (one-time; see README). Leave
+# the token blank until you've created the outpost — the authentik-ldap container
+# won't connect without it.
+HOLA_AUTHENTIK_LDAP_BASE_DN=dc=hola,dc=internal
+AUTHENTIK_LDAP_OUTPOST_TOKEN=

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -151,12 +151,31 @@ The Authentik services (`authentik-server`, `authentik-worker`, `authentik-postg
 and the login UI is served at `HOLA_AUTHENTIK_DOMAIN`. First admin login is `akadmin` with the
 generated `AUTHENTIK_BOOTSTRAP_PASSWORD`.
 
+**App auth styles.** Hola auto-provisions three integration styles per app:
+- **native-OIDC** — registers an OIDC client and injects (or, for CLI-configured apps like Gitea,
+  runs a setup command with) the issuer/client id/secret. Works out of the box.
+- **forward-auth** — protects apps with no native auth via the embedded proxy outpost (Traefik
+  forward-auth middleware). Works out of the box.
+- **native-LDAP** — for apps that bind to an LDAP directory; **needs one-time setup** (below).
+
+### native-LDAP one-time setup
+The bind-account half is automatic (Hola creates a per-app LDAP service account on install), but the
+shared LDAP directory needs an outpost you create once:
+1. In Authentik, create an **LDAP Provider** (set its **Base DN**, e.g. `dc=hola,dc=internal`) and an
+   **Outpost** of type *LDAP* bound to it.
+2. Copy the outpost's **token** into `AUTHENTIK_LDAP_OUTPOST_TOKEN` in `.env`, and set
+   `HOLA_AUTHENTIK_LDAP_BASE_DN` to the same Base DN.
+3. `docker compose up -d authentik-ldap` — the outpost connects and serves the directory at
+   `authentik-ldap:3389` on the `hola` network. native-LDAP apps then bind automatically.
+
+(Pinning the outpost token without this manual copy is a known Authentik gap; revisit when upstream
+supports it.)
+
 Notes & limitations:
 - The bootstrap token is the **akadmin superuser** token. Acceptable for first delivery; a scoped
   least-privilege service-account token is a planned hardening follow-up.
 - We **do not** mount the Docker socket into Authentik — Hola runs any outposts as its own services.
-- Currently only **native-OIDC** apps are auto-provisioned. `forward-auth` and `native-ldap` are
-  planned (see the auth/SSO epic). A lightweight Authelia+LLDAP backend is tracked separately.
+- A lightweight Authelia+LLDAP backend (for low-RAM hosts) is tracked separately.
 
 ## Deploying apps & routing
 When you deploy an app through Hola, the server writes a Traefik router/service for it into

--- a/packages/compose/docker-compose.yml
+++ b/packages/compose/docker-compose.yml
@@ -80,6 +80,9 @@ services:
       - HOLA_AUTHENTIK_URL=${HOLA_AUTHENTIK_URL:-http://authentik-server:9000}
       - HOLA_AUTHENTIK_PUBLIC_URL=${HOLA_AUTHENTIK_PUBLIC_URL:-}
       - HOLA_AUTHENTIK_API_TOKEN=${HOLA_AUTHENTIK_API_TOKEN:-}
+      # Base DN of the shared LDAP directory (for native-ldap apps); host/port
+      # default to the authentik-ldap outpost service.
+      - HOLA_AUTHENTIK_LDAP_BASE_DN=${HOLA_AUTHENTIK_LDAP_BASE_DN:-dc=hola,dc=internal}
     volumes:
       # Orchestrate deployments by talking to the host Docker engine.
       # SECURITY: this grants control of the host's Docker - see README.
@@ -184,6 +187,24 @@ services:
       - authentik-media:/media
       - authentik-templates:/templates
       - authentik-certs:/certs
+    labels:
+      traefik.enable: "false"
+
+  # LDAP outpost — serves the shared directory that `native-ldap` apps bind to,
+  # reachable internally on the `hola` network at authentik-ldap:3389. Requires a
+  # one-time setup: create an LDAP provider + outpost in Authentik and copy the
+  # outpost token into AUTHENTIK_LDAP_OUTPOST_TOKEN (see README "Authentication & SSO").
+  authentik-ldap:
+    image: ghcr.io/goauthentik/ldap:2025.10
+    container_name: authentik-ldap
+    profiles: [authentik]
+    restart: unless-stopped
+    environment:
+      AUTHENTIK_HOST: http://authentik-server:9000
+      AUTHENTIK_INSECURE: "true"
+      AUTHENTIK_TOKEN: ${AUTHENTIK_LDAP_OUTPOST_TOKEN:-}
+    depends_on:
+      - authentik-server
     labels:
       traefik.enable: "false"
 

--- a/packages/server/src/__tests__/deployments/auth-provisioning.test.ts
+++ b/packages/server/src/__tests__/deployments/auth-provisioning.test.ts
@@ -101,6 +101,19 @@ class SpyProvisioner implements ProvisionerService {
         middleware: { name: 'ak-gitea-x', outpostUrl: 'http://authentik-server:9000' },
       };
     }
+    if (input.mode === 'native-ldap' && input.ldap) {
+      const e = input.ldap.env;
+      return {
+        env: {
+          [e.host]: 'authentik-ldap',
+          [e.port]: '3389',
+          [e.bindDn]: 'cn=svc,ou=users,dc=hola,dc=internal',
+          [e.bindPassword]: 'ldap-pw',
+          [e.baseDn]: 'dc=hola,dc=internal',
+        },
+        ref: input.existingRef ?? { mode: 'native-ldap', bindAccountPk: 9 },
+      };
+    }
     return { env: {}, ref: { mode: input.mode } };
   }
 
@@ -340,6 +353,28 @@ describe('Auth provisioning lifecycle', () => {
     // Delete tears the provider down.
     await sys.deployments.deleteDeployment(created.deploymentId);
     expect(spy.deprovisions[0].ref?.mode).toBe('forward-auth');
+  });
+
+  test('native-ldap: injects the bind config into the ingress service', async () => {
+    const sys = makeSystem({
+      auth: {
+        mode: 'native-ldap',
+        ldap: { env: { host: 'LDAP_HOST', port: 'LDAP_PORT', bindDn: 'LDAP_BIND_DN', bindPassword: 'LDAP_BIND_PW', baseDn: 'LDAP_BASE_DN' } },
+      },
+    });
+    const spy = sys.provisioner as SpyProvisioner;
+
+    const created = await sys.deployments.createFromDraft({ draftId: await finalizedDraft(sys.drafts), name: 'gitea' });
+    expect((await waitForJob(sys.jobs, created.jobId!)).status).toBe('completed');
+
+    expect(spy.provisions[0].mode).toBe('native-ldap');
+    const env = await readMaterializedEnv(sys.storage, created.deploymentId);
+    expect(env.LDAP_HOST).toBe('authentik-ldap');
+    expect(env.LDAP_BIND_DN).toBe('cn=svc,ou=users,dc=hola,dc=internal');
+    expect(env.LDAP_BIND_PW).toBe('ldap-pw');
+
+    await sys.deployments.deleteDeployment(created.deploymentId);
+    expect(spy.deprovisions[0].ref?.mode).toBe('native-ldap');
   });
 
   test('post-deploy setup is idempotent: skips the command when already configured', async () => {

--- a/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
+++ b/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
@@ -18,6 +18,9 @@ const CONFIG: AuthConfig = {
   authentikPublicUrl: 'https://auth.example.com',
   authentikApiToken: 'test-token',
   fetchTimeoutMs: 5000,
+  ldapHost: 'authentik-ldap',
+  ldapPort: '3389',
+  ldapBaseDn: 'dc=hola,dc=internal',
 };
 
 interface RecordedCall {
@@ -68,6 +71,15 @@ function installFetch(handler?: (call: RecordedCall) => Response | undefined) {
     }
     if (method === 'GET' && url.pathname.startsWith('/api/v3/outposts/instances/')) {
       return json({ pk: 1, providers: [55] });
+    }
+    if (method === 'POST' && url.pathname === '/api/v3/core/users/') {
+      return json({ pk: 88, username: body.username }, 201);
+    }
+    if (method === 'POST' && /^\/api\/v3\/core\/users\/\d+\/set_password\/$/.test(url.pathname)) {
+      return new Response(null, { status: 204 });
+    }
+    if (method === 'POST' && /^\/api\/v3\/rbac\/permissions\/assigned\/users\/\d+\/assign\/$/.test(url.pathname)) {
+      return json({});
     }
     if (method === 'PATCH') {
       return json({ pk: 1 });
@@ -180,10 +192,53 @@ describe('RealAuthentikProvisionerService (REST contract)', () => {
     ).resolves.toBeUndefined();
   });
 
-  test('native-ldap is not implemented yet', async () => {
+  const LDAP_INPUT = {
+    deploymentId: 'dep-abcdef0123456789',
+    appName: 'nextcloud',
+    mode: 'native-ldap' as const,
+    host: 'nextcloud.example.com',
+    ldap: {
+      env: { host: 'LDAP_HOST', port: 'LDAP_PORT', bindDn: 'LDAP_BIND_DN', bindPassword: 'LDAP_BIND_PW', baseDn: 'LDAP_BASE_DN' },
+    },
+  };
+
+  test('native-ldap provision creates a bind service account, sets its password, maps env', async () => {
     installFetch();
     const svc = new RealAuthentikProvisionerService(CONFIG);
-    await expect(svc.provision({ ...OIDC_INPUT, mode: 'native-ldap', oidc: undefined })).rejects.toThrow(/not implemented/);
+
+    const result = await svc.provision(LDAP_INPUT);
+
+    // A service-account user was created and given a password.
+    const userCall = calls.find(c => c.method === 'POST' && c.path === '/api/v3/core/users/')!;
+    expect(userCall).toBeDefined();
+    expect((userCall.body as Record<string, unknown>).type).toBe('service_account');
+    expect(calls.some(c => c.method === 'POST' && /\/api\/v3\/core\/users\/88\/set_password\/$/.test(c.path))).toBe(true);
+
+    // Env mapped onto the app's expected names, with a DN derived from the username.
+    expect(result.env.LDAP_HOST).toBe('authentik-ldap');
+    expect(result.env.LDAP_PORT).toBe('3389');
+    expect(result.env.LDAP_BASE_DN).toBe('dc=hola,dc=internal');
+    expect(result.env.LDAP_BIND_DN).toMatch(/^cn=hola-nextcloud-.*,ou=users,dc=hola,dc=internal$/);
+    expect(typeof result.env.LDAP_BIND_PW).toBe('string');
+    expect(result.ref).toMatchObject({ mode: 'native-ldap', bindAccountPk: 88 });
+  });
+
+  test('native-ldap re-provision reuses the bind account (only resets the password)', async () => {
+    installFetch();
+    const svc = new RealAuthentikProvisionerService(CONFIG);
+
+    await svc.provision({ ...LDAP_INPUT, existingRef: { mode: 'native-ldap', bindAccountPk: 88 } });
+
+    // No new user created; password re-set on the existing account.
+    expect(calls.some(c => c.method === 'POST' && c.path === '/api/v3/core/users/')).toBe(false);
+    expect(calls.some(c => /\/api\/v3\/core\/users\/88\/set_password\/$/.test(c.path))).toBe(true);
+  });
+
+  test('native-ldap deprovision deletes the bind account', async () => {
+    installFetch();
+    const svc = new RealAuthentikProvisionerService(CONFIG);
+    await svc.deprovision({ deploymentId: 'x', ref: { mode: 'native-ldap', bindAccountPk: 88 } });
+    expect(calls.some(c => c.method === 'DELETE' && c.path === '/api/v3/core/users/88/')).toBe(true);
   });
 
   test('forward-auth provision creates a proxy provider, app, and binds the outpost', async () => {

--- a/packages/server/src/config/auth.ts
+++ b/packages/server/src/config/auth.ts
@@ -29,6 +29,12 @@ export interface AuthConfig {
   authentikApiToken?: string;
   /** Network timeout for Authentik API calls. */
   fetchTimeoutMs: number;
+  /** LDAP outpost service host apps bind to (compose DNS name). */
+  ldapHost: string;
+  /** LDAP outpost port (3389 plain / 6636 TLS). */
+  ldapPort: string;
+  /** Base DN of the shared LDAP directory served by the outpost. */
+  ldapBaseDn: string;
 }
 
 function stripTrailingSlash(url: string | undefined): string | undefined {
@@ -44,6 +50,9 @@ export const defaultAuthConfig: AuthConfig = {
     stripTrailingSlash(process.env.HOLA_AUTHENTIK_URL),
   authentikApiToken: process.env.HOLA_AUTHENTIK_API_TOKEN || undefined,
   fetchTimeoutMs: Number(process.env.HOLA_AUTHENTIK_FETCH_TIMEOUT_MS) || 5000,
+  ldapHost: process.env.HOLA_AUTHENTIK_LDAP_HOST || 'authentik-ldap',
+  ldapPort: process.env.HOLA_AUTHENTIK_LDAP_PORT || '3389',
+  ldapBaseDn: process.env.HOLA_AUTHENTIK_LDAP_BASE_DN || 'dc=hola,dc=internal',
 };
 
 export function loadAuthConfig(): AuthConfig {

--- a/packages/server/src/services/core/provisioner.ts
+++ b/packages/server/src/services/core/provisioner.ts
@@ -104,7 +104,7 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
       case 'forward-auth':
         return this.provisionForwardAuth(input);
       case 'native-ldap':
-        throw new ProvisioningError(`auth mode '${input.mode}' is not implemented yet`);
+        return this.provisionLdap(input);
       case 'none':
         return { env: {}, ref: { mode: 'none' } };
       default:
@@ -138,6 +138,13 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
         await this.apiDeleteIgnoreMissing(`/api/v3/providers/proxy/${ref.providerPk}/`);
       }
       this.logger.info('Deprovisioned forward-auth provider', { deploymentId: input.deploymentId, providerPk: ref.providerPk });
+      return;
+    }
+    if (ref.mode === 'native-ldap') {
+      if (ref.bindAccountPk != null) {
+        await this.apiDeleteIgnoreMissing(`/api/v3/core/users/${ref.bindAccountPk}/`);
+      }
+      this.logger.info('Deprovisioned LDAP bind account', { deploymentId: input.deploymentId, bindAccountPk: ref.bindAccountPk });
     }
   }
 
@@ -301,6 +308,62 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
     }
   }
 
+  // ---- native-ldap -------------------------------------------------------
+
+  private async provisionLdap(input: ProvisionInput): Promise<ProvisionResult> {
+    const ldap = input.ldap;
+    if (!ldap) throw new ProvisioningError('native-ldap requires an ldap config block');
+
+    const username = slugify(`hola-${input.appName}-${input.deploymentId.slice(0, 8)}-ldap`);
+    const password = randomBytes(24).toString('hex');
+    const baseDn = this.config.ldapBaseDn;
+    const bindDn = `cn=${username},ou=users,${baseDn}`;
+
+    // Create the bind service account on first provision; reuse it on re-deploy.
+    let bindAccountPk = input.existingRef?.mode === 'native-ldap' ? input.existingRef.bindAccountPk : undefined;
+    if (bindAccountPk == null) {
+      const user = await this.api<{ pk: number }>('POST', '/api/v3/core/users/', {
+        username,
+        name: `Hola ${input.appName} LDAP bind`,
+        type: 'service_account',
+        path: 'goauthentik.io/outposts/ldap',
+        is_active: true,
+      });
+      bindAccountPk = user.pk;
+      await this.grantLdapSearch(bindAccountPk);
+    }
+    // (Re)set the bind password and inject it fresh each deploy.
+    await this.api('POST', `/api/v3/core/users/${bindAccountPk}/set_password/`, { password });
+
+    this.logger.info('Provisioned LDAP bind account', { deploymentId: input.deploymentId, bindAccountPk });
+
+    return {
+      env: {
+        [ldap.env.host]: this.config.ldapHost,
+        [ldap.env.port]: this.config.ldapPort,
+        [ldap.env.bindDn]: bindDn,
+        [ldap.env.bindPassword]: password,
+        [ldap.env.baseDn]: baseDn,
+      },
+      ref: { mode: 'native-ldap', bindAccountPk },
+    };
+  }
+
+  /** Grant the bind account directory-search rights. Best-effort: the permission
+   *  codename can vary by Authentik version, so a failure is logged, not fatal. */
+  private async grantLdapSearch(userPk: number): Promise<void> {
+    try {
+      await this.api('POST', `/api/v3/rbac/permissions/assigned/users/${userPk}/assign/`, {
+        permissions: ['authentik_providers_ldap.search_full_directory'],
+      });
+    } catch (error) {
+      this.logger.warn('Could not assign LDAP search permission (verify codename for your Authentik version)', {
+        userPk,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
   private oidcEnv(
     names: { issuer: string; clientId: string; clientSecret: string; redirectUri: string } | undefined,
     clientId: string,
@@ -431,6 +494,20 @@ export class MockProvisionerService implements ProvisionerService {
         env: {},
         ref: input.existingRef ?? { mode: 'forward-auth', providerPk: 2, applicationSlug: slug, outpostPk: 1 },
         middleware: { name: `ak-${slug}`, outpostUrl: 'http://authentik-server:9000' },
+      };
+    }
+    if (input.mode === 'native-ldap' && input.ldap) {
+      const username = slugify(`hola-${input.appName}-${input.deploymentId.slice(0, 8)}-ldap`);
+      const e = input.ldap.env;
+      return {
+        env: {
+          [e.host]: 'authentik-ldap',
+          [e.port]: '3389',
+          [e.bindDn]: `cn=${username},ou=users,dc=hola,dc=internal`,
+          [e.bindPassword]: `mock-ldap-pw-${input.deploymentId.slice(0, 8)}`,
+          [e.baseDn]: 'dc=hola,dc=internal',
+        },
+        ref: input.existingRef ?? { mode: 'native-ldap', bindAccountPk: 3 },
       };
     }
     // none / unimplemented modes: no-op so a deploy proceeds without auth wiring.


### PR DESCRIPTION
Closes #93. The **last** of epic #89's three auth styles. Builds on #94/#98/#99/#100 (all merged).

Apps that bind to an LDAP directory get a **per-app bind service account** provisioned in Authentik on install, with the connection details injected into the app's env.

## What's here
- **provisioner**: `provision('native-ldap')` creates a service-account user, sets its password (idempotent re-provision reuses the account, only resets the password), best-effort grants the directory-search permission, and returns LDAP env (`host`/`port`/`bindDn`/`bindPassword`/`baseDn`) mapped onto the app's `auth.ldap.env` names. `deprovision` deletes the account. The env-injection path is the **same generic one** native-oidc uses, so the deploy lifecycle needed no changes.
- **config**: `HOLA_AUTHENTIK_LDAP_HOST/PORT/BASE_DN`.
- **compose**: `authentik-ldap` outpost container (authentik profile, no host ports — apps bind at `authentik-ldap:3389` on the `hola` network); base DN passed to the server; `.env.example` LDAP settings.
- **docs**: README "native-LDAP one-time setup".
- **tests**: native-ldap provision/reuse/deprovision REST contract + lifecycle env injection. Full suite **219 green**, 3× no flake; lint + build clean.

## Honest scoping note
The **bind-account half is automatic**; the **shared LDAP outpost** needs a one-time manual step — create an LDAP provider + outpost in Authentik and copy its token into `AUTHENTIK_LDAP_OUTPOST_TOKEN`. Pinning that token automatically is a known Authentik gap (goauthentik/authentik#9711), so I documented the manual step rather than ship an unverified blueprint. The RBAC search-permission codename can vary by Authentik version, so that grant is best-effort (logged, not fatal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)