### PR TITLE
fix(compose): force USE_MOCK_DATA=false in the production server (fixes #131)

### DIFF
--- a/packages/compose/docker-compose.yml
+++ b/packages/compose/docker-compose.yml
@@ -64,6 +64,11 @@ services:
     restart: unless-stopped
     environment:
       - NODE_ENV=production
+      # The mock-data subsystem (src/mock-data) defaults ON unless USE_MOCK_DATA is
+      # exactly "false", so it stays active even with NODE_ENV=production — which
+      # simulates deploys (fake logs, random job "errors") instead of running real
+      # `docker compose`. Force it off for the production stack.
+      - USE_MOCK_DATA=false
       - HOLA_DATA_DIR=/data
       - HOLA_USE_AUTH=${HOLA_USE_AUTH:-true}
       # Optional fixed admin key; if unset, the server generates one on first boot


### PR DESCRIPTION
## Problem

With `NODE_ENV=production`, a real install still runs the **mock-data subsystem**: deployments are simulated, logs are fabricated (`postgres`/`redis`/`nextcloud` "Log line N"), and jobs randomly "error" — an app appears to deploy, then errors, with no real container.

Root cause — `packages/server/src/mock-data/index.ts:12`:

```js
USE_MOCK_DATA: Bun.env.USE_MOCK_DATA !== 'false', // Default to true
```

`USE_MOCK_DATA` defaults to **true** unless explicitly the string `'false'`, and neither the compose stack nor `.env.example` set it.

## Fix

Set `USE_MOCK_DATA=false` in the production server's `environment`. (A deeper fix — flipping the code default to opt-in or gating on `NODE_ENV` — is worth considering as a follow-up; this change is the minimal, verified production fix.)

## Verification

After setting it on the host and recreating the server, deploys run real `docker compose` and start real containers (verified with the `homepage` app).

Fixes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)