### PR TITLE
chore: release 0.2.0 — version bump + add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,77 @@
+# CLAUDE.md
+
+Guidance for working in this repository.
+
+## What Hola is
+
+Hola is a self-hosted app-deployment platform: a browsable **catalog** of apps that
+install as **Docker Compose** stacks, orchestrated by a server and routed by
+**Traefik**. Apps become reachable at `<app>.<HOLA_BASE_DOMAIN>`. Optional **SSO**
+(Authentik) auto-provisions per-app auth on install.
+
+## Monorepo layout (Bun workspaces, `packages/*`)
+
+- **`server`** — the orchestrator API (Bun). Owns the deploy lifecycle, catalog,
+  drafts, Traefik routing, and the auth provisioner. Most logic lives here.
+- **`web`** — the SPA dashboard (Vite/React). Single origin: nginx serves it and
+  proxies `/api` to the server.
+- **`shared`** — types + the compose validator (`@hola/shared/compose-validate`)
+  shared across packages.
+- **`sdk`** / **`cli`** — typed client and CLI against the server API. The CLI is
+  the only thing released as a binary (`cli-release.yml`, on `cli-v*` tags).
+- **`compose`** — the production Docker Compose stack (Traefik + web + server,
+  plus an optional Authentik profile) and `scripts/install.sh`.
+
+## Commands
+
+- `bun run typecheck` · `bun run lint` · `bun run build` — across all packages.
+- `bun run test` — server unit suite + web tests. `bun --cwd packages/server test`
+  for server only.
+- **Integration tests** (`*.it.ts`) are **excluded** from the default suite and
+  **gated on a reachable Docker daemon** (`describe.skipIf(!dockerOk)`). Run via
+  `bun run test:integration`. Some boot real Authentik (slow: image pull +
+  migrations).
+- Always run typecheck + lint + test + build before opening a PR. Note: CI's
+  typecheck has caught issues the local run missed after a lint auto-fix — re-run
+  typecheck after lint fixes.
+
+## Architecture notes that matter
+
+- **Traefik-only ingress.** Apps have **no host ports**; the server emits Traefik
+  file-provider config (`/data/runtime/traefik/dynamic.yml`) and joins each app's
+  ingress service to the external `hola` network. The compose **validator rejects
+  host ports** and requires pinned image tags.
+- **Deploy lifecycle is async.** `createFromDraft`/`promote`/`rollback` enqueue a
+  job; the actual `docker compose up` runs later in `RealDeploymentService.runLifecycleJob`.
+  Per-deploy work (auth provisioning, env injection) belongs there, not at create time.
+- **Services use a Real/Mock pair** registered in `services/simple-factory.ts`
+  (test/dev → Mock, production → Real). Follow that convention for new services.
+- **Catalog → deploy.** `RealCatalogService` fetches a remote `catalog.json`
+  (`HOLA_CATALOG_URL`); app compose/manifest live in OCI bundles pulled via `oras`.
+  Per-app metadata (incl. the `auth` block) comes from the bundle `manifest.json`,
+  not `catalog.json`.
+- **Auth/SSO (Authentik).** `ProvisionerService` (`services/core/provisioner.ts`)
+  provisions per-app auth at deploy time for three modes declared in the app
+  manifest's `auth` block: `native-oidc` (env injection and/or a post-deploy setup
+  command for CLI/DB-configured apps like Gitea), `forward-auth` (Traefik gate via
+  Authentik's embedded outpost), and `native-ldap` (per-app bind accounts). The
+  interface is platform-agnostic (an Authelia+LLDAP backend is tracked in #88). The
+  server self-bootstraps a least-privilege scoped token from an admin bootstrap
+  token. Authentik is opt-in via `HOLA_AUTH_MODE=authentik` (a compose profile).
+
+## Conventions
+
+- **Branch + PR for changes** (don't push to `main`). PRs squash-merge; CI runs on
+  PRs targeting `main` only. For stacked work, rebase each branch onto `main` after
+  the parent merges (the repo squashes, so stacked branches need `git rebase --onto`).
+- Commit messages end with: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
+- PR bodies end with: `🤖 Generated with [Claude Code](https://claude.com/claude-code)`
+- Versions across published packages are kept in sync (`web` is intentionally
+  `0.0.0`/unversioned).
+
+## Where to read more
+
+- `docs/ARCHITECTURE.md` — system design and deployment lifecycle.
+- `docs/OPERATIONS.md` — install, recovery, backup, SSO.
+- `packages/compose/README.md` — the production stack, catalog, and Authentik setup.
+- `docs/adr/` — architecture decision records (e.g. authentication).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hola",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "workspaces": [
     "packages/*"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Release prep for **0.2.0** (minor bump, pre-1.0, marks the auth/SSO + catalog→deploy feature set; no breaking changes).

- Bump all published packages `0.1.0` → `0.2.0` (`web` stays intentionally unversioned at `0.0.0`). Internal deps use `workspace:*`, so resolution is unaffected (build verified green).
- **Add `CLAUDE.md`** (the repo had none): project overview, monorepo layout, commands, the key architecture (Traefik-only ingress, async deploy lifecycle, Real/Mock service factory, catalog→deploy, the auth provisioner + three modes), and conventions (branch/PR, commit/PR trailers, stacked-rebase, integration-test gating).

After merge I'll tag `cli-v0.2.0` to cut the release (publishes CLI binaries + a GitHub Release).