### PR TITLE
feat(server): apps-data capability — gated read-only mount of all app data

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,15 @@ install as **Docker Compose** stacks, orchestrated by a server and routed by
   is empty when `HOLA_CATALOG_URL` is unset/unreachable (no fake-app fallback).
   `MockCatalogService` (test env) is an empty catalog; tests inject their own
   stub when they need catalog data.
+- **Cross-app integration (ADR 0002).** An app declares capabilities in its
+  manifest `consumes` array and the server reconciles a generic primitive at
+  deploy time — never per-app/format-specific logic. `app-registry` → the server
+  writes `registry.json` (installed apps) into the app's data root on app-set
+  change (a bundle bolt-on renders it, e.g. Homepage's dashboard). `apps-data` →
+  the server injects a **read-only** identity mount of the apps root
+  (`materializeCompose` → `compose-mounts.ts`), granting a trusted app (e.g. the
+  `backrest` backup app) read access to all app data. `apps-data` is privileged;
+  reserve it for trusted catalog apps.
 - **Auth/SSO (Authentik).** `ProvisionerService` (`services/core/provisioner.ts`)
   provisions per-app auth at deploy time for three modes declared in the app
   manifest's `auth` block: `native-oidc` (env injection and/or a post-deploy setup

--- a/docs/adr/0002-cross-app-integration.md
+++ b/docs/adr/0002-cross-app-integration.md
@@ -76,6 +76,25 @@ each app's data-root) and includes those paths in its backup set — again, bund
 The server has an **internal** event (app-set change → rewrite registry feeds). Subscribers
 are the server's own feed-writer, never the apps.
 
+### 3. Privileged data access is a separate, gated primitive (`apps-data`)
+
+Some consumers (a **backup** tool, future monitoring/AV) need to *read other apps' data*,
+not just their metadata. That can't be a bundle bolt-on — only the server can grant
+cross-app access. An app declares `consumes: apps-data`; at materialization the server
+injects a **read-only, identity-mapped** bind mount of the apps root
+(`<HOLA_APPS_BIND_ROOT>:<…>:ro`) into the app's services (like the other injections,
+post-validation — a deliberate grant, not user-authored).
+
+This is the most privileged capability: the consumer can read every app's data and (for
+backup) holds the off-site destination + encryption key. It is **read-only** and **gated**
+by the explicit manifest declaration; reserve it for trusted catalog apps. (Future: an
+operator approval flow for privileged capabilities.)
+
+**Backup (Phase 2)** uses this primitive, not the registry feed: the `backrest` app
+(restic + web UI) gets the read-only apps-root mount and the operator configures one backup
+plan over it. Registry-driven *per-app* plans remain a future option; consistent backups of
+running DB-backed apps are tracked separately (per-app pre/post-backup hooks).
+
 ### Rejected alternatives
 
 - **App-to-app notification bus** — apps subscribe to system events and react. Turns

--- a/packages/server/src/__tests__/deployments/auth-provisioning.test.ts
+++ b/packages/server/src/__tests__/deployments/auth-provisioning.test.ts
@@ -295,6 +295,32 @@ describe('Auth provisioning lifecycle', () => {
     }
   });
 
+  test('consumes: apps-data injects a read-only mount of the apps root', async () => {
+    const prev = process.env.HOLA_APPS_BIND_ROOT;
+    const base = join(dataRoot, 'apps');
+    process.env.HOLA_APPS_BIND_ROOT = base;
+    try {
+      const sys = makeSystem({ consumes: ['apps-data'] });
+      const created = await sys.deployments.createFromDraft({ draftId: await finalizedDraft(sys.drafts), name: 'gitea' });
+      expect((await waitForJob(sys.jobs, created.jobId!)).status).toBe('completed');
+
+      const raw = await sys.storage.readFileAsString(`deployments/${created.deploymentId}/runtime/docker-compose.yml`);
+      const doc = parse(raw) as { services: Record<string, { volumes?: string[] }> };
+      expect(doc.services.gitea.volumes).toContain(`${base}:${base}:ro`);
+    } finally {
+      if (prev === undefined) delete process.env.HOLA_APPS_BIND_ROOT;
+      else process.env.HOLA_APPS_BIND_ROOT = prev;
+    }
+  });
+
+  test('no apps-data capability: no apps-root mount injected', async () => {
+    const sys = makeSystem({ auth: undefined });
+    const created = await sys.deployments.createFromDraft({ draftId: await finalizedDraft(sys.drafts), name: 'gitea' });
+    expect((await waitForJob(sys.jobs, created.jobId!)).status).toBe('completed');
+    const raw = await sys.storage.readFileAsString(`deployments/${created.deploymentId}/runtime/docker-compose.yml`);
+    expect(raw).not.toContain(':ro');
+  });
+
   test('no auth block: deploys normally with no provisioning and no injected env', async () => {
     const sys = makeSystem({ auth: undefined });
     const spy = sys.provisioner as SpyProvisioner;

--- a/packages/server/src/__tests__/routing/compose-mounts.test.ts
+++ b/packages/server/src/__tests__/routing/compose-mounts.test.ts
@@ -1,0 +1,47 @@
+/**
+ * apps-data read-only mount injection (ADR 0002, backup Phase 2).
+ *
+ * The server grants a trusted app read-only access to all app data roots by
+ * injecting an identity-mapped `<base>:<base>:ro` mount into every service.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { parse } from 'yaml';
+
+import { injectReadonlyMount } from '../../services/core/compose-mounts';
+
+const ROOT = '/srv/hola/apps';
+const out = (yaml: string) => parse(injectReadonlyMount(yaml, { hostPath: ROOT }));
+
+describe('injectReadonlyMount', () => {
+  test('adds the read-only mount to every service, preserving existing volumes', () => {
+    const input = [
+      'services:',
+      '  backrest:',
+      '    image: garethgeorge/backrest:v1',
+      '    volumes:',
+      '      - ${HOLA_APP_DATA}/config:/config',
+      '  helper:',
+      '    image: alpine:3',
+      '',
+    ].join('\n');
+    const doc = out(input);
+
+    expect(doc.services.backrest.volumes).toEqual([
+      '${HOLA_APP_DATA}/config:/config',
+      `${ROOT}:${ROOT}:ro`,
+    ]);
+    expect(doc.services.helper.volumes).toEqual([`${ROOT}:${ROOT}:ro`]);
+  });
+
+  test('is idempotent (no duplicate mount)', () => {
+    const once = injectReadonlyMount('services:\n  app:\n    image: app:1\n', { hostPath: ROOT });
+    const twice = injectReadonlyMount(once, { hostPath: ROOT });
+    expect(parse(twice).services.app.volumes).toEqual([`${ROOT}:${ROOT}:ro`]);
+  });
+
+  test('no services -> returns input unchanged', () => {
+    const input = 'networks:\n  hola:\n    external: true\n';
+    expect(injectReadonlyMount(input, { hostPath: ROOT })).toBe(input);
+  });
+});

--- a/packages/server/src/services/core/compose-mounts.ts
+++ b/packages/server/src/services/core/compose-mounts.ts
@@ -1,0 +1,44 @@
+/**
+ * Inject a server-granted read-only mount into a deployed app's compose.
+ *
+ * The `apps-data` capability (declared in a manifest as `consumes: apps-data`)
+ * grants a trusted app — e.g. a backup tool — read-only access to ALL apps' data
+ * roots. The mount is identity-mapped (`<hostPath>:<hostPath>:ro`) so absolute
+ * host paths resolve unchanged inside the container (the apps bind root is
+ * identity-mounted into the server too — see packages/compose). Like the network
+ * and platform-defaults injections, this happens after validation: it's a
+ * deliberate platform grant, not user-authored, and is gated by the capability.
+ *
+ * SECURITY: this exposes every app's data to the consumer. It is read-only and
+ * reserved for trusted catalog apps that explicitly declare the capability.
+ */
+
+import { parse, stringify } from 'yaml';
+
+import type { ComposeDoc } from './compose-network';
+
+/** Manifest capability granting read-only access to all app data roots. */
+export const APPS_DATA_CAPABILITY = 'apps-data';
+
+/**
+ * Return the compose YAML with `<hostPath>:<hostPath>:ro` added to every
+ * service's `volumes` (deduped). Returns the input unchanged when there are no
+ * services. Parse errors propagate (mirrors the sibling injection helpers).
+ */
+export function injectReadonlyMount(composeYaml: string, opts: { hostPath: string }): string {
+  const mount = `${opts.hostPath}:${opts.hostPath}:ro`;
+  const doc = (parse(composeYaml) ?? {}) as ComposeDoc;
+  const services = doc.services;
+  if (!services || typeof services !== 'object' || Object.keys(services).length === 0) {
+    return composeYaml;
+  }
+
+  for (const service of Object.values(services)) {
+    if (!service || typeof service !== 'object') continue;
+    const existing = Array.isArray(service.volumes) ? service.volumes : [];
+    if (existing.includes(mount)) continue;
+    service.volumes = [...existing, mount];
+  }
+
+  return stringify(doc);
+}

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -50,6 +50,7 @@ import { attachToHolaNetwork, injectEnvironment } from './compose-network';
 import { applyPlatformDefaults } from './compose-defaults';
 import { composeDefaultsConfig } from '../../config/compose-defaults';
 import { APP_REGISTRY_CAPABILITY, REGISTRY_FILENAME, buildRegistry, type RegistryApp } from './app-registry';
+import { APPS_DATA_CAPABILITY, injectReadonlyMount } from './compose-mounts';
 
 /** Default host base for per-app data roots when HOLA_APPS_BIND_ROOT is unset. */
 const DEFAULT_APPS_BIND_ROOT = '/srv/hola/apps';
@@ -836,6 +837,14 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     // wins for fill-if-absent fields; hardening is additive. See compose-defaults.
     content = applyPlatformDefaults(content, composeDefaultsConfig);
 
+    // Grant a trusted app (e.g. a backup tool) read-only access to ALL apps'
+    // data when its manifest declares `consumes: apps-data`. Identity-mapped so
+    // absolute host paths resolve unchanged. Read-only; gated by the capability.
+    const consumes = await this.readActiveConsumes(deployment);
+    if (consumes.includes(APPS_DATA_CAPABILITY)) {
+      content = injectReadonlyMount(content, { hostPath: this.appsBindRoot() });
+    }
+
     // The runtime compose may hold a client secret in cleartext; restrict it.
     await this.storageService.writeFile(
       `deployments/${deployment.id}/runtime/docker-compose.yml`,
@@ -873,10 +882,14 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     }
   }
 
+  /** Absolute host base that holds every app's data root. */
+  private appsBindRoot(): string {
+    return (process.env.HOLA_APPS_BIND_ROOT?.trim() || DEFAULT_APPS_BIND_ROOT).replace(/\/+$/, '');
+  }
+
   /** Absolute host data root for a deployment (`<HOLA_APPS_BIND_ROOT>/<id>`). */
   private appRootFor(deploymentId: string): string {
-    const base = (process.env.HOLA_APPS_BIND_ROOT?.trim() || DEFAULT_APPS_BIND_ROOT).replace(/\/+$/, '');
-    return `${base}/${deploymentId}`;
+    return `${this.appsBindRoot()}/${deploymentId}`;
   }
 
   /**


### PR DESCRIPTION
## What

The server side of Phase 2 (backup). A new privileged capability: when a deployment's manifest declares **`consumes: apps-data`**, the server injects a **read-only, identity-mapped** bind mount of the apps root (`<HOLA_APPS_BIND_ROOT>:<…>:ro`) into the app's services at materialization — so a trusted app (e.g. the `backrest` backup app) can read every app's data.

## Why a server primitive (not a bundle bolt-on)

The dashboard could be a pure bundle bolt-on because it only needs *metadata* (the registry feed). Reading other apps' *data* can only be granted by the server — a bundle can't mount paths outside its own `${HOLA_APP_DATA}` (the validator forbids it, and it doesn't know the bind root). So this is a deliberate, gated grant, consistent with ADR 0002's "server provides primitives."

## Security

- **Read-only.** The consumer cannot modify other apps' data.
- **Gated** by the explicit `consumes: apps-data` manifest declaration — reserve it for trusted catalog apps. (Future: operator approval for privileged capabilities.)
- Most-privileged catalog app: it reads all app data and (for backup) holds the destination creds + encryption key.

## Changes
- `services/core/compose-mounts.ts` (new): `APPS_DATA_CAPABILITY` + `injectReadonlyMount` (identity mount on every service, deduped) — mirrors the network/platform-defaults injection helpers, applied **post-validation** (a grant, not user-authored).
- `deployment.ts`: inject in `materializeCompose` when the active manifest consumes `apps-data`; factored out `appsBindRoot()` (shared with `appRootFor`).
- `docs/adr/0002` addendum + `CLAUDE.md` note: the privileged `apps-data` primitive; backup v1 uses the mount (single-root), **not** the registry feed; trust boundary.
- Tests: `injectReadonlyMount` (unit) + e2e (an `apps-data` app's materialized compose carries the `:ro` mount; non-consumers don't).

All gates green: server **247**, typecheck · lint · build.

## Companion / related
- Catalog app `backrest` → try-hola/apps (separate PR).
- Per-app pre/post-backup hooks (consistent DB backups) → #121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)