### PR TITLE
fix(compose): pass AUTHENTIK_BOOTSTRAP_* to authentik-worker (fixes #136)

### DIFF
--- a/packages/compose/docker-compose.yml
+++ b/packages/compose/docker-compose.yml
@@ -207,6 +207,13 @@ services:
       AUTHENTIK_POSTGRESQL__USER: authentik
       AUTHENTIK_POSTGRESQL__NAME: authentik
       AUTHENTIK_POSTGRESQL__PASSWORD: ${AUTHENTIK_PG_PASS}
+      # The WORKER runs the bootstrap that creates the akadmin user and the API
+      # token from AUTHENTIK_BOOTSTRAP_TOKEN. Without these here the token is never
+      # created, and the server's provisioner credential (same value) is rejected
+      # by Authentik (403), failing every SSO deploy. Must match authentik-server.
+      AUTHENTIK_BOOTSTRAP_PASSWORD: ${AUTHENTIK_BOOTSTRAP_PASSWORD:-}
+      AUTHENTIK_BOOTSTRAP_TOKEN: ${AUTHENTIK_BOOTSTRAP_TOKEN:-}
+      AUTHENTIK_BOOTSTRAP_EMAIL: ${AUTHENTIK_BOOTSTRAP_EMAIL:-admin@example.com}
     depends_on:
       authentik-postgres:
         condition: service_healthy


### PR DESCRIPTION
## Problem

With `HOLA_AUTH_MODE=authentik`, **every** app deploy fails at provisioning:

```
Deployment action 'deploy' failed: Authentik GET /api/v3/core/users/?username=hola-provisioner failed: 403
```

The Authentik **worker** runs the bootstrap that creates the akadmin user + API token from `AUTHENTIK_BOOTSTRAP_TOKEN`, but the `authentik-worker` service was missing the `AUTHENTIK_BOOTSTRAP_*` vars (only `authentik-server` had them). So the token was never created, and the server's provisioner credential (the same value) was rejected by Authentik (`403 / "Token invalid/expired"`).

Verified on a real host:
```
.env / authentik-server / hola-server  AUTHENTIK_BOOTSTRAP_TOKEN  len=64
authentik-worker                       AUTHENTIK_BOOTSTRAP_TOKEN  len=0  ← empty
```

## Fix

Mirror the three `AUTHENTIK_BOOTSTRAP_*` vars onto `authentik-worker` (as the upstream Authentik compose does).

## Verification

After applying on the host and recreating the worker:
- `GET /api/v3/core/users/ → 200` with the bootstrap token
- a forward-auth app (`homepage`) deploys successfully with its Authentik SSO gate provisioned and the route activated

Fixes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)