### PR TITLE
feat(server): per-app data root + slug-hash deployment IDs

### DIFF
--- a/packages/compose/docker-compose.yml
+++ b/packages/compose/docker-compose.yml
@@ -89,11 +89,23 @@ services:
       # Base DN of the shared LDAP directory (for native-ldap apps); host/port
       # default to the authentik-ldap outpost service.
       - HOLA_AUTHENTIK_LDAP_BASE_DN=${HOLA_AUTHENTIK_LDAP_BASE_DN:-dc=hola,dc=internal}
+      # Per-app data root (default /srv/hola/apps). Apps declare persistent
+      # storage under the ${HOLA_APP_DATA} token (enforced by the compose
+      # validator); the server resolves it to <HOLA_APPS_BIND_ROOT>/<deploymentId>/
+      # so all of an app's data lives in one backup-friendly host folder. The
+      # path MUST be identity-mounted below (same path on host and in-container)
+      # because the daemon resolves bind sources on the host.
+      - HOLA_APPS_BIND_ROOT=${HOLA_APPS_BIND_ROOT:-/srv/hola/apps}
     volumes:
       # Orchestrate deployments by talking to the host Docker engine.
       # SECURITY: this grants control of the host's Docker - see README.
       - /var/run/docker.sock:/var/run/docker.sock
       - hola-data:/data
+      # Identity mount for the per-app bind root (see HOLA_APPS_BIND_ROOT). The
+      # source and target are the SAME host path so paths the server creates
+      # match what the Docker daemon binds into app containers. No-op when the
+      # var is blank (defaults to a host dir that simply goes unused).
+      - ${HOLA_APPS_BIND_ROOT:-/srv/hola/apps}:${HOLA_APPS_BIND_ROOT:-/srv/hola/apps}
     # Internal only: reached through the web container's /api proxy, not exposed by Traefik.
     labels:
       traefik.enable: "false"

--- a/packages/server/src/__tests__/routing/routing-service.test.ts
+++ b/packages/server/src/__tests__/routing/routing-service.test.ts
@@ -22,10 +22,11 @@ describe('RoutingService', () => {
   });
 
   test('generates a deterministic host-based rule', () => {
-    const rule = routing.generateRule({ deploymentId: 'deploy-abc123def456', appName: 'gitea', port: 3000 });
+    const rule = routing.generateRule({ deploymentId: 'gitea-abc123de', appName: 'gitea', port: 3000 });
     expect(rule.host).toBe('gitea.local.hola');
-    expect(rule.serviceName).toBe('gitea-deploy-abc12');
-    expect(rule.networkName).toBe('hola-deploy-abc12');
+    // The (already compact, unique) deployment id is used whole — not truncated.
+    expect(rule.serviceName).toBe('gitea-abc123de');
+    expect(rule.networkName).toBe('hola-gitea-abc123de');
     expect(rule.port).toBe(3000);
   });
 
@@ -54,14 +55,14 @@ describe('RoutingService', () => {
   });
 
   test('activate emits routing map and deterministic Traefik dynamic config', async () => {
-    const rule = routing.generateRule({ deploymentId: 'dep-a', appName: 'gitea', port: 3000 });
+    const rule = routing.generateRule({ deploymentId: 'gitea-dep-a', appName: 'gitea', port: 3000 });
     await routing.activateRoute(rule);
 
     expect(await storage.fileExists('runtime/traefik/routing-map.json')).toBe(true);
     expect(await storage.fileExists('runtime/traefik/dynamic.yml')).toBe(true);
 
     const map = await routing.getRoutingMap();
-    expect(map['gitea.local.hola']?.deploymentId).toBe('dep-a');
+    expect(map['gitea.local.hola']?.deploymentId).toBe('gitea-dep-a');
 
     const dynamic = parseYAML(await storage.readFileAsString('runtime/traefik/dynamic.yml'));
     expect(dynamic.http.routers['gitea-dep-a'].rule).toBe('Host(`gitea.local.hola`)');
@@ -74,7 +75,7 @@ describe('RoutingService', () => {
   });
 
   test('forward-auth rule emits the outpost middleware + path-prefix router', async () => {
-    const base = routing.generateRule({ deploymentId: 'dep-a', appName: 'grafana', port: 3000 });
+    const base = routing.generateRule({ deploymentId: 'grafana-dep-a', appName: 'grafana', port: 3000 });
     const rule = { ...base, forwardAuth: { name: 'ak-grafana-dep-a', outpostUrl: 'http://authentik-server:9000' } };
     await routing.activateRoute(rule);
 

--- a/packages/server/src/__tests__/validation/compose-validate.test.ts
+++ b/packages/server/src/__tests__/validation/compose-validate.test.ts
@@ -51,8 +51,8 @@ services:
     environment:
       APP_ENV: production
     volumes:
-      - data:/var/lib/app
-      - ./config:/etc/app:ro
+      - \${HOLA_APP_DATA}/app:/var/lib/app
+      - \${HOLA_APP_DATA}/config:/etc/app:ro
     networks:
       - backend
     secrets:
@@ -60,12 +60,9 @@ services:
   db:
     image: postgres:16
     volumes:
-      - db:/var/lib/postgresql/data
+      - \${HOLA_APP_DATA}/db:/var/lib/postgresql/data
     networks:
       - backend
-volumes:
-  data:
-  db:
 networks:
   backend:
 secrets:
@@ -212,7 +209,7 @@ services:
   });
 
   describe('undefined resource references', () => {
-    test('undefined named volume is rejected', () => {
+    test('named volumes are not allowed (must use the app-data root)', () => {
       const yaml = `
 services:
   web:
@@ -221,10 +218,10 @@ services:
       - data:/var/lib/app
 `;
       const errs = errors(validateComposeDocument(yaml));
-      expect(errs.map((e) => e.code)).toContain('UNDEFINED_VOLUME');
+      expect(errs.map((e) => e.code)).toContain('NAMED_VOLUME_NOT_ALLOWED');
     });
 
-    test('bind-mount paths do not require a top-level volume', () => {
+    test('bind mounts must be rooted at the app-data token', () => {
       const yaml = `
 services:
   web:
@@ -232,6 +229,18 @@ services:
     volumes:
       - ./config:/etc/app:ro
       - /var/run/docker.sock:/var/run/docker.sock
+`;
+      expect(codes(validateComposeDocument(yaml))).toContain('VOLUME_NOT_UNDER_APP_DATA');
+    });
+
+    test('bind mounts under the app-data root are accepted', () => {
+      const yaml = `
+services:
+  web:
+    image: nginx:1.27
+    volumes:
+      - \${HOLA_APP_DATA}/config:/etc/app:ro
+      - \${HOLA_APP_DATA}/data:/data
 `;
       expect(validateComposeDocument(yaml)).toEqual([]);
     });

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -45,7 +45,24 @@ import type { DraftService, FinalizedArtifacts, FinalizedManifest } from './draf
 import type { RoutingService } from './routing';
 import type { LoggingService } from './logging';
 import type { ProvisionerService, ProvisionResult } from './provisioner';
+import { APP_DATA_TOKEN } from '@hola/shared/compose-validate';
 import { attachToHolaNetwork, injectEnvironment } from './compose-network';
+
+/** Default host base for per-app data roots when HOLA_APPS_BIND_ROOT is unset. */
+const DEFAULT_APPS_BIND_ROOT = '/srv/hola/apps';
+
+/**
+ * Build a human-readable, collision-safe deployment id: the app slug plus a
+ * short random suffix (e.g. `gitea-3f9a2c7b`). Stable for the install's life
+ * (reused across promote/rollback), so it keys the project name, routing, and
+ * the per-app data root. The random suffix keeps two installs of the same app
+ * distinct.
+ */
+function makeDeploymentId(appId: string): string {
+  const slug = appId.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'app';
+  const suffix = crypto.randomUUID().replace(/-/g, '').slice(0, 8);
+  return `${slug}-${suffix}`;
+}
 
 type ProvisionCredentials = NonNullable<ProvisionResult['credentials']>;
 
@@ -390,21 +407,22 @@ abstract class InMemoryDeploymentService implements DeploymentService {
 
   async createFromDraft(request: CreateDeploymentFromDraftRequest): Promise<CreateDeploymentFromDraftResponse> {
     await this.ensureLoaded();
-    const deploymentId = crypto.randomUUID();
     const releaseId = crypto.randomUUID();
     const now = new Date().toISOString();
-
-    this.logger.info('Creating deployment from draft', {
-      deploymentId,
-      releaseId,
-      draftId: request.draftId,
-      name: request.name,
-    });
+    let deploymentId = '';
 
     try {
       // Build the release from the finalized draft FIRST so an unfinalized draft
       // fails before any deployment directory or record is created (no partial state).
       const artifacts = await this.loadFinalizedArtifacts(request.draftId);
+      // Mint a human-readable id from the app slug now that we know it.
+      deploymentId = makeDeploymentId(artifacts?.manifest.appId ?? 'app');
+      this.logger.info('Creating deployment from draft', {
+        deploymentId,
+        releaseId,
+        draftId: request.draftId,
+        name: request.name,
+      });
       const { app, version, release } = await this.buildReleaseFromDraft(artifacts, request, deploymentId, releaseId);
 
       // Reject a routing (host) conflict before creating any deployment state.
@@ -723,7 +741,7 @@ export class RealDeploymentService extends InMemoryDeploymentService {
 
   /** Deterministic Compose project name (aligns with the routing network name). */
   private projectName(deploymentId: string): string {
-    return `hola-${deploymentId.slice(0, 12)}`;
+    return `hola-${deploymentId}`;
   }
 
   /** Absolute working directory that holds the materialized docker-compose.yml. */
@@ -765,6 +783,20 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     const hasSecret = Object.keys(injectedEnv).length > 0;
     if (hasSecret) {
       content = injectEnvironment(content, injectedEnv, { ingressService: deployment.app });
+    }
+
+    // Resolve the per-app data root: apps declare persistent storage under the
+    // `${HOLA_APP_DATA}` token (enforced by the compose validator), which we
+    // point at one stable per-install host directory so all of an app's data
+    // lives in a single backup-friendly folder (`<base>/<deploymentId>/...`).
+    // The base must be identity-mounted into the server (same path on host and
+    // in-container) so the path the server creates matches what the daemon binds
+    // into app containers — see packages/compose.
+    if (content.includes(APP_DATA_TOKEN)) {
+      const base = (process.env.HOLA_APPS_BIND_ROOT?.trim() || DEFAULT_APPS_BIND_ROOT).replace(/\/+$/, '');
+      const appRoot = `${base}/${deployment.id}`;
+      await this.storageService.ensureDir(appRoot);
+      content = content.replaceAll(APP_DATA_TOKEN, appRoot);
     }
 
     // The runtime compose may hold a client secret in cleartext; restrict it.

--- a/packages/server/src/services/core/routing.ts
+++ b/packages/server/src/services/core/routing.ts
@@ -49,14 +49,16 @@ export interface RoutingService extends HealthCheckable {
 /** Build a deterministic routing rule (pure; shared by real and mock services). */
 function buildRule(input: GenerateRuleInput, domain: string): TraefikRoutingRule {
   const host = `${input.appName}.${domain}`;
-  const shortId = input.deploymentId.slice(0, 12);
+  // The deployment id is already a compact, unique `<slug>-<hash>` (it embeds the
+  // app slug), so use it whole — truncating it would collide between two installs
+  // of the same app.
   return {
     deploymentId: input.deploymentId,
     appName: input.appName,
     host,
     domain,
-    serviceName: `${input.appName}-${shortId}`,
-    networkName: `hola-${shortId}`,
+    serviceName: input.deploymentId,
+    networkName: `hola-${input.deploymentId}`,
     port: input.port,
     createdAt: new Date().toISOString(),
   };

--- a/packages/shared/src/compose-validate.ts
+++ b/packages/shared/src/compose-validate.ts
@@ -118,10 +118,18 @@ function validateEnvironment(env: unknown, basePath: string, issues: ValidationI
   issues.push(issue('INVALID_ENV_FORM', 'error', 'environment must be a list or a mapping', basePath));
 }
 
+/**
+ * The single host mount root every app's persistent storage must live under.
+ * Hola resolves this token to one stable per-install directory at deploy time,
+ * so all of an app's data lands in one backup-friendly folder. Apps mount
+ * sub-dirs of it (e.g. `${HOLA_APP_DATA}/data:/data`).
+ */
+export const APP_DATA_TOKEN = '${HOLA_APP_DATA}';
+
 function validateVolumes(
   vols: unknown,
   basePath: string,
-  defined: Set<string>,
+  _defined: Set<string>,
   issues: ValidationIssue[],
 ): void {
   if (!Array.isArray(vols)) return;
@@ -131,15 +139,29 @@ function validateVolumes(
     let isNamed = false;
     if (typeof entry === 'string') {
       source = entry.split(':')[0];
-      // A named volume has no path separators and is not relative/absolute.
-      isNamed = !!source && !source.includes('/') && !source.startsWith('.') && !source.startsWith('~');
+      // A named volume has no path separators and is not relative/absolute/interpolated.
+      isNamed =
+        !!source &&
+        !source.includes('/') &&
+        !source.startsWith('.') &&
+        !source.startsWith('~') &&
+        !source.startsWith('$');
     } else if (isPlainObject(entry)) {
       const type = entry.type;
+      if (type === 'tmpfs') return; // ephemeral; no host storage to anchor
       source = typeof entry.source === 'string' ? entry.source : undefined;
       isNamed = type === 'volume' && !!source;
     }
-    if (isNamed && source && !defined.has(source)) {
-      issues.push(issue('UNDEFINED_VOLUME', 'error', `Volume '${source}' is not defined under top-level 'volumes'`, path));
+
+    // Contract: persistent storage is bind-mounted under a single per-app root.
+    if (isNamed) {
+      issues.push(issue('NAMED_VOLUME_NOT_ALLOWED', 'error',
+        `Named volume '${source}' is not allowed; mount persistent storage under '${APP_DATA_TOKEN}' instead (e.g. '${APP_DATA_TOKEN}/data:/data')`, path));
+      return;
+    }
+    if (source !== undefined && !source.startsWith(APP_DATA_TOKEN)) {
+      issues.push(issue('VOLUME_NOT_UNDER_APP_DATA', 'error',
+        `Bind source '${source}' must be under '${APP_DATA_TOKEN}' so all of an app's data lives in one root`, path));
     }
   });
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -668,7 +668,9 @@ export type ComposeIssueCode =
   | 'UNDEFINED_VOLUME'
   | 'UNDEFINED_NETWORK'
   | 'UNDEFINED_SECRET'
-  | 'HOST_PORT_NOT_ALLOWED';
+  | 'HOST_PORT_NOT_ALLOWED'
+  | 'NAMED_VOLUME_NOT_ALLOWED'
+  | 'VOLUME_NOT_UNDER_APP_DATA';
 
 /**
  * Codes emitted by the broader ValidationService (drafts, env, resources).


### PR DESCRIPTION
## What

Two related changes that give every app a single, backup-friendly data folder and human-readable identifiers.

### 1. Per-app data root (`${HOLA_APP_DATA}`)
Apps declare persistent storage under a single token; the server resolves it to one stable per-install host directory at materialization:

```
${HOLA_APP_DATA}/data:/data   →   /srv/hola/apps/<deploymentId>/data:/data
```

So all of an app's data lives in one host folder (`tar` one directory to back up an app). The **compose validator now enforces the contract** — named volumes (`NAMED_VOLUME_NOT_ALLOWED`) and bind sources not under the token (`VOLUME_NOT_UNDER_APP_DATA`) are rejected, so there is no blind volume conversion. Bind mounts auto-create their host path, sidestepping the still-open named-volume `subpath` auto-create gap ([moby/moby#47842](https://github.com/moby/moby/issues/47842)).

Base dir is `HOLA_APPS_BIND_ROOT` (default `/srv/hola/apps`), identity-mounted into the server so the path the server creates matches what the daemon binds into app containers.

### 2. Slug-hash deployment IDs
`createFromDraft` now mints `<app-slug>-<8hex>` (e.g. `gitea-3f9a2c7b`) from the app slug, stable across promote/rollback. `projectName` and the routing service use the id whole — the old `slice(0, 12)` would truncate the random suffix and collide between two installs of the same app.

## Files
- **shared:** `${HOLA_APP_DATA}` contract + two new `ComposeIssueCode`s in `compose-validate`
- **server:** token resolve + `ensureDir` at materialize; `makeDeploymentId`; `projectName`
- **routing:** `serviceName`/`networkName` use the full deployment id
- **compose:** `HOLA_APPS_BIND_ROOT` env + identity mount

## Companion / coordination
Requires the app conversions in **try-hola/apps#10**. Land/release together: once this strict validator ships, an app still on named volumes won't finalize.

## Tests
`bun run typecheck` · `lint` · `build` · server suite (224 pass) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
