### PR TITLE
feat(server): act on auth.fallback — gate native-oidc/none apps behind forward-auth (#102)

### DIFF
--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -158,6 +158,9 @@ generated `AUTHENTIK_BOOTSTRAP_PASSWORD`.
   forward-auth middleware). Works out of the box.
 - **native-LDAP** — for apps that bind to an LDAP directory; **needs one-time setup** (below).
 
+An app's manifest can also set `auth.fallback: forward-auth` to gate a native-OIDC (or
+no-auth) app behind the proxy *as well*, for defense-in-depth.
+
 ### native-LDAP one-time setup
 The bind-account half is automatic (Hola creates a per-app LDAP service account on install), but the
 shared LDAP directory needs an outpost you create once:

--- a/packages/server/src/__tests__/deployments/auth-provisioning.test.ts
+++ b/packages/server/src/__tests__/deployments/auth-provisioning.test.ts
@@ -376,6 +376,31 @@ describe('Auth provisioning lifecycle', () => {
     expect(mapAfter['gitea.local.hola']?.forwardAuth?.name).toBe('ak-gitea-x');
   });
 
+  test('fallback: a native-oidc app is also gated behind forward-auth', async () => {
+    const sys = makeSystem({ auth: { ...OIDC_AUTH, fallback: 'forward-auth' } });
+    const spy = sys.provisioner as SpyProvisioner;
+
+    const created = await sys.deployments.createFromDraft({ draftId: await finalizedDraft(sys.drafts), name: 'gitea' });
+    expect((await waitForJob(sys.jobs, created.jobId!)).status).toBe('completed');
+
+    // Both the primary (oidc) and the fallback (forward-auth) were provisioned.
+    expect(spy.provisions.map(p => p.mode)).toEqual(['native-oidc', 'forward-auth']);
+
+    // OIDC env was injected AND the route is gated by the forward-auth middleware.
+    const env = await readMaterializedEnv(sys.storage, created.deploymentId);
+    expect(env.GITEA_OIDC_CLIENT_ID).toBe('cid-123');
+    const map = JSON.parse(await sys.storage.readFileAsString('runtime/traefik/routing-map.json'));
+    expect(map['gitea.local.hola']?.forwardAuth?.name).toBe('ak-gitea-x');
+
+    // Both refs persisted; delete tears both down.
+    const meta = JSON.parse(await sys.storage.readFileAsString(`deployments/${created.deploymentId}/metadata.json`));
+    expect(meta.metadata.auth.ref.providerPk).toBe(42);
+    expect(meta.metadata.auth.fallbackRef.mode).toBe('forward-auth');
+
+    await sys.deployments.deleteDeployment(created.deploymentId);
+    expect(spy.deprovisions.map(d => d.ref?.mode).sort()).toEqual(['forward-auth', 'native-oidc']);
+  });
+
   test('native-ldap: injects the bind config into the ingress service', async () => {
     const sys = makeSystem({
       auth: {

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -31,7 +31,8 @@ import type {
   DeploymentAction,
   DeploymentDirectoryLayout,
   Job,
-  DeploymentListItem
+  DeploymentListItem,
+  ProvisionedAuthRef
 } from '@hola/shared';
 
 import { getLogger } from '../../lib/logger';
@@ -802,7 +803,9 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     deployment: EnhancedDeploymentDetail
   ): Promise<{ env: Record<string, string>; credentials?: ProvisionCredentials; auth: NonNullable<FinalizedManifest['auth']> } | null> {
     const auth = await this.readActiveAuth(deployment);
-    if (!auth || auth.mode === 'none') return null;
+    // Nothing to do for `none` unless it's explicitly gated by a forward-auth fallback.
+    const wantsFallback = auth?.fallback === 'forward-auth' && auth.mode !== 'forward-auth';
+    if (!auth || (auth.mode === 'none' && !wantsFallback)) return null;
 
     const rule = this.routingRuleFor(deployment);
     const result = await this.provisioner.provision({
@@ -816,8 +819,25 @@ export class RealDeploymentService extends InMemoryDeploymentService {
       forwardAuth: auth.forwardAuth,
     });
 
-    // Persist the provisioned ref so re-deploy reuses it and delete can tear it down.
-    deployment.metadata.auth = { mode: auth.mode, ref: result.ref, middleware: result.middleware };
+    // Defense-in-depth: also gate the app behind forward-auth when requested,
+    // even though it has its own (OIDC) login. Provisions a second proxy provider.
+    let middleware = result.middleware;
+    let fallbackRef: ProvisionedAuthRef | undefined;
+    if (wantsFallback) {
+      const fa = await this.provisioner.provision({
+        deploymentId: deployment.id,
+        appName: deployment.app,
+        mode: 'forward-auth',
+        host: rule.host,
+        existingRef: deployment.metadata.auth?.fallbackRef,
+        forwardAuth: auth.forwardAuth,
+      });
+      middleware = fa.middleware;
+      fallbackRef = fa.ref;
+    }
+
+    // Persist the provisioned refs so re-deploy reuses them and delete can tear them down.
+    deployment.metadata.auth = { mode: auth.mode, ref: result.ref, middleware, fallbackRef };
     this.deployments.set(deployment.id, deployment);
     await this.persistDeployment(deployment);
 
@@ -888,7 +908,10 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     logBoth: (level: 'info' | 'warn' | 'error' | 'debug', message: string) => Promise<void>
   ): Promise<void> {
     await this.runPostDeploySetup(deployment, provisioned, projectName, logBoth);
-    if (provisioned.auth.mode === 'forward-auth') {
+    // Re-emit the route with the gate whenever a forward-auth middleware was
+    // provisioned — either `forward-auth` mode or a `fallback: forward-auth` on a
+    // native-oidc/none app. routingRuleFor reads the persisted middleware.
+    if (deployment.metadata.auth?.middleware) {
       await this.routingService.activateRoute(this.routingRuleFor(deployment));
       await logBoth('info', 'Auth: forward-auth gate applied to route');
     }
@@ -1076,7 +1099,7 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     // they activate immediately with the gate.
     if (!rule.forwardAuth) {
       const auth = await this.readActiveAuth(deployment);
-      if (auth?.mode === 'forward-auth') {
+      if (auth?.mode === 'forward-auth' || auth?.fallback === 'forward-auth') {
         this.logger.info('Deferring route activation until forward-auth is provisioned', { deploymentId });
         return;
       }
@@ -1092,6 +1115,10 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     const auth = deployment.metadata.auth;
     if (!auth) return;
     await this.provisioner.deprovision({ deploymentId: deployment.id, ref: auth.ref });
+    // Tear down the extra forward-auth provider from a `fallback: forward-auth` too.
+    if (auth.fallbackRef) {
+      await this.provisioner.deprovision({ deploymentId: deployment.id, ref: auth.fallbackRef });
+    }
   }
 
   protected override async loadFinalizedArtifacts(draftId: string): Promise<FinalizedArtifacts | null> {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -789,7 +789,9 @@ export type EnhancedDeploymentDetail = DeploymentDetail & {
     // reused on re-deploy and torn down on delete. Keyed on deploymentId.
     // `middleware` is set for forward-auth apps so the route can be re-emitted
     // with the gate on restart without re-provisioning.
-    auth?: { mode: AuthMode; ref: ProvisionedAuthRef; middleware?: ForwardAuthMiddleware };
+    // `ref` is the primary mode's artifact; `fallbackRef` is the extra forward-auth
+    // provider when `auth.fallback: forward-auth` gates a native-oidc/none app too.
+    auth?: { mode: AuthMode; ref: ProvisionedAuthRef; middleware?: ForwardAuthMiddleware; fallbackRef?: ProvisionedAuthRef };
   };
 };
 


### PR DESCRIPTION
Part of #102. `auth.fallback: forward-auth` was coerced/typed but **inert** — now it's wired.

An app that declares `auth.fallback: forward-auth` gets, **in addition to** its primary mode, a forward-auth proxy provider + Traefik gate. Defense-in-depth for an app that also has its own OIDC login, or a way to gate a `none` app at the proxy.

- **`provisionAuth`**: after the primary provision, if fallback is requested (and mode isn't already `forward-auth`), provision a **second** forward-auth provider (idempotent via a persisted `fallbackRef`) and attach its middleware to the route. `none`+fallback no longer short-circuits to "nothing to do".
- **`completeAuthWiring`**: re-activates the route whenever a middleware was provisioned (forward-auth mode OR fallback), and the first-deploy activation **deferral** (#105) now also covers fallback apps — no ungated window.
- **`onDeprovision`**: tears down the `fallbackRef` too.
- **shared**: `metadata.auth.fallbackRef`.

**Test:** a native-oidc app with `fallback: forward-auth` provisions both (`['native-oidc','forward-auth']`), injects the OIDC env **and** gates the route with the middleware, persists both refs, and deletes both on teardown. Full suite 222 green, lint/build clean. README note added.

This was the last substantive feature item in #102; remaining items are upstream-blocked (LDAP outpost token pinning), a release-time chore (image bump), or the full Gitea browser-login e2e.