### PR TITLE
feat(server,compose): Traefik file-provider core routes — drop the Docker provider + socket (#128)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -39,9 +39,11 @@ browser ──TLS──▶ Traefik ──▶ web (nginx: SPA + /api proxy) ─�
 - **Single origin.** The `web` container serves the SPA and reverse-proxies
   `/api` (including SSE log streams) to the server, so the browser talks to one
   origin — no CORS, one `HOLA_DOMAIN` to configure.
-- **Traefik** terminates TLS, routes `HOLA_DOMAIN` → web, and reads the
-  server-emitted dynamic config (file provider) to route each deployed app at
-  `<app>.<HOLA_BASE_DOMAIN>`.
+- **Traefik** terminates TLS and routes everything from the server-emitted file
+  provider at `/data/runtime/traefik`: the platform's own routes (`core.yml` — the
+  UI at `HOLA_DOMAIN`, the dashboard, the Authentik UI) and each deployed app at
+  `<app>.<HOLA_BASE_DOMAIN>` (`dynamic.yml`). Traefik runs **no Docker provider and
+  mounts no Docker socket** — only the server holds the socket.
 - **Ingress is Traefik-only.** Apps are reachable through Traefik routing, not
   by publishing host ports. There is no host-port registry; the Compose
   validator rejects `ports:` exposure (use `expose:` for container-internal
@@ -117,7 +119,9 @@ Key locations:
 - `deployments/<id>/` — deployment record, releases, materialized
   `runtime/docker-compose.yml`.
 - `runtime/traefik/{routing-map.json,dynamic.yml}` — canonical routing state and
-  the Traefik file-provider config.
+  the Traefik file-provider config for deployed apps.
+- `runtime/traefik/core.yml` — file-provider routes for the platform's own
+  services (UI, dashboard, Authentik), emitted at server startup.
 - `data/hola.db` — SQLite (jobs, durable records).
 - `config/admin-api-key` — generated admin key (first-boot bootstrap).
 - `logs/` — server logs.

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -10,9 +10,11 @@ reachable at `<app>.<HOLA_BASE_DOMAIN>`.
 - **Single origin** — the `web` container (nginx) serves the SPA and reverse-proxies `/api`
   (including SSE log streams) to `hola-server:3001`. The browser only ever talks to one origin,
   so there is no CORS and only **one Hola domain** (`HOLA_DOMAIN`) to configure.
-- **Traefik** terminates TLS, routes `HOLA_DOMAIN` → web, redirects HTTP→HTTPS at the
-  entrypoint, and reads the server-emitted dynamic config from `/data/runtime/traefik` (file
-  provider) to route each deployed app.
+- **Traefik** terminates TLS, redirects HTTP→HTTPS at the entrypoint, and routes everything
+  from the **file provider** at `/data/runtime/traefik` — both the server-emitted per-app routes
+  (`dynamic.yml`) and the platform's own routes (`core.yml`: the UI at `HOLA_DOMAIN`, the
+  dashboard, and the Authentik login UI). Traefik uses **no Docker provider and mounts no Docker
+  socket**; the server is the single source of routing truth.
 - **Persistence** — all server state (deployments, releases, sqlite, logs, generated Traefik
   config) lives in the `hola-data` named volume mounted at `/data`. It survives restarts and is
   the single thing to back up.
@@ -248,6 +250,13 @@ app container, the app's Compose services must join the external `hola` network 
 name Hola expects. Validating this end-to-end (e.g. deploying Gitea) on a real Docker host is
 covered by the integration test in issue #19.
 
+The platform's own services route the same way: at startup the server emits `core.yml` next to
+`dynamic.yml`, with file-provider routers for the UI (`HOLA_DOMAIN` → `hola-web:80`), the Traefik
+dashboard (`TRAEFIK_DASHBOARD_DOMAIN` → the built-in `api@internal`), and — when
+`HOLA_AUTH_MODE=authentik` — the Authentik login UI (`HOLA_AUTHENTIK_DOMAIN` →
+`authentik-server:9000`). Because everything comes from the file provider, **Traefik mounts no
+Docker socket** (only the `server` container does, to orchestrate deployments).
+
 ## Troubleshooting
 - `docker compose config` — validate your `.env` and merged configuration.
 - `./scripts/logs.sh` / `docker compose logs -f traefik server web` — follow logs.
@@ -258,7 +267,7 @@ covered by the integration test in issue #19.
   `/data/runtime/traefik/dynamic.yml` contains its router.
 
 ## Files
-- `docker-compose.yml` — production stack (build, socket, data volume, Traefik file provider).
+- `docker-compose.yml` — production stack (build, server socket, data volume, Traefik file provider only).
 - `docker-compose.dev.yml` — opt-in local dev overlay (Bun dev servers, HTTP only); `HOLA_DEV=1`.
 - `docker-compose.dns01.yml` — opt-in DNS-01 TLS overlay (wildcard cert for private/homelab
   hosts); auto-included when `ACME_DNS_PROVIDER` is set.

--- a/packages/compose/docker-compose.dev.yml
+++ b/packages/compose/docker-compose.dev.yml
@@ -10,6 +10,9 @@
 
 services:
   traefik:
+    # Development keeps the Docker provider + labels for simple HTTP-only routing
+    # (no TLS, no server-emitted core.yml). Production drops both; this overlay
+    # restates the full command AND re-mounts the socket the base no longer mounts.
     command:
       - --api.dashboard=true
       - --providers.docker=true
@@ -17,10 +20,16 @@ services:
       - --providers.file.directory=/data/runtime/traefik
       - --providers.file.watch=true
       - --entrypoints.web.address=:80
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - hola-data:/data:ro
     labels:
       # Dashboard over plain HTTP in development.
+      traefik.enable: "true"
       traefik.http.routers.traefik.entrypoints: web
       traefik.http.routers.traefik.tls: "false"
+      traefik.http.routers.traefik.rule: Host(`${TRAEFIK_DASHBOARD_DOMAIN}`)
+      traefik.http.routers.traefik.service: api@internal
 
   server:
     build: !reset null

--- a/packages/compose/docker-compose.dns01.yml
+++ b/packages/compose/docker-compose.dns01.yml
@@ -17,9 +17,9 @@ services:
     # `command` REPLACES the base command (compose does not merge lists), so the
     # full set is restated here with DNS-01 + the wildcard request.
     command:
+      - --api=true
       - --api.dashboard=true
-      - --providers.docker=true
-      - --providers.docker.exposedbydefault=false
+      # File provider ONLY (no Docker provider/socket) — see docker-compose.yml.
       - --providers.file.directory=/data/runtime/traefik
       - --providers.file.watch=true
       - --entrypoints.web.address=:80

--- a/packages/compose/docker-compose.yml
+++ b/packages/compose/docker-compose.yml
@@ -3,6 +3,9 @@
 # The API server orchestrates app deployments via the Docker socket and emits
 # Traefik dynamic configuration into its data volume, which Traefik reads through
 # its file provider, so deployed apps become routable at <app>.<HOLA_BASE_DOMAIN>.
+# The platform's OWN routes (the UI, the Traefik dashboard, and the Authentik login
+# UI) are emitted the same way (core.yml) — so Traefik uses the file provider ONLY
+# and needs neither the Docker provider nor a mounted Docker socket.
 #
 #   cp .env.example .env   # then edit
 #   ./scripts/install.sh   # or: docker compose -f docker-compose.yml up -d --build
@@ -13,14 +16,17 @@
 
 services:
   traefik:
-    image: traefik:v3.1
+    image: traefik:v3.5
     container_name: traefik
     restart: unless-stopped
     command:
+      # --api enables the built-in api@internal service; the Hola server emits a
+      # file-provider router for it (core.yml) at TRAEFIK_DASHBOARD_DOMAIN.
+      - --api=true
       - --api.dashboard=true
-      - --providers.docker=true
-      - --providers.docker.exposedbydefault=false
-      # App routes emitted by the Hola server land here (shared data volume).
+      # File provider ONLY — no Docker provider, no Docker socket. Both the
+      # server-emitted app routes AND the platform's core routes (UI, dashboard,
+      # Authentik) land in this watched directory (shared data volume).
       - --providers.file.directory=/data/runtime/traefik
       - --providers.file.watch=true
       - --entrypoints.web.address=:80
@@ -45,15 +51,10 @@ services:
       - "${TRAEFIK_HTTP_PORT:-80}:80"
       - "${TRAEFIK_HTTPS_PORT:-443}:443"
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
+      # No Docker socket: Traefik discovers nothing from Docker; all routing comes
+      # from the file provider below (server-emitted app routes + core.yml).
       - hola-data:/data:ro
       - ./traefik/acme:/letsencrypt
-    labels:
-      traefik.enable: "true"
-      traefik.http.routers.traefik.rule: Host(`${TRAEFIK_DASHBOARD_DOMAIN}`)
-      traefik.http.routers.traefik.entrypoints: websecure
-      traefik.http.routers.traefik.service: api@internal
-      traefik.http.routers.traefik.tls: "true"
 
   server:
     image: hola/server:latest
@@ -65,6 +66,12 @@ services:
     environment:
       - NODE_ENV=production
       - HOLA_DATA_DIR=/data
+      # Platform hosts the server emits Traefik file-provider routes for (core.yml):
+      # the UI itself, the Traefik dashboard, and (when SSO is on) the Authentik UI.
+      # These replace the Docker-label routers Traefik used to discover.
+      - HOLA_DOMAIN=${HOLA_DOMAIN}
+      - TRAEFIK_DASHBOARD_DOMAIN=${TRAEFIK_DASHBOARD_DOMAIN}
+      - HOLA_AUTHENTIK_DOMAIN=${HOLA_AUTHENTIK_DOMAIN:-}
       - HOLA_USE_AUTH=${HOLA_USE_AUTH:-true}
       # Optional fixed admin key; if unset, the server generates one on first boot
       # and writes it to /data/config/admin-api-key (see README).
@@ -117,9 +124,8 @@ services:
       # match what the Docker daemon binds into app containers. No-op when the
       # var is blank (defaults to a host dir that simply goes unused).
       - ${HOLA_APPS_BIND_ROOT:-/srv/hola/apps}:${HOLA_APPS_BIND_ROOT:-/srv/hola/apps}
-    # Internal only: reached through the web container's /api proxy, not exposed by Traefik.
-    labels:
-      traefik.enable: "false"
+    # Internal only: reached through the web container's /api proxy. Not routed by
+    # Traefik (no Docker provider; only core.yml/app routes are served).
 
   web:
     image: hola/web:latest
@@ -130,12 +136,8 @@ services:
     restart: unless-stopped
     depends_on:
       - server
-    labels:
-      traefik.enable: "true"
-      traefik.http.routers.hola-web.rule: Host(`${HOLA_DOMAIN}`)
-      traefik.http.routers.hola-web.entrypoints: websecure
-      traefik.http.routers.hola-web.tls: "true"
-      traefik.http.services.hola-web.loadbalancer.server.port: "80"
+    # Routed by the server-emitted core.yml (Host=${HOLA_DOMAIN} -> hola-web:80),
+    # not Docker labels — Traefik has no Docker provider.
 
   # --- Authentik (SSO platform) -------------------------------------------
   # Opt-in: only started when the `authentik` compose profile is active
@@ -162,8 +164,6 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-    labels:
-      traefik.enable: "false"
 
   authentik-server:
     image: ghcr.io/goauthentik/server:2025.10
@@ -188,12 +188,8 @@ services:
     volumes:
       - authentik-media:/media
       - authentik-templates:/templates
-    labels:
-      traefik.enable: "true"
-      traefik.http.routers.authentik.rule: Host(`${HOLA_AUTHENTIK_DOMAIN:-auth.local.hola}`)
-      traefik.http.routers.authentik.entrypoints: websecure
-      traefik.http.routers.authentik.tls: "true"
-      traefik.http.services.authentik.loadbalancer.server.port: "9000"
+    # Routed by the server-emitted core.yml (Host=${HOLA_AUTHENTIK_DOMAIN} ->
+    # authentik-server:9000) when HOLA_AUTH_MODE=authentik — not Docker labels.
 
   authentik-worker:
     image: ghcr.io/goauthentik/server:2025.10
@@ -214,8 +210,6 @@ services:
       - authentik-media:/media
       - authentik-templates:/templates
       - authentik-certs:/certs
-    labels:
-      traefik.enable: "false"
 
   # LDAP outpost — serves the shared directory that `native-ldap` apps bind to,
   # reachable internally on the `hola` network at authentik-ldap:3389. Requires a
@@ -232,8 +226,6 @@ services:
       AUTHENTIK_TOKEN: ${AUTHENTIK_LDAP_OUTPOST_TOKEN:-}
     depends_on:
       - authentik-server
-    labels:
-      traefik.enable: "false"
 
 volumes:
   hola-data:

--- a/packages/server/src/__tests__/routing/routing-service.test.ts
+++ b/packages/server/src/__tests__/routing/routing-service.test.ts
@@ -9,7 +9,7 @@
 import { describe, test, expect, beforeEach } from 'bun:test';
 import { parse as parseYAML } from 'yaml';
 
-import { RealRoutingService } from '../../services/core/routing';
+import { RealRoutingService, coreRoutesFromEnv } from '../../services/core/routing';
 import { MockStorageService } from '../../services/core/storage';
 
 describe('RoutingService', () => {
@@ -128,5 +128,54 @@ describe('RoutingService', () => {
     const map = await fresh.getRoutingMap();
     expect(Object.keys(map).sort()).toEqual(['grafana.local.hola', 'vaultwarden.local.hola']);
     expect(map['gitea.local.hola']).toBeUndefined();
+  });
+
+  describe('core routes (platform UI/dashboard/Authentik)', () => {
+    test('coreRoutesFromEnv builds UI + dashboard, and Authentik only when SSO is on', () => {
+      const base = {
+        HOLA_DOMAIN: 'app.example.com',
+        TRAEFIK_DASHBOARD_DOMAIN: 'traefik.example.com',
+        HOLA_AUTHENTIK_DOMAIN: 'auth.example.com',
+      };
+
+      // SSO off -> no Authentik route.
+      expect(coreRoutesFromEnv({ ...base, HOLA_AUTH_MODE: 'none' }).map(r => r.name).sort())
+        .toEqual(['hola-web', 'traefik-dashboard']);
+
+      // SSO on -> Authentik route added.
+      const withAuth = coreRoutesFromEnv({ ...base, HOLA_AUTH_MODE: 'authentik' });
+      expect(withAuth.map(r => r.name).sort()).toEqual(['authentik', 'hola-web', 'traefik-dashboard']);
+      expect(withAuth.find(r => r.name === 'authentik')?.url).toBe('http://authentik-server:9000');
+
+      // Unset hosts are skipped entirely.
+      expect(coreRoutesFromEnv({})).toEqual([]);
+    });
+
+    test('emitCoreRoutes writes deterministic file-provider config', async () => {
+      await routing.emitCoreRoutes([
+        { name: 'hola-web', host: 'app.example.com', url: 'http://hola-web:80' },
+        { name: 'traefik-dashboard', host: 'traefik.example.com', service: 'api@internal' },
+      ]);
+
+      const core = parseYAML(await storage.readFileAsString('runtime/traefik/core.yml'));
+
+      // UI router -> its own load-balancer service.
+      expect(core.http.routers['hola-web'].rule).toBe('Host(`app.example.com`)');
+      expect(core.http.routers['hola-web'].entryPoints).toEqual(['websecure']);
+      expect(core.http.routers['hola-web'].tls).toEqual({});
+      expect(core.http.services['hola-web'].loadBalancer.servers[0].url).toBe('http://hola-web:80');
+
+      // Dashboard router references the built-in service and emits NO load balancer.
+      expect(core.http.routers['traefik-dashboard'].service).toBe('api@internal');
+      expect(core.http.services['traefik-dashboard']).toBeUndefined();
+
+      // Deterministic: re-emitting identical input yields identical output.
+      const first = await storage.readFileAsString('runtime/traefik/core.yml');
+      await routing.emitCoreRoutes([
+        { name: 'hola-web', host: 'app.example.com', url: 'http://hola-web:80' },
+        { name: 'traefik-dashboard', host: 'traefik.example.com', service: 'api@internal' },
+      ]);
+      expect(await storage.readFileAsString('runtime/traefik/core.yml')).toBe(first);
+    });
   });
 });

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -54,6 +54,7 @@ import type { LogLevel } from './lib/logger';
 import { initializeMetrics } from './lib/metrics';
 import { createRequestMiddleware, createHealthMiddleware, getRequestContext, type RequestContext } from './middleware/request';
 import { getServices, resetServices } from './services/simple-factory';
+import { coreRoutesFromEnv } from './services/core/routing';
 import { createSSEStream, createSSEHeaders } from './utils/sse';
 
 // Phase 1: Enhanced observability imports
@@ -106,7 +107,11 @@ async function initializeInfrastructure() {
   
   try {
     // Initialize services using simplified factory
-    getServices();
+    const services = getServices();
+    // Emit the platform's own Traefik routes (UI, dashboard, Authentik) into the
+    // file provider so Traefik needs neither the Docker provider nor the socket.
+    // Mock routing (test/dev) no-ops; production writes /data/runtime/traefik/core.yml.
+    await services.routing.emitCoreRoutes(coreRoutesFromEnv());
   } catch (error) {
     console.error('');
     console.error('❌ Server startup failed:');

--- a/packages/server/src/services/core/routing.ts
+++ b/packages/server/src/services/core/routing.ts
@@ -5,6 +5,9 @@
  * - generating a deterministic Traefik routing rule for a deployment,
  * - validating host conflicts against the active routing map,
  * - emitting deterministic Traefik dynamic (file-provider) configuration,
+ * - emitting the platform's own "core" routes (the Hola UI, the Traefik
+ *   dashboard, and — when SSO is on — the Authentik login UI) into the same
+ *   file provider, so Traefik needs no Docker provider and no Docker socket,
  * - atomically activating/removing routes on promote/rollback/delete, and
  * - reconciling routing from persisted deployments on restart.
  *
@@ -21,6 +24,10 @@ import type { StorageService } from './storage';
 
 const ROUTING_MAP_PATH = 'runtime/traefik/routing-map.json';
 const DYNAMIC_CONFIG_PATH = 'runtime/traefik/dynamic.yml';
+// Platform routes (UI / dashboard / Authentik) live in their OWN file so the
+// per-app `persist()` (which rewrites dynamic.yml) never clobbers them. Traefik's
+// file provider merges every file in the watched directory.
+const CORE_CONFIG_PATH = 'runtime/traefik/core.yml';
 const DEFAULT_BASE_DOMAIN = 'local.hola';
 
 export interface GenerateRuleInput {
@@ -28,6 +35,43 @@ export interface GenerateRuleInput {
   appName: string;
   /** Internal container/service port Traefik forwards to (defaults to 80). */
   port?: number;
+}
+
+/**
+ * A platform-owned ("core") Traefik route. These are the Hola server's own
+ * services — not deployed apps — that used to be discovered via Docker labels.
+ * Emitting them through the file provider lets the stack drop the Docker
+ * provider and the mounted Docker socket from Traefik entirely.
+ */
+export interface CoreRoute {
+  /** Stable router/service key, e.g. `hola-web`. */
+  name: string;
+  /** Host the router matches, e.g. `app.example.com`. */
+  host: string;
+  /** Upstream URL (e.g. `http://hola-web:80`). Omit when `service` is set. */
+  url?: string;
+  /** Reference a built-in Traefik service instead of a load balancer
+   *  (e.g. `api@internal` for the dashboard). Mutually exclusive with `url`. */
+  service?: string;
+}
+
+/**
+ * Build the platform's core routes from the process environment. Hosts that are
+ * unset are skipped (e.g. dev without a real domain); the Authentik route is
+ * only emitted when SSO is enabled.
+ */
+export function coreRoutesFromEnv(env: NodeJS.ProcessEnv = process.env): CoreRoute[] {
+  const routes: CoreRoute[] = [];
+  const uiHost = env.HOLA_DOMAIN?.trim();
+  if (uiHost) routes.push({ name: 'hola-web', host: uiHost, url: 'http://hola-web:80' });
+  const dashboardHost = env.TRAEFIK_DASHBOARD_DOMAIN?.trim();
+  // The dashboard is Traefik's built-in api@internal service (enabled by --api).
+  if (dashboardHost) routes.push({ name: 'traefik-dashboard', host: dashboardHost, service: 'api@internal' });
+  if ((env.HOLA_AUTH_MODE?.trim() || 'none') === 'authentik') {
+    const authHost = env.HOLA_AUTHENTIK_DOMAIN?.trim();
+    if (authHost) routes.push({ name: 'authentik', host: authHost, url: 'http://authentik-server:9000' });
+  }
+  return routes;
 }
 
 export interface RoutingService extends HealthCheckable {
@@ -44,6 +88,9 @@ export interface RoutingService extends HealthCheckable {
   /** Replace the entire routing map (used to rebuild from persisted state). */
   reconcile(rules: TraefikRoutingRule[]): Promise<void>;
   getRoutingMap(): Promise<TraefikRoutingMap>;
+  /** (Re)write the platform's core routes (UI/dashboard/Authentik) into the
+   *  file provider. Idempotent; called once at startup. */
+  emitCoreRoutes(routes: CoreRoute[]): Promise<void>;
 }
 
 /** Build a deterministic routing rule (pure; shared by real and mock services). */
@@ -153,6 +200,30 @@ function renderDynamicConfig(map: TraefikRoutingMap): string {
   return stringifyYAML({ http });
 }
 
+/** Render the file-provider config for the platform's core routes (deterministic). */
+function renderCoreConfig(routes: CoreRoute[]): string {
+  const routers: Record<string, unknown> = {};
+  const services: Record<string, unknown> = {};
+  for (const route of [...routes].sort((a, b) => a.name.localeCompare(b.name))) {
+    routers[route.name] = {
+      rule: `Host(\`${route.host}\`)`,
+      // Built-in services (api@internal) are referenced directly; everything else
+      // gets a load balancer pointing at the upstream URL below.
+      service: route.service ?? route.name,
+      entryPoints: ['websecure'],
+      // Empty TLS block inherits the entrypoint's default cert resolver (and the
+      // DNS-01 wildcard domains), exactly like the server-emitted app routes.
+      tls: {},
+    };
+    if (!route.service) {
+      services[route.name] = { loadBalancer: { servers: [{ url: route.url }] } };
+    }
+  }
+  const http: Record<string, unknown> = { routers };
+  if (Object.keys(services).length > 0) http.services = services;
+  return stringifyYAML({ http });
+}
+
 export class RealRoutingService implements RoutingService {
   private logger = getLogger().child({ service: 'RoutingService' });
   private domain: string;
@@ -244,6 +315,15 @@ export class RealRoutingService implements RoutingService {
     return { ...this.map };
   }
 
+  async emitCoreRoutes(routes: CoreRoute[]): Promise<void> {
+    await this.storageService.ensureDir('runtime/traefik');
+    await this.storageService.writeFile(CORE_CONFIG_PATH, renderCoreConfig(routes));
+    this.logger.info('Emitted core Traefik routes', {
+      count: routes.length,
+      hosts: routes.map(r => r.host),
+    });
+  }
+
   /** Persist the routing map and re-emit the Traefik dynamic config (atomic writes). */
   private async persist(): Promise<void> {
     await this.storageService.ensureDir('runtime/traefik');
@@ -301,5 +381,9 @@ export class MockRoutingService implements RoutingService {
 
   async getRoutingMap(): Promise<TraefikRoutingMap> {
     return { ...this.map };
+  }
+
+  async emitCoreRoutes(): Promise<void> {
+    // No file emission in tests/dev.
   }
 }


### PR DESCRIPTION
## What & why

Traefik discovered the Hola UI, its own dashboard, and the Authentik login UI via the **Docker provider** (container labels), which required mounting the **Docker socket** into Traefik. That model breaks on modern Docker Engine (29.x raised the minimum API version above what Traefik's non-negotiating docker provider speaks → dashboard/UI 404) and needlessly grants Traefik host control.

This moves those **core** routes into the same **file provider** the server already uses for deployed-app routes, so Traefik runs file-provider-**only** — no Docker provider, no Docker socket. Only the `server` container holds the socket (it must, to orchestrate deployments).

This is the gating fix for a clean `hola bootstrap` on current Docker; PRs #138–142 fix everything downstream of routing, but not this.

## Changes

**server**
- `RealRoutingService.emitCoreRoutes()` writes `/data/runtime/traefik/core.yml` — a **separate** file from `dynamic.yml`, so per-app `persist()` (which rewrites `dynamic.yml`) never clobbers it. Traefik's file provider merges both.
- `coreRoutesFromEnv()` derives the routes from `HOLA_DOMAIN` (→ `hola-web:80`), `TRAEFIK_DASHBOARD_DOMAIN` (→ built-in `api@internal`), and — only when `HOLA_AUTH_MODE=authentik` — `HOLA_AUTHENTIK_DOMAIN` (→ `authentik-server:9000`). Unset hosts are skipped.
- Emitted once at server startup; `MockRoutingService` no-ops (tests/dev).

**compose**
- Drop `--providers.docker` and the Traefik Docker-socket mount.
- Add `--api=true` so the dashboard's `api@internal` is reachable from a file-provider router.
- Remove the now-dead label routers (traefik/web/authentik) and the inert `traefik.enable` labels.
- Bump Traefik `v3.1` → `v3.5`.
- Pass `HOLA_DOMAIN` / `TRAEFIK_DASHBOARD_DOMAIN` / `HOLA_AUTHENTIK_DOMAIN` to the server.
- **dev overlay** keeps the Docker provider for simple HTTP-only routing and re-mounts the socket the base no longer mounts (plus the full dashboard router labels the base used to provide).
- **dns01 overlay** restated command updated to match (file-provider only).

**docs** — README + ARCHITECTURE updated to describe `core.yml` and the socket-free Traefik.

## Verification
- `bun run typecheck` / `lint` / `build` clean; `bun --cwd packages/server test` → 249 pass (incl. new `coreRoutesFromEnv` + `emitCoreRoutes` coverage).
- `docker compose config` validates the **base**, **base + dns01 + authentik profile**, and **dev** overlays; confirmed the Traefik service has no socket and no docker provider, and the dev overlay re-adds both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)