### PR TITLE
test(server): assert LDAP bind account gets the search grant (e2e)

### DIFF
--- a/packages/server/src/__tests__/integration/authentik-provision.it.ts
+++ b/packages/server/src/__tests__/integration/authentik-provision.it.ts
@@ -253,6 +253,15 @@ describe.skipIf(!dockerOk)('Authentik provisioner (real daemon)', () => {
     const user = await akGet(`/api/v3/core/users/${result.ref.bindAccountPk}/`);
     expect(user.status).toBe(200);
 
+    // ...and was granted directory-search rights (regression guard for the grant
+    // endpoint/codename — this is otherwise a best-effort, swallowed call).
+    const perms = (await akGet(`/api/v3/rbac/permissions/?user=${result.ref.bindAccountPk}`)) as {
+      status: number;
+      body: { results: Array<{ app_label: string; codename: string }> };
+    };
+    expect(perms.status).toBe(200);
+    expect(perms.body.results.some(p => p.app_label === 'authentik_providers_ldap' && p.codename === 'search_full_directory')).toBe(true);
+
     await svc.deprovision({ deploymentId: 'dep-ldap-0003abcd', ref: result.ref });
     expect((await akGet(`/api/v3/core/users/${result.ref.bindAccountPk}/`)).status).toBe(404);
   }, 120_000);


### PR DESCRIPTION
Part of #102. Closes the "LDAP search-permission codename" question.

`grantLdapSearch` is a best-effort, swallowed call, so a wrong endpoint or codename would fail silently (LDAP bind accounts wouldn't actually be able to search). #104 fixed the endpoint (`assigned/users` → `assigned_by_users`); this PR proves the grant lands.

**Verified against real Authentik (2025.10):**
- `authentik_providers_ldap.search_full_directory` is the correct codename (confirmed the earlier "missing" was just a truncated permission dump).
- After a native-ldap provision, the bind account's global permissions (`GET /api/v3/rbac/permissions/?user=<pk>`) include it.

Extends the native-ldap case in the Docker-gated e2e with that assertion (regression guard). 4/4 e2e pass; default suite 221 green; lint/build clean. Test-only change.