### PR TITLE
feat(server): defer forward-auth route activation until provisioned (#102)

### DIFF
--- a/packages/server/src/__tests__/deployments/auth-provisioning.test.ts
+++ b/packages/server/src/__tests__/deployments/auth-provisioning.test.ts
@@ -355,6 +355,27 @@ describe('Auth provisioning lifecycle', () => {
     expect(spy.deprovisions[0].ref?.mode).toBe('forward-auth');
   });
 
+  test('forward-auth: route activation is deferred until the gate is provisioned (no ungated window)', async () => {
+    const sys = makeSystem({ auth: { mode: 'forward-auth', forwardAuth: {} } });
+
+    // Create without auto-start: the release is promoted (route activation seam runs)
+    // but provisioning hasn't happened yet, so the route must NOT be live ungated.
+    const created = await sys.deployments.createFromDraft({
+      draftId: await finalizedDraft(sys.drafts),
+      name: 'gitea',
+      options: { autoStart: false },
+    });
+    const mapExists = await sys.storage.fileExists('runtime/traefik/routing-map.json');
+    const mapBefore = mapExists ? JSON.parse(await sys.storage.readFileAsString('runtime/traefik/routing-map.json')) : {};
+    expect(mapBefore['gitea.local.hola']).toBeUndefined();
+
+    // Once started, provisioning runs and the route appears WITH the gate.
+    const start = await sys.deployments.executeAction(created.deploymentId, { action: 'start' });
+    expect((await waitForJob(sys.jobs, start.jobId!)).status).toBe('completed');
+    const mapAfter = JSON.parse(await sys.storage.readFileAsString('runtime/traefik/routing-map.json'));
+    expect(mapAfter['gitea.local.hola']?.forwardAuth?.name).toBe('ak-gitea-x');
+  });
+
   test('native-ldap: injects the bind config into the ingress service', async () => {
     const sys = makeSystem({
       auth: {

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -1068,7 +1068,20 @@ export class RealDeploymentService extends InMemoryDeploymentService {
   protected override async onActiveReleaseChanged(deploymentId: string): Promise<void> {
     const deployment = this.deployments.get(deploymentId);
     if (!deployment) return;
-    await this.routingService.activateRoute(this.routingRuleFor(deployment));
+    const rule = this.routingRuleFor(deployment);
+    // Avoid a brief unauthenticated window: if the app must be gated by forward-auth
+    // but the gate hasn't been provisioned yet (first deploy — no middleware on the
+    // rule), defer route activation to completeAuthWiring after the deploy job
+    // provisions it. Re-deploys/restarts already carry the persisted middleware, so
+    // they activate immediately with the gate.
+    if (!rule.forwardAuth) {
+      const auth = await this.readActiveAuth(deployment);
+      if (auth?.mode === 'forward-auth') {
+        this.logger.info('Deferring route activation until forward-auth is provisioned', { deploymentId });
+        return;
+      }
+    }
+    await this.routingService.activateRoute(rule);
   }
 
   protected override async onDeploymentRemoved(deploymentId: string): Promise<void> {


### PR DESCRIPTION
Part of #102. Closes the brief **unauthenticated window** on a forward-auth app's first deploy.

Previously the route was activated at promote time — before the deploy job provisioned the Authentik proxy provider + Traefik middleware — so the app was briefly reachable **ungated** until the job finished.

`onActiveReleaseChanged` now **defers** route activation when the active release declares `forward-auth` and no middleware is persisted yet (first deploy). `completeAuthWiring` activates the route *with* the gate after provisioning. Unaffected paths:
- **Re-deploys/restarts** already carry the persisted middleware → activate immediately with the gate.
- **Reconcile on restart** rebuilds gated routes from `metadata.auth.middleware`.
- **native-oidc / no-auth** apps activate at promote as before (only `forward-auth` defers).

If provisioning fails, the route stays inactive — correct, never expose ungated.

**Test:** a forward-auth deploy with `autoStart=false` leaves no route in the map; after `start`, the route appears with the `forwardAuth` gate. Full suite 221 green (3× no flake), lint/build clean.