### PR TITLE
chore: release 0.3.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -1,4 +1,4 @@
 // Single source of the CLI version, used for the --version banner and to default
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // builds a server image matching this CLI. Keep in sync with package.json.
-export const CLI_VERSION = '0.2.0';
+export const CLI_VERSION = '0.3.0';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Cuts **0.3.0** so the published CLI binaries include the guided installer.

Bumps the 5 published packages `0.2.0 → 0.3.0` (web stays `0.0.0`) and `CLI_VERSION` to match. After merge, tagging `cli-v0.3.0` triggers `cli-release.yml` to build the 4 binaries.

**Since 0.2.0:** `hola init` + `hola bootstrap` (guided Day-0 install), DNS-01 wildcard TLS for private/homelab hosts, optional `oidc.env.redirectUri`.

Note: `CLI_VERSION=0.3.0` also makes `hola bootstrap` default `--ref` to `cli-v0.3.0`, so the host builds a server matching the CLI.

Verified: typecheck/lint/build green; 25 CLI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)