### PR TITLE
feat(compose): DNS-01 wildcard TLS for private/homelab hosts (opt-in)

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -173,8 +173,10 @@ list. Common cases:
 
 - **502 from the UI** — the `server` container isn't healthy yet;
   `docker compose logs server`.
-- **No TLS cert** — domains must be public and resolve to the host (Let's Encrypt
-  HTTP-01).
+- **No TLS cert** — with the default HTTP-01 the host must be internet-reachable on
+  port 80. For private/homelab hosts use DNS-01 instead (set `ACME_DNS_PROVIDER` +
+  provider credentials in `.env` for a wildcard cert — see the
+  [compose README](../packages/compose/README.md#private--homelab-tls-dns-01)).
 - **Deployed app not routable** — confirm its Compose joined the `hola` network
   and that `/data/runtime/traefik/dynamic.yml` contains its router.
 - **Validate config** — `docker compose config` validates the merged `.env`.

--- a/packages/compose/.env.example
+++ b/packages/compose/.env.example
@@ -10,6 +10,26 @@ TRAEFIK_HTTPS_PORT=443
 TRAEFIK_DASHBOARD_DOMAIN=traefik.local.hola
 LETSENCRYPT_EMAIL=admin@example.com
 
+# --- TLS challenge (Let's Encrypt) ---
+# Blank (default): HTTP-01 — needs this host reachable from the internet on :80.
+# For PRIVATE / homelab hosts NOT reachable from the internet, use DNS-01: set your
+# DNS provider below and its API credentials. scripts/up.sh then auto-includes the
+# DNS-01 overlay and requests a single WILDCARD cert for *.${HOLA_BASE_DOMAIN}
+# (covers the UI, the Traefik dashboard, the Authentik login UI, and every deployed
+# app). The host never needs an inbound port; only DNS TXT records are written.
+#   Supported here: route53, cloudflare (Traefik/lego supports ~100 more).
+ACME_DNS_PROVIDER=
+# AWS Route 53 (ACME_DNS_PROVIDER=route53). IAM credentials allowed to change
+# records in the hosted zone (route53:ChangeResourceRecordSets / GetChange /
+# ListHostedZonesByName / ListResourceRecordSets). AWS_HOSTED_ZONE_ID is optional
+# (pin it if the account has multiple zones); leave blank to auto-detect.
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_REGION=us-east-1
+AWS_HOSTED_ZONE_ID=
+# Cloudflare (ACME_DNS_PROVIDER=cloudflare). A scoped token with Zone:DNS:Edit.
+CF_DNS_API_TOKEN=
+
 # --- Hola UI/API (single origin: web serves the SPA and proxies /api) ---
 HOLA_DOMAIN=app.local.hola
 

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -75,8 +75,48 @@ Then open `http://app.local.hola`. (Auth is disabled in development.)
 ## TLS (production)
 - Set `LETSENCRYPT_EMAIL` and use real, internet-resolvable domains for `HOLA_DOMAIN` and
   `TRAEFIK_DASHBOARD_DOMAIN` pointing at the host.
-- `install.sh` creates `traefik/acme/acme.json` (chmod 600). Certs are issued via HTTP-01 on the
-  `web` entrypoint and stored there.
+- `install.sh` creates `traefik/acme/acme.json` (chmod 600). Certs are stored there.
+- **Default is HTTP-01** — a per-host cert is issued on demand for each domain (the UI, the
+  dashboard, the Authentik UI, and every deployed app at `<app>.<HOLA_BASE_DOMAIN>`). This
+  requires the host to be **reachable from the internet on port 80** so Let's Encrypt can
+  validate.
+
+### Private / homelab TLS (DNS-01)
+If the host is **not reachable from the internet** (e.g. a homelab box behind NAT), HTTP-01
+can't validate. Use **DNS-01** instead: Traefik proves domain control by writing a TXT record
+through your DNS provider's API, so no inbound port is needed — and it can issue a single
+**wildcard** cert (`*.<HOLA_BASE_DOMAIN>`) covering the UI, dashboard, Authentik, and every app.
+
+Your A records can point at private IPs (`10.x` / `192.168.x`); only the domain's *public DNS*
+needs to be API-manageable. (A made-up internal-only domain like `*.home`/`*.lan` won't work —
+Let's Encrypt can't sign names it can't validate; you'd need an internal CA for those.)
+
+Enable it in `.env`:
+
+```bash
+ACME_DNS_PROVIDER=route53            # or: cloudflare
+# Route 53:
+AWS_ACCESS_KEY_ID=...
+AWS_SECRET_ACCESS_KEY=...
+AWS_REGION=us-east-1
+# AWS_HOSTED_ZONE_ID=...             # optional; pin if the account has several zones
+# Cloudflare instead:
+# CF_DNS_API_TOKEN=...               # scoped token with Zone:DNS:Edit
+```
+
+Then run `./scripts/install.sh` (or `./scripts/up.sh`). When `ACME_DNS_PROVIDER` is set, the
+DNS-01 overlay (`docker-compose.dns01.yml`) is included automatically and a wildcard cert is
+requested for `*.<HOLA_BASE_DOMAIN>`. Manually that's:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dns01.yml up -d
+```
+
+Example for `HOLA_BASE_DOMAIN=hola.get2know.io`: one `*.hola.get2know.io` cert serves
+`app.hola.get2know.io` (UI), `traefik.`/`auth.`, and `gitea.`/`n8n.`/… apps. The Route 53 IAM
+principal needs `route53:ChangeResourceRecordSets`, `GetChange`, `ListHostedZonesByName`, and
+`ListResourceRecordSets` on the zone. Note the wildcard is single-level, so deployed apps must
+be one label under the base (they are: `<app>.<HOLA_BASE_DOMAIN>`).
 
 ## Upgrade
 
@@ -199,6 +239,8 @@ covered by the integration test in issue #19.
 ## Files
 - `docker-compose.yml` — production stack (build, socket, data volume, Traefik file provider).
 - `docker-compose.dev.yml` — opt-in local dev overlay (Bun dev servers, HTTP only); `HOLA_DEV=1`.
+- `docker-compose.dns01.yml` — opt-in DNS-01 TLS overlay (wildcard cert for private/homelab
+  hosts); auto-included when `ACME_DNS_PROVIDER` is set.
 - `../server/Dockerfile`, `../web/Dockerfile`, `../web/nginx.conf` — images.
 - `.env.example` — domains, ports, admin auth, catalog URL, SSO (Authentik) settings.
 - `scripts/` — install/up/down/logs/status helpers.

--- a/packages/compose/docker-compose.dns01.yml
+++ b/packages/compose/docker-compose.dns01.yml
@@ -1,0 +1,49 @@
+# DNS-01 TLS overlay (opt-in) — for PRIVATE / homelab hosts that are NOT reachable
+# from the internet on :80, where Let's Encrypt's HTTP-01 challenge can't validate.
+#
+# DNS-01 proves domain control by writing a TXT record via your DNS provider's API,
+# so the host itself never needs an inbound port open. It also supports WILDCARD
+# certs, so a single cert covers the UI, the Traefik dashboard, the Authentik login
+# UI, and every deployed app: *.${HOLA_BASE_DOMAIN}.
+#
+# scripts/up.sh auto-includes this file when ACME_DNS_PROVIDER is set in .env.
+# Manually it's:
+#   docker compose -f docker-compose.yml -f docker-compose.dns01.yml up -d
+#
+# Configure ACME_DNS_PROVIDER + the provider credentials in .env. See README
+# "Private/homelab TLS (DNS-01)".
+services:
+  traefik:
+    # `command` REPLACES the base command (compose does not merge lists), so the
+    # full set is restated here with DNS-01 + the wildcard request.
+    command:
+      - --api.dashboard=true
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --providers.file.directory=/data/runtime/traefik
+      - --providers.file.watch=true
+      - --entrypoints.web.address=:80
+      - --entrypoints.websecure.address=:443
+      - --entrypoints.websecure.http.tls.certresolver=le
+      # One wildcard cert for the whole base domain. Routers (UI, dashboard, auth,
+      # and the server-emitted app routes) inherit this entrypoint default, so they
+      # are all served from the single *.${HOLA_BASE_DOMAIN} cert — no per-host certs.
+      - --entrypoints.websecure.http.tls.domains[0].main=${HOLA_BASE_DOMAIN}
+      - --entrypoints.websecure.http.tls.domains[0].sans=*.${HOLA_BASE_DOMAIN}
+      - --entrypoints.web.http.redirections.entrypoint.to=websecure
+      - --entrypoints.web.http.redirections.entrypoint.scheme=https
+      - --certificatesresolvers.le.acme.email=${LETSENCRYPT_EMAIL}
+      - --certificatesresolvers.le.acme.storage=/letsencrypt/acme.json
+      # DNS-01 instead of HTTP-01 — no inbound :80 reachability required.
+      - --certificatesresolvers.le.acme.dnschallenge=true
+      - --certificatesresolvers.le.acme.dnschallenge.provider=${ACME_DNS_PROVIDER}
+    environment:
+      # Credentials for the DNS provider's API. lego reads only the vars the chosen
+      # ACME_DNS_PROVIDER needs; the others stay empty and are ignored.
+      # AWS Route 53 (ACME_DNS_PROVIDER=route53):
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
+      AWS_REGION: ${AWS_REGION:-}
+      AWS_HOSTED_ZONE_ID: ${AWS_HOSTED_ZONE_ID:-}
+      # Cloudflare (ACME_DNS_PROVIDER=cloudflare):
+      CF_DNS_API_TOKEN: ${CF_DNS_API_TOKEN:-}

--- a/packages/compose/docker-compose.yml
+++ b/packages/compose/docker-compose.yml
@@ -29,6 +29,9 @@ services:
       # file provider, which set `tls: {}` without a resolver) get Let's Encrypt
       # certificates automatically — every deployed app at <app>.<base-domain>
       # is served over valid TLS, not Traefik's self-signed default.
+      # Default resolver for ALL websecure routers (UI, dashboard, auth, and the
+      # server-emitted app routes) so none need a per-router certresolver label.
+      # The DNS-01 overlay (docker-compose.dns01.yml) adds wildcard domains here.
       - --entrypoints.websecure.http.tls.certresolver=le
       # Global HTTP -> HTTPS redirect at the entrypoint (no per-service middleware).
       - --entrypoints.web.http.redirections.entrypoint.to=websecure
@@ -51,7 +54,6 @@ services:
       traefik.http.routers.traefik.entrypoints: websecure
       traefik.http.routers.traefik.service: api@internal
       traefik.http.routers.traefik.tls: "true"
-      traefik.http.routers.traefik.tls.certresolver: le
 
   server:
     image: hola/server:latest
@@ -110,7 +112,6 @@ services:
       traefik.http.routers.hola-web.rule: Host(`${HOLA_DOMAIN}`)
       traefik.http.routers.hola-web.entrypoints: websecure
       traefik.http.routers.hola-web.tls: "true"
-      traefik.http.routers.hola-web.tls.certresolver: le
       traefik.http.services.hola-web.loadbalancer.server.port: "80"
 
   # --- Authentik (SSO platform) -------------------------------------------
@@ -169,7 +170,6 @@ services:
       traefik.http.routers.authentik.rule: Host(`${HOLA_AUTHENTIK_DOMAIN:-auth.local.hola}`)
       traefik.http.routers.authentik.entrypoints: websecure
       traefik.http.routers.authentik.tls: "true"
-      traefik.http.routers.authentik.tls.certresolver: le
       traefik.http.services.authentik.loadbalancer.server.port: "9000"
 
   authentik-worker:

--- a/packages/compose/scripts/_common.sh
+++ b/packages/compose/scripts/_common.sh
@@ -8,6 +8,10 @@ export COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME:-hola}
 COMPOSE_FILE="$ROOT_DIR/docker-compose.yml"
 ENV_FILE="$ROOT_DIR/.env"
 DEV_FILE="$ROOT_DIR/docker-compose.dev.yml"
+DNS01_FILE="$ROOT_DIR/docker-compose.dns01.yml"
+
+# Read a key from .env without sourcing it (values may contain spaces/quotes).
+env_file_get() { [[ -f "$ENV_FILE" ]] && grep -E "^$1=" "$ENV_FILE" | tail -1 | cut -d= -f2- | xargs || true; }
 
 # Default to the PRODUCTION stack. The dev override (Bun dev servers, HTTP only,
 # auth disabled) is opt-in via HOLA_DEV=1, so a fresh-host install is correct.
@@ -24,6 +28,18 @@ if [[ "${HOLA_DEV:-}" == "1" || "${HOLA_DEV:-}" == "true" ]]; then
   fi
 fi
 export HOLA_MODE
+
+# DNS-01 TLS overlay (opt-in): activated when ACME_DNS_PROVIDER is set in .env.
+# For private/homelab hosts not reachable on :80 — issues a wildcard cert via the
+# DNS provider's API instead of HTTP-01. Not used in dev (HTTP only).
+if [[ "$HOLA_MODE" == "production" && -n "$(env_file_get ACME_DNS_PROVIDER)" ]]; then
+  if [[ -f "$DNS01_FILE" ]]; then
+    COMPOSE_FILES+=("-f" "$DNS01_FILE")
+    echo "[compose] DNS-01 TLS enabled (provider: $(env_file_get ACME_DNS_PROVIDER))" >&2
+  else
+    echo "[compose] ACME_DNS_PROVIDER set but $DNS01_FILE not found; using HTTP-01" >&2
+  fi
+fi
 
 if [[ ! -f "$ENV_FILE" ]]; then
   echo "[compose] No .env found, using defaults from .env.example" >&2

--- a/packages/compose/scripts/install.sh
+++ b/packages/compose/scripts/install.sh
@@ -74,6 +74,28 @@ if [[ "$AUTH_MODE" == "authentik" ]]; then
   fi
 fi
 
+# --- TLS challenge sanity check ----------------------------------------------
+# DNS-01 (for private/homelab hosts) is opt-in via ACME_DNS_PROVIDER; _common.sh
+# auto-includes the overlay. Warn early if the provider is set but credentials are
+# missing, since cert issuance would otherwise fail silently after startup.
+ACME_DNS_PROVIDER="$(env_get ACME_DNS_PROVIDER | xargs || true)"
+if [[ -n "$ACME_DNS_PROVIDER" ]]; then
+  base_domain="$(env_get HOLA_BASE_DOMAIN | xargs || true)"
+  echo "[install] DNS-01 TLS enabled (provider: $ACME_DNS_PROVIDER) — wildcard *.${base_domain:-<HOLA_BASE_DOMAIN>}"
+  case "$ACME_DNS_PROVIDER" in
+    route53)
+      if [[ -z "$(env_get AWS_ACCESS_KEY_ID | xargs || true)" || -z "$(env_get AWS_SECRET_ACCESS_KEY | xargs || true)" ]]; then
+        echo "[install] WARNING: route53 selected but AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY are blank in .env — cert issuance will fail." >&2
+      fi
+      ;;
+    cloudflare)
+      if [[ -z "$(env_get CF_DNS_API_TOKEN | xargs || true)" ]]; then
+        echo "[install] WARNING: cloudflare selected but CF_DNS_API_TOKEN is blank in .env — cert issuance will fail." >&2
+      fi
+      ;;
+  esac
+fi
+
 # Create basic data/logs dirs
 mkdir -p "$ROOT_DIR/logs" "$ROOT_DIR/data"
 mkdir -p "$ROOT_DIR/traefik/acme"


### PR DESCRIPTION
## Why
The default Traefik stack uses Let's Encrypt **HTTP-01**, which needs the host reachable from the internet on port 80. **Homelab/private hosts behind NAT can't validate that way** — so they can't get TLS today. This adds an opt-in **DNS-01** path: Traefik proves domain control by writing a TXT record via your DNS provider's API (no inbound port), and issues a single **wildcard** cert (`*.${HOLA_BASE_DOMAIN}`) covering the UI, the Traefik dashboard, the Authentik login UI, and every deployed app.

## What
- **`docker-compose.dns01.yml`** (new, opt-in overlay) — overrides the Traefik `command` to use `dnschallenge` + `${ACME_DNS_PROVIDER}`, and sets the `websecure` entrypoint's default `tls.domains` to `main=${HOLA_BASE_DOMAIN}` / `sans=*.${HOLA_BASE_DOMAIN}`. Passes Route 53 / Cloudflare credentials to the container.
- **`scripts/_common.sh`** — auto-includes the overlay (production only) when `ACME_DNS_PROVIDER` is set in `.env`, mirroring the `HOLA_DEV` overlay pattern.
- **`docker-compose.yml`** — drops the redundant per-router `tls.certresolver: le` labels (traefik dashboard, hola-web, authentik). They already inherit the entrypoint default resolver; removing them lets the DNS-01 wildcard serve those routers too. **Behavior-neutral for the HTTP-01 default.**
- **`scripts/install.sh`** — reports DNS-01 mode and warns early if the provider is set but its credentials are blank.
- **`.env.example` + README + OPERATIONS** — document `ACME_DNS_PROVIDER`, Route53/Cloudflare creds, the wildcard behavior, IAM permissions, and the single-level wildcard caveat.

## Default unchanged
Public installs keep HTTP-01 per-host certs exactly as before. DNS-01 is purely additive and opt-in.

## Verification (`docker compose config`)
- **Base only**: `httpchallenge` intact, `--entrypoints.websecure.http.tls.certresolver=le` default, routers keep `tls: "true"` (no per-router resolver).
- **Base + overlay** (`ACME_DNS_PROVIDER=route53`): renders `dnschallenge` + `provider=route53`, `tls.domains[0].main=hola.get2know.io` / `sans=*.hola.get2know.io`, AWS creds passed, zero leftover `httpchallenge`.
- **+ authentik profile**: combined config valid; authentik router has `tls: "true"`, no resolver.
- `bun run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)