### PR TITLE
feat(cli): hola uninstall — remove a deployment

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -44,6 +44,7 @@ Commands are registered in `src/index.tsx` with lazy loaders and implemented und
 - `hola stop <deploymentId>` — stop a deployment. Options: `--no-stream`, `--json`.
 - `hola restart <deploymentId>` — restart a deployment. Options: `--no-stream`, `--json`.
 - `hola rollback <deploymentId>` — roll back to a previous release. Options: `--to <releaseId>` (defaults to the previous release), `--reason <text>`, `--no-stream`, `--json`.
+- `hola uninstall <deploymentId>` — **destructive**: stop the deployment and remove its containers, data, and auth. Prompts for confirmation unless `--yes`/`-y`. Options: `--yes`, `--json`.
 
 Lifecycle commands (`install`/`stop`/`restart`/`rollback`) watch the resulting job and stream its progress unless `--no-stream` is passed, and exit non-zero if the job fails.
 

--- a/packages/cli/src/__tests__/deployment-actions.test.ts
+++ b/packages/cli/src/__tests__/deployment-actions.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
-import { runDeploymentAction, runRollback } from '../commands/deployments/actions';
+import { runDeploymentAction, runRollback, runUninstall } from '../commands/deployments/actions';
 import type { HolaSdk } from '@hola/sdk';
+import { scriptedPrompter } from '../install/prompter';
 
 function makeSdk(overrides: { deployments?: Record<string, unknown>; jobs?: Record<string, unknown> } = {}) {
   const calls: string[] = [];
@@ -13,6 +14,8 @@ function makeSdk(overrides: { deployments?: Record<string, unknown>; jobs?: Reco
         calls.push('rollback');
         return { jobId: 'j1', targetReleaseId: 'r0', previousReleaseId: 'r1' };
       }),
+      byId: vi.fn(async () => { calls.push('byId'); return { id: 'dep1', name: 'Gitea' }; }),
+      delete: vi.fn(async () => { calls.push('delete'); }),
       ...(overrides.deployments ?? {}),
     },
     jobs: { byId: vi.fn(async () => ({ status: 'completed' })), ...(overrides.jobs ?? {}) },
@@ -69,5 +72,44 @@ describe('deployment lifecycle actions', () => {
     const sdk = makeSdk();
     await runRollback('dep1', { noStream: true }, { sdk: sdk as unknown as HolaSdk });
     expect(sdk.deployments.rollback).toHaveBeenCalledWith('dep1', {});
+  });
+
+  it('uninstall deletes after confirmation', async () => {
+    const sdk = makeSdk();
+    const res = await runUninstall('dep1', {}, {
+      sdk: sdk as unknown as HolaSdk,
+      prompter: scriptedPrompter({ confirm: 'true' }),
+    });
+    expect(sdk.deployments.byId).toHaveBeenCalledWith('dep1');
+    expect(sdk.deployments.delete).toHaveBeenCalledWith('dep1');
+    expect(res?.uninstalled).toBe('dep1');
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('uninstall aborts (no delete) when the confirmation is declined', async () => {
+    const sdk = makeSdk();
+    const res = await runUninstall('dep1', {}, {
+      sdk: sdk as unknown as HolaSdk,
+      prompter: scriptedPrompter({ confirm: 'false' }),
+    });
+    expect(sdk.deployments.delete).not.toHaveBeenCalled();
+    expect(res).toBeUndefined();
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('uninstall --yes skips the prompt and deletes', async () => {
+    const sdk = makeSdk();
+    await runUninstall('dep1', { yes: true }, { sdk: sdk as unknown as HolaSdk });
+    expect(sdk.deployments.delete).toHaveBeenCalledWith('dep1');
+  });
+
+  it('uninstall fails fast (exit 1, no delete) on an unknown deployment', async () => {
+    const sdk = makeSdk({
+      deployments: { byId: vi.fn(async () => { throw new Error('HTTP 404 Not Found'); }) },
+    });
+    const res = await runUninstall('nope', { yes: true }, { sdk: sdk as unknown as HolaSdk });
+    expect(res).toBeUndefined();
+    expect(sdk.deployments.delete).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
   });
 });

--- a/packages/cli/src/commands/deployments/actions.ts
+++ b/packages/cli/src/commands/deployments/actions.ts
@@ -1,7 +1,8 @@
 import { HolaSdk } from '@hola/sdk';
-import type { PostDeploymentActionResponse, RollbackResponse } from '@hola/shared';
+import type { GetDeploymentResponse, PostDeploymentActionResponse, RollbackResponse } from '@hola/shared';
 
 import { watchJob, reportDeployError } from '../../lib/deploy-flow';
+import { clackPrompter, PromptCancelled, type Prompter } from '../../install/prompter';
 
 export interface ActionOptions {
   noStream?: boolean;
@@ -78,6 +79,66 @@ export async function runRollback(
     if (status === 'failed') process.exitCode = 1;
     return res;
   } catch (err) {
+    return reportDeployError(err);
+  }
+}
+
+export interface UninstallOptions {
+  yes?: boolean;
+  json?: boolean;
+}
+
+/**
+ * Uninstall a deployment via DELETE /api/deployments/:id — stops its containers,
+ * deprovisions auth, and removes its record, releases, and data. Destructive and
+ * synchronous (no job to watch); confirms first unless `--yes`.
+ */
+export async function runUninstall(
+  deploymentId: string,
+  opts: UninstallOptions,
+  injected?: { sdk?: HolaSdk; prompter?: Prompter }
+): Promise<{ uninstalled: string } | undefined> {
+  const sdk = injected?.sdk ?? new HolaSdk();
+  const out = (m: string) => console.log(m);
+  try {
+    // Resolve the name up front: confirms the deployment exists (fail fast on a
+    // typo'd id) and makes the confirmation prompt unambiguous.
+    let name = deploymentId;
+    try {
+      const dep = (await sdk.deployments.byId(deploymentId)) as GetDeploymentResponse;
+      if (dep?.name) name = dep.name;
+    } catch (err) {
+      return reportDeployError(err);
+    }
+
+    if (!opts.yes) {
+      const prompter = injected?.prompter ?? clackPrompter();
+      const answer = await prompter.prompt({
+        key: 'confirm',
+        type: 'confirm',
+        message: `Uninstall ${name} (${deploymentId})? This removes its containers, data, and auth.`,
+        default: 'false',
+      });
+      if (answer !== 'true') {
+        out('Aborted.');
+        return undefined;
+      }
+    }
+
+    out(`Uninstalling ${deploymentId}…`);
+    await sdk.deployments.delete(deploymentId);
+
+    if (opts.json) {
+      console.log(JSON.stringify({ uninstalled: deploymentId }, null, 2));
+    } else {
+      out(`Uninstalled ${name}.`);
+    }
+    return { uninstalled: deploymentId };
+  } catch (err) {
+    if (err instanceof PromptCancelled) {
+      console.log('Aborted.');
+      return undefined;
+    }
     return reportDeployError(err);
   }
 }

--- a/packages/cli/src/index.tsx
+++ b/packages/cli/src/index.tsx
@@ -113,6 +113,17 @@ prog
     await runDeploymentAction('restart', deploymentId, opts);
   });
 
+// uninstall — remove a deployment (containers, data, auth) — destructive
+prog
+  .command('uninstall <deploymentId>')
+  .describe('Uninstall a deployment: stop it and remove its containers, data, and auth')
+  .option('--yes, -y', 'Skip the confirmation prompt', false)
+  .option('--json', 'Print the result as JSON', false)
+  .action(async (deploymentId, opts) => {
+    const { runUninstall } = await load(import('./commands/deployments/actions'));
+    await runUninstall(deploymentId, opts);
+  });
+
 // rollback — roll a deployment back to a previous release
 prog
   .command('rollback <deploymentId>')


### PR DESCRIPTION
## What

Adds `hola uninstall <deploymentId>`, completing the deployment lifecycle surface (`install` → `stop`/`restart`/`rollback` → `uninstall`). Follows up #124.

Backed by the existing **`DELETE /api/deployments/:id`** endpoint (SDK `deployments.delete`), which stops containers, deprovisions auth artifacts, and removes the record, releases, and data. **No server changes.**

### Behavior
- Resolves the deployment **name first** via `byId` — fails fast on a typo'd id and makes the confirmation prompt unambiguous.
- **Confirms before deleting** (destructive op) using the existing `Prompter` abstraction; skip with `--yes`/`-y`.
- `--json` prints `{ "uninstalled": "<id>" }`.
- The delete is synchronous (no job), so there's nothing to watch.

## Tests
`deployment-actions.test.ts` adds: deletes after confirmation; aborts (no delete) when declined; `--yes` skips the prompt; unknown deployment → exit 1 with no delete.

## Gates
`bun run typecheck` · `bun run lint` · `bun run build` · CLI vitest (44 passed) — all green. `--help` lists `uninstall` with `--yes`/`--json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)