### PR TITLE
feat(server): resolve install tokens ${HOLA_APP_HOST} / ${HOLA_BASE_DOMAIN}

### DIFF
--- a/packages/server/src/__tests__/deployments/auth-provisioning.test.ts
+++ b/packages/server/src/__tests__/deployments/auth-provisioning.test.ts
@@ -201,6 +201,32 @@ describe('Auth provisioning lifecycle', () => {
     expect(meta.metadata.auth.ref.providerPk).toBe(42);
   });
 
+  test('resolves install tokens (${HOLA_APP_HOST} / ${HOLA_BASE_DOMAIN}) in app env', async () => {
+    const sys = makeSystem({ auth: undefined });
+    const compose = [
+      'services:',
+      '  gitea:',
+      '    image: gitea/gitea:1.21.0',
+      '    environment:',
+      '      ROOT_URL: https://${HOLA_APP_HOST}/',
+      '      ALLOWED_HOST: ${HOLA_APP_HOST}',
+      '      BASE: ${HOLA_BASE_DOMAIN}',
+      '',
+    ].join('\n');
+    const { draftId } = await sys.drafts.createDraft({ appId: 'gitea', version: '1.0.0' });
+    await sys.drafts.updateDraft(draftId, { composeOverride: compose });
+    await sys.drafts.finalizeDraft(draftId);
+
+    const created = await sys.deployments.createFromDraft({ draftId, name: 'gitea' });
+    expect((await waitForJob(sys.jobs, created.jobId!)).status).toBe('completed');
+
+    const env = await readMaterializedEnv(sys.storage, created.deploymentId);
+    // baseDomain is local.hola, app is gitea -> host gitea.local.hola
+    expect(env.ROOT_URL).toBe('https://gitea.local.hola/');
+    expect(env.ALLOWED_HOST).toBe('gitea.local.hola');
+    expect(env.BASE).toBe('local.hola');
+  });
+
   test('no auth block: deploys normally with no provisioning and no injected env', async () => {
     const sys = makeSystem({ auth: undefined });
     const spy = sys.provisioner as SpyProvisioner;

--- a/packages/server/src/__tests__/validation/compose-validate.test.ts
+++ b/packages/server/src/__tests__/validation/compose-validate.test.ts
@@ -245,6 +245,32 @@ services:
       expect(validateComposeDocument(yaml)).toEqual([]);
     });
 
+    test('known platform tokens in env are accepted', () => {
+      const yaml = `
+services:
+  web:
+    image: nginx:1.27
+    environment:
+      DOMAIN: https://\${HOLA_APP_HOST}/
+      BASE: \${HOLA_BASE_DOMAIN}
+`;
+      expect(validateComposeDocument(yaml)).toEqual([]);
+    });
+
+    test('unknown HOLA_* token is warned (likely a typo)', () => {
+      const yaml = `
+services:
+  web:
+    image: nginx:1.27
+    environment:
+      DOMAIN: \${HOLA_APP_HSOT}
+`;
+      const issues = validateComposeDocument(yaml);
+      expect(codes(issues)).toContain('UNKNOWN_PLATFORM_TOKEN');
+      // Advisory only — does not block.
+      expect(issues.every((i) => i.severity !== 'error')).toBe(true);
+    });
+
     test('undefined network is rejected', () => {
       const yaml = `
 services:

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -45,7 +45,7 @@ import type { DraftService, FinalizedArtifacts, FinalizedManifest } from './draf
 import type { RoutingService } from './routing';
 import type { LoggingService } from './logging';
 import type { ProvisionerService, ProvisionResult } from './provisioner';
-import { APP_DATA_TOKEN } from '@hola/shared/compose-validate';
+import { APP_DATA_TOKEN, APP_HOST_TOKEN, BASE_DOMAIN_TOKEN } from '@hola/shared/compose-validate';
 import { attachToHolaNetwork, injectEnvironment } from './compose-network';
 
 /** Default host base for per-app data roots when HOLA_APPS_BIND_ROOT is unset. */
@@ -764,12 +764,16 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     }
     const raw = await this.storageService.readFileAsString(src);
 
+    // The routing rule gives us the install-specific values apps reference as
+    // tokens (public host, base domain) plus the network alias. generateRule is
+    // pure, so compute it once up front and reuse it below.
+    const rule = this.routingService.generateRule({ deploymentId: deployment.id, appName: deployment.app });
+
     // Attach the ingress service to the Traefik network so the emitted routing
     // config can reach it (the alias must match the routing service name).
     let content = raw;
     try {
-      const alias = this.routingService.generateRule({ deploymentId: deployment.id, appName: deployment.app }).serviceName;
-      content = attachToHolaNetwork(raw, { alias, ingressService: deployment.app });
+      content = attachToHolaNetwork(raw, { alias: rule.serviceName, ingressService: deployment.app });
     } catch (error) {
       this.logger.warn('Could not attach app to Traefik network; deploying compose as-is', {
         deploymentId: deployment.id,
@@ -798,6 +802,15 @@ export class RealDeploymentService extends InMemoryDeploymentService {
       await this.storageService.ensureDir(appRoot);
       content = content.replaceAll(APP_DATA_TOKEN, appRoot);
     }
+
+    // Resolve install-specific tokens apps reference in their env, so the catalog
+    // carries no hardcoded per-install values: the app's public host
+    // (`<app>.<base-domain>`) and the install base domain. Each app still names
+    // its own env key (e.g. `DOMAIN: https://${HOLA_APP_HOST}`); only the value
+    // is a token. (${HOLA_APP_DATA} above is the storage equivalent.)
+    content = content
+      .replaceAll(APP_HOST_TOKEN, rule.host)
+      .replaceAll(BASE_DOMAIN_TOKEN, rule.domain);
 
     // The runtime compose may hold a client secret in cleartext; restrict it.
     await this.storageService.writeFile(

--- a/packages/shared/src/compose-validate.ts
+++ b/packages/shared/src/compose-validate.ts
@@ -126,6 +126,40 @@ function validateEnvironment(env: unknown, basePath: string, issues: ValidationI
  */
 export const APP_DATA_TOKEN = '${HOLA_APP_DATA}';
 
+/**
+ * Install-specific values the server resolves into an app's compose at deploy
+ * time, so the catalog stays free of hardcoded per-install values:
+ *   ${HOLA_APP_HOST}     the app's public host (`<app>.<base-domain>`)
+ *   ${HOLA_BASE_DOMAIN}  the install's base domain
+ * Apps reference these (e.g. `DOMAIN: https://${HOLA_APP_HOST}`); each app still
+ * names its own env key, only the value is a token.
+ */
+export const APP_HOST_TOKEN = '${HOLA_APP_HOST}';
+export const BASE_DOMAIN_TOKEN = '${HOLA_BASE_DOMAIN}';
+
+/** Every `${HOLA_*}` token the server knows how to resolve. */
+export const KNOWN_PLATFORM_TOKENS: readonly string[] = [
+  APP_DATA_TOKEN,
+  APP_HOST_TOKEN,
+  BASE_DOMAIN_TOKEN,
+];
+
+/**
+ * Warn on `${HOLA_*}` tokens the server won't resolve — almost always a typo
+ * (e.g. `${HOLA_APP_HSOT}`) that would otherwise silently deploy as an empty
+ * string. Reserved prefix: only the platform mints `HOLA_*` tokens.
+ */
+function validatePlatformTokens(yamlText: string, issues: ValidationIssue[]): void {
+  const seen = new Set<string>();
+  for (const match of yamlText.matchAll(/\$\{(HOLA_[A-Z0-9_]+)\}/g)) {
+    const token = `\${${match[1]}}`;
+    if (seen.has(token) || KNOWN_PLATFORM_TOKENS.includes(token)) continue;
+    seen.add(token);
+    issues.push(issue('UNKNOWN_PLATFORM_TOKEN', 'warning',
+      `Unknown platform token '${token}'; the server won't resolve it (known: ${KNOWN_PLATFORM_TOKENS.join(', ')})`));
+  }
+}
+
 function validateVolumes(
   vols: unknown,
   basePath: string,
@@ -303,5 +337,7 @@ export function validateComposeDocument(yamlText: string): ValidationIssue[] {
   if (parsed === null || parsed === undefined) {
     return [issue('NO_SERVICES', 'error', "Compose document is empty; define at least one service under 'services'", 'services')];
   }
-  return validateComposeObject(parsed);
+  const issues = validateComposeObject(parsed);
+  validatePlatformTokens(yamlText, issues);
+  return issues;
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -670,7 +670,8 @@ export type ComposeIssueCode =
   | 'UNDEFINED_SECRET'
   | 'HOST_PORT_NOT_ALLOWED'
   | 'NAMED_VOLUME_NOT_ALLOWED'
-  | 'VOLUME_NOT_UNDER_APP_DATA';
+  | 'VOLUME_NOT_UNDER_APP_DATA'
+  | 'UNKNOWN_PLATFORM_TOKEN';
 
 /**
  * Codes emitted by the broader ValidationService (drafts, env, resources).


### PR DESCRIPTION
## What

Apps reference install-specific values via **tokens** in their compose `environment:` — each app still names its own env key, only the *value* is a token — and the server resolves them at materialization from the routing rule:

```yaml
# gitea
GITEA__server__DOMAIN: ${HOLA_APP_HOST}            # -> gitea.local.hola
GITEA__server__ROOT_URL: https://${HOLA_APP_HOST}/ # -> https://gitea.local.hola/
# vaultwarden
DOMAIN: https://${HOLA_APP_HOST}
```

- `${HOLA_APP_HOST}` → the app's public host (`<app>.<base-domain>`)
- `${HOLA_BASE_DOMAIN}` → the install's base domain

This is the env counterpart to the `${HOLA_APP_DATA}` storage token from #115.

## Why

It keeps the catalog **free of hardcoded per-install values** — no more `example.com` placeholders or the manual post-install edit step. The server already computes `<app>.<base-domain>` for the Traefik rule; this just exposes it to apps. A wildcard compose overlay couldn't do this because each app uses a different env key for "my public URL" — the token keeps the app-specific key while making the value install-aware.

## Validator guardrail

`${HOLA_*}` is a reserved prefix. The validator now **warns** (`UNKNOWN_PLATFORM_TOKEN`, non-blocking) on any `${HOLA_*}` token it doesn't know — catching typos like `${HOLA_APP_HSOT}` that would otherwise silently deploy as an empty string.

## Notes

- Resolution runs on the materialized compose, so it applies to the app's compose `environment:` (the values that actually reach the container). Host-derived keys that today live in manifest `defaultEnv` don't reach the container — the companion app PR moves them into compose `environment:` with the token.
- `generateRule` is computed once and reused for the network alias + tokens.

## Tests
End-to-end token resolution (deploy → read materialized compose) + validator warning. `bun run typecheck` · `lint` · `build` · server suite (227 pass) all green.

## Companion
App conversions in **try-hola/apps#11**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
