### PR TITLE
fix(web): re-resolve the server upstream per request in nginx (fixes #135)

### DIFF
--- a/packages/web/nginx.conf
+++ b/packages/web/nginx.conf
@@ -12,7 +12,14 @@ server {
 
   # API + SSE proxy. The server container is reachable as "hola-server".
   location /api/ {
-    proxy_pass http://hola-server:3001;
+    # Re-resolve the upstream per request via Docker's embedded DNS (127.0.0.11)
+    # instead of caching the IP at startup. A static `proxy_pass http://name`
+    # resolves once at config load, so if the server container is recreated (its
+    # IP changes) nginx keeps proxying to the stale IP and every /api call 502s
+    # until web is restarted. Using a variable upstream forces per-request DNS.
+    resolver 127.0.0.11 valid=10s;
+    set $hola_upstream "hola-server:3001";
+    proxy_pass http://$hola_upstream;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Problem

`packages/web/nginx.conf` uses a static `proxy_pass http://hola-server:3001`, which nginx resolves **once at config load** and caches. When the `server` container is recreated (upgrade / config change) its IP changes, and nginx keeps proxying to the **stale** IP — so every `/api` call 502s until `hola-web` is restarted.

## Fix

Add Docker's embedded DNS `resolver 127.0.0.11` + a variable upstream so nginx re-resolves per request.

## Verification

On a real host, forced the server onto a new IP (`172.18.0.8 → 172.18.0.9`) with an IP-hog container, leaving `web` untouched:
- **before** (static `proxy_pass`): `/api` → 502
- **after** (this change): `/api/health` → `200` (3×)

Fixes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)