### PR TITLE
fix(compose): make DNS-01 work on split-horizon homelab networks (fixes #129)

### DIFF
--- a/packages/compose/.env.example
+++ b/packages/compose/.env.example
@@ -29,6 +29,12 @@ AWS_REGION=us-east-1
 AWS_HOSTED_ZONE_ID=
 # Cloudflare (ACME_DNS_PROVIDER=cloudflare). A scoped token with Zone:DNS:Edit.
 CF_DNS_API_TOKEN=
+# DNS-01 propagation check: recursive resolvers (comma-separated host:port) used
+# to confirm the challenge TXT record before asking Let's Encrypt to validate.
+# Defaults to public resolvers so issuance works on split-horizon / DNS-redirecting
+# homelab networks (UniFi/pfSense) where the zone's authoritative nameservers
+# aren't directly reachable. Leave blank to use the default (1.1.1.1, 9.9.9.9).
+ACME_DNS_RESOLVERS=
 
 # --- Hola UI/API (single origin: web serves the SPA and proxies /api) ---
 HOLA_DOMAIN=app.local.hola

--- a/packages/compose/docker-compose.dns01.yml
+++ b/packages/compose/docker-compose.dns01.yml
@@ -37,6 +37,15 @@ services:
       # DNS-01 instead of HTTP-01 — no inbound :80 reachability required.
       - --certificatesresolvers.le.acme.dnschallenge=true
       - --certificatesresolvers.le.acme.dnschallenge.provider=${ACME_DNS_PROVIDER}
+      # Split-horizon / DNS-redirection safety. lego's default propagation check
+      # queries the zone's AUTHORITATIVE nameservers directly on :53; on homelab
+      # networks that redirect/intercept outbound DNS (UniFi/pfSense "redirect all
+      # DNS to the gateway", NAT hairpin on :53) those queries are REFUSED and
+      # issuance hangs until it times out — the classic "needed a separate ACME
+      # container" failure. Skip the authoritative-NS check and verify against
+      # public recursive resolvers instead (override ACME_DNS_RESOLVERS in .env).
+      - --certificatesresolvers.le.acme.dnschallenge.propagation.disableanschecks=true
+      - --certificatesresolvers.le.acme.dnschallenge.resolvers=${ACME_DNS_RESOLVERS:-1.1.1.1:53,9.9.9.9:53}
     environment:
       # Credentials for the DNS provider's API. lego reads only the vars the chosen
       # ACME_DNS_PROVIDER needs; the others stay empty and are ignored.


### PR DESCRIPTION
## Problem

Traefik/lego's DNS-01 **propagation check** queries the zone's **authoritative nameservers directly on :53** before letting Let's Encrypt validate. On split-horizon / DNS-redirecting homelab networks (UniFi/pfSense "redirect all DNS to the gateway", NAT hairpin on :53), those direct queries are intercepted/refused, so lego never sees the TXT record "propagate" and the order **times out with no cert** — the classic reason people resort to a separate ACME container.

## Fix

Add lego's propagation controls to the `le` resolver in `docker-compose.dns01.yml`:

- `propagation.disableanschecks=true` — skip the authoritative-NS check
- `dnschallenge.resolvers=${ACME_DNS_RESOLVERS:-1.1.1.1:53,9.9.9.9:53}` — verify against public recursive resolvers instead

Plus a documented `ACME_DNS_RESOLVERS` knob in `.env.example`.

## Notes

The flags are live on a real homelab host (Route 53 zone) and the wildcard cert issues cleanly; they're the Traefik-documented remedy for the "waiting for DNS record propagation" failure mode and are harmless when DNS isn't redirected.

Fixes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)