### PR TITLE
feat(cli): browse the catalog and install apps by id

### DIFF
--- a/packages/cli/src/__tests__/catalog.test.ts
+++ b/packages/cli/src/__tests__/catalog.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { runCatalog } from '../commands/catalog/catalog';
+import type { HolaSdk } from '@hola/sdk';
+
+function makeSdk(items: Array<{ id: string; name: string; description: string; icon: string }>) {
+  return {
+    catalog: {
+      apps: vi.fn(async () => ({ items, page: 1, limit: 100, total: items.length })),
+    },
+  };
+}
+
+describe('catalog', () => {
+  let logs: string[];
+  beforeEach(() => {
+    process.exitCode = 0;
+    logs = [];
+    vi.spyOn(console, 'log').mockImplementation((m?: unknown) => { logs.push(String(m)); });
+  });
+  afterEach(() => { vi.restoreAllMocks(); process.exitCode = 0; });
+
+  it('lists apps and passes the query through to the catalog endpoint', async () => {
+    const sdk = makeSdk([{ id: 'gitea', name: 'Gitea', description: 'Git service', icon: '🍵' }]);
+    await runCatalog('git', { category: 'apps' }, { sdk: sdk as unknown as HolaSdk });
+
+    expect(sdk.catalog.apps).toHaveBeenCalledWith({ q: 'git', category: 'apps', page: 1, limit: 100 });
+    expect(logs.join('\n')).toContain('gitea');
+    expect(logs.join('\n')).toContain('Git service');
+  });
+
+  it('emits JSON with --json', async () => {
+    const sdk = makeSdk([{ id: 'gitea', name: 'Gitea', description: 'Git service', icon: '🍵' }]);
+    await runCatalog(undefined, { json: true }, { sdk: sdk as unknown as HolaSdk });
+    const parsed = JSON.parse(logs.join('\n'));
+    expect(parsed.items[0].id).toBe('gitea');
+  });
+
+  it('handles an empty catalog', async () => {
+    const sdk = makeSdk([]);
+    await runCatalog(undefined, {}, { sdk: sdk as unknown as HolaSdk });
+    expect(logs.join('\n')).toMatch(/No apps found/i);
+  });
+});

--- a/packages/cli/src/__tests__/install.test.ts
+++ b/packages/cli/src/__tests__/install.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { runInstall } from '../commands/install/install';
+import type { HolaSdk } from '@hola/sdk';
+
+function makeSdk(overrides: { drafts?: Record<string, unknown> } = {}) {
+  const calls: string[] = [];
+  return {
+    calls,
+    drafts: {
+      create: vi.fn(async () => { calls.push('create'); return { draftId: 'd1' }; }),
+      byId: vi.fn(async () => { calls.push('byId'); return { draftId: 'd1', appEnv: [{ key: 'A', value: '1', isSecret: false }] }; }),
+      update: vi.fn(async () => { calls.push('update'); return { ok: true }; }),
+      validate: vi.fn(async () => { calls.push('validate'); return { ok: true, errors: [], warnings: [] }; }),
+      preflight: vi.fn(async () => { calls.push('preflight'); return { ok: true, checks: [] }; }),
+      finalize: vi.fn(async () => { calls.push('finalize'); return { spec: {}, checksum: 'x' }; }),
+      ...(overrides.drafts ?? {}),
+    },
+    deployments: {
+      create: vi.fn(async () => { calls.push('deploy'); return { deploymentId: 'dep1', releaseId: 'r1', jobId: 'j1' }; }),
+    },
+    jobs: { byId: vi.fn(async () => ({ status: 'completed' })) },
+  };
+}
+
+describe('install', () => {
+  beforeEach(() => { process.exitCode = 0; });
+  afterEach(() => { process.exitCode = 0; });
+
+  it('seeds a draft from the catalog (no update without --set) and runs the deploy flow', async () => {
+    const sdk = makeSdk();
+    const res = await runInstall('gitea', { noStream: true, json: true }, { sdk: sdk as unknown as HolaSdk });
+
+    expect(sdk.calls).toEqual(['create', 'validate', 'preflight', 'finalize', 'deploy']);
+    expect(sdk.drafts.create).toHaveBeenCalledWith({ appId: 'gitea', version: 'latest' });
+    expect(res?.deploymentId).toBe('dep1');
+    expect(res?.status).toBe('completed');
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('merges --set overrides onto the catalog-seeded appEnv', async () => {
+    const sdk = makeSdk();
+    await runInstall('gitea', { set: ['A=2', 'B=x'], noStream: true }, { sdk: sdk as unknown as HolaSdk });
+
+    expect(sdk.drafts.byId).toHaveBeenCalledWith('d1');
+    expect(sdk.drafts.update).toHaveBeenCalledWith('d1', {
+      appEnv: [
+        { key: 'A', value: '2', isSecret: false },
+        { key: 'B', value: 'x', isSecret: false },
+      ],
+    });
+  });
+
+  it('fails (exit 1) on validation errors under --strict and does not deploy', async () => {
+    const sdk = makeSdk({
+      drafts: { validate: vi.fn(async () => ({ ok: true, errors: [{ message: 'bad' }], warnings: [] })) },
+    });
+    const res = await runInstall('gitea', { strict: true, noStream: true }, { sdk: sdk as unknown as HolaSdk });
+
+    expect(res).toBeUndefined();
+    expect(sdk.deployments.create).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('rejects a malformed --set', async () => {
+    const sdk = makeSdk();
+    const res = await runInstall('gitea', { set: 'NOEQUALS', noStream: true }, { sdk: sdk as unknown as HolaSdk });
+    expect(res).toBeUndefined();
+    expect(sdk.drafts.create).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/packages/cli/src/commands/bundle/deploy.ts
+++ b/packages/cli/src/commands/bundle/deploy.ts
@@ -1,14 +1,9 @@
 import { HolaSdk } from '@hola/sdk';
-import { API } from '@hola/shared';
-import type {
-  CreateDraftResponse,
-  CreateDeploymentFromDraftResponse,
-  AppEnvVar,
-} from '@hola/shared';
+import type { CreateDraftResponse, AppEnvVar } from '@hola/shared';
 import { promises as fs } from 'fs';
 import path from 'path';
 
-import { streamSSE } from '../../lib/sse';
+import { DeployAbort, finalizeAndDeploy, reportDeployError, type DeployResult } from '../../lib/deploy-flow';
 
 export interface BundleDeployOptions {
   path?: string;
@@ -21,17 +16,9 @@ export interface BundleDeployOptions {
   strict?: boolean;
 }
 
-export interface BundleDeployResult {
-  deploymentId: string;
-  releaseId: string;
-  jobId?: string;
-  status: string;
-}
+export type BundleDeployResult = DeployResult;
 
 const COMPOSE_CANDIDATES = ['docker-compose.yaml', 'docker-compose.yml', 'compose.yaml', 'compose.yml'];
-
-/** Raised after a user-facing failure has been reported and the exit code set. */
-class DeployAbort extends Error {}
 
 async function readCompose(dir: string): Promise<string> {
   for (const candidate of COMPOSE_CANDIDATES) {
@@ -61,8 +48,8 @@ async function readEnvFile(dir: string): Promise<AppEnvVar[]> {
 }
 
 /**
- * One-shot bundle deploy: import → draft → validate → preflight → finalize →
- * deployment create → watch job. Returns the result, or undefined on failure
+ * One-shot bundle deploy: import → draft → update → (validate → preflight →
+ * finalize → deploy → watch). Returns the result, or undefined on failure
  * (after setting a non-zero exit code).
  */
 export async function runBundleDeploy(
@@ -88,100 +75,13 @@ export async function runBundleDeploy(
       ...(port && Number.isFinite(port) ? { ports: [{ container: port, protocol: 'tcp' }] } : {}),
     });
 
-    out('Validating…');
-    const report = (await sdk.drafts.validate(draft.draftId)) as {
-      ok?: boolean; errors?: Array<{ message: string }>; warnings?: Array<{ message: string }>;
-    };
-    for (const w of report.warnings ?? []) out(`  warning: ${w.message}`);
-    if (report.errors?.length) {
-      for (const e of report.errors) console.error(`  error: ${e.message}`);
-      if (opts.strict || report.ok === false) throw new DeployAbort('Validation failed.');
-    }
-
-    out('Preflight…');
-    const preflight = (await sdk.drafts.preflight(draft.draftId)) as {
-      ok?: boolean; checks?: Array<{ name: string; status: string; detail?: string }>;
-    };
-    for (const c of preflight.checks ?? []) {
-      if (c.status !== 'pass') out(`  ${c.status}: ${c.name}${c.detail ? ` — ${c.detail}` : ''}`);
-    }
-    if (preflight.ok === false) throw new DeployAbort('Preflight failed.');
-
-    out('Finalizing…');
-    await sdk.drafts.finalize(draft.draftId);
-
-    out('Creating deployment…');
-    const dep = (await sdk.deployments.create({ draftId: draft.draftId, name: appId })) as CreateDeploymentFromDraftResponse;
-    out(`Deployment ${dep.deploymentId} created (release ${dep.releaseId}).`);
-
-    let status = 'created';
-    if (dep.jobId && !opts.noStream) {
-      status = await watchJob(sdk, dep.jobId, out);
-    } else if (dep.jobId) {
-      const job = (await sdk.jobs.byId(dep.jobId)) as { status?: string };
-      status = job.status ?? 'queued';
-    }
-
-    const result: BundleDeployResult = {
-      deploymentId: dep.deploymentId,
-      releaseId: dep.releaseId,
-      jobId: dep.jobId,
-      status,
-    };
+    const result = await finalizeAndDeploy(sdk, draft.draftId, { name: appId, strict: opts.strict, noStream: opts.noStream }, out);
 
     if (opts.json) console.log(JSON.stringify(result, null, 2));
-    else out(`Done. Job status: ${status}`);
-    if (status === 'failed' || status === 'error') process.exitCode = 1;
+    else out(`Done. Job status: ${result.status}`);
+    if (result.status === 'failed' || result.status === 'error') process.exitCode = 1;
     return result;
   } catch (err) {
-    if (err instanceof DeployAbort) {
-      console.error(err.message);
-      process.exitCode = 1;
-      return undefined;
-    }
-    const msg = err instanceof Error ? err.message : String(err);
-    console.error(`Deploy failed: ${msg}`);
-    if (/401|unauthor/i.test(msg)) console.error('Hint: set HOLA_TOKEN to your admin API key.');
-    if (/fetch failed|ECONNREFUSED|network|connect/i.test(msg)) console.error('Hint: set HOLA_API_URL (default http://localhost:3001).');
-    process.exitCode = 1;
-    return undefined;
+    return reportDeployError(err);
   }
-}
-
-/** Stream job logs and poll until the job reaches a terminal state. */
-async function watchJob(sdk: HolaSdk, jobId: string, out: (msg: string) => void): Promise<string> {
-  const base = process.env.HOLA_API_URL || 'http://localhost:3001';
-  const token = process.env.HOLA_TOKEN;
-  const controller = new AbortController();
-
-  const streaming = streamSSE(
-    `${base}${API.jobs.logs(jobId)}`,
-    { headers: token ? { Authorization: `Bearer ${token}` } : undefined, signal: controller.signal },
-    (msg) => {
-      try {
-        const evt = JSON.parse(msg.data) as { data?: { message?: string } };
-        if (evt?.data?.message) out(`  ${evt.data.message}`);
-      } catch {
-        // ignore non-JSON frames (heartbeats)
-      }
-    }
-  ).catch(() => { /* aborted or stream error — non-fatal */ });
-
-  try {
-    for (;;) {
-      const job = (await sdk.jobs.byId(jobId)) as { status?: string };
-      const status = job.status ?? 'queued';
-      if (status === 'completed' || status === 'failed') {
-        return status;
-      }
-      await sleep(500);
-    }
-  } finally {
-    controller.abort();
-    await streaming;
-  }
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms));
 }

--- a/packages/cli/src/commands/catalog/catalog.ts
+++ b/packages/cli/src/commands/catalog/catalog.ts
@@ -1,0 +1,47 @@
+import { HolaSdk } from '@hola/sdk';
+import type { GetCatalogAppsResponse } from '@hola/shared';
+
+export interface CatalogOptions {
+  category?: string;
+  limit?: number | string;
+  json?: boolean;
+}
+
+/** List/search the app catalog (GET /api/catalog/apps). */
+export async function runCatalog(
+  query: string | undefined,
+  opts: CatalogOptions,
+  injected?: { sdk?: HolaSdk }
+): Promise<void> {
+  const sdk = injected?.sdk ?? new HolaSdk();
+  try {
+    const limit = opts.limit !== undefined ? Number(opts.limit) : 100;
+    const res = (await sdk.catalog.apps({
+      q: query,
+      category: opts.category,
+      page: 1,
+      limit: Number.isFinite(limit) ? limit : 100,
+    })) as GetCatalogAppsResponse;
+
+    if (opts.json) {
+      console.log(JSON.stringify(res, null, 2));
+      return;
+    }
+
+    if (!res.items.length) {
+      console.log('No apps found. (Is HOLA_CATALOG_URL set on the server?)');
+      return;
+    }
+
+    const idWidth = Math.max(3, ...res.items.map(a => a.id.length));
+    for (const app of res.items) {
+      console.log(`${(app.icon || '📦')} ${app.id.padEnd(idWidth)}  ${app.description}`);
+    }
+    console.log(`\n${res.total} app(s). Install with: hola install <id>`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`Catalog list failed: ${msg}`);
+    if (/fetch failed|ECONNREFUSED|network|connect/i.test(msg)) console.error('Hint: set HOLA_API_URL (default http://localhost:3001).');
+    process.exitCode = 1;
+  }
+}

--- a/packages/cli/src/commands/deployments/deployments.ts
+++ b/packages/cli/src/commands/deployments/deployments.ts
@@ -1,0 +1,79 @@
+import { HolaSdk } from '@hola/sdk';
+import type { GetDeploymentsResponse } from '@hola/shared';
+
+export interface DeploymentsListOptions {
+  status?: string;
+  json?: boolean;
+}
+
+/** List deployments (GET /api/deployments). */
+export async function runDeploymentsList(
+  opts: DeploymentsListOptions,
+  injected?: { sdk?: HolaSdk }
+): Promise<void> {
+  const sdk = injected?.sdk ?? new HolaSdk();
+  try {
+    const res = (await sdk.deployments.list({
+      ...(opts.status ? { status: opts.status as GetDeploymentsResponse['items'][number]['status'] } : {}),
+      limit: 100,
+    })) as GetDeploymentsResponse;
+
+    if (opts.json) {
+      console.log(JSON.stringify(res, null, 2));
+      return;
+    }
+    if (!res.items.length) {
+      console.log('No deployments.');
+      return;
+    }
+    const idWidth = Math.max(2, ...res.items.map(d => d.id.length));
+    const nameWidth = Math.max(4, ...res.items.map(d => d.name.length));
+    for (const d of res.items) {
+      const url = d.url ? `  ${d.url}` : '';
+      console.log(`${d.id.padEnd(idWidth)}  ${d.name.padEnd(nameWidth)}  ${d.status.padEnd(10)}${url}`);
+    }
+    console.log(`\n${res.total} deployment(s).`);
+  } catch (err) {
+    reportListError(err);
+  }
+}
+
+export interface DeploymentLogsOptions {
+  json?: boolean;
+}
+
+/** Print recent logs for a deployment (GET /api/deployments/:id/logs). */
+export async function runDeploymentLogs(
+  deploymentId: string,
+  opts: DeploymentLogsOptions,
+  injected?: { sdk?: HolaSdk }
+): Promise<void> {
+  const sdk = injected?.sdk ?? new HolaSdk();
+  try {
+    const res = (await sdk.deployments.logs(deploymentId)) as {
+      entries?: Array<{ timestamp?: string; message?: string }>;
+    };
+    if (opts.json) {
+      console.log(JSON.stringify(res, null, 2));
+      return;
+    }
+    const entries = res.entries ?? [];
+    if (!entries.length) {
+      console.log('No logs.');
+      return;
+    }
+    for (const e of entries) {
+      console.log(`${e.timestamp ? `${e.timestamp} ` : ''}${e.message ?? ''}`);
+    }
+  } catch (err) {
+    reportListError(err);
+  }
+}
+
+function reportListError(err: unknown): void {
+  const msg = err instanceof Error ? err.message : String(err);
+  console.error(`Failed: ${msg}`);
+  if (/401|unauthor/i.test(msg)) console.error('Hint: set HOLA_TOKEN to your admin API key.');
+  if (/fetch failed|ECONNREFUSED|network|connect/i.test(msg)) console.error('Hint: set HOLA_API_URL (default http://localhost:3001).');
+  process.exitCode = 1;
+}

--- a/packages/cli/src/commands/install/install.ts
+++ b/packages/cli/src/commands/install/install.ts
@@ -1,0 +1,70 @@
+import { HolaSdk } from '@hola/sdk';
+import type { CreateDraftResponse, GetDraftResponse, AppEnvVar } from '@hola/shared';
+
+import { finalizeAndDeploy, reportDeployError, type DeployResult } from '../../lib/deploy-flow';
+
+export interface InstallOptions {
+  version?: string;
+  name?: string;
+  set?: string | string[];
+  noStream?: boolean;
+  json?: boolean;
+  strict?: boolean;
+}
+
+/** Parse repeated `--set KEY=VALUE` into a map. */
+function parseSet(set?: string | string[]): Record<string, string> {
+  const items = set === undefined ? [] : Array.isArray(set) ? set : [set];
+  const out: Record<string, string> = {};
+  for (const item of items) {
+    const eq = String(item).indexOf('=');
+    if (eq <= 0) throw new Error(`Invalid --set '${item}' (expected KEY=VALUE)`);
+    out[String(item).slice(0, eq).trim()] = String(item).slice(eq + 1);
+  }
+  return out;
+}
+
+/**
+ * Install a catalog app by id: create a draft (the server seeds compose/env from
+ * the catalog bundle), apply any `--set` env overrides, then validate → preflight
+ * → finalize → deploy → watch. Uses only existing endpoints — the same flow the
+ * web install wizard drives.
+ */
+export async function runInstall(
+  appId: string,
+  opts: InstallOptions,
+  injected?: { sdk?: HolaSdk }
+): Promise<DeployResult | undefined> {
+  const sdk = injected?.sdk ?? new HolaSdk();
+  const version = opts.version ?? 'latest';
+  const name = opts.name ?? appId;
+  const out = (msg: string) => { if (!opts.json) console.log(msg); };
+
+  try {
+    const overrides = parseSet(opts.set);
+
+    out(`Creating draft for ${appId}@${version} (from catalog)`);
+    const draft = (await sdk.drafts.create({ appId, version })) as CreateDraftResponse;
+
+    // Apply env overrides onto the catalog-seeded appEnv (merge by key).
+    if (Object.keys(overrides).length) {
+      const current = (await sdk.drafts.byId(draft.draftId)) as GetDraftResponse;
+      const appEnv: AppEnvVar[] = [...(current.appEnv ?? [])];
+      for (const [key, value] of Object.entries(overrides)) {
+        const existing = appEnv.find(e => e.key === key);
+        if (existing) existing.value = value;
+        else appEnv.push({ key, value, isSecret: false });
+      }
+      await sdk.drafts.update(draft.draftId, { appEnv });
+    }
+
+    const result = await finalizeAndDeploy(sdk, draft.draftId, { name, strict: opts.strict, noStream: opts.noStream }, out);
+
+    if (opts.json) console.log(JSON.stringify(result, null, 2));
+    else out(`Done. ${appId} → job status: ${result.status}`);
+    if (result.status === 'failed' || result.status === 'error') process.exitCode = 1;
+    return result;
+  } catch (err) {
+    return reportDeployError(err);
+  }
+}

--- a/packages/cli/src/index.tsx
+++ b/packages/cli/src/index.tsx
@@ -43,6 +43,54 @@ prog
     await runBootstrap(opts);
   });
 
+// catalog — browse the app catalog
+prog
+  .command('catalog [query]')
+  .describe('Browse the app catalog (optionally filter by query)')
+  .option('--category', 'Filter by category')
+  .option('--limit', 'Max apps to list', 100)
+  .option('--json', 'Print raw JSON output', false)
+  .action(async (query, opts) => {
+    const { runCatalog } = await load(import('./commands/catalog/catalog'));
+    await runCatalog(query, opts);
+  });
+
+// install — install a catalog app by id (draft from catalog → finalize → deploy)
+prog
+  .command('install <appId>')
+  .describe('Install a catalog app: draft from catalog → validate → finalize → deploy → watch')
+  .option('--version', 'App version', 'latest')
+  .option('--name', 'Deployment name (default: the app id)')
+  .option('--set', 'Override an env var, KEY=VALUE (repeatable)')
+  .option('--strict', 'Fail on validation warnings', false)
+  .option('--no-stream', 'Do not watch the deployment job', false)
+  .option('--json', 'Print the result as JSON', false)
+  .action(async (appId, opts) => {
+    const { runInstall } = await load(import('./commands/install/install'));
+    await runInstall(appId, opts);
+  });
+
+// deployments — list installed deployments
+prog
+  .command('deployments')
+  .describe('List deployments')
+  .option('--status', 'Filter by status (running, stopped, error, …)')
+  .option('--json', 'Print raw JSON output', false)
+  .action(async (opts) => {
+    const { runDeploymentsList } = await load(import('./commands/deployments/deployments'));
+    await runDeploymentsList(opts);
+  });
+
+// logs — print recent logs for a deployment
+prog
+  .command('logs <deploymentId>')
+  .describe('Print recent logs for a deployment')
+  .option('--json', 'Print raw JSON output', false)
+  .action(async (deploymentId, opts) => {
+    const { runDeploymentLogs } = await load(import('./commands/deployments/deployments'));
+    await runDeploymentLogs(deploymentId, opts);
+  });
+
 // bundle validate
 prog
   .command('bundle validate')
@@ -75,7 +123,7 @@ prog
 // Fallback banner when no args
 if (process.argv.length <= 2) {
   // Minimal banner when no args
-  console.log('Hola CLI ready. Try: hola bundle validate -p ./bundle or hola bundle deploy -p ./bundle');
+  console.log('Hola CLI ready. Try: hola catalog · hola install <app> · hola deployments');
 } else {
   prog.parse(process.argv);
 }

--- a/packages/cli/src/lib/deploy-flow.ts
+++ b/packages/cli/src/lib/deploy-flow.ts
@@ -1,0 +1,117 @@
+import { HolaSdk } from '@hola/sdk';
+import { API } from '@hola/shared';
+import type { CreateDeploymentFromDraftResponse } from '@hola/shared';
+
+import { streamSSE } from './sse';
+
+/** Raised after a user-facing failure has been reported; callers set the exit code. */
+export class DeployAbort extends Error {}
+
+export interface DeployResult {
+  deploymentId: string;
+  releaseId: string;
+  jobId?: string;
+  status: string;
+}
+
+/**
+ * The shared tail of every deploy: validate → preflight → finalize → create
+ * deployment → watch the job. Used by both `bundle deploy` (draft from a local
+ * compose) and `install` (draft seeded from the catalog). Throws `DeployAbort`
+ * on validation/preflight failure (after reporting it).
+ */
+export async function finalizeAndDeploy(
+  sdk: HolaSdk,
+  draftId: string,
+  opts: { name: string; strict?: boolean; noStream?: boolean },
+  out: (msg: string) => void
+): Promise<DeployResult> {
+  out('Validating…');
+  const report = (await sdk.drafts.validate(draftId)) as {
+    ok?: boolean; errors?: Array<{ message: string }>; warnings?: Array<{ message: string }>;
+  };
+  for (const w of report.warnings ?? []) out(`  warning: ${w.message}`);
+  if (report.errors?.length) {
+    for (const e of report.errors) console.error(`  error: ${e.message}`);
+    if (opts.strict || report.ok === false) throw new DeployAbort('Validation failed.');
+  }
+
+  out('Preflight…');
+  const preflight = (await sdk.drafts.preflight(draftId)) as {
+    ok?: boolean; checks?: Array<{ name: string; status: string; detail?: string }>;
+  };
+  for (const c of preflight.checks ?? []) {
+    if (c.status !== 'pass') out(`  ${c.status}: ${c.name}${c.detail ? ` — ${c.detail}` : ''}`);
+  }
+  if (preflight.ok === false) throw new DeployAbort('Preflight failed.');
+
+  out('Finalizing…');
+  await sdk.drafts.finalize(draftId);
+
+  out('Creating deployment…');
+  const dep = (await sdk.deployments.create({ draftId, name: opts.name })) as CreateDeploymentFromDraftResponse;
+  out(`Deployment ${dep.deploymentId} created (release ${dep.releaseId}).`);
+
+  let status = 'created';
+  if (dep.jobId && !opts.noStream) {
+    status = await watchJob(sdk, dep.jobId, out);
+  } else if (dep.jobId) {
+    const job = (await sdk.jobs.byId(dep.jobId)) as { status?: string };
+    status = job.status ?? 'queued';
+  }
+
+  return { deploymentId: dep.deploymentId, releaseId: dep.releaseId, jobId: dep.jobId, status };
+}
+
+/** Stream job logs and poll until the job reaches a terminal state. */
+export async function watchJob(sdk: HolaSdk, jobId: string, out: (msg: string) => void): Promise<string> {
+  const base = process.env.HOLA_API_URL || 'http://localhost:3001';
+  const token = process.env.HOLA_TOKEN;
+  const controller = new AbortController();
+
+  const streaming = streamSSE(
+    `${base}${API.jobs.logs(jobId)}`,
+    { headers: token ? { Authorization: `Bearer ${token}` } : undefined, signal: controller.signal },
+    (msg) => {
+      try {
+        const evt = JSON.parse(msg.data) as { data?: { message?: string } };
+        if (evt?.data?.message) out(`  ${evt.data.message}`);
+      } catch {
+        // ignore non-JSON frames (heartbeats)
+      }
+    }
+  ).catch(() => { /* aborted or stream error — non-fatal */ });
+
+  try {
+    for (;;) {
+      const job = (await sdk.jobs.byId(jobId)) as { status?: string };
+      const status = job.status ?? 'queued';
+      if (status === 'completed' || status === 'failed') {
+        return status;
+      }
+      await sleep(500);
+    }
+  } finally {
+    controller.abort();
+    await streaming;
+  }
+}
+
+/** Map a CLI error to a friendly message + non-zero exit code. Returns undefined. */
+export function reportDeployError(err: unknown): undefined {
+  if (err instanceof DeployAbort) {
+    console.error(err.message);
+    process.exitCode = 1;
+    return undefined;
+  }
+  const msg = err instanceof Error ? err.message : String(err);
+  console.error(`Failed: ${msg}`);
+  if (/401|unauthor/i.test(msg)) console.error('Hint: set HOLA_TOKEN to your admin API key.');
+  if (/fetch failed|ECONNREFUSED|network|connect/i.test(msg)) console.error('Hint: set HOLA_API_URL (default http://localhost:3001).');
+  process.exitCode = 1;
+  return undefined;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -8,9 +8,12 @@ import {
   // Phase 7 Deployment types
   CreateDeploymentFromDraftRequest, CreateDeploymentFromDraftResponse,
   GetDeploymentsRequest, GetDeploymentsResponse, GetDeploymentResponse,
-  PatchDeploymentRequest, PatchDeploymentResponse, 
+  PatchDeploymentRequest, PatchDeploymentResponse,
   PostDeploymentActionRequest, PostDeploymentActionResponse,
-  RollbackRequest, RollbackResponse, GetDeploymentHistoryResponse
+  RollbackRequest, RollbackResponse, GetDeploymentHistoryResponse,
+  // Catalog types
+  GetCatalogAppsRequest, GetCatalogAppsResponse, GetCatalogAppResponse,
+  GetCatalogAppVersionsResponse, GetCatalogAppVersionDetailResponse
 } from '@hola/shared';
 
 export type SdkInitOptions = {
@@ -79,6 +82,13 @@ export class HolaSdk {
   health() { return this.get(API.health); }
   me() { return this.get(API.me); }
   summary() { return this.get(API.summary); }
+
+  catalog = {
+    apps: (qs?: GetCatalogAppsRequest) => this.get<GetCatalogAppsResponse>(`${API.catalog.apps}${buildQuery(qs as Record<string, string | number | boolean | undefined>)}`),
+    app: (appId: string) => this.get<GetCatalogAppResponse>(API.catalog.appById(appId)),
+    versions: (appId: string) => this.get<GetCatalogAppVersionsResponse>(API.catalog.versions(appId)),
+    versionDetail: (appId: string, version: string) => this.get<GetCatalogAppVersionDetailResponse>(API.catalog.versionDetail(appId, version)),
+  };
 
   drafts = {
     create: (data: CreateDraftRequest) => this.post<CreateDraftResponse>(API.drafts.create, data),


### PR DESCRIPTION
## What

Closes the CLI gap: it can now **browse the catalog** and **install an app by id** — entirely over the **existing** server endpoints (no new endpoints, per the constraint).

| Command | Does |
| --- | --- |
| `hola catalog [query]` | List/search the app catalog (`--category`, `--limit`, `--json`) |
| `hola install <appId>` | Draft from catalog → validate → preflight → finalize → deploy → watch (`--version`, `--name`, `--set KEY=VALUE`, `--strict`, `--no-stream`, `--json`) |
| `hola deployments` | List deployments (`--status`, `--json`) |
| `hola logs <deploymentId>` | Print recent deployment logs (`--json`) |

## How `install` works (existing endpoints only)
`sdk.drafts.create({ appId, version })` → the **server already seeds** the draft's compose/env from the catalog bundle (the same path the web install wizard uses) → optional `--set` overrides patched onto the seeded `appEnv` → `validate` → `preflight` → `finalize` → `deployments.create` → watch the job. No new server surface.

## Changes
- **sdk**: expose the `catalog` resource (`apps`/`app`/`versions`/`versionDetail`) over the already-defined `/api/catalog/*` routes — the SDK previously had **no** catalog methods despite the routes existing.
- **cli**: `catalog`, `install`, `deployments`, `logs` commands.
- **Refactor**: factored the shared `validate → preflight → finalize → create → watch` flow into `lib/deploy-flow.ts` (`finalizeAndDeploy`, `watchJob`, `reportDeployError`); `bundle deploy` now reuses it (SDK call order unchanged — its tests pass untouched).
- **Tests**: new `install` + `catalog` tests (mock SDK); existing `bundle-deploy` tests green.

All gates green: typecheck · lint · build · CLI suite (**32 tests**). Verified `hola --help` lists the new commands.

## Not included (per scope)
No server endpoints added. Deployment lifecycle actions (stop/restart/rollback) and log *streaming* for `logs` are easy follow-ups (the SDK already supports actions; logs uses the GET endpoint, not SSE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)