### PR TITLE
feat(server): app-registry feed for cross-app integration (ADR 0002)

### DIFF
--- a/docs/adr/0002-cross-app-integration.md
+++ b/docs/adr/0002-cross-app-integration.md
@@ -56,10 +56,12 @@ On every app-set change (install / uninstall), the server writes a canonical
 `registry.json` into that app's data root (`${HOLA_APP_DATA}/registry.json`):
 
 ```jsonc
-{ "apps": [ { "id", "app", "name", "url", "icon", "status" }, ... ] }
+{ "version": 1, "apps": [ { "id", "app", "name", "url", "icon", "status" }, ... ] }
 ```
 
-That schema is the **only** contract the server owns. It never learns what Homepage or
+The document carries a `version` so the schema can be revved later without breaking
+consumers (they read `version` and tolerate unknown fields). That schema is the
+**only** contract the server owns. It never learns what Homepage or
 Homer is, and adding a new dashboard app to the catalog requires **no server change**.
 
 **Rendering — turning the registry into an app's own config format — lives in the

--- a/docs/adr/0002-cross-app-integration.md
+++ b/docs/adr/0002-cross-app-integration.md
@@ -1,4 +1,4 @@
-# ADR 0002: Cross-app integration via capability providers
+# ADR 0002: Cross-app integration via a registry feed + bundle bolt-ons
 
 - **Status:** Accepted (June 2026)
 - **Context:** Discussion of a default dashboard (Homer/Homepage) and how apps like a
@@ -9,74 +9,101 @@
 
 Some apps are only useful in relation to *other* installed apps:
 
-- a **dashboard** (Homer, gethomepage/homepage) wants a tile per app — name, icon, URL;
+- a **dashboard** (Homer, gethomepage/homepage) wants a tile per app — name, URL, icon;
 - a **backup** tool wants every app's data directory in its backup set.
 
 Two questions follow. (1) Should Hola ship/auto-install a dashboard? (2) What is the
-mechanism by which such an app gets wired to the current set of installed apps?
+mechanism by which such an app learns the current set of installed apps?
 
-Hola already centrally owns the source of truth these apps need. The routing layer
-maintains the full map of every deployment → its public host (`<app>.<base-domain>`),
-emitted as Traefik config; the catalog supplies icons; `${HOLA_APP_DATA}` gives each app
-one stable data root. The server is already the orchestrator that *reconciles* derived
-state (Traefik dynamic config, per-app auth via `ProvisionerService` + the manifest
-`auth` block) from the deployment set whenever it changes.
+Hola already centrally owns the source of truth these apps need: the routing layer knows
+every deployment's public host (`<app>.<base-domain>`), and `${HOLA_APP_DATA}` gives each
+app one stable data root the server writes into. The server is already the orchestrator
+that reconciles derived state (Traefik config, per-app auth via `ProvisionerService` + the
+manifest `auth` block) from the deployment set whenever it changes.
 
-A tempting alternative is an **app-to-app notification bus**: apps subscribe to "app
-installed/removed" events and mutate themselves. Rejected — see below.
+## Guiding principle: the bundle is the integration layer
+
+A Hola catalog bundle is **the upstream app, untouched, plus hola-centric glue bolted
+around it.** The server exposes a small set of **generic, stable primitives**; the bundle
+*composes* them around the core image to deliver hola-specific benefits. The upstream image
+never has to know about Hola, and **the server never has to know about the upstream app.**
+
+This is already how the platform works: `${HOLA_APP_DATA}` (a data-root primitive),
+`${HOLA_APP_HOST}`/`${HOLA_BASE_DOMAIN}` (install primitives), and platform defaults
+(generic ops policy) are all primitives the bundle leans on. Cross-app integration is the
+next primitive, and the app-specific part lives in the bundle — not the server.
 
 ## Decision
 
 ### 1. No auto-installed dashboard; Hola's own UI is the default home
 
 Hola does not auto-install a separate dashboard app. The default landing (`/apps`) is a
-read-only launcher in Hola's own web UI, rendered from data the server already has
-(deployments joined with catalog icons). This is always present and needs no
-synchronization. Homer/Homepage remain **opt-in** catalog apps for users who want a
-customizable, public-facing dashboard distinct from the admin console.
+read-only launcher in Hola's own web UI, rendered from data the server already has. It is
+always present and needs no synchronization. Homer/Homepage remain **opt-in** catalog apps
+for users who want a customizable, public-facing dashboard distinct from the admin console.
 
-### 2. Cross-app wiring is server-owned reconciliation, not app-to-app events
+### 2. The server publishes a generic registry feed; the bundle renders it
 
-Integration is modeled on the existing `auth`-block + `ProvisionerService` pattern: an app
-**declares a capability** in its manifest; the **server** does the wiring by reconciling
-that app's config from the registry it already maintains, on every install/uninstall.
+The server's entire role is to maintain an **app registry** and deliver it to any app that
+declares it wants it:
 
-```
-manifest.json:
-  provides: dashboard     # or: backup   (a capability the server reconciles)
+```jsonc
+// manifest.json
+"consumes": "app-registry"
 ```
 
-- **Dashboard provider** → on app-set change, the server regenerates the provider's config
-  (e.g. Homepage `services.yaml`) into its `${HOLA_APP_DATA}/config` from the routing map
-  (app, host, icon).
-- **Backup provider** → the server maintains the provider's include list of per-app data
-  roots (`<HOLA_APPS_BIND_ROOT>/<deploymentId>/`).
+On every app-set change (install / uninstall), the server writes a canonical
+`registry.json` into that app's data root (`${HOLA_APP_DATA}/registry.json`):
 
-The event bus exists, but it is **internal to the server** (install/uninstall → run
-reconcilers). Subscribers are server-side reconcilers, never the apps themselves.
+```jsonc
+{ "apps": [ { "id", "app", "name", "url", "icon", "status" }, ... ] }
+```
 
-### Rejected: app-to-app notifications
+That schema is the **only** contract the server owns. It never learns what Homepage or
+Homer is, and adding a new dashboard app to the catalog requires **no server change**.
 
-Letting catalog apps receive system events and react turns curated, static compose
-bundles into active agents: each would need a callback token / API access and the right to
-mutate config, and would own its own ordering, idempotency, retry, and partial-failure
-handling outside Hola's control. This is a large security and complexity escalation for no
-benefit over server-owned reconciliation, since the server already holds the registry.
+**Rendering — turning the registry into an app's own config format — lives in the
+bundle**, as a bolt-on around the core image: a small **watcher sidecar** that reads
+`registry.json` and writes the app's config (e.g. Homepage's `services.yaml`), re-rendering
+when the registry changes. It runs in the app's own Docker sandbox, holds no tokens, calls
+no API, and touches no other app.
+
+The same primitive serves backups: a backup bundle consumes the registry (which carries
+each app's data-root) and includes those paths in its backup set — again, bundle-side.
+
+The server has an **internal** event (app-set change → rewrite registry feeds). Subscribers
+are the server's own feed-writer, never the apps.
+
+### Rejected alternatives
+
+- **App-to-app notification bus** — apps subscribe to system events and react. Turns
+  curated, static bundles into active agents needing callback tokens / API access, each
+  owning ordering, idempotency, retry, and failure handling outside Hola's control. Large
+  security and complexity escalation for no benefit over the registry feed.
+- **Server-side per-app rendering** — the server generating each provider's native config
+  (a Homepage renderer, a Homer renderer, …). Rejected because it pulls app-format
+  knowledge into the orchestrator: every new dashboard app would need a server release, and
+  any format the server's engine can't express becomes a server change. That re-centralizes
+  exactly what should evolve in the catalog. (A *generic* renderer sidecar image may be
+  offered later as optional authoring sugar — but as a container, never server code.)
 
 ## Consequences
 
-- The app launcher ships first as a thin, read-only view (no new app, no sync). This ADR's
-  initial increment populates `deployment.url` server-side and adds the `/apps` landing.
-- Provider apps stay "dumb" bundles that only declare a capability; integration logic lives
-  in Hola — testable, idempotent, version-controlled, and security-reviewed in one place.
-- The model generalizes: dashboards and backups are both reconcilers over the same
-  registry; future consumers (e.g. monitoring) follow the same shape.
-- A reconciler writes into a provider's `${HOLA_APP_DATA}`, which the server already creates
-  and owns — no new privileged surface on the apps.
+- The server stays a pure data-publisher with one tiny, versioned contract (`registry.json`
+  + the `consumes` flag). All app-specific logic and execution lives in the catalog and runs
+  in container sandboxes — testable and evolvable without server releases.
+- The security boundary holds: the server pushes data one-way into a sandbox; apps never get
+  events, tokens, API access, or reach into other apps.
+- The model generalizes: dashboards and backups are both registry consumers; future
+  consumers (monitoring, status pages) follow the same shape with no new server surface.
+- Reactivity to later installs is the bundle's concern (a watcher sidecar), keeping the
+  server free of per-provider restart logic.
 
 ## Status of follow-on work
 
-- **Now (this increment):** `/apps` landing + server-populated `deployment.url`.
-- **Phase 1:** manifest `provides` capability + server reconciler hook on app-set change;
-  dashboard reconciler first (Homepage as reference provider, opt-in).
-- **Phase 2:** backup reconciler as a second provider over the per-app data roots.
+- **Done:** `/apps` landing + server-populated `deployment.url` (#118).
+- **This increment:** generic `consumes: app-registry` → `registry.json` feed on the server,
+  written to consumers' data roots on app-set change.
+- **Catalog (try-hola/apps):** Homepage bundle gains a watcher-sidecar bolt-on that renders
+  `registry.json` → `services.yaml` and declares `consumes: app-registry`.
+- **Later:** backup consumer; optional generic renderer-sidecar image as authoring sugar.

--- a/packages/server/src/__tests__/bundles/app-registry.test.ts
+++ b/packages/server/src/__tests__/bundles/app-registry.test.ts
@@ -1,0 +1,36 @@
+/**
+ * App registry feed: pure helpers (ADR 0002).
+ */
+
+import { describe, test, expect } from 'bun:test';
+
+import { buildRegistry, coerceConsumes, type RegistryApp } from '../../services/core/app-registry';
+
+describe('buildRegistry', () => {
+  const apps: RegistryApp[] = [
+    { id: 'vaultwarden-2', app: 'vaultwarden', name: 'Vaultwarden', url: 'https://vw.x', icon: '🔐', status: 'running' },
+    { id: 'gitea-1', app: 'gitea', name: 'Gitea', url: 'https://gitea.x', icon: '📦', status: 'stopped' },
+  ];
+
+  test('emits a deterministic, name-sorted document', () => {
+    const doc = JSON.parse(buildRegistry(apps));
+    expect(doc.apps.map((a: RegistryApp) => a.name)).toEqual(['Gitea', 'Vaultwarden']);
+    expect(doc.apps[0]).toEqual({
+      id: 'gitea-1', app: 'gitea', name: 'Gitea', url: 'https://gitea.x', icon: '📦', status: 'stopped',
+    });
+  });
+
+  test('byte-identical for the same set regardless of input order', () => {
+    expect(buildRegistry(apps)).toBe(buildRegistry([...apps].reverse()));
+  });
+});
+
+describe('coerceConsumes', () => {
+  test('accepts a string, an array, and rejects junk', () => {
+    expect(coerceConsumes('app-registry')).toEqual(['app-registry']);
+    expect(coerceConsumes([' app-registry ', 'backup'])).toEqual(['app-registry', 'backup']);
+    expect(coerceConsumes([])).toBeUndefined();
+    expect(coerceConsumes(undefined)).toBeUndefined();
+    expect(coerceConsumes(42)).toBeUndefined();
+  });
+});

--- a/packages/server/src/__tests__/bundles/app-registry.test.ts
+++ b/packages/server/src/__tests__/bundles/app-registry.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, test, expect } from 'bun:test';
 
-import { buildRegistry, coerceConsumes, type RegistryApp } from '../../services/core/app-registry';
+import { buildRegistry, coerceConsumes, REGISTRY_SCHEMA_VERSION, type RegistryApp } from '../../services/core/app-registry';
 
 describe('buildRegistry', () => {
   const apps: RegistryApp[] = [
@@ -12,8 +12,9 @@ describe('buildRegistry', () => {
     { id: 'gitea-1', app: 'gitea', name: 'Gitea', url: 'https://gitea.x', icon: '📦', status: 'stopped' },
   ];
 
-  test('emits a deterministic, name-sorted document', () => {
+  test('emits a versioned, deterministic, name-sorted document', () => {
     const doc = JSON.parse(buildRegistry(apps));
+    expect(doc.version).toBe(REGISTRY_SCHEMA_VERSION);
     expect(doc.apps.map((a: RegistryApp) => a.name)).toEqual(['Gitea', 'Vaultwarden']);
     expect(doc.apps[0]).toEqual({
       id: 'gitea-1', app: 'gitea', name: 'Gitea', url: 'https://gitea.x', icon: '📦', status: 'stopped',

--- a/packages/server/src/__tests__/deployments/auth-provisioning.test.ts
+++ b/packages/server/src/__tests__/deployments/auth-provisioning.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { mkdtemp, rm } from 'fs/promises';
+import { mkdtemp, rm, readFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { parse } from 'yaml';
@@ -48,13 +48,14 @@ const OIDC_AUTH: AppAuthConfig = {
   },
 };
 
-function makeCatalog(auth?: AppAuthConfig): CatalogArg {
+function makeCatalog(auth?: AppAuthConfig, consumes?: string[]): CatalogArg {
   return {
     getApp: async (appId: string) => ({ id: appId, name: 'Gitea', icon: '🍵' }),
     getVersionDetail: async () => ({
       defaultEnv: [],
       defaults: { ports: [{ host: 3000, container: 3000, protocol: 'tcp' as const }], volumes: [] },
       auth,
+      consumes,
     }),
   } as unknown as CatalogArg;
 }
@@ -148,13 +149,13 @@ describe('Auth provisioning lifecycle', () => {
     await rm(dataRoot, { recursive: true, force: true });
   });
 
-  function makeSystem(opts: { auth?: AppAuthConfig; provisioner?: ProvisionerService; docker?: DockerService } = {}) {
+  function makeSystem(opts: { auth?: AppAuthConfig; consumes?: string[]; provisioner?: ProvisionerService; docker?: DockerService } = {}) {
     const storage = new RealStorageService({ holaDir: dataRoot });
     const database = new RealDatabaseService(storage);
     const logging = new RealLoggingService(storage);
     const jobs = new RealJobService(database, logging);
     const routing = new RealRoutingService(storage, { baseDomain: 'local.hola' });
-    const drafts = new RealDraftService(storage, makeCatalog(opts.auth), makeValidation());
+    const drafts = new RealDraftService(storage, makeCatalog(opts.auth, opts.consumes), makeValidation());
     const provisioner = opts.provisioner ?? new SpyProvisioner();
     const docker = opts.docker ?? new MockDockerService();
     const deployments = new RealDeploymentService(storage, jobs, docker, drafts, routing, logging, provisioner);
@@ -259,6 +260,37 @@ describe('Auth provisioning lifecycle', () => {
         options: { 'max-size': '10m', 'max-file': '3' },
       });
       expect(doc.services[svc].security_opt).toEqual(['no-new-privileges:true']);
+    }
+  });
+
+  test('writes registry.json into consumers (consumes: app-registry) on app-set change', async () => {
+    const prev = process.env.HOLA_APPS_BIND_ROOT;
+    process.env.HOLA_APPS_BIND_ROOT = join(dataRoot, 'apps');
+    try {
+      const sys = makeSystem({ consumes: ['app-registry'] });
+      const finalizeFor = async (appId: string): Promise<string> => {
+        const { draftId } = await sys.drafts.createDraft({ appId, version: '1.0.0' });
+        await sys.drafts.updateDraft(draftId, { composeOverride: COMPOSE });
+        await sys.drafts.finalizeDraft(draftId);
+        return draftId;
+      };
+
+      // A registry consumer (e.g. a dashboard) installs first... (distinct apps
+      // so their routing hosts don't collide).
+      const consumer = await sys.deployments.createFromDraft({ draftId: await finalizeFor('homepage'), name: 'homepage' });
+      expect((await waitForJob(sys.jobs, consumer.jobId!)).status).toBe('completed');
+      // ...then a second app installs, which must show up in the consumer's feed.
+      const other = await sys.deployments.createFromDraft({ draftId: await finalizeFor('gitea'), name: 'gitea' });
+      expect((await waitForJob(sys.jobs, other.jobId!)).status).toBe('completed');
+
+      const feed = join(process.env.HOLA_APPS_BIND_ROOT, consumer.deploymentId, 'registry.json');
+      const doc = JSON.parse(await readFile(feed, 'utf-8')) as { apps: Array<{ name: string; url?: string; status: string }> };
+      const names = doc.apps.map((a) => a.name);
+      expect(names).toEqual(['gitea', 'homepage']); // sorted, both present
+      expect(doc.apps.find((a) => a.name === 'gitea')?.url).toBe('https://gitea.local.hola');
+    } finally {
+      if (prev === undefined) delete process.env.HOLA_APPS_BIND_ROOT;
+      else process.env.HOLA_APPS_BIND_ROOT = prev;
     }
   });
 

--- a/packages/server/src/__tests__/deployments/auth-provisioning.test.ts
+++ b/packages/server/src/__tests__/deployments/auth-provisioning.test.ts
@@ -284,7 +284,8 @@ describe('Auth provisioning lifecycle', () => {
       expect((await waitForJob(sys.jobs, other.jobId!)).status).toBe('completed');
 
       const feed = join(process.env.HOLA_APPS_BIND_ROOT, consumer.deploymentId, 'registry.json');
-      const doc = JSON.parse(await readFile(feed, 'utf-8')) as { apps: Array<{ name: string; url?: string; status: string }> };
+      const doc = JSON.parse(await readFile(feed, 'utf-8')) as { version: number; apps: Array<{ name: string; url?: string; status: string }> };
+      expect(doc.version).toBe(1); // versioned feed
       const names = doc.apps.map((a) => a.name);
       expect(names).toEqual(['gitea', 'homepage']); // sorted, both present
       expect(doc.apps.find((a) => a.name === 'gitea')?.url).toBe('https://gitea.local.hola');

--- a/packages/server/src/services/core/app-registry.ts
+++ b/packages/server/src/services/core/app-registry.ts
@@ -13,6 +13,14 @@ export const APP_REGISTRY_CAPABILITY = 'app-registry';
 /** File the feed is written as, inside the consumer's data root (`${HOLA_APP_DATA}`). */
 export const REGISTRY_FILENAME = 'registry.json';
 
+/**
+ * Schema version of the `registry.json` document. Consumers should read this and
+ * tolerate unknown fields (forward-compatible). Bump it when the shape changes
+ * in a way consumers must react to; purely additive fields can keep the version
+ * but a bump is the explicit signal that something changed.
+ */
+export const REGISTRY_SCHEMA_VERSION = 1;
+
 /** One installed app as seen by consumers. */
 export interface RegistryApp {
   /** Deployment id (`<slug>-<hash>`). */
@@ -35,7 +43,7 @@ export interface RegistryApp {
  */
 export function buildRegistry(apps: RegistryApp[]): string {
   const sorted = [...apps].sort((a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id));
-  return JSON.stringify({ apps: sorted }, null, 2) + '\n';
+  return JSON.stringify({ version: REGISTRY_SCHEMA_VERSION, apps: sorted }, null, 2) + '\n';
 }
 
 /** Coerce a manifest `consumes` field (string or string[]) to a clean list. */

--- a/packages/server/src/services/core/app-registry.ts
+++ b/packages/server/src/services/core/app-registry.ts
@@ -1,0 +1,46 @@
+/**
+ * The app registry: the generic, stable feed Hola publishes for cross-app
+ * integration (ADR 0002). The server writes `registry.json` into the data root
+ * of every deployment whose manifest declares `consumes: app-registry`; a
+ * bundle-side bolt-on (e.g. a watcher sidecar) renders it into the app's own
+ * config format. The schema below is the entire contract — the server never
+ * learns what any consumer is.
+ */
+
+/** Manifest capability a consumer declares to receive the registry feed. */
+export const APP_REGISTRY_CAPABILITY = 'app-registry';
+
+/** File the feed is written as, inside the consumer's data root (`${HOLA_APP_DATA}`). */
+export const REGISTRY_FILENAME = 'registry.json';
+
+/** One installed app as seen by consumers. */
+export interface RegistryApp {
+  /** Deployment id (`<slug>-<hash>`). */
+  id: string;
+  /** App slug (stable key consumers can map to their own icon set). */
+  app: string;
+  /** Display name. */
+  name: string;
+  /** Public URL (`https://<app>.<base-domain>`), if known. */
+  url?: string;
+  /** Icon hint (may be a generic fallback; consumers may prefer `app`). */
+  icon?: string;
+  /** Current deployment status. */
+  status: string;
+}
+
+/**
+ * Render the canonical registry document. Deterministic (apps sorted by name)
+ * so unchanged state produces byte-identical output — no needless rewrites.
+ */
+export function buildRegistry(apps: RegistryApp[]): string {
+  const sorted = [...apps].sort((a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id));
+  return JSON.stringify({ apps: sorted }, null, 2) + '\n';
+}
+
+/** Coerce a manifest `consumes` field (string or string[]) to a clean list. */
+export function coerceConsumes(raw: unknown): string[] | undefined {
+  const arr = Array.isArray(raw) ? raw : typeof raw === 'string' ? [raw] : [];
+  const out = arr.filter((x): x is string => typeof x === 'string' && x.trim().length > 0).map((s) => s.trim());
+  return out.length ? out : undefined;
+}

--- a/packages/server/src/services/core/catalog.ts
+++ b/packages/server/src/services/core/catalog.ts
@@ -12,6 +12,7 @@ import type {
   CatalogAppVersion,
 } from '@hola/shared';
 import { coerceManifestAuth } from './manifest-auth';
+import { coerceConsumes } from './app-registry';
 
 // Shape of remote catalog JSON (minimal for now)
 type RemoteCatalog = {
@@ -141,6 +142,7 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
           volumes?: Array<{ hostPath?: unknown; containerPath: unknown; readOnly?: unknown }>;
         };
         auth?: unknown;
+        consumes?: unknown;
       };
 
       const manifest: Manifest = JSON.parse(raw) as unknown as Manifest;
@@ -191,7 +193,11 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
       // the auth block must be coerced or it silently vanishes downstream.
       const auth = coerceManifestAuth(manifest.auth);
 
-      return { ...merged, composeOverride, auth } satisfies GetCatalogAppVersionDetailResponse;
+      // Cross-app capabilities the app consumes (e.g. `app-registry`); generic,
+      // so new capability names need no server change (ADR 0002).
+      const consumes = coerceConsumes(manifest.consumes);
+
+      return { ...merged, composeOverride, auth, consumes } satisfies GetCatalogAppVersionDetailResponse;
     } catch (error) {
       this.logger.warn('Failed to read or parse bundle manifest; deferring to mocks', { appId, version, error: error instanceof Error ? error.message : String(error) });
       throw new Error('MANIFEST_UNAVAILABLE', { cause: error });

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -49,6 +49,7 @@ import { APP_DATA_TOKEN, APP_HOST_TOKEN, BASE_DOMAIN_TOKEN } from '@hola/shared/
 import { attachToHolaNetwork, injectEnvironment } from './compose-network';
 import { applyPlatformDefaults } from './compose-defaults';
 import { composeDefaultsConfig } from '../../config/compose-defaults';
+import { APP_REGISTRY_CAPABILITY, REGISTRY_FILENAME, buildRegistry, type RegistryApp } from './app-registry';
 
 /** Default host base for per-app data roots when HOLA_APPS_BIND_ROOT is unset. */
 const DEFAULT_APPS_BIND_ROOT = '/srv/hola/apps';
@@ -816,8 +817,7 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     // in-container) so the path the server creates matches what the daemon binds
     // into app containers — see packages/compose.
     if (content.includes(APP_DATA_TOKEN)) {
-      const base = (process.env.HOLA_APPS_BIND_ROOT?.trim() || DEFAULT_APPS_BIND_ROOT).replace(/\/+$/, '');
-      const appRoot = `${base}/${deployment.id}`;
+      const appRoot = this.appRootFor(deployment.id);
       await this.storageService.ensureDir(appRoot);
       content = content.replaceAll(APP_DATA_TOKEN, appRoot);
     }
@@ -856,6 +856,66 @@ export class RealDeploymentService extends InMemoryDeploymentService {
       return manifest.auth;
     } catch {
       return undefined;
+    }
+  }
+
+  /** Cross-app capabilities the active release declares it consumes (ADR 0002). */
+  private async readActiveConsumes(deployment: EnhancedDeploymentDetail): Promise<string[]> {
+    const releaseId = deployment.currentReleaseId;
+    if (!releaseId) return [];
+    const manifestPath = `deployments/${deployment.id}/releases/${releaseId}/manifest.json`;
+    if (!(await this.storageService.fileExists(manifestPath))) return [];
+    try {
+      const manifest = JSON.parse(await this.storageService.readFileAsString(manifestPath)) as FinalizedManifest;
+      return manifest.consumes ?? [];
+    } catch {
+      return [];
+    }
+  }
+
+  /** Absolute host data root for a deployment (`<HOLA_APPS_BIND_ROOT>/<id>`). */
+  private appRootFor(deploymentId: string): string {
+    const base = (process.env.HOLA_APPS_BIND_ROOT?.trim() || DEFAULT_APPS_BIND_ROOT).replace(/\/+$/, '');
+    return `${base}/${deploymentId}`;
+  }
+
+  /**
+   * Publish the app registry feed (ADR 0002): build the canonical list of
+   * installed apps and write `registry.json` into the data root of every
+   * deployment that declares `consumes: app-registry`. Rendering into each app's
+   * own config format is a bundle bolt-on, not the server's concern. Never
+   * throws — a feed failure must not fail a deploy.
+   */
+  private async reconcileAppRegistry(): Promise<void> {
+    try {
+      const apps: RegistryApp[] = Array.from(this.deployments.values()).map((d) => ({
+        id: d.id,
+        app: d.app,
+        name: d.name,
+        url: d.url,
+        icon: d.icon,
+        status: d.status,
+      }));
+      const content = buildRegistry(apps);
+
+      for (const d of this.deployments.values()) {
+        const consumes = await this.readActiveConsumes(d);
+        if (!consumes.includes(APP_REGISTRY_CAPABILITY)) continue;
+        try {
+          const root = this.appRootFor(d.id);
+          await this.storageService.ensureDir(root);
+          await this.storageService.writeFile(`${root}/${REGISTRY_FILENAME}`, content);
+        } catch (error) {
+          this.logger.warn('Failed to write app registry feed', {
+            deploymentId: d.id,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    } catch (error) {
+      this.logger.warn('App registry reconcile failed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
     }
   }
 
@@ -1056,6 +1116,9 @@ export class RealDeploymentService extends InMemoryDeploymentService {
       this.deployments.set(deploymentId, deployment);
       await this.persistDeployment(deployment);
 
+      // App-set / status changed → refresh the registry feed for consumers.
+      await this.reconcileAppRegistry();
+
       await logBoth('info', `Deployment action '${action}' completed`);
       return true;
     } catch (error) {
@@ -1178,6 +1241,8 @@ export class RealDeploymentService extends InMemoryDeploymentService {
 
   protected override async onDeploymentRemoved(deploymentId: string): Promise<void> {
     await this.routingService.deactivateRoute(deploymentId);
+    // The removed app drops out of the registry feed for remaining consumers.
+    await this.reconcileAppRegistry();
   }
 
   protected override async onDeprovision(deployment: EnhancedDeploymentDetail): Promise<void> {

--- a/packages/server/src/services/core/draft.ts
+++ b/packages/server/src/services/core/draft.ts
@@ -56,6 +56,9 @@ export interface FinalizedManifest {
   // App auth capability carried from the catalog manifest so the deploy
   // lifecycle can provision SSO without re-reading the bundle.
   auth?: AppAuthConfig;
+  // Cross-app capabilities consumed (e.g. `app-registry`); carried so the
+  // deploy lifecycle can publish the right feeds without re-reading the bundle.
+  consumes?: string[];
   files: FinalizedManifestFile[];
   checksum: string;
   finalizedAt: string;
@@ -318,6 +321,7 @@ export class RealDraftService implements DraftService {
         ports: defaults.defaults.ports,
         composeOverride,
         auth: defaults.auth,
+        consumes: defaults.consumes,
         files: [],
       };
 
@@ -568,6 +572,7 @@ export class RealDraftService implements DraftService {
         ports: draft.ports,
         composeOverride: draft.composeOverride ?? '',
         auth: draft.auth,
+        consumes: draft.consumes,
         files: specFiles,
       };
 
@@ -645,7 +650,7 @@ export class RealDraftService implements DraftService {
     };
   }
 
-  async getDraftDefaults(appId: string, version?: string): Promise<{ env: AppEnvVar[]; defaults: DraftDefaults; composeOverride: string; auth?: AppAuthConfig }> {
+  async getDraftDefaults(appId: string, version?: string): Promise<{ env: AppEnvVar[]; defaults: DraftDefaults; composeOverride: string; auth?: AppAuthConfig; consumes?: string[] }> {
     try {
       const versionDetail = await this.catalogService.getVersionDetail(appId, version || 'latest');
       return {
@@ -653,6 +658,7 @@ export class RealDraftService implements DraftService {
         defaults: versionDetail.defaults,
         composeOverride: versionDetail.composeOverride ?? '',
         auth: versionDetail.auth,
+        consumes: versionDetail.consumes,
       };
     } catch (error) {
       this.logger.warn('Failed to get app defaults, using fallback', { appId, version, error: error instanceof Error ? error.message : String(error) });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -259,6 +259,10 @@ export type GetCatalogAppVersionDetailResponse = {
   // Drives provisioning at deploy time (see AppAuthConfig). Optional: apps
   // that don't declare it behave as `none` (no auth wiring).
   auth?: AppAuthConfig;
+  // Cross-app capabilities the app consumes, declared in its bundle manifest
+  // (e.g. `app-registry`). The server writes the corresponding feed into the
+  // app's data root on app-set change; rendering is a bundle bolt-on (ADR 0002).
+  consumes?: string[];
 };
 
 // ------------------------------------------------------
@@ -341,6 +345,9 @@ export type Draft = {
   // App auth capability seeded from the catalog bundle manifest (read-only; not
   // user-editable). Carried through finalize so the deploy lifecycle can provision.
   auth?: AppAuthConfig;
+  // Cross-app capabilities consumed (e.g. `app-registry`), seeded from the bundle
+  // manifest and carried through finalize (ADR 0002).
+  consumes?: string[];
   files: Array<{ uploadId: string; name: string; size: number; kind: 'composeOverride' | 'additionalFile' | 'env' | 'secret' }>;
 };
 


### PR DESCRIPTION
## What

The server side of cross-app integration (ADR 0002, revised in this PR). The server publishes a **generic registry feed** so apps can integrate with the set of installed apps — without the server knowing what any of them are.

On every app-set change (deploy/start/stop/rollback success, and uninstall), the server writes a canonical `registry.json` into the data root of every deployment whose manifest declares `consumes: app-registry`:

```jsonc
{ "apps": [ { "id", "app", "name", "url", "icon", "status" }, ... ] }
```

That schema is the **entire contract**. Rendering it into an app's own config format (e.g. Homepage's `services.yaml`) is a **bundle bolt-on** — a watcher sidecar around the core image — not the server's concern.

## Why this shape (the design correction)

Earlier drafts of ADR 0002 had the *server* generate each provider's native config. That re-centralizes app-format knowledge: every new dashboard app would need a server release. This PR moves rendering into the bundle, so:
- **the server stays generic** — one tiny, versioned contract; new dashboard/backup apps need no server change;
- **the security boundary holds** — the server pushes data one-way into a sandbox; apps get no events, tokens, or API access (vs. the also-rejected app-to-app notification bus).

This follows the existing principle that **the bundle is the integration layer** (it bolts hola glue around an untouched upstream image), the same way `${HOLA_APP_DATA}` / `${HOLA_APP_HOST}` / platform defaults are server primitives the bundle composes.

## Changes
- **shared**: `consumes?: string[]` on catalog version detail + `Draft`.
- **catalog**: parse manifest `consumes` (`coerceConsumes`), carried through draft finalize into the finalized manifest — mirrors the `auth` block exactly.
- **`services/core/app-registry.ts`**: `buildRegistry` (deterministic, name-sorted) + `coerceConsumes`.
- **`deployment.ts`**: `readActiveConsumes` + `reconcileAppRegistry` (non-fatal), invoked on lifecycle success and `onDeploymentRemoved`; `appRootFor()` shared with `materializeCompose`.
- **ADR 0002**: revised to "registry feed + bundle bolt-ons".
- **tests**: registry helpers (unit) + end-to-end (a `consumes: app-registry` deployment receives a `registry.json` listing the other installed app, with its URL).

All gates green: server **242**, web **126**, typecheck · lint · build.

## Companion (next)
`try-hola/apps`: Homepage bundle gains a watcher-sidecar bolt-on that renders `registry.json` → `services.yaml` and declares `consumes: app-registry`. That needs a small generic renderer image — separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)