### PR TITLE
feat(server): make oidc.env.redirectUri optional for env-injected OIDC

### DIFF
--- a/packages/server/src/__tests__/deployments/auth-provisioning.test.ts
+++ b/packages/server/src/__tests__/deployments/auth-provisioning.test.ts
@@ -86,7 +86,12 @@ class SpyProvisioner implements ProvisionerService {
       const issuer = 'https://auth.example.com/application/o/gitea-x/';
       const names = input.oidc.env;
       const env = names
-        ? { [names.issuer]: issuer, [names.clientId]: 'cid-123', [names.clientSecret]: 'csecret-456', [names.redirectUri]: redirectUri }
+        ? {
+            [names.issuer]: issuer,
+            [names.clientId]: 'cid-123',
+            [names.clientSecret]: 'csecret-456',
+            ...(names.redirectUri ? { [names.redirectUri]: redirectUri } : {}),
+          }
         : {};
       return {
         env,

--- a/packages/server/src/__tests__/provisioner/manifest-auth.test.ts
+++ b/packages/server/src/__tests__/provisioner/manifest-auth.test.ts
@@ -47,6 +47,25 @@ describe('coerceManifestAuth', () => {
     });
   });
 
+  test('native-oidc env without redirectUri is valid (app derives its own redirect URI)', () => {
+    const result = coerceManifestAuth({
+      mode: 'native-oidc',
+      oidc: {
+        redirectPath: '/openid/callback',
+        scopes: ['openid', 'email', 'profile'],
+        env: { issuer: 'ACTUAL_OPENID_DISCOVERY_URL', clientId: 'ACTUAL_OPENID_CLIENT_ID', clientSecret: 'ACTUAL_OPENID_CLIENT_SECRET' },
+      },
+    });
+    expect(result).toEqual({
+      mode: 'native-oidc',
+      oidc: {
+        redirectPath: '/openid/callback',
+        scopes: ['openid', 'email', 'profile'],
+        env: { issuer: 'ACTUAL_OPENID_DISCOVERY_URL', clientId: 'ACTUAL_OPENID_CLIENT_ID', clientSecret: 'ACTUAL_OPENID_CLIENT_SECRET' },
+      },
+    });
+  });
+
   test('native-oidc with an incomplete env mapping degrades to undefined', () => {
     expect(
       coerceManifestAuth({

--- a/packages/server/src/services/core/manifest-auth.ts
+++ b/packages/server/src/services/core/manifest-auth.ts
@@ -34,6 +34,20 @@ function coerceEnvMap<K extends string>(v: unknown, keys: readonly K[]): Record<
   return out;
 }
 
+/**
+ * Coerce the native-oidc env-var name map. issuer/clientId/clientSecret are
+ * required; redirectUri is optional (apps that derive their own redirect URI
+ * from their base URL — e.g. Actual Budget — have no env var for it).
+ */
+function coerceOidcEnv(
+  v: unknown
+): { issuer: string; clientId: string; clientSecret: string; redirectUri?: string } | undefined {
+  const required = coerceEnvMap(v, ['issuer', 'clientId', 'clientSecret'] as const);
+  if (!required) return undefined;
+  const redirectUri = asString(asRecord(v)?.redirectUri);
+  return { ...required, ...(redirectUri ? { redirectUri } : {}) };
+}
+
 /** Coerce a post-deploy OIDC setup command. Requires a non-empty string[] command. */
 function coerceOidcSetup(value: unknown): OidcSetupCommand | undefined {
   const rec = asRecord(value);
@@ -74,7 +88,7 @@ export function coerceManifestAuth(value: unknown): AppAuthConfig | undefined {
     const oidc = asRecord(rec.oidc);
     const redirectPath = asString(oidc?.redirectPath);
     const scopes = asStringArray(oidc?.scopes);
-    const env = coerceEnvMap(oidc?.env, ['issuer', 'clientId', 'clientSecret', 'redirectUri'] as const);
+    const env = coerceOidcEnv(oidc?.env);
     const setup = coerceOidcSetup(oidc?.setup);
     // Require redirectPath + scopes, and at least one wiring mechanism (env or setup).
     if (!redirectPath || !scopes || (!env && !setup)) return undefined;

--- a/packages/server/src/services/core/provisioner.ts
+++ b/packages/server/src/services/core/provisioner.ts
@@ -35,8 +35,10 @@ export interface ProvisionInput {
     redirectPath: string;
     scopes: string[];
     /** The app's expected env-var NAMES for each OIDC setting (optional — apps that
-     *  configure OIDC via a setup command rather than env omit this). */
-    env?: { issuer: string; clientId: string; clientSecret: string; redirectUri: string };
+     *  configure OIDC via a setup command rather than env omit this). `redirectUri`
+     *  is optional: apps that derive their own redirect URI from their base URL have
+     *  no env var for the literal callback. */
+    env?: { issuer: string; clientId: string; clientSecret: string; redirectUri?: string };
   };
   ldap?: {
     env: { host: string; port: string; bindDn: string; bindPassword: string; baseDn: string };
@@ -401,7 +403,7 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
   }
 
   private oidcEnv(
-    names: { issuer: string; clientId: string; clientSecret: string; redirectUri: string } | undefined,
+    names: { issuer: string; clientId: string; clientSecret: string; redirectUri?: string } | undefined,
     clientId: string,
     clientSecret: string,
     redirectUri: string,
@@ -412,7 +414,8 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
       [names.issuer]: this.issuerUrl(slug),
       [names.clientId]: clientId,
       [names.clientSecret]: clientSecret,
-      [names.redirectUri]: redirectUri,
+      // Only inject the literal redirect URI when the app exposes an env var for it.
+      ...(names.redirectUri ? { [names.redirectUri]: redirectUri } : {}),
     };
   }
 
@@ -602,7 +605,12 @@ export class MockProvisionerService implements ProvisionerService {
       const issuer = `https://auth.mock/application/o/${slug}/`;
       const names = input.oidc.env;
       const env = names
-        ? { [names.issuer]: issuer, [names.clientId]: clientId, [names.clientSecret]: clientSecret, [names.redirectUri]: redirectUri }
+        ? {
+            [names.issuer]: issuer,
+            [names.clientId]: clientId,
+            [names.clientSecret]: clientSecret,
+            ...(names.redirectUri ? { [names.redirectUri]: redirectUri } : {}),
+          }
         : {};
       return {
         env,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -298,7 +298,11 @@ export type AppAuthConfig = {
   oidc?: {
     redirectPath: string;
     scopes: string[];
-    env?: { issuer: string; clientId: string; clientSecret: string; redirectUri: string };
+    // `redirectUri` is optional: many apps derive their own redirect URI from
+    // their base URL and have no env var for the literal callback URL (e.g.
+    // Actual Budget uses ACTUAL_OPENID_SERVER_HOSTNAME). issuer/clientId/
+    // clientSecret are always required when an env map is present.
+    env?: { issuer: string; clientId: string; clientSecret: string; redirectUri?: string };
     setup?: OidcSetupCommand;
   };
   // For `native-ldap`: the env-var NAMES this app expects its LDAP bind settings in.


### PR DESCRIPTION
## Summary

The `native-oidc` env-name map (`auth.oidc.env`) required all four keys — `issuer`, `clientId`, `clientSecret`, `redirectUri`. But many OIDC apps **derive their own redirect URI from their base URL** and expose no env var for the literal callback URL (e.g. **Actual Budget** uses `ACTUAL_OPENID_SERVER_HOSTNAME` + its own `/openid/callback` path). The mandatory `redirectUri` key blocked that common env-injection shape, forcing such apps onto setup commands (which they don't support) or `none`.

This makes `redirectUri` **optional** end-to-end. `issuer`/`clientId`/`clientSecret` stay required; `redirectUri` is injected only when the app maps it. Authentik still registers the redirect URI from `oidc.redirectPath` regardless, so the callback is wired correctly even when the app derives its own.

## Changes
- **shared**: `AppAuthConfig.oidc.env.redirectUri` is now optional.
- **provisioner**: `ProvisionInput.oidc.env` + `oidcEnv()` (Real) and the Mock omit `redirectUri` when unmapped.
- **manifest-auth**: new `coerceOidcEnv()` — requires the issuer/clientId/clientSecret trio, optional `redirectUri`.
- **tests**: partial-env map (no `redirectUri`) is valid; the full-map and incomplete-trio cases are unchanged.

## Why now
Unblocks Actual Budget (and the common "app derives its own redirect URI" shape) for turnkey env-injected OIDC, part of rounding out the first five catalog apps.

## Verification
`bun run typecheck` · `bun run lint` · `bun --cwd packages/server test` (223 pass) · `bun run build` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)