### PR TITLE
docs(cli): document the full command surface

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
 # @hola/cli
 
-Developer-facing command-line interface built with React + Ink. The CLI talks to the Hola Server over the same REST API used by the web app and SDK. It’s optimized for fast iteration on deployment flows, logs, and contract testing.
+Developer- and operator-facing command-line interface (built on [Sade](https://github.com/lukeed/sade)). The CLI talks to the Hola Server over the same REST API used by the web app and SDK — via the typed `@hola/sdk` client and shared route constants/types from `@hola/shared`. It’s optimized for fast iteration on deployment flows, logs, and contract testing.
 
 ## How It Fits
 - Role: Local tool for developers/operators to interact with the Hola platform from a terminal.
@@ -26,7 +26,30 @@ hola --help
 - Directly in package: `bun --cwd packages/cli dev`
 - Built standalone binary: `bun build packages/cli/src/index.tsx --compile --external react-devtools-core --outfile hola`
 
-Commands are organized under `src/commands/` (e.g., `bundle`, `deploy`). The CLI renders TUI screens via Ink components defined in `src/`.
+Commands are registered in `src/index.tsx` with lazy loaders and implemented under `src/commands/`. Run `hola --help` (or `hola <command> --help`) for the authoritative, always-current list.
+
+## Commands
+
+### Setup
+- `hola init` — interactively generate a validated Hola `.env` (runs locally; no server needed).
+- `hola bootstrap --host user@vm` — set up Hola on a remote host over SSH (wizard + install).
+
+### Catalog & install
+- `hola catalog [query]` — browse/search the app catalog. Options: `--category`, `--limit`, `--json`.
+- `hola install <appId>` — install a catalog app (draft from catalog → validate → finalize → deploy → watch). Options: `--version`, `--name`, `--set KEY=VALUE` (repeatable), `--strict`, `--no-stream`, `--json`.
+
+### Deployments
+- `hola deployments` — list deployments. Options: `--status`, `--json`.
+- `hola logs <deploymentId>` — print recent logs, or live-tail with `--follow`/`-f` (streams over SSE until Ctrl-C). Options: `--follow`, `--json`.
+- `hola stop <deploymentId>` — stop a deployment. Options: `--no-stream`, `--json`.
+- `hola restart <deploymentId>` — restart a deployment. Options: `--no-stream`, `--json`.
+- `hola rollback <deploymentId>` — roll back to a previous release. Options: `--to <releaseId>` (defaults to the previous release), `--reason <text>`, `--no-stream`, `--json`.
+
+Lifecycle commands (`install`/`stop`/`restart`/`rollback`) watch the resulting job and stream its progress unless `--no-stream` is passed, and exit non-zero if the job fails.
+
+### Bundle authoring (catalog app developers)
+- `hola bundle validate` — validate a local `compose`/`env` bundle against the server's ValidationService. Options: `--path`/`-p`, `--strict`, `--json`.
+- `hola bundle deploy` — one-shot import → draft → validate → preflight → finalize → deploy → watch. Options: `--path`/`-p`, `--app-id`, `--version`, `--port`, `--traefik`, `--strict`, `--no-stream`, `--json`.
 
 ## Environment
 - `HOLA_API_URL`: API base (default `http://localhost:3001`)


### PR DESCRIPTION
## What

The CLI README was stale — it described a "React + Ink" TUI and listed **no commands**. This rewrites the framing (Sade + `@hola/sdk`) and adds a **Commands reference** grouped by purpose:

- **Setup:** `init`, `bootstrap`
- **Catalog & install:** `catalog`, `install`
- **Deployments:** `deployments`, `logs` (incl. `--follow`/`-f` SSE tail), `stop`, `restart`, `rollback`
- **Bundle authoring:** `bundle validate`, `bundle deploy`

Each entry lists its flags, and notes that lifecycle commands watch the resulting job (unless `--no-stream`) and exit non-zero on failure. Follows up #124, which added the streaming/lifecycle commands.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)