### PR TITLE
feat(web): Apps landing — read-only launcher for installed apps

### DIFF
--- a/docs/adr/0002-cross-app-integration.md
+++ b/docs/adr/0002-cross-app-integration.md
@@ -1,0 +1,82 @@
+# ADR 0002: Cross-app integration via capability providers
+
+- **Status:** Accepted (June 2026)
+- **Context:** Discussion of a default dashboard (Homer/Homepage) and how apps like a
+  dashboard or a backup tool should learn about other installed apps. Builds on the
+  per-app data root (`${HOLA_APP_DATA}`) and install tokens (`${HOLA_APP_HOST}`).
+
+## Context
+
+Some apps are only useful in relation to *other* installed apps:
+
+- a **dashboard** (Homer, gethomepage/homepage) wants a tile per app — name, icon, URL;
+- a **backup** tool wants every app's data directory in its backup set.
+
+Two questions follow. (1) Should Hola ship/auto-install a dashboard? (2) What is the
+mechanism by which such an app gets wired to the current set of installed apps?
+
+Hola already centrally owns the source of truth these apps need. The routing layer
+maintains the full map of every deployment → its public host (`<app>.<base-domain>`),
+emitted as Traefik config; the catalog supplies icons; `${HOLA_APP_DATA}` gives each app
+one stable data root. The server is already the orchestrator that *reconciles* derived
+state (Traefik dynamic config, per-app auth via `ProvisionerService` + the manifest
+`auth` block) from the deployment set whenever it changes.
+
+A tempting alternative is an **app-to-app notification bus**: apps subscribe to "app
+installed/removed" events and mutate themselves. Rejected — see below.
+
+## Decision
+
+### 1. No auto-installed dashboard; Hola's own UI is the default home
+
+Hola does not auto-install a separate dashboard app. The default landing (`/apps`) is a
+read-only launcher in Hola's own web UI, rendered from data the server already has
+(deployments joined with catalog icons). This is always present and needs no
+synchronization. Homer/Homepage remain **opt-in** catalog apps for users who want a
+customizable, public-facing dashboard distinct from the admin console.
+
+### 2. Cross-app wiring is server-owned reconciliation, not app-to-app events
+
+Integration is modeled on the existing `auth`-block + `ProvisionerService` pattern: an app
+**declares a capability** in its manifest; the **server** does the wiring by reconciling
+that app's config from the registry it already maintains, on every install/uninstall.
+
+```
+manifest.json:
+  provides: dashboard     # or: backup   (a capability the server reconciles)
+```
+
+- **Dashboard provider** → on app-set change, the server regenerates the provider's config
+  (e.g. Homepage `services.yaml`) into its `${HOLA_APP_DATA}/config` from the routing map
+  (app, host, icon).
+- **Backup provider** → the server maintains the provider's include list of per-app data
+  roots (`<HOLA_APPS_BIND_ROOT>/<deploymentId>/`).
+
+The event bus exists, but it is **internal to the server** (install/uninstall → run
+reconcilers). Subscribers are server-side reconcilers, never the apps themselves.
+
+### Rejected: app-to-app notifications
+
+Letting catalog apps receive system events and react turns curated, static compose
+bundles into active agents: each would need a callback token / API access and the right to
+mutate config, and would own its own ordering, idempotency, retry, and partial-failure
+handling outside Hola's control. This is a large security and complexity escalation for no
+benefit over server-owned reconciliation, since the server already holds the registry.
+
+## Consequences
+
+- The app launcher ships first as a thin, read-only view (no new app, no sync). This ADR's
+  initial increment populates `deployment.url` server-side and adds the `/apps` landing.
+- Provider apps stay "dumb" bundles that only declare a capability; integration logic lives
+  in Hola — testable, idempotent, version-controlled, and security-reviewed in one place.
+- The model generalizes: dashboards and backups are both reconcilers over the same
+  registry; future consumers (e.g. monitoring) follow the same shape.
+- A reconciler writes into a provider's `${HOLA_APP_DATA}`, which the server already creates
+  and owns — no new privileged surface on the apps.
+
+## Status of follow-on work
+
+- **Now (this increment):** `/apps` landing + server-populated `deployment.url`.
+- **Phase 1:** manifest `provides` capability + server reconciler hook on app-set change;
+  dashboard reconciler first (Homepage as reference provider, opt-in).
+- **Phase 2:** backup reconciler as a second provider over the per-app data roots.

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -323,6 +323,13 @@ abstract class InMemoryDeploymentService implements DeploymentService {
     void app;
   }
 
+  /** Public URL the app is reachable at; the real service derives it from routing. */
+  protected appUrl(deploymentId: string, app: string): string | undefined {
+    void deploymentId;
+    void app;
+    return undefined;
+  }
+
   /** Routing cleanup when a deployment is removed (issue #16). Default no-op. */
   protected async onDeploymentRemoved(deploymentId: string): Promise<void> {
     void deploymentId;
@@ -432,6 +439,10 @@ abstract class InMemoryDeploymentService implements DeploymentService {
 
       await this.ensureLayout(deploymentId);
 
+      // Public URL the app is reachable at (Traefik routes <app>.<base-domain>);
+      // the Real service derives it from routing, the mock leaves it unset.
+      const url = this.appUrl(deploymentId, app);
+
       const deployment: EnhancedDeploymentDetail = {
         id: deploymentId,
         name: request.name || `deployment-${deploymentId.slice(0, 8)}`,
@@ -444,6 +455,7 @@ abstract class InMemoryDeploymentService implements DeploymentService {
         resources: { cpu: '0%', memory: '0MB' },
         ports: [],
         version,
+        url,
         lastUpdated: now,
         metadata: {
           createdAt: now,
@@ -740,6 +752,11 @@ export class RealDeploymentService extends InMemoryDeploymentService {
   /** Post-deploy auth-setup retry tuning (overridable in tests to avoid real waits). */
   authSetupMaxAttempts = 18;
   authSetupIntervalMs = 5000;
+
+  /** Public URL the app is reachable at (Traefik routes `<app>.<base-domain>`). */
+  protected override appUrl(deploymentId: string, app: string): string {
+    return `https://${this.routingService.generateRule({ deploymentId, appName: app }).host}`;
+  }
 
   /** Deterministic Compose project name (aligns with the routing network name). */
   private projectName(deploymentId: string): string {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -6,6 +6,7 @@ import { VerySimpleStrictTest } from './pages/VerySimpleStrictTest';
 import { LiveFeaturesDemo } from './pages/LiveFeaturesDemo';
 import PerformanceOptimizationsDemo from './pages/PerformanceOptimizationsDemo';
 import ErrorHandlingDemo from './pages/ErrorHandlingDemo';
+import { Apps } from './pages/Apps';
 import { Catalog } from './pages/Catalog';
 import { Deployments } from './pages/Deployments';
 import { DeploymentDetail } from './pages/DeploymentDetail';
@@ -20,7 +21,8 @@ function App() {
       <div className="min-h-screen bg-surface-0 text-text-strong">
         <AppShell>
           <Routes>
-            <Route path="/" element={<Navigate to="/dashboard" replace />} />
+            <Route path="/" element={<Navigate to="/apps" replace />} />
+            <Route path="/apps" element={<Apps />} />
             <Route path="/dashboard" element={<Dashboard />} />
             <Route path="/very-simple-strict" element={<VerySimpleStrictTest />} />
             <Route path="/live-features-demo" element={<LiveFeaturesDemo />} />

--- a/packages/web/src/__tests__/pages/Apps.test.tsx
+++ b/packages/web/src/__tests__/pages/Apps.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { API } from '@hola/shared';
+
+import { Apps } from '../../pages/Apps';
+import { globalCache } from '../../utils/cache';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  globalCache.clear(); // hooks cache by key; isolate tests
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+function mockApi(deployments: unknown[], catalog: unknown[]) {
+  global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes(API.catalog.apps)) {
+      return new Response(JSON.stringify({ items: catalog, page: 1, limit: 100, total: catalog.length }), {
+        status: 200, headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (url.includes(API.deployments.base)) {
+      return new Response(JSON.stringify({ items: deployments, page: 1, limit: 100, total: deployments.length }), {
+        status: 200, headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    return new Response('Not Found', { status: 404 });
+  }) as unknown as typeof fetch;
+}
+
+const renderApps = () => render(<MemoryRouter><Apps /></MemoryRouter>);
+
+describe('Apps landing', () => {
+  it('lists installed apps with a link to the public URL and catalog icon', async () => {
+    mockApi(
+      [{ id: 'gitea-abc12345', name: 'Gitea', app: 'gitea', icon: '📦', status: 'running', ports: [], lastUpdated: 'now', url: 'https://gitea.local.hola' }],
+      [{ id: 'gitea', name: 'Gitea', description: '', icon: '🍵', category: 'apps', rating: 0, downloads: 0, tags: [], featured: false }],
+    );
+
+    renderApps();
+
+    const link = await screen.findByTitle('Open Gitea');
+    expect(link).toHaveAttribute('href', 'https://gitea.local.hola');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(screen.getByText('Gitea')).toBeInTheDocument();
+    expect(screen.getByText('🍵')).toBeInTheDocument(); // catalog icon wins over fallback
+    expect(screen.getByText('running')).toBeInTheDocument();
+  });
+
+  it('falls back to the deployment detail link when no URL is set', async () => {
+    mockApi(
+      [{ id: 'x-1', name: 'NoUrl', app: 'x', icon: '📦', status: 'installing', ports: [], lastUpdated: 'now' }],
+      [],
+    );
+
+    renderApps();
+
+    const link = await screen.findByTitle('NoUrl');
+    expect(link).toHaveAttribute('href', '/deployments/x-1');
+  });
+
+  it('shows an empty state when nothing is installed', async () => {
+    mockApi([], []);
+    renderApps();
+    await waitFor(() => {
+      expect(screen.getByText(/No apps installed yet/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/web/src/components/layout/Sidebar.tsx
+++ b/packages/web/src/components/layout/Sidebar.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { 
-  LayoutDashboard, 
-  Package, 
-  Server, 
-  Shield, 
-  Bell, 
+import {
+  LayoutDashboard,
+  LayoutGrid,
+  Package,
+  Server,
+  Shield,
+  Bell,
   Settings,
   Activity,
   ChevronLeft,
@@ -17,6 +18,7 @@ import {
 } from 'lucide-react';
 
 const navigationItems = [
+  { name: 'Apps', path: '/apps', icon: LayoutGrid },
   { name: 'Dashboard', path: '/dashboard', icon: LayoutDashboard },
   { name: 'Catalog', path: '/catalog', icon: Package },
   { name: 'Deployments', path: '/deployments', icon: Server },

--- a/packages/web/src/pages/Apps.tsx
+++ b/packages/web/src/pages/Apps.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { ExternalLink, Package } from 'lucide-react';
+
+import { useDeploymentsApi } from '../hooks/useDeploymentsApi';
+import { useCatalogAppsApi } from '../hooks/useCatalogApi';
+import type { DeploymentStatus, GetDeploymentsRequest } from '@hola/shared';
+
+/**
+ * Apps — the default landing: a read-only launcher for installed apps.
+ *
+ * Everything here is data the server already owns (deployments + the catalog for
+ * icons), joined client-side — no separate dashboard app to keep in sync.
+ */
+
+const STATUS_STYLES: Record<DeploymentStatus, string> = {
+  running: 'bg-success/10 text-success border-success/20',
+  installing: 'bg-info/10 text-info border-info/20',
+  updating: 'bg-info/10 text-info border-info/20',
+  stopped: 'bg-surface-2 text-text-muted border-border',
+  error: 'bg-danger/10 text-danger border-danger/20',
+};
+
+const DEPLOYMENTS_PARAMS: GetDeploymentsRequest = { page: 1, limit: 100 };
+const CATALOG_PARAMS = { page: 1, limit: 100 };
+
+export const Apps: React.FC = () => {
+  const { data: deploymentsData, loading, error } = useDeploymentsApi(DEPLOYMENTS_PARAMS);
+  const { data: catalogData } = useCatalogAppsApi(CATALOG_PARAMS);
+
+  // Join app id -> catalog icon so tiles show the real app glyph, not a fallback.
+  const iconByApp = React.useMemo(() => {
+    const map = new Map<string, string>();
+    for (const app of catalogData?.items ?? []) map.set(app.id, app.icon);
+    return map;
+  }, [catalogData]);
+
+  const apps = deploymentsData?.items ?? [];
+
+  return (
+    <div className="p-6">
+      <div className="mb-6">
+        <h1 className="text-2xl font-semibold text-text-strong">Apps</h1>
+        <p className="text-text-muted mt-1">Your installed apps. Click a tile to open it.</p>
+      </div>
+
+      {loading && apps.length === 0 && (
+        <div className="text-text-muted">Loading apps…</div>
+      )}
+
+      {error && (
+        <div className="bg-danger/10 border border-danger/20 text-danger rounded-lg p-4">
+          Could not load apps: {error}
+        </div>
+      )}
+
+      {!loading && !error && apps.length === 0 && (
+        <div className="bg-surface-1 border border-border rounded-lg p-8 text-center">
+          <Package className="w-8 h-8 text-text-muted mx-auto mb-3" />
+          <p className="text-text-strong font-medium">No apps installed yet</p>
+          <p className="text-text-muted mt-1">
+            Browse the <Link to="/catalog" className="text-primary hover:underline">catalog</Link> to install your first app.
+          </p>
+        </div>
+      )}
+
+      {apps.length > 0 && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+          {apps.map((app) => {
+            const icon = iconByApp.get(app.app) || app.icon || '📦';
+            const tile = (
+              <div className="bg-surface-1 rounded-lg border border-border p-4 h-full hover:border-primary/50 transition-colors flex items-center space-x-3">
+                <div className="text-3xl leading-none">{icon}</div>
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center justify-between gap-2">
+                    <h3 className="font-medium text-text-strong truncate">{app.name}</h3>
+                    {app.url && <ExternalLink className="w-4 h-4 text-text-muted shrink-0" />}
+                  </div>
+                  <div className="mt-1">
+                    <span className={`text-xs px-2 py-0.5 rounded border capitalize ${STATUS_STYLES[app.status]}`}>
+                      {app.status}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            );
+
+            // Link out to the running app when we have a URL; otherwise the tile
+            // links to its deployment detail so it's never a dead end.
+            return app.url ? (
+              <a
+                key={app.id}
+                href={app.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="block"
+                title={`Open ${app.name}`}
+              >
+                {tile}
+              </a>
+            ) : (
+              <Link key={app.id} to={`/deployments/${app.id}`} className="block" title={app.name}>
+                {tile}
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Apps;


### PR DESCRIPTION
## What

A new **`/apps`** landing (the default home) that lists installed apps as tiles — icon, name, status, and a click-through to the app's public URL. It's a view over data the server already owns: deployments joined client-side with the catalog (for real app icons), so there's **no separate dashboard app to keep in sync**.

This is the "now-ish" first increment of **ADR 0002** (also in this PR).

## Changes

**Server**
- Populate `deployment.url` at creation from the routing host (`https://<app>.<base-domain>`), via a new overridable `appUrl()` hook — the real service derives it from routing, the mock leaves it unset (keeps the shared base free of the routing dependency, matching the existing `onBeforeCreate`/`ensureLayout` hook pattern).
- Fixes a latent gap: the existing Deployments page already rendered `deployment.url`, but it was never set.

**Web**
- `pages/Apps.tsx` — read-only tile grid; links to the app URL (new tab), falls back to the deployment detail page when no URL; empty state points at the catalog.
- Root now redirects to `/apps`; added an "Apps" sidebar entry (first).
- Joins catalog icons by app id so tiles show the real glyph, not the `📦` fallback.

**Docs**
- `docs/adr/0002-cross-app-integration.md` — decision record: no auto-installed dashboard (Hola's own UI is the home; Homer/Homepage stay opt-in); cross-app wiring (dashboards, backups) is **server-owned reconciliation** off a manifest-declared `provides` capability, **not** app-to-app events. Phases 1/2 (dashboard + backup reconcilers) are scoped as follow-on work.

## Tests
New `Apps.test.tsx` (link to URL + catalog icon, detail-link fallback, empty state). Full sweep green: server **238**, web **126**, typecheck · lint · build.

## Note
Changes the default route from `/dashboard` → `/apps`. The admin Dashboard remains available in the nav.

🤖 Generated with [Claude Code](https://claude.com/claude-code)