### PR TITLE
feat(server): platform defaults for deployed apps (restart/logging/hardening/TZ)

### DIFF
--- a/packages/cli/src/install/schema.ts
+++ b/packages/cli/src/install/schema.ts
@@ -123,6 +123,13 @@ export const INSTALL_SCHEMA: InstallField[] = [
     validate: isUrlOrEmpty,
   },
   {
+    key: 'HOLA_DEFAULT_TZ',
+    type: 'text',
+    prompt: 'Default timezone for deployed apps (TZ, blank to leave unset)',
+    help: 'e.g. UTC or America/New_York; applied to apps that do not set TZ',
+    default: '',
+  },
+  {
     key: 'HOLA_AUTH_MODE',
     type: 'select',
     prompt: 'SSO platform for catalog apps',

--- a/packages/compose/.env.example
+++ b/packages/compose/.env.example
@@ -43,6 +43,13 @@ HOLA_BASE_DOMAIN=local.hola
 # pasted/uploaded compose).
 HOLA_CATALOG_URL=https://raw.githubusercontent.com/try-hola/apps/main/catalog.json
 
+# --- Platform defaults for deployed apps ---
+# Operational defaults the server applies to every app's compose. The app wins
+# for fill-if-absent fields; hardening is additive. Restart policy, log rotation,
+# and no-new-privileges are on by default (see docker-compose.yml). Optional:
+# default timezone applied to apps that don't set TZ (blank to leave unset).
+HOLA_DEFAULT_TZ=
+
 # --- Admin API auth (see docs/adr/0001-authentication.md) ---
 # Auth is on by default in production. Set a fixed admin API key here, or leave
 # it blank to have the server generate one on first boot and write it to

--- a/packages/compose/docker-compose.yml
+++ b/packages/compose/docker-compose.yml
@@ -96,6 +96,17 @@ services:
       # path MUST be identity-mounted below (same path on host and in-container)
       # because the daemon resolves bind sources on the host.
       - HOLA_APPS_BIND_ROOT=${HOLA_APPS_BIND_ROOT:-/srv/hola/apps}
+      # Platform defaults applied to every deployed app's compose (the app wins
+      # for fill-if-absent fields; hardening is additive). Restart policy, log
+      # rotation, and no-new-privileges are on by default; TZ and resource limits
+      # are off unless set. See packages/server/src/config/compose-defaults.ts.
+      - HOLA_DEFAULT_RESTART_POLICY=${HOLA_DEFAULT_RESTART_POLICY:-unless-stopped}
+      - HOLA_DEFAULT_LOG_MAX_SIZE=${HOLA_DEFAULT_LOG_MAX_SIZE:-10m}
+      - HOLA_DEFAULT_LOG_MAX_FILE=${HOLA_DEFAULT_LOG_MAX_FILE:-3}
+      - HOLA_DEFAULT_NO_NEW_PRIVILEGES=${HOLA_DEFAULT_NO_NEW_PRIVILEGES:-true}
+      - HOLA_DEFAULT_TZ=${HOLA_DEFAULT_TZ:-}
+      - HOLA_DEFAULT_MEM_LIMIT=${HOLA_DEFAULT_MEM_LIMIT:-}
+      - HOLA_DEFAULT_CPUS=${HOLA_DEFAULT_CPUS:-}
     volumes:
       # Orchestrate deployments by talking to the host Docker engine.
       # SECURITY: this grants control of the host's Docker - see README.

--- a/packages/server/src/__tests__/config/compose-defaults.test.ts
+++ b/packages/server/src/__tests__/config/compose-defaults.test.ts
@@ -1,0 +1,51 @@
+/**
+ * compose-defaults config: honors HOLA_DEFAULT_* env with documented fallbacks.
+ */
+
+import { describe, test, expect, afterEach } from 'bun:test';
+
+import { loadComposeDefaultsConfig } from '../../config/compose-defaults';
+
+const KEYS = [
+  'HOLA_DEFAULT_RESTART_POLICY',
+  'HOLA_DEFAULT_LOG_MAX_SIZE',
+  'HOLA_DEFAULT_LOG_MAX_FILE',
+  'HOLA_DEFAULT_NO_NEW_PRIVILEGES',
+  'HOLA_DEFAULT_TZ',
+  'HOLA_DEFAULT_MEM_LIMIT',
+  'HOLA_DEFAULT_CPUS',
+];
+
+afterEach(() => {
+  for (const k of KEYS) delete process.env[k];
+});
+
+describe('loadComposeDefaultsConfig', () => {
+  test('defaults when env is unset', () => {
+    for (const k of KEYS) delete process.env[k];
+    expect(loadComposeDefaultsConfig()).toEqual({
+      restartPolicy: 'unless-stopped',
+      logMaxSize: '10m',
+      logMaxFile: '3',
+      noNewPrivileges: true,
+      tz: undefined,
+      memLimit: undefined,
+      cpus: undefined,
+    });
+  });
+
+  test('env overrides are honored; no-new-privileges disables on "false"', () => {
+    process.env.HOLA_DEFAULT_RESTART_POLICY = '';
+    process.env.HOLA_DEFAULT_NO_NEW_PRIVILEGES = 'false';
+    process.env.HOLA_DEFAULT_TZ = 'UTC';
+    process.env.HOLA_DEFAULT_MEM_LIMIT = '512m';
+    process.env.HOLA_DEFAULT_CPUS = '1.5';
+
+    const cfg = loadComposeDefaultsConfig();
+    expect(cfg.restartPolicy).toBe('');
+    expect(cfg.noNewPrivileges).toBe(false);
+    expect(cfg.tz).toBe('UTC');
+    expect(cfg.memLimit).toBe('512m');
+    expect(cfg.cpus).toBe('1.5');
+  });
+});

--- a/packages/server/src/__tests__/deployments/auth-provisioning.test.ts
+++ b/packages/server/src/__tests__/deployments/auth-provisioning.test.ts
@@ -227,6 +227,41 @@ describe('Auth provisioning lifecycle', () => {
     expect(env.BASE).toBe('local.hola');
   });
 
+  test('applies platform defaults (restart/logging/no-new-privileges) to every service, app wins', async () => {
+    const sys = makeSystem({ auth: undefined });
+    // app sets its own restart on one service; a second (non-ingress) service has none.
+    const compose = [
+      'services:',
+      '  gitea:',
+      '    image: gitea/gitea:1.21.0',
+      '    restart: always',
+      '  db:',
+      '    image: postgres:16',
+      '',
+    ].join('\n');
+    const { draftId } = await sys.drafts.createDraft({ appId: 'gitea', version: '1.0.0' });
+    await sys.drafts.updateDraft(draftId, { composeOverride: compose });
+    await sys.drafts.finalizeDraft(draftId);
+
+    const created = await sys.deployments.createFromDraft({ draftId, name: 'gitea' });
+    expect((await waitForJob(sys.jobs, created.jobId!)).status).toBe('completed');
+
+    const raw = await sys.storage.readFileAsString(`deployments/${created.deploymentId}/runtime/docker-compose.yml`);
+    const doc = parse(raw) as { services: Record<string, Record<string, unknown>> };
+
+    // App's restart is kept; default fills the service that had none.
+    expect(doc.services.gitea.restart).toBe('always');
+    expect(doc.services.db.restart).toBe('unless-stopped');
+    // Logging + hardening applied to BOTH services (defaults on).
+    for (const svc of ['gitea', 'db']) {
+      expect(doc.services[svc].logging).toEqual({
+        driver: 'json-file',
+        options: { 'max-size': '10m', 'max-file': '3' },
+      });
+      expect(doc.services[svc].security_opt).toEqual(['no-new-privileges:true']);
+    }
+  });
+
   test('no auth block: deploys normally with no provisioning and no injected env', async () => {
     const sys = makeSystem({ auth: undefined });
     const spy = sys.provisioner as SpyProvisioner;

--- a/packages/server/src/__tests__/routing/compose-defaults.test.ts
+++ b/packages/server/src/__tests__/routing/compose-defaults.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Platform-defaults transform tests.
+ *
+ * applyPlatformDefaults injects install-wide operational defaults (restart, log
+ * rotation, no-new-privileges, optional TZ/limits) onto EVERY service of a
+ * deployed app's compose, with explicit precedence: the app wins for
+ * fill-if-absent fields; no-new-privileges is additive.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { parse } from 'yaml';
+
+import { applyPlatformDefaults } from '../../services/core/compose-defaults';
+import type { ComposeDefaultsConfig } from '../../config/compose-defaults';
+
+const ON: ComposeDefaultsConfig = {
+  restartPolicy: 'unless-stopped',
+  logMaxSize: '10m',
+  logMaxFile: '3',
+  noNewPrivileges: true,
+};
+
+const out = (yaml: string, opts: ComposeDefaultsConfig = ON) => parse(applyPlatformDefaults(yaml, opts));
+
+describe('applyPlatformDefaults', () => {
+  test('fills restart, logging, and no-new-privileges on a bare service', () => {
+    const doc = out('services:\n  app:\n    image: app:1\n');
+    expect(doc.services.app.restart).toBe('unless-stopped');
+    expect(doc.services.app.logging).toEqual({
+      driver: 'json-file',
+      options: { 'max-size': '10m', 'max-file': '3' },
+    });
+    expect(doc.services.app.security_opt).toEqual(['no-new-privileges:true']);
+  });
+
+  test('app wins for restart and logging (fill-if-absent)', () => {
+    const input = [
+      'services:',
+      '  app:',
+      '    image: app:1',
+      '    restart: "no"',
+      '    logging:',
+      '      driver: syslog',
+      '',
+    ].join('\n');
+    const doc = out(input);
+    expect(doc.services.app.restart).toBe('no');
+    expect(doc.services.app.logging).toEqual({ driver: 'syslog' });
+  });
+
+  test('no-new-privileges is appended, preserving app security_opt and deduped', () => {
+    const input = [
+      'services:',
+      '  app:',
+      '    image: app:1',
+      '    security_opt:',
+      '      - seccomp:unconfined',
+      '',
+    ].join('\n');
+    const doc = out(input);
+    expect(doc.services.app.security_opt).toEqual(['seccomp:unconfined', 'no-new-privileges:true']);
+
+    // Already present -> not duplicated.
+    const already = out('services:\n  app:\n    image: app:1\n    security_opt:\n      - no-new-privileges:true\n');
+    expect(already.services.app.security_opt).toEqual(['no-new-privileges:true']);
+  });
+
+  test('applies to every service, not just the first/ingress', () => {
+    const input = 'services:\n  app:\n    image: app:1\n  db:\n    image: postgres:16\n';
+    const doc = out(input);
+    expect(doc.services.app.restart).toBe('unless-stopped');
+    expect(doc.services.db.restart).toBe('unless-stopped');
+    expect(doc.services.db.security_opt).toEqual(['no-new-privileges:true']);
+  });
+
+  test('TZ is added when configured, app wins if already set (array + map env)', () => {
+    const opts: ComposeDefaultsConfig = { ...ON, tz: 'America/New_York' };
+
+    const mapForm = out('services:\n  app:\n    image: app:1\n    environment:\n      FOO: bar\n', opts);
+    expect(mapForm.services.app.environment).toEqual({ FOO: 'bar', TZ: 'America/New_York' });
+
+    // App already sets TZ -> environment is left untouched (stays array form).
+    const arrForm = out('services:\n  app:\n    image: app:1\n    environment:\n      - TZ=UTC\n', opts);
+    expect(arrForm.services.app.environment).toEqual(['TZ=UTC']);
+  });
+
+  test('resource limits applied as service-level keys when set (fill-if-absent)', () => {
+    const opts: ComposeDefaultsConfig = { ...ON, memLimit: '512m', cpus: '1.5' };
+    const doc = out('services:\n  app:\n    image: app:1\n    mem_limit: 256m\n', opts);
+    expect(doc.services.app.mem_limit).toBe('256m'); // app wins
+    expect(doc.services.app.cpus).toBe('1.5'); // filled
+  });
+
+  test('disabled fields are skipped; all-off is a verbatim no-op', () => {
+    const off: ComposeDefaultsConfig = { restartPolicy: '', logMaxSize: '', logMaxFile: '3', noNewPrivileges: false };
+    const input = 'services:\n  app:\n    image: app:1\n';
+    expect(applyPlatformDefaults(input, off)).toBe(input);
+  });
+
+  test('no services -> returns input unchanged', () => {
+    const input = 'networks:\n  hola:\n    external: true\n';
+    expect(applyPlatformDefaults(input, ON)).toBe(input);
+  });
+});

--- a/packages/server/src/config/compose-defaults.ts
+++ b/packages/server/src/config/compose-defaults.ts
@@ -1,0 +1,43 @@
+/**
+ * Install-wide operational defaults applied to every deployed app's compose at
+ * materialization time (restart policy, log rotation, no-new-privileges
+ * hardening, optional TZ and resource limits). Operators tune ops policy once
+ * for the whole install via `HOLA_DEFAULT_*` rather than per app; apps keep
+ * authoring lean compose.
+ *
+ * Follows the config pattern in `config/catalog.ts` / `config/auth.ts`: a typed
+ * default object read from `process.env`, a `load*` accessor, and a singleton.
+ */
+
+export interface ComposeDefaultsConfig {
+  /** `restart:` value for services that don't declare one (`''`/`none` disables). */
+  restartPolicy: string;
+  /** `logging.options.max-size` for services without a `logging` block (blank disables rotation). */
+  logMaxSize: string;
+  /** `logging.options.max-file` count (paired with logMaxSize). */
+  logMaxFile: string;
+  /** Append `no-new-privileges:true` to every service's `security_opt`. */
+  noNewPrivileges: boolean;
+  /** Default `TZ` env added to services that don't set it (unset → not injected). */
+  tz?: string;
+  /** Default `mem_limit` (unset → off). */
+  memLimit?: string;
+  /** Default `cpus` (unset → off). */
+  cpus?: string;
+}
+
+/** Read the platform defaults from the environment (re-read on each call). */
+export function loadComposeDefaultsConfig(): ComposeDefaultsConfig {
+  return {
+    restartPolicy: process.env.HOLA_DEFAULT_RESTART_POLICY ?? 'unless-stopped',
+    logMaxSize: process.env.HOLA_DEFAULT_LOG_MAX_SIZE ?? '10m',
+    logMaxFile: process.env.HOLA_DEFAULT_LOG_MAX_FILE ?? '3',
+    noNewPrivileges: process.env.HOLA_DEFAULT_NO_NEW_PRIVILEGES !== 'false',
+    tz: process.env.HOLA_DEFAULT_TZ?.trim() || undefined,
+    memLimit: process.env.HOLA_DEFAULT_MEM_LIMIT?.trim() || undefined,
+    cpus: process.env.HOLA_DEFAULT_CPUS?.trim() || undefined,
+  };
+}
+
+/** Singleton snapshot taken at startup (used by the deploy lifecycle). */
+export const composeDefaultsConfig = loadComposeDefaultsConfig();

--- a/packages/server/src/services/core/compose-defaults.ts
+++ b/packages/server/src/services/core/compose-defaults.ts
@@ -1,0 +1,93 @@
+/**
+ * Apply install-wide operational defaults to a deployed app's compose
+ * (restart policy, log rotation, no-new-privileges hardening, optional TZ and
+ * resource limits) — the "platform defaults" layer.
+ *
+ * Unlike network/auth injection (ingress service only), these are container-level
+ * concerns and apply to EVERY service in the app's compose.
+ *
+ * Precedence (see plan): the app wins for fill-if-absent fields (restart,
+ * logging, TZ, limits); `no-new-privileges` is additive policy (appended,
+ * preserving any app-declared `security_opt`).
+ */
+
+import { parse, stringify } from 'yaml';
+
+import type { ComposeDefaultsConfig } from '../../config/compose-defaults';
+import type { ComposeDoc, ComposeService } from './compose-network';
+import { toEnvMap } from './compose-network';
+
+const NO_NEW_PRIVILEGES = 'no-new-privileges:true';
+
+/** True when the config would change nothing — lets us skip parse/stringify. */
+function isNoop(opts: ComposeDefaultsConfig): boolean {
+  return (
+    !opts.restartPolicy &&
+    !opts.logMaxSize &&
+    !opts.noNewPrivileges &&
+    !opts.tz &&
+    !opts.memLimit &&
+    !opts.cpus
+  );
+}
+
+function applyToService(service: ComposeService, opts: ComposeDefaultsConfig): void {
+  // restart — fill-if-absent (app wins).
+  if (opts.restartPolicy && service.restart === undefined) {
+    service.restart = opts.restartPolicy;
+  }
+
+  // logging — fill-if-absent (app wins).
+  if (opts.logMaxSize && service.logging === undefined) {
+    service.logging = {
+      driver: 'json-file',
+      options: { 'max-size': opts.logMaxSize, 'max-file': opts.logMaxFile },
+    };
+  }
+
+  // security_opt — additive policy: ensure no-new-privileges, preserve app entries.
+  if (opts.noNewPrivileges) {
+    const existing = Array.isArray(service.security_opt)
+      ? (service.security_opt as unknown[]).filter((e): e is string => typeof e === 'string')
+      : [];
+    if (!existing.includes(NO_NEW_PRIVILEGES)) existing.push(NO_NEW_PRIVILEGES);
+    service.security_opt = existing;
+  }
+
+  // TZ — env add-if-absent (app wins).
+  if (opts.tz) {
+    const envMap = toEnvMap(service.environment);
+    if (!('TZ' in envMap)) {
+      envMap.TZ = opts.tz;
+      service.environment = envMap;
+    }
+  }
+
+  // resource limits — fill-if-absent (service-level keys for `docker compose up`,
+  // not the swarm-only `deploy.resources`).
+  if (opts.memLimit && service.mem_limit === undefined) service.mem_limit = opts.memLimit;
+  if (opts.cpus && service.cpus === undefined) service.cpus = opts.cpus;
+}
+
+/**
+ * Return the compose YAML with platform defaults applied to every service.
+ * Returns the input unchanged when nothing would change or when the document
+ * has no services. Parse-failure tolerant: callers may rely on this not throwing
+ * on already-validated compose, but a parse error propagates (mirrors the
+ * sibling helpers).
+ */
+export function applyPlatformDefaults(composeYaml: string, opts: ComposeDefaultsConfig): string {
+  if (isNoop(opts)) return composeYaml;
+
+  const doc = (parse(composeYaml) ?? {}) as ComposeDoc;
+  const services = doc.services;
+  if (!services || typeof services !== 'object' || Object.keys(services).length === 0) {
+    return composeYaml;
+  }
+
+  for (const service of Object.values(services)) {
+    if (service && typeof service === 'object') applyToService(service, opts);
+  }
+
+  return stringify(doc);
+}

--- a/packages/server/src/services/core/compose-network.ts
+++ b/packages/server/src/services/core/compose-network.ts
@@ -20,15 +20,36 @@ export interface AttachOptions {
   networkName?: string;
 }
 
-interface ComposeService {
+export interface ComposeService {
   networks?: string[] | Record<string, unknown>;
   [key: string]: unknown;
 }
 
-interface ComposeDoc {
+export interface ComposeDoc {
   services?: Record<string, ComposeService>;
   networks?: Record<string, unknown>;
   [key: string]: unknown;
+}
+
+/**
+ * Normalize a service's `environment` (Compose allows a `KEY=value` array or a
+ * map) to a flat map. Shared by env injection and platform-defaults.
+ */
+export function toEnvMap(existing: unknown): Record<string, string> {
+  const envMap: Record<string, string> = {};
+  if (Array.isArray(existing)) {
+    for (const entry of existing) {
+      if (typeof entry !== 'string') continue;
+      const eq = entry.indexOf('=');
+      if (eq === -1) envMap[entry] = '';
+      else envMap[entry.slice(0, eq)] = entry.slice(eq + 1);
+    }
+  } else if (existing && typeof existing === 'object') {
+    for (const [k, v] of Object.entries(existing as Record<string, unknown>)) {
+      envMap[k] = v == null ? '' : String(v);
+    }
+  }
+  return envMap;
 }
 
 function toNetworkMap(networks: ComposeService['networks']): Record<string, unknown> {
@@ -107,21 +128,7 @@ export function injectEnvironment(
   const service = services[ingress];
 
   // Normalize an existing `environment` (which may be a `KEY=value` array) to a map.
-  const existing = service.environment;
-  const envMap: Record<string, string> = {};
-  if (Array.isArray(existing)) {
-    for (const entry of existing) {
-      if (typeof entry !== 'string') continue;
-      const eq = entry.indexOf('=');
-      if (eq === -1) envMap[entry] = '';
-      else envMap[entry.slice(0, eq)] = entry.slice(eq + 1);
-    }
-  } else if (existing && typeof existing === 'object') {
-    for (const [k, v] of Object.entries(existing as Record<string, unknown>)) {
-      envMap[k] = v == null ? '' : String(v);
-    }
-  }
-
+  const envMap = toEnvMap(service.environment);
   for (const k of keys) envMap[k] = env[k];
   service.environment = envMap;
 

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -47,6 +47,8 @@ import type { LoggingService } from './logging';
 import type { ProvisionerService, ProvisionResult } from './provisioner';
 import { APP_DATA_TOKEN, APP_HOST_TOKEN, BASE_DOMAIN_TOKEN } from '@hola/shared/compose-validate';
 import { attachToHolaNetwork, injectEnvironment } from './compose-network';
+import { applyPlatformDefaults } from './compose-defaults';
+import { composeDefaultsConfig } from '../../config/compose-defaults';
 
 /** Default host base for per-app data roots when HOLA_APPS_BIND_ROOT is unset. */
 const DEFAULT_APPS_BIND_ROOT = '/srv/hola/apps';
@@ -811,6 +813,11 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     content = content
       .replaceAll(APP_HOST_TOKEN, rule.host)
       .replaceAll(BASE_DOMAIN_TOKEN, rule.domain);
+
+    // Apply install-wide operational defaults (restart, log rotation,
+    // no-new-privileges hardening, optional TZ/limits) to every service. The app
+    // wins for fill-if-absent fields; hardening is additive. See compose-defaults.
+    content = applyPlatformDefaults(content, composeDefaultsConfig);
 
     // The runtime compose may hold a client secret in cleartext; restrict it.
     await this.storageService.writeFile(


### PR DESCRIPTION
## What

Layer A of the compose-injection work. The server now applies **install-wide operational defaults** to **every service** of a deployed app's compose at materialization time — extending the existing pipeline (Traefik network, auth env, `${HOLA_*}` tokens) with a new `applyPlatformDefaults` step. Apps stay lean; operators tune ops policy once per install instead of per app.

| Default | Env | On by default | Semantics |
|---|---|---|---|
| restart policy | `HOLA_DEFAULT_RESTART_POLICY` (`unless-stopped`) | ✅ | fill-if-absent (app wins) |
| log rotation | `HOLA_DEFAULT_LOG_MAX_SIZE`/`_MAX_FILE` (`10m`/`3`) | ✅ | fill-if-absent (app wins) |
| no-new-privileges | `HOLA_DEFAULT_NO_NEW_PRIVILEGES` (`true`) | ✅ | additive (appended to `security_opt`, deduped) |
| TZ | `HOLA_DEFAULT_TZ` | ➖ opt-in | env add-if-absent (app wins) |
| resource limits | `HOLA_DEFAULT_MEM_LIMIT`/`_CPUS` | ➖ opt-in | fill-if-absent (app wins) |

## Design notes

- **Applies to all services** (not just the ingress one like network/auth) — these are container-level concerns; a multi-service app's `db` gets the same restart/logging/hardening.
- **Precedence is explicit:** the app wins for fill-if-absent fields; `no-new-privileges` is the one additive policy (it never clobbers app-declared `security_opt`).
- **Service-level keys** (`restart`, `mem_limit`, `cpus`) — not the swarm-only `deploy.resources`, since hola runs `docker compose up`.
- **No re-validation of the materialized compose** (intentional): after token resolution, volume sources are absolute paths the strict validator rejects by design. `applyPlatformDefaults` only emits well-formed structured fields; covered by unit tests instead.

## Files
- `config/compose-defaults.ts` — typed config from `HOLA_DEFAULT_*`
- `services/core/compose-defaults.ts` — pure `applyPlatformDefaults`
- `services/core/compose-network.ts` — export `ComposeDoc`/`ComposeService`; factor out shared `toEnvMap()`
- `services/core/deployment.ts` — one call in `materializeCompose`
- `compose/docker-compose.yml` + `.env.example` + `cli/install/schema.ts` — `HOLA_DEFAULT_*` plumbing

## Tests
Unit (transform: fill-if-absent, app-wins, security_opt append/dedupe, multi-service, TZ array+map, limits, no-op), config (env overrides), and end-to-end (deploy a 2-service app → assert materialized compose keeps app's `restart`, fills the other, applies logging + hardening to both). `bun run typecheck` · `lint` · `build` · server suite (**238 pass**) all green.

## Catalog
No app changes required (defaults are additive). Optional follow-up: drop the now-redundant `restart: unless-stopped` lines from try-hola/apps.

## Out of scope (future)
Per-deployment override of defaults via the (currently inert) `systemOverrides` map; policy-mode that overrides app-declared values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)