### PR TITLE
feat(cli): hola bootstrap — remote install over SSH

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -34,6 +34,10 @@ cp .env.example .env          # set HOLA_DOMAIN, HOLA_BASE_DOMAIN, LETSENCRYPT_E
 ./scripts/install.sh          # builds + runs the production stack
 ```
 
+Or use the guided CLI, which validates the config up front and (optionally) installs on a
+remote host over SSH — `hola init` to generate a `.env`, or `hola bootstrap --host user@vm`
+for the full remote install. See the [compose README](../packages/compose/README.md#guided-recommended--the-hola-cli).
+
 ### Authenticate
 
 Auth is **on by default in production**. If you did not set `HOLA_API_KEY` in

--- a/packages/cli/src/__tests__/bootstrap.test.ts
+++ b/packages/cli/src/__tests__/bootstrap.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { runBootstrap } from '../commands/bootstrap/bootstrap';
+import { scriptedPrompter } from '../install/prompter';
+import type { Runner } from '../lib/runner';
+
+const answers: Record<string, string> = {
+  HOLA_BASE_DOMAIN: 'hola.example.com',
+  HOLA_DOMAIN: 'app.hola.example.com',
+  TRAEFIK_DASHBOARD_DOMAIN: 'traefik.hola.example.com',
+  LETSENCRYPT_EMAIL: 'admin@example.com',
+  ACME_DNS_PROVIDER: 'route53',
+  AWS_ACCESS_KEY_ID: 'AKIA123',
+  AWS_SECRET_ACCESS_KEY: 'super-secret-value',
+  AWS_REGION: 'us-east-1',
+  HOLA_CATALOG_URL: 'https://example.com/catalog.json',
+  HOLA_AUTH_MODE: 'none',
+  HOLA_USE_AUTH: 'true',
+  HOLA_API_KEY: '',
+};
+
+const OK_PREFLIGHT = 'docker=ok\ngit=ok\ncompose=ok\ndockerperm=ok\n';
+
+function makeRunner(preflight = OK_PREFLIGHT): Runner & { calls: { cmd: string; input?: string }[] } {
+  const calls: { cmd: string; input?: string }[] = [];
+  return {
+    calls,
+    ssh: vi.fn(async (_host: string, cmd: string, opts?: { input?: string }) => {
+      calls.push({ cmd, input: opts?.input });
+      if (cmd.includes('command -v')) return { code: 0, stdout: preflight, stderr: '' };
+      if (cmd.includes('curl')) return { code: 0, stdout: '200', stderr: '' };
+      return { code: 0, stdout: '', stderr: '' };
+    }),
+    local: vi.fn(async () => ({ code: 0, stdout: '', stderr: '' })),
+  } as Runner & { calls: { cmd: string; input?: string }[] };
+}
+
+describe('hola bootstrap', () => {
+  beforeEach(() => { process.exitCode = 0; });
+  afterEach(() => { process.exitCode = 0; });
+
+  it('runs the remote steps in order and streams .env over stdin', async () => {
+    const runner = makeRunner();
+    const res = await runBootstrap(
+      { host: 'me@vm', skipChecks: true, json: true, ref: 'cli-v0.2.0' },
+      { prompter: scriptedPrompter(answers), runner }
+    );
+
+    expect(res?.steps).toEqual([
+      'Preflight host',
+      'Fetch Hola cli-v0.2.0 into ~/hola',
+      'Write .env (over stdin)',
+      'Run install.sh',
+      'Verify https://app.hola.example.com',
+    ]);
+
+    // The .env is written via the `cat >` step's stdin, not via argv.
+    const writeCall = runner.calls.find((c) => c.cmd.includes('cat >'))!;
+    expect(writeCall.input).toContain('AWS_SECRET_ACCESS_KEY=super-secret-value');
+    // The secret never appears in any command string.
+    expect(runner.calls.every((c) => !c.cmd.includes('super-secret-value'))).toBe(true);
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('clones the repo at the requested ref and writes .env to packages/compose', async () => {
+    const runner = makeRunner();
+    await runBootstrap(
+      { host: 'me@vm', ref: 'main', dir: '/opt/hola', skipChecks: true, json: true },
+      { prompter: scriptedPrompter(answers), runner }
+    );
+    expect(runner.calls.some((c) => /git clone .*--branch main .*\/opt\/hola/.test(c.cmd))).toBe(true);
+    expect(runner.calls.some((c) => c.cmd.includes('cat > /opt/hola/packages/compose/.env'))).toBe(true);
+    expect(runner.calls.some((c) => c.cmd.includes('cd /opt/hola/packages/compose && ./scripts/install.sh'))).toBe(true);
+  });
+
+  it('--dry-run connects to nothing and exits 0', async () => {
+    const runner = makeRunner();
+    const res = await runBootstrap(
+      { host: 'me@vm', dryRun: true, skipChecks: true, json: true },
+      { prompter: scriptedPrompter(answers), runner }
+    );
+    expect(runner.calls).toHaveLength(0);
+    expect(res?.steps.length).toBeGreaterThan(0);
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('aborts before install when preflight finds Docker missing', async () => {
+    const runner = makeRunner('docker=missing\ngit=ok\ncompose=missing\ndockerperm=fail\n');
+    const res = await runBootstrap(
+      { host: 'me@vm', skipChecks: true, json: true },
+      { prompter: scriptedPrompter(answers), runner }
+    );
+    expect(res).toBeUndefined();
+    expect(process.exitCode).toBe(1);
+    expect(runner.calls.some((c) => c.cmd.includes('install.sh'))).toBe(false);
+  });
+
+  it('requires --host', async () => {
+    const res = await runBootstrap({ skipChecks: true, json: true }, { prompter: scriptedPrompter(answers), runner: makeRunner() });
+    expect(res).toBeUndefined();
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/packages/cli/src/commands/bootstrap/bootstrap.ts
+++ b/packages/cli/src/commands/bootstrap/bootstrap.ts
@@ -1,0 +1,191 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+import { clackPrompter, PromptCancelled, type Prompter } from '../../install/prompter';
+import { parseEnv, renderEnv, schemaTemplate } from '../../install/render-env';
+import { secretKeys, type ConfigMap } from '../../install/schema';
+import { runWizard, WizardError } from '../../install/wizard';
+import type { CheckResult } from '../../install/checks';
+import { systemRunner, type Runner } from '../../lib/runner';
+import { CLI_VERSION } from '../../version';
+
+export interface BootstrapOptions {
+  host?: string;
+  repo?: string;
+  ref?: string;
+  dir?: string;
+  envFile?: string;
+  skipChecks?: boolean;
+  dryRun?: boolean;
+  json?: boolean;
+}
+
+export interface BootstrapResult {
+  host: string;
+  dir: string;
+  ref: string;
+  steps: string[];
+}
+
+class BootstrapAbort extends Error {}
+
+const DEFAULT_REPO = 'https://github.com/try-hola/hola.git';
+
+/**
+ * End-to-end remote install: collect config (wizard or --env-file), then over SSH
+ * preflight the host, clone/update the Hola repo, write the .env (streamed via
+ * stdin so secrets never hit argv), run scripts/install.sh, and verify. Returns
+ * the result, or undefined on failure (after setting a non-zero exit code).
+ */
+export async function runBootstrap(
+  opts: BootstrapOptions,
+  injected?: { prompter?: Prompter; runner?: Runner; checks?: (c: ConfigMap) => Promise<CheckResult[]> }
+): Promise<BootstrapResult | undefined> {
+  const prompter = injected?.prompter ?? clackPrompter();
+  const runner = injected?.runner ?? systemRunner();
+  const out = (msg: string) => { if (!opts.json) console.log(msg); };
+
+  const host = opts.host;
+  const repo = opts.repo ?? DEFAULT_REPO;
+  const ref = opts.ref ?? `cli-v${CLI_VERSION}`;
+  const dir = opts.dir ?? '~/hola';
+  const composeDir = `${dir}/packages/compose`;
+  const envPath = `${composeDir}/.env`;
+  const steps: string[] = [];
+
+  try {
+    if (!host) throw new BootstrapAbort('--host user@vm is required.');
+
+    // 1) Config → rendered .env (reuse an init-produced file, or run the wizard).
+    let rendered: string;
+    let config: ConfigMap;
+    if (opts.envFile) {
+      const p = path.resolve(process.cwd(), opts.envFile);
+      rendered = await fs.readFile(p, 'utf8');
+      config = parseEnv(rendered);
+      out(`Using ${p}`);
+    } else {
+      out('Hola setup — answer a few questions, then I will install on the host.\n');
+      const wiz = await runWizard({ prompter, skipChecks: opts.skipChecks, checks: injected?.checks });
+      config = wiz.config;
+      rendered = renderEnv(config, schemaTemplate());
+    }
+    const keyList = Object.keys(config);
+
+    // Helper: run a remote step (or describe it under --dry-run).
+    const ssh = async (title: string, cmd: string, o?: { input?: string; stream?: boolean }) => {
+      steps.push(title);
+      if (opts.dryRun) {
+        out(`# ${title}`);
+        out(`  ssh ${host} ${o?.input != null ? '(stdin: .env redacted) ' : ''}${cmd}`);
+        return { code: 0, stdout: '', stderr: '' };
+      }
+      out(`==> ${title}`);
+      const r = await runner.ssh(host, cmd, {
+        input: o?.input,
+        stream: o?.stream ? (l) => out(`  ${l}`) : undefined,
+      });
+      return r;
+    };
+
+    // 2) Preflight (single remote probe → key=value lines).
+    const probe =
+      'for c in docker git; do command -v "$c" >/dev/null 2>&1 && echo "$c=ok" || echo "$c=missing"; done; ' +
+      'docker compose version >/dev/null 2>&1 && echo compose=ok || echo compose=missing; ' +
+      'docker ps >/dev/null 2>&1 && echo dockerperm=ok || echo dockerperm=fail';
+    if (opts.dryRun) {
+      await ssh('Preflight host', probe);
+    } else {
+      const r = await ssh('Preflight host', probe);
+      if (r.code !== 0) throw new BootstrapAbort(`Could not connect to ${host} (ssh exit ${r.code}).`);
+      const p = parsePreflight(r.stdout);
+      assertPreflight(p);
+      out('  host OK (docker, compose, git, permissions)');
+    }
+
+    // 3) Clone or update the repo at the target ref (full repo: compose builds from ../..).
+    const clone =
+      `if [ -d ${dir}/.git ]; then git -C ${dir} fetch --depth 1 origin ${ref} && git -C ${dir} checkout --force FETCH_HEAD; ` +
+      `else git clone --depth 1 --branch ${ref} ${repo} ${dir}; fi`;
+    const cloneRes = await ssh(`Fetch Hola ${ref} into ${dir}`, clone, { stream: true });
+    if (!opts.dryRun && cloneRes.code !== 0) {
+      throw new BootstrapAbort(`git clone/update failed (exit ${cloneRes.code}). Check --repo/--ref and host network.`);
+    }
+
+    // 4) Write .env — streamed over stdin so values never appear in argv/ps/history.
+    const writeRes = await ssh('Write .env (over stdin)', `cat > ${envPath} && chmod 600 ${envPath}`, { input: rendered });
+    if (!opts.dryRun && writeRes.code !== 0) throw new BootstrapAbort(`Writing ${envPath} failed (exit ${writeRes.code}).`);
+
+    // 5) Run the installer, streaming its output.
+    const installRes = await ssh('Run install.sh', `cd ${composeDir} && ./scripts/install.sh`, { stream: true });
+    if (!opts.dryRun && installRes.code !== 0) throw new BootstrapAbort(`install.sh failed (exit ${installRes.code}).`);
+
+    // 6) Best-effort verify (warn-only: DNS/cert may still be settling).
+    if (!opts.dryRun && config.HOLA_DOMAIN) {
+      const verify = await ssh(
+        `Verify https://${config.HOLA_DOMAIN}`,
+        `curl -sk -o /dev/null -w "%{http_code}" https://${config.HOLA_DOMAIN}/api/health || true`,
+      );
+      const codeStr = verify.stdout.trim();
+      out(codeStr === '200' ? '  UI is responding (200).' : `  UI not ready yet (got "${codeStr || 'no response'}") — may take a minute for TLS/DNS.`);
+    }
+
+    const result: BootstrapResult = { host, dir, ref, steps };
+    if (opts.json) {
+      console.log(JSON.stringify({ host, dir, ref, steps, keys: opts.dryRun ? keyList : undefined }, null, 2));
+    } else if (opts.dryRun) {
+      out(`\nDry run — would write a .env with ${keyList.length} keys: ${redactKeyList(keyList)}`);
+      out('No connection was made. Re-run without --dry-run to execute.');
+    } else {
+      out(`\nDone. Hola is installed on ${host}. Open https://${config.HOLA_DOMAIN ?? '<your HOLA_DOMAIN>'}`);
+    }
+    return result;
+  } catch (err) {
+    if (err instanceof BootstrapAbort || err instanceof WizardError || err instanceof PromptCancelled) {
+      console.error(err.message);
+      process.exitCode = 1;
+      return undefined;
+    }
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`bootstrap failed: ${msg}`);
+    if (/ENOENT|spawn ssh/i.test(msg)) console.error('Hint: the `ssh` client must be installed and on PATH.');
+    process.exitCode = 1;
+    return undefined;
+  }
+}
+
+function parsePreflight(stdout: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const line of stdout.split('\n')) {
+    const t = line.trim();
+    const eq = t.indexOf('=');
+    if (eq > 0) out[t.slice(0, eq)] = t.slice(eq + 1);
+  }
+  return out;
+}
+
+function assertPreflight(p: Record<string, string>): void {
+  if (p.docker !== 'ok' || p.compose !== 'ok') {
+    throw new BootstrapAbort(
+      'Docker + the Compose v2 plugin are required on the host. Install with:\n' +
+        '  curl -fsSL https://get.docker.com | sh\n' +
+        'then re-run bootstrap.',
+    );
+  }
+  if (p.dockerperm !== 'ok') {
+    throw new BootstrapAbort(
+      "This SSH user can't run docker. Add them to the docker group:\n" +
+        '  sudo usermod -aG docker $USER   (then reconnect)\n' +
+        'then re-run bootstrap.',
+    );
+  }
+  if (p.git !== 'ok') {
+    throw new BootstrapAbort('git is required on the host (e.g. `sudo apt-get install -y git`), then re-run bootstrap.');
+  }
+}
+
+/** Show key names for dry-run, redacting secret values' keys to a count is unnecessary — keys aren't secret. */
+function redactKeyList(keys: string[]): string {
+  const secrets = secretKeys();
+  return keys.map((k) => (secrets.has(k) ? `${k}(secret)` : k)).join(', ');
+}

--- a/packages/cli/src/index.tsx
+++ b/packages/cli/src/index.tsx
@@ -1,13 +1,15 @@
 #!/usr/bin/env node
 import sade from 'sade';
 
+import { CLI_VERSION } from './version';
+
 // Lazy command loaders to avoid unnecessary dependencies until invoked
 const load = async <T,>(p: Promise<T>): Promise<T> => p;
 
 const prog = sade('hola');
 
 prog
-  .version('0.2.0')
+  .version(CLI_VERSION)
   .describe('Hola CLI — install, deployments, and the bundle developer workflow');
 
 // init — guided first-time setup (writes .env on this machine; no server needed)
@@ -22,6 +24,23 @@ prog
   .action(async (opts) => {
     const { runInit } = await load(import('./commands/init/init'));
     await runInit(opts);
+  });
+
+// bootstrap — wizard + SSH into the host and run the full install
+prog
+  .command('bootstrap')
+  .describe('Set up Hola on a remote host over SSH (wizard + install)')
+  .option('--host', 'Target host, e.g. user@vm (required)')
+  .option('--repo', 'Hola git repo to clone', 'https://github.com/try-hola/hola.git')
+  .option('--ref', `Git ref to build on the host (default cli-v${CLI_VERSION})`)
+  .option('--dir', 'Install directory on the host', '~/hola')
+  .option('--env-file', 'Use an existing .env (skip the wizard)')
+  .option('--skip-checks', 'Skip live DNS/credential/catalog validation', false)
+  .option('--dry-run', 'Print the plan without connecting', false)
+  .option('--json', 'Print the result as JSON', false)
+  .action(async (opts) => {
+    const { runBootstrap } = await load(import('./commands/bootstrap/bootstrap'));
+    await runBootstrap(opts);
   });
 
 // bundle validate

--- a/packages/cli/src/lib/runner.ts
+++ b/packages/cli/src/lib/runner.ts
@@ -1,0 +1,64 @@
+// Command runner used by `hola bootstrap`. Shells out to the system `ssh` so it
+// inherits the user's ssh-agent, known_hosts, and ~/.ssh/config (ProxyJump etc.)
+// — no SSH library is bundled. Injectable so tests use a fake that records calls.
+
+export interface RunResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+export interface RunOptions {
+  /** Written to the child's stdin (e.g. the .env piped to `cat`), then closed. */
+  input?: string;
+  /** Called with each complete output line as it arrives. */
+  stream?: (line: string) => void;
+}
+
+export interface Runner {
+  /** Run a command on a remote host over SSH. `remoteCmd` is executed by the remote shell. */
+  ssh(host: string, remoteCmd: string, opts?: RunOptions): Promise<RunResult>;
+  /** Run a command locally. */
+  local(cmd: string, args: string[], opts?: RunOptions): Promise<RunResult>;
+}
+
+/** Production runner backed by child_process.spawn of the system ssh/local binaries. */
+export function systemRunner(extraSshArgs: string[] = []): Runner {
+  const run = (cmd: string, args: string[], opts?: RunOptions): Promise<RunResult> =>
+    new Promise((resolve, reject) => {
+      import('node:child_process').then(({ spawn }) => {
+        const child = spawn(cmd, args, { stdio: ['pipe', 'pipe', 'pipe'] });
+        let stdout = '';
+        let stderr = '';
+        const onOut = lineEmitter((l) => opts?.stream?.(l));
+        const onErr = lineEmitter((l) => opts?.stream?.(l));
+        child.stdout?.on('data', (d) => { const s = String(d); stdout += s; onOut(s); });
+        child.stderr?.on('data', (d) => { const s = String(d); stderr += s; onErr(s); });
+        child.on('error', reject);
+        child.on('close', (code) => { onOut('\n'); onErr('\n'); resolve({ code: code ?? 1, stdout, stderr }); });
+        if (opts?.input != null) child.stdin?.write(opts.input);
+        child.stdin?.end();
+      }, reject);
+    });
+
+  return {
+    ssh: (host, remoteCmd, opts) =>
+      run('ssh', [...extraSshArgs, '-o', 'ConnectTimeout=10', host, remoteCmd], opts),
+    local: (cmd, args, opts) => run(cmd, args, opts),
+  };
+}
+
+/** Buffer partial chunks and emit each complete line (trailing newline flushes). */
+function lineEmitter(emit: (line: string) => void): (chunk: string) => void {
+  let buf = '';
+  return (chunk: string) => {
+    buf += chunk;
+    let nl = buf.indexOf('\n');
+    while (nl >= 0) {
+      const line = buf.slice(0, nl);
+      if (line) emit(line);
+      buf = buf.slice(nl + 1);
+      nl = buf.indexOf('\n');
+    }
+  };
+}

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -1,0 +1,4 @@
+// Single source of the CLI version, used for the --version banner and to default
+// `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
+// builds a server image matching this CLI. Keep in sync with package.json.
+export const CLI_VERSION = '0.2.0';

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -29,6 +29,27 @@ browser ──TLS──▶ Traefik ──▶ web (nginx: SPA + /api proxy) ─�
 
 ## Install (production)
 
+### Guided (recommended) — the `hola` CLI
+
+The CLI walks you through the config, **validates it before anything is applied** (DNS, TLS/DNS-01
+credentials, catalog reachability), and writes the `.env` for you:
+
+```bash
+# On your laptop — produce a validated .env (no server contact):
+hola init
+
+# …or do it all the way to a remote host over SSH (wizard → clone → install):
+hola bootstrap --host user@your-vm        # add --dry-run first to preview the plan
+```
+
+`hola bootstrap` SSHes in (reusing your ssh-agent / `~/.ssh/config`), checks the host has Docker +
+Compose v2, clones this repo at your CLI's release tag, writes the `.env` (streamed over stdin so
+secrets never hit the command line), and runs `./scripts/install.sh` — streaming the output back.
+Secrets (Authentik keys etc.) are generated **on the host** and never leave it. Re-running is an
+upgrade: it fetches the new ref and re-runs the idempotent installer.
+
+### Manual
+
 ```bash
 cd packages/compose
 cp .env.example .env          # set HOLA_DOMAIN, HOLA_BASE_DOMAIN, LETSENCRYPT_EMAIL, ...


### PR DESCRIPTION
Second of two PRs for the guided install experience (PR #112 added `hola init`). This adds `hola bootstrap --host user@vm` — the wizard, then a full install on a remote host over SSH.

## Flow (each step streamed; `--dry-run` previews without connecting)
1. **Preflight** the host: Docker + Compose v2 present, the SSH user can run `docker`, `git` present. Missing Docker → **detect-and-instruct** (`get.docker.com`); no remote sudo.
2. **Clone-or-update** the Hola repo at `--ref` (default `cli-v<this CLI's version>`, so the host builds a server matching your CLI) into `--dir` (default `~/hola`). Full repo is required because the compose builds server/web from `context: ../..`.
3. **Write `.env` over stdin** (`cat > … && chmod 600`) — values never appear in argv/`ps`/history.
4. **Run `scripts/install.sh`**, which generates secrets **on the host**.
5. Best-effort health verify.

Re-running is an **upgrade**: fetch the new ref + re-run the idempotent installer; the `.env` merge preserves host-generated secrets.

## Files
- `lib/runner.ts` — injectable `Runner` over the system `ssh` (inherits ssh-agent / `~/.ssh/config` ProxyJump; no SSH library bundled), line-streaming output.
- `commands/bootstrap/bootstrap.ts` — reuses `install/wizard` + `render-env`; `--env-file` skips the wizard and reuses an `init`-produced `.env`.
- `version.ts` — shared `CLI_VERSION` (drives `--version` and the default ref).
- `index.tsx` registration; README + OPERATIONS document `init`/`bootstrap` as the recommended install path.

## Security properties
- Secrets generated on the host, never traverse the laptop.
- `.env` transferred via **stdin**, not argv — verified by a test asserting the secret value appears in the `cat` step's stdin but in **no** command string.

## Verification
- `bun run typecheck` · `bun run lint` · `bun run build` green; `bun --compile` bundles and `hola bootstrap --help` runs from the binary.
- 25 CLI tests pass, incl. bootstrap: ordered remote plan, `.env` over stdin with the secret absent from all argv, `--dry-run` connects to nothing, preflight-missing-Docker aborts before install, `--host` required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)