### PR TITLE
fix(cli): multi-word flags were silently ignored (--env-file, --skip-checks, --dry-run, …)

### DIFF
--- a/packages/cli/src/__tests__/opts.test.ts
+++ b/packages/cli/src/__tests__/opts.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+
+import { camelKeys } from '../lib/opts';
+
+describe('camelKeys', () => {
+  it('camelCases kebab-case flag keys (the sade/mri multi-word fix)', () => {
+    const out = camelKeys({
+      'env-file': '/tmp/x',
+      'skip-checks': true,
+      'tarball-url': 'https://e/x.tgz',
+      'dry-run': true,
+    });
+    expect(out).toEqual({
+      envFile: '/tmp/x',
+      skipChecks: true,
+      tarballUrl: 'https://e/x.tgz',
+      dryRun: true,
+    });
+  });
+
+  it('leaves single-word keys (and mri --no-x → {x:false}) untouched', () => {
+    const out = camelKeys({ host: 'me@vm', json: false, stream: false, _: ['a'] });
+    expect(out).toEqual({ host: 'me@vm', json: false, stream: false, _: ['a'] });
+  });
+});

--- a/packages/cli/src/index.tsx
+++ b/packages/cli/src/index.tsx
@@ -2,6 +2,7 @@
 import sade from 'sade';
 
 import { CLI_VERSION } from './version';
+import { camelKeys } from './lib/opts';
 
 // Lazy command loaders to avoid unnecessary dependencies until invoked
 const load = async <T,>(p: Promise<T>): Promise<T> => p;
@@ -23,7 +24,7 @@ prog
   .option('--json', 'Print the resolved config as JSON (secrets redacted)', false)
   .action(async (opts) => {
     const { runInit } = await load(import('./commands/init/init'));
-    await runInit(opts);
+    await runInit(camelKeys(opts));
   });
 
 // bootstrap — wizard + SSH into the host and run the full install
@@ -41,7 +42,7 @@ prog
   .option('--json', 'Print the result as JSON', false)
   .action(async (opts) => {
     const { runBootstrap } = await load(import('./commands/bootstrap/bootstrap'));
-    await runBootstrap(opts);
+    await runBootstrap(camelKeys(opts));
   });
 
 // catalog — browse the app catalog
@@ -53,7 +54,7 @@ prog
   .option('--json', 'Print raw JSON output', false)
   .action(async (query, opts) => {
     const { runCatalog } = await load(import('./commands/catalog/catalog'));
-    await runCatalog(query, opts);
+    await runCatalog(query, camelKeys(opts));
   });
 
 // install — install a catalog app by id (draft from catalog → finalize → deploy)
@@ -68,7 +69,7 @@ prog
   .option('--json', 'Print the result as JSON', false)
   .action(async (appId, opts) => {
     const { runInstall } = await load(import('./commands/install/install'));
-    await runInstall(appId, opts);
+    await runInstall(appId, camelKeys(opts));
   });
 
 // deployments — list installed deployments
@@ -79,7 +80,7 @@ prog
   .option('--json', 'Print raw JSON output', false)
   .action(async (opts) => {
     const { runDeploymentsList } = await load(import('./commands/deployments/deployments'));
-    await runDeploymentsList(opts);
+    await runDeploymentsList(camelKeys(opts));
   });
 
 // logs — print recent logs for a deployment (or live-tail with --follow)
@@ -90,7 +91,7 @@ prog
   .option('--json', 'Print raw JSON output', false)
   .action(async (deploymentId, opts) => {
     const { runDeploymentLogs } = await load(import('./commands/deployments/deployments'));
-    await runDeploymentLogs(deploymentId, opts);
+    await runDeploymentLogs(deploymentId, camelKeys(opts));
   });
 
 // stop / restart — lifecycle actions on a deployment
@@ -101,7 +102,7 @@ prog
   .option('--json', 'Print the result as JSON', false)
   .action(async (deploymentId, opts) => {
     const { runDeploymentAction } = await load(import('./commands/deployments/actions'));
-    await runDeploymentAction('stop', deploymentId, opts);
+    await runDeploymentAction('stop', deploymentId, camelKeys(opts));
   });
 
 prog
@@ -111,7 +112,7 @@ prog
   .option('--json', 'Print the result as JSON', false)
   .action(async (deploymentId, opts) => {
     const { runDeploymentAction } = await load(import('./commands/deployments/actions'));
-    await runDeploymentAction('restart', deploymentId, opts);
+    await runDeploymentAction('restart', deploymentId, camelKeys(opts));
   });
 
 // uninstall — remove a deployment (containers, data, auth) — destructive
@@ -122,7 +123,7 @@ prog
   .option('--json', 'Print the result as JSON', false)
   .action(async (deploymentId, opts) => {
     const { runUninstall } = await load(import('./commands/deployments/actions'));
-    await runUninstall(deploymentId, opts);
+    await runUninstall(deploymentId, camelKeys(opts));
   });
 
 // rollback — roll a deployment back to a previous release
@@ -135,7 +136,7 @@ prog
   .option('--json', 'Print the result as JSON', false)
   .action(async (deploymentId, opts) => {
     const { runRollback } = await load(import('./commands/deployments/actions'));
-    await runRollback(deploymentId, opts);
+    await runRollback(deploymentId, camelKeys(opts));
   });
 
 // bundle validate
@@ -147,7 +148,7 @@ prog
   .option('--json', 'Print raw JSON output', false)
   .action(async (opts) => {
     const { runBundleValidate } = await load(import('./commands/bundle/validate'));
-    await runBundleValidate(opts);
+    await runBundleValidate(camelKeys(opts));
   });
 
 // bundle deploy (one-shot)
@@ -164,7 +165,7 @@ prog
   .option('--json', 'Print the result as JSON', false)
   .action(async (opts) => {
     const { runBundleDeploy } = await load(import('./commands/bundle/deploy'));
-    await runBundleDeploy(opts);
+    await runBundleDeploy(camelKeys(opts));
   });
 
 // Fallback banner when no args

--- a/packages/cli/src/lib/opts.ts
+++ b/packages/cli/src/lib/opts.ts
@@ -1,0 +1,11 @@
+// sade/mri parse `--multi-word` flags into kebab-case keys (`env-file`,
+// `skip-checks`, `tarball-url`), but the command handlers read camelCase
+// (`opts.envFile`, …). Normalize so multi-word flags actually take effect.
+// Single-word keys (and mri's `--no-x` → `{ x: false }`) are unchanged.
+export const camelKeys = <T extends Record<string, unknown>>(opts: T): T => {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(opts)) {
+    out[k.replace(/-([a-z])/g, (_m, c: string) => c.toUpperCase())] = v;
+  }
+  return out as T;
+};


### PR DESCRIPTION
## Summary

`sade` (via `mri`) parses `--multi-word` flags into **kebab-case** keys (`env-file`, `skip-checks`, `dry-run`, `tarball-url`, `compose-dir`, `app-id`), but every command action reads **camelCase** (`opts.envFile`, `opts.skipChecks`, …). The two never matched, so **all multi-word flags silently did nothing** through the real CLI. Only the direct `runX()` unit tests caught behavior — they pass camelCase objects, bypassing the parser.

Found while testing the new bootstrap path on a live host: `hola bootstrap --env-file <f>` launched the interactive wizard instead of using the file.

## Fix
- Add `lib/opts.ts` `camelKeys()` that camelCases parsed opt keys; apply it in every command action.
- Single-word keys are unchanged; mri's `--no-x` → `{ x: false }` (already camel) is unaffected.
- Unit test for the mapping.

This also makes `--tarball-url` (added in #148) actually reachable.

## Verification
- New `opts.test.ts` ✓; `bun --cwd packages/cli test` 47 pass.
- Manually confirmed against the test host: `hola bootstrap --host … --env-file /tmp/hola.env --dir ~/hola-v4 --skip-checks` now reads the file (no wizard), downloads `hola-compose-0.4.0.tar.gz`, and the host pulls `ghcr.io/try-hola/{server,web}:0.4.0` (server `/healthz` reports `"version":"0.4.0"`).
- `bun run lint` ✓ · CLI typecheck ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)