### PR TITLE
chore: release 0.4.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "packages/cli": {
       "name": "@hola/cli",
-      "version": "0.2.0",
+      "version": "0.4.0",
       "bin": {
         "hola": "./bin/hola",
       },
@@ -40,11 +40,11 @@
     },
     "packages/compose": {
       "name": "@hola/compose",
-      "version": "0.2.0",
+      "version": "0.4.0",
     },
     "packages/sdk": {
       "name": "@hola/sdk",
-      "version": "0.2.0",
+      "version": "0.4.0",
       "dependencies": {
         "@hola/shared": "workspace:*",
       },
@@ -58,7 +58,7 @@
     },
     "packages/server": {
       "name": "@hola/server",
-      "version": "0.2.0",
+      "version": "0.4.0",
       "dependencies": {
         "@hola/shared": "workspace:*",
         "yaml": "^2.9.0",
@@ -73,7 +73,7 @@
     },
     "packages/shared": {
       "name": "@hola/shared",
-      "version": "0.2.0",
+      "version": "0.4.0",
       "dependencies": {
         "yaml": "^2.9.0",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.3.0';
+export const CLI_VERSION = '0.4.0';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

Version bump for the **0.4.0** release. Bumps the five published packages `0.3.0 → 0.4.0` (`cli`, `compose`, `sdk`, `server`, `shared`) and `CLI_VERSION` to match; `web` stays `0.0.0` and the private workspace root stays `0.2.0` (mirrors the 0.3.0 release commit). `bun.lock` refreshed.

## Why now

Since 0.3.0: **versioned GHCR images + compose bundle** (#148). Tagging `cli-v0.4.0` after this merges will, via `cli-release.yml`:
- build & push multi-arch `ghcr.io/try-hola/server:0.4.0` + `web:0.4.0` (+`:latest`),
- attach `hola-compose-0.4.0.tar.gz` and the 4 CLI binaries to the release.

`CLI_VERSION=0.4.0` makes `hola bootstrap` default `--ref` to `cli-v0.4.0`, so the CLI installs a matching server version.

## Reminder
This is the **first** tag exercising the image-publish workflow — GHCR creates packages private, so after the run set `ghcr.io/try-hola/{server,web}` to **Public** in the org package settings (documented in the workflow + compose README).

## Verification
`bun run lint` ✓ · `bun run test` ✓ (server 249, web 127, CLI 45) · `bun run build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)