### PR TITLE
feat(cli): log streaming + stop/restart/rollback lifecycle commands

### DIFF
--- a/packages/cli/src/__tests__/deployment-actions.test.ts
+++ b/packages/cli/src/__tests__/deployment-actions.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { runDeploymentAction, runRollback } from '../commands/deployments/actions';
+import type { HolaSdk } from '@hola/sdk';
+
+function makeSdk(overrides: { deployments?: Record<string, unknown>; jobs?: Record<string, unknown> } = {}) {
+  const calls: string[] = [];
+  return {
+    calls,
+    deployments: {
+      action: vi.fn(async () => { calls.push('action'); return { ok: true, jobId: 'j1' }; }),
+      rollback: vi.fn(async () => {
+        calls.push('rollback');
+        return { jobId: 'j1', targetReleaseId: 'r0', previousReleaseId: 'r1' };
+      }),
+      ...(overrides.deployments ?? {}),
+    },
+    jobs: { byId: vi.fn(async () => ({ status: 'completed' })), ...(overrides.jobs ?? {}) },
+  };
+}
+
+describe('deployment lifecycle actions', () => {
+  beforeEach(() => {
+    process.exitCode = 0;
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => { vi.restoreAllMocks(); process.exitCode = 0; });
+
+  it('stop calls the action endpoint with action=stop and watches the job', async () => {
+    const sdk = makeSdk();
+    const res = await runDeploymentAction('stop', 'dep1', { noStream: true }, { sdk: sdk as unknown as HolaSdk });
+    expect(sdk.deployments.action).toHaveBeenCalledWith('dep1', { action: 'stop' });
+    expect(sdk.jobs.byId).toHaveBeenCalledWith('j1');
+    expect(res?.status).toBe('completed');
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('restart calls the action endpoint with action=restart', async () => {
+    const sdk = makeSdk();
+    await runDeploymentAction('restart', 'dep1', { noStream: true }, { sdk: sdk as unknown as HolaSdk });
+    expect(sdk.deployments.action).toHaveBeenCalledWith('dep1', { action: 'restart' });
+  });
+
+  it('sets exit code 1 when the action job fails', async () => {
+    const sdk = makeSdk({ jobs: { byId: vi.fn(async () => ({ status: 'failed' })) } });
+    await runDeploymentAction('stop', 'dep1', { noStream: true }, { sdk: sdk as unknown as HolaSdk });
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('reports a friendly error and exits 1 when the action throws', async () => {
+    const sdk = makeSdk({
+      deployments: { action: vi.fn(async () => { throw new Error('HTTP 401 Unauthorized'); }) },
+    });
+    const res = await runDeploymentAction('stop', 'dep1', { noStream: true }, { sdk: sdk as unknown as HolaSdk });
+    expect(res).toBeUndefined();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('rollback passes --to and --reason through to the rollback endpoint', async () => {
+    const sdk = makeSdk();
+    const res = await runRollback('dep1', { to: 'r0', reason: 'bad deploy', noStream: true }, { sdk: sdk as unknown as HolaSdk });
+    expect(sdk.deployments.rollback).toHaveBeenCalledWith('dep1', { targetReleaseId: 'r0', reason: 'bad deploy' });
+    expect(res?.targetReleaseId).toBe('r0');
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('rollback without --to omits targetReleaseId (server uses the previous release)', async () => {
+    const sdk = makeSdk();
+    await runRollback('dep1', { noStream: true }, { sdk: sdk as unknown as HolaSdk });
+    expect(sdk.deployments.rollback).toHaveBeenCalledWith('dep1', {});
+  });
+});

--- a/packages/cli/src/__tests__/deployment-logs.test.ts
+++ b/packages/cli/src/__tests__/deployment-logs.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { runDeploymentLogs } from '../commands/deployments/deployments';
+import type { HolaSdk } from '@hola/sdk';
+import type { streamSSE } from '../lib/sse';
+
+describe('deployment logs', () => {
+  let logs: string[];
+  beforeEach(() => {
+    process.exitCode = 0;
+    logs = [];
+    vi.spyOn(console, 'log').mockImplementation((m?: unknown) => { logs.push(String(m)); });
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => { vi.restoreAllMocks(); process.exitCode = 0; });
+
+  it('prints recent entries without --follow (one-shot GET)', async () => {
+    const sdk = {
+      deployments: { logs: vi.fn(async () => ({ entries: [{ timestamp: 't1', message: 'hello' }] })) },
+    };
+    await runDeploymentLogs('dep1', {}, { sdk: sdk as unknown as HolaSdk });
+    expect(sdk.deployments.logs).toHaveBeenCalledWith('dep1');
+    expect(logs.join('\n')).toContain('hello');
+  });
+
+  it('streams over SSE with --follow and prints message frames', async () => {
+    const sdk = { deployments: { logs: vi.fn() } };
+    const stream: typeof streamSSE = vi.fn(async (_url, _opts, onEvent) => {
+      onEvent?.({ data: JSON.stringify({ data: { timestamp: 't1', message: 'streamed line' } }) } as never);
+      onEvent?.({ data: 'heartbeat' } as never); // non-JSON ignored
+    });
+    await runDeploymentLogs('dep1', { follow: true }, { sdk: sdk as unknown as HolaSdk, stream });
+
+    expect(stream).toHaveBeenCalledOnce();
+    const url = (stream as unknown as { mock: { calls: unknown[][] } }).mock.calls[0][0] as string;
+    expect(url).toContain('/api/deployments/dep1/logs/stream');
+    expect(sdk.deployments.logs).not.toHaveBeenCalled();
+    expect(logs.join('\n')).toContain('streamed line');
+  });
+});

--- a/packages/cli/src/commands/deployments/actions.ts
+++ b/packages/cli/src/commands/deployments/actions.ts
@@ -1,0 +1,83 @@
+import { HolaSdk } from '@hola/sdk';
+import type { PostDeploymentActionResponse, RollbackResponse } from '@hola/shared';
+
+import { watchJob, reportDeployError } from '../../lib/deploy-flow';
+
+export interface ActionOptions {
+  noStream?: boolean;
+  json?: boolean;
+}
+
+/** stop/restart a deployment via POST /api/deployments/:id/actions, watching any job. */
+export async function runDeploymentAction(
+  action: 'stop' | 'restart',
+  deploymentId: string,
+  opts: ActionOptions,
+  injected?: { sdk?: HolaSdk }
+): Promise<{ jobId?: string; status?: string } | undefined> {
+  const sdk = injected?.sdk ?? new HolaSdk();
+  const out = (m: string) => console.log(m);
+  try {
+    out(`${action === 'stop' ? 'Stopping' : 'Restarting'} ${deploymentId}…`);
+    const res = (await sdk.deployments.action(deploymentId, { action })) as PostDeploymentActionResponse;
+
+    let status: string | undefined;
+    if (res.jobId && !opts.noStream) {
+      status = await watchJob(sdk, res.jobId, (m) => out(m));
+    } else if (res.jobId) {
+      const job = (await sdk.jobs.byId(res.jobId)) as { status?: string };
+      status = job.status ?? 'queued';
+    }
+
+    if (opts.json) {
+      console.log(JSON.stringify({ ...res, status }, null, 2));
+    } else {
+      out(status ? `Done (${status}).` : 'Done.');
+    }
+    if (status === 'failed') process.exitCode = 1;
+    return { jobId: res.jobId, status };
+  } catch (err) {
+    return reportDeployError(err);
+  }
+}
+
+export interface RollbackOptions extends ActionOptions {
+  to?: string;
+  reason?: string;
+}
+
+/** Roll a deployment back via POST /api/deployments/:id/rollback, watching the job. */
+export async function runRollback(
+  deploymentId: string,
+  opts: RollbackOptions,
+  injected?: { sdk?: HolaSdk }
+): Promise<RollbackResponse | undefined> {
+  const sdk = injected?.sdk ?? new HolaSdk();
+  const out = (m: string) => console.log(m);
+  try {
+    out(`Rolling back ${deploymentId}${opts.to ? ` to ${opts.to}` : ' to the previous release'}…`);
+    const res = (await sdk.deployments.rollback(deploymentId, {
+      ...(opts.to ? { targetReleaseId: opts.to } : {}),
+      ...(opts.reason ? { reason: opts.reason } : {}),
+    })) as RollbackResponse;
+    out(`Target release ${res.targetReleaseId} (was ${res.previousReleaseId}).`);
+
+    let status: string | undefined;
+    if (res.jobId && !opts.noStream) {
+      status = await watchJob(sdk, res.jobId, (m) => out(m));
+    } else if (res.jobId) {
+      const job = (await sdk.jobs.byId(res.jobId)) as { status?: string };
+      status = job.status ?? 'queued';
+    }
+
+    if (opts.json) {
+      console.log(JSON.stringify({ ...res, status }, null, 2));
+    } else {
+      out(status ? `Done (${status}).` : 'Done.');
+    }
+    if (status === 'failed') process.exitCode = 1;
+    return res;
+  } catch (err) {
+    return reportDeployError(err);
+  }
+}

--- a/packages/cli/src/commands/deployments/deployments.ts
+++ b/packages/cli/src/commands/deployments/deployments.ts
@@ -1,5 +1,8 @@
 import { HolaSdk } from '@hola/sdk';
+import { API } from '@hola/shared';
 import type { GetDeploymentsResponse } from '@hola/shared';
+
+import { streamSSE } from '../../lib/sse';
 
 export interface DeploymentsListOptions {
   status?: string;
@@ -40,14 +43,21 @@ export async function runDeploymentsList(
 
 export interface DeploymentLogsOptions {
   json?: boolean;
+  follow?: boolean;
 }
 
-/** Print recent logs for a deployment (GET /api/deployments/:id/logs). */
+/** A streamer matching `streamSSE`, injectable for tests. */
+type Streamer = typeof streamSSE;
+
+/** Print recent logs for a deployment, or live-tail them with `--follow`. */
 export async function runDeploymentLogs(
   deploymentId: string,
   opts: DeploymentLogsOptions,
-  injected?: { sdk?: HolaSdk }
+  injected?: { sdk?: HolaSdk; stream?: Streamer }
 ): Promise<void> {
+  if (opts.follow) {
+    return followDeploymentLogs(deploymentId, injected?.stream ?? streamSSE);
+  }
   const sdk = injected?.sdk ?? new HolaSdk();
   try {
     const res = (await sdk.deployments.logs(deploymentId)) as {
@@ -67,6 +77,34 @@ export async function runDeploymentLogs(
     }
   } catch (err) {
     reportListError(err);
+  }
+}
+
+/** Live-tail a deployment's logs over SSE until Ctrl-C. */
+async function followDeploymentLogs(deploymentId: string, stream: Streamer): Promise<void> {
+  const base = process.env.HOLA_API_URL || 'http://localhost:3001';
+  const token = process.env.HOLA_TOKEN;
+  const controller = new AbortController();
+  const onSigint = () => controller.abort();
+  process.once('SIGINT', onSigint);
+  try {
+    await stream(
+      `${base}${API.deployments.logsStream(deploymentId)}`,
+      { headers: token ? { Authorization: `Bearer ${token}` } : undefined, signal: controller.signal },
+      (msg) => {
+        try {
+          const evt = JSON.parse(msg.data) as { data?: { message?: string; timestamp?: string } };
+          const d = evt?.data;
+          if (d?.message) console.log(`${d.timestamp ? `${d.timestamp} ` : ''}${d.message}`);
+        } catch {
+          // ignore non-JSON frames (heartbeats)
+        }
+      }
+    );
+  } catch (err) {
+    if (!controller.signal.aborted) reportListError(err);
+  } finally {
+    process.removeListener('SIGINT', onSigint);
   }
 }
 

--- a/packages/cli/src/index.tsx
+++ b/packages/cli/src/index.tsx
@@ -81,14 +81,49 @@ prog
     await runDeploymentsList(opts);
   });
 
-// logs — print recent logs for a deployment
+// logs — print recent logs for a deployment (or live-tail with --follow)
 prog
   .command('logs <deploymentId>')
   .describe('Print recent logs for a deployment')
+  .option('--follow, -f', 'Live-tail logs over SSE until Ctrl-C', false)
   .option('--json', 'Print raw JSON output', false)
   .action(async (deploymentId, opts) => {
     const { runDeploymentLogs } = await load(import('./commands/deployments/deployments'));
     await runDeploymentLogs(deploymentId, opts);
+  });
+
+// stop / restart — lifecycle actions on a deployment
+prog
+  .command('stop <deploymentId>')
+  .describe('Stop a deployment')
+  .option('--no-stream', 'Do not watch the action job', false)
+  .option('--json', 'Print the result as JSON', false)
+  .action(async (deploymentId, opts) => {
+    const { runDeploymentAction } = await load(import('./commands/deployments/actions'));
+    await runDeploymentAction('stop', deploymentId, opts);
+  });
+
+prog
+  .command('restart <deploymentId>')
+  .describe('Restart a deployment')
+  .option('--no-stream', 'Do not watch the action job', false)
+  .option('--json', 'Print the result as JSON', false)
+  .action(async (deploymentId, opts) => {
+    const { runDeploymentAction } = await load(import('./commands/deployments/actions'));
+    await runDeploymentAction('restart', deploymentId, opts);
+  });
+
+// rollback — roll a deployment back to a previous release
+prog
+  .command('rollback <deploymentId>')
+  .describe('Roll a deployment back to a previous release')
+  .option('--to', 'Target release id (default: the previous release)')
+  .option('--reason', 'Reason recorded with the rollback')
+  .option('--no-stream', 'Do not watch the rollback job', false)
+  .option('--json', 'Print the result as JSON', false)
+  .action(async (deploymentId, opts) => {
+    const { runRollback } = await load(import('./commands/deployments/actions'));
+    await runRollback(deploymentId, opts);
   });
 
 // bundle validate


### PR DESCRIPTION
## What

Extends the `hola` CLI with live log streaming and deployment lifecycle controls, using **only existing server endpoints** (no server changes).

### Log streaming
- `hola logs <id> --follow` / `-f` — live-tails over SSE via `GET /api/deployments/:id/logs/stream`, printing each frame's `data.message` (with timestamp), and aborts cleanly on Ctrl-C. Without `--follow`, the previous one-shot GET behavior is unchanged.

### Lifecycle commands
- `hola stop <id>` / `hola restart <id>` → `POST /api/deployments/:id/actions` with `{ action }`.
- `hola rollback <id> [--to <releaseId>] [--reason <text>]` → `POST /api/deployments/:id/rollback`.
- All watch the returned job (reusing `watchJob` from `lib/deploy-flow.ts`) unless `--no-stream`, support `--json`, set exit code 1 on a failed job, and surface friendly `HOLA_TOKEN`/`HOLA_API_URL` hints via `reportDeployError`.

## Tests
- `deployment-actions.test.ts` — stop/restart hit the action endpoint with the right action and watch the job; rollback threads `--to`/`--reason` (and omits `targetReleaseId` when absent); failed job → exit 1; thrown error → exit 1.
- `deployment-logs.test.ts` — non-follow GET path and the `--follow` SSE path (streams to the stream endpoint, prints message frames, ignores heartbeats).

## Gates
`bun run typecheck` · `bun run lint` · `bun run build` · `bun --cwd packages/cli test` (40 passed) — all green. `--help` lists the new commands and `logs --follow`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)