### PR TITLE
feat(cli)!: default install dir /opt/hola + release 0.4.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "packages/cli": {
       "name": "@hola/cli",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "bin": {
         "hola": "./bin/hola",
       },
@@ -40,11 +40,11 @@
     },
     "packages/compose": {
       "name": "@hola/compose",
-      "version": "0.4.0",
+      "version": "0.4.1",
     },
     "packages/sdk": {
       "name": "@hola/sdk",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "@hola/shared": "workspace:*",
       },
@@ -58,7 +58,7 @@
     },
     "packages/server": {
       "name": "@hola/server",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "@hola/shared": "workspace:*",
         "yaml": "^2.9.0",
@@ -73,7 +73,7 @@
     },
     "packages/shared": {
       "name": "@hola/shared",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "yaml": "^2.9.0",
       },

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -17,10 +17,11 @@ Prerequisites: a host with **Docker**, the **Docker Compose v2** plugin, and
 curl -fsSL https://raw.githubusercontent.com/try-hola/hola/main/install.sh | sh
 ```
 
-This clones Hola (to `$HOLA_HOME`, default `$HOME/hola`), prompts for the domain
-settings (or reads `HOLA_DOMAIN` / `HOLA_BASE_DOMAIN` / `LETSENCRYPT_EMAIL` from
-the environment), builds and starts the production stack, and prints the admin
-API key. Re-running upgrades an existing install.
+This clones Hola (to `$HOLA_HOME`, default `/opt/hola` — created with `sudo` +
+`chown` to your user when needed), prompts for the domain settings (or reads
+`HOLA_DOMAIN` / `HOLA_BASE_DOMAIN` / `LETSENCRYPT_EMAIL` from the environment),
+builds and starts the production stack, and prints the admin API key. Re-running
+upgrades an existing install.
 
 ### Manual install
 

--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@
 # defaults when run non-interactively).
 #
 # Environment overrides:
-#   HOLA_HOME           install directory                 (default: $HOME/hola)
+#   HOLA_HOME           install directory                 (default: /opt/hola)
 #   HOLA_DOMAIN         UI/API domain                     (e.g. app.example.com)
 #   HOLA_BASE_DOMAIN    base domain for deployed apps     (e.g. example.com)
 #   LETSENCRYPT_EMAIL   email for Let's Encrypt           (e.g. you@example.com)
@@ -23,7 +23,7 @@ set -eu
 
 REPO="${HOLA_REPO:-https://github.com/try-hola/hola.git}"
 BRANCH="${HOLA_BRANCH:-main}"
-HOLA_HOME="${HOLA_HOME:-$HOME/hola}"
+HOLA_HOME="${HOLA_HOME:-/opt/hola}"
 
 info() { printf '\033[1;36m[hola]\033[0m %s\n' "$1"; }
 warn() { printf '\033[1;33m[hola]\033[0m %s\n' "$1" >&2; }
@@ -33,6 +33,22 @@ die()  { printf '\033[1;31m[hola] error:\033[0m %s\n' "$1" >&2; exit 1; }
 command -v git >/dev/null 2>&1 || die "git not found. Install git and re-run."
 command -v docker >/dev/null 2>&1 || die "Docker not found. See https://docs.docker.com/engine/install/"
 docker compose version >/dev/null 2>&1 || die "Docker Compose v2 plugin not found. Update Docker to include 'docker compose'."
+
+# --- ensure the install dir exists and is owned by us ----------------------
+# The default (/opt/hola) lives under a root-owned parent, so create it with
+# sudo + chown once; everything after runs unprivileged. An unprivileged dir
+# (e.g. HOLA_HOME=$HOME/hola) skips sudo entirely.
+if [ ! -d "$HOLA_HOME" ]; then
+  parent=$(dirname "$HOLA_HOME")
+  if [ -w "$parent" ]; then
+    mkdir -p "$HOLA_HOME"
+  elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+    info "Creating $HOLA_HOME (sudo)"
+    sudo mkdir -p "$HOLA_HOME" && sudo chown "$(id -u):$(id -g)" "$HOLA_HOME"
+  else
+    die "cannot create $HOLA_HOME (no write access to $parent, no passwordless sudo). Pre-create it: sudo mkdir -p $HOLA_HOME && sudo chown \$USER $HOLA_HOME"
+  fi
+fi
 
 # --- fetch or update the repo ----------------------------------------------
 if [ -d "$HOLA_HOME/.git" ]; then

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/__tests__/bootstrap.test.ts
+++ b/packages/cli/src/__tests__/bootstrap.test.ts
@@ -48,7 +48,7 @@ describe('hola bootstrap', () => {
 
     expect(res?.steps).toEqual([
       'Preflight host',
-      'Download Hola 0.2.0 stack into ~/hola',
+      'Download Hola 0.2.0 stack into /opt/hola',
       'Write .env (over stdin)',
       'Run install.sh',
       'Verify https://app.hola.example.com',
@@ -75,6 +75,11 @@ describe('hola bootstrap', () => {
     ).toBe(true);
     expect(runner.calls.some((c) => c.cmd.includes('cat > /opt/hola/.env'))).toBe(true);
     expect(runner.calls.some((c) => c.cmd.includes('cd /opt/hola && ./scripts/install.sh'))).toBe(true);
+    // /opt is root-owned: the fetch step creates the dir with sudo + chown when
+    // the parent isn't writable (and plain mkdir when it is).
+    const fetch = runner.calls.find((c) => c.cmd.includes('tar xz -C /opt/hola'))!;
+    expect(fetch.cmd).toContain('sudo mkdir -p /opt/hola');
+    expect(fetch.cmd).toContain('chown');
   });
 
   it('honors --tarball-url for the bundle download', async () => {

--- a/packages/cli/src/commands/bootstrap/bootstrap.ts
+++ b/packages/cli/src/commands/bootstrap/bootstrap.ts
@@ -32,6 +32,7 @@ export interface BootstrapResult {
 class BootstrapAbort extends Error {}
 
 const DEFAULT_REPO = 'https://github.com/try-hola/hola.git';
+const DEFAULT_DIR = '/opt/hola';
 
 /** Strip a leading `cli-v` from a release tag to get the bare version (cli-v0.3.0 → 0.3.0). */
 function versionFromRef(ref: string): string {
@@ -64,7 +65,7 @@ export async function runBootstrap(
   const version = versionFromRef(ref);
   // The bundle extracts compose's contents directly into `dir` — no git checkout,
   // so there's no packages/compose nesting on the host.
-  const dir = opts.dir ?? '~/hola';
+  const dir = opts.dir ?? DEFAULT_DIR;
   const composeDir = dir;
   const envPath = `${composeDir}/.env`;
   const tarballUrl = opts.tarballUrl ?? `${releaseBase(repo)}/releases/download/${ref}/hola-compose-${version}.tar.gz`;
@@ -123,10 +124,27 @@ export async function runBootstrap(
 
     // 3) Download + extract the version-pinned compose bundle (no git, no source
     //    build on the host — the images are prebuilt and pulled at `up` time).
+    //    The default dir (/opt/hola) lives under a root-owned parent, so create
+    //    it with sudo + chown to this user when the parent isn't writable; an
+    //    unprivileged dir (e.g. ~/hola) skips sudo entirely. Exit 13 = needs a
+    //    one-time manual pre-create (no write access and no passwordless sudo).
     const fetchStack =
-      `set -e; mkdir -p ${composeDir}; ` +
-      `curl -fsSL ${tarballUrl} | tar xz -C ${composeDir}`;
+      `set -e; ` +
+      `if [ ! -d ${dir} ]; then ` +
+      `  parent=$(dirname ${dir}); ` +
+      `  if [ -w "$parent" ]; then mkdir -p ${dir}; ` +
+      `  elif sudo -n true 2>/dev/null; then sudo mkdir -p ${dir} && sudo chown "$(id -u):$(id -g)" ${dir}; ` +
+      `  else exit 13; fi; ` +
+      `fi; ` +
+      `curl -fsSL ${tarballUrl} | tar xz -C ${dir}`;
     const fetchRes = await ssh(`Download Hola ${version} stack into ${composeDir}`, fetchStack, { stream: true });
+    if (!opts.dryRun && fetchRes.code === 13) {
+      throw new BootstrapAbort(
+        `Cannot create ${dir}: no write access to its parent and no passwordless sudo.\n` +
+          `Pre-create it once, then re-run bootstrap:\n` +
+          `  ssh ${host} 'sudo mkdir -p ${dir} && sudo chown $(id -u):$(id -g) ${dir}'`,
+      );
+    }
     if (!opts.dryRun && fetchRes.code !== 0) {
       throw new BootstrapAbort(
         `Downloading the compose bundle failed (exit ${fetchRes.code}). ` +

--- a/packages/cli/src/index.tsx
+++ b/packages/cli/src/index.tsx
@@ -35,7 +35,7 @@ prog
   .option('--repo', 'Hola repo to download release assets from', 'https://github.com/try-hola/hola.git')
   .option('--ref', `Release tag to install (default cli-v${CLI_VERSION})`)
   .option('--tarball-url', 'Override the compose-bundle download URL (advanced)')
-  .option('--dir', 'Install directory on the host', '~/hola')
+  .option('--dir', 'Install directory on the host', '/opt/hola')
   .option('--env-file', 'Use an existing .env (skip the wizard)')
   .option('--skip-checks', 'Skip live DNS/credential/catalog validation', false)
   .option('--dry-run', 'Print the plan without connecting', false)

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.4.0';
+export const CLI_VERSION = '0.4.1';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

Two things, bundled as the **0.4.1** release:

### 1. Default install dir `~/hola` → `/opt/hola`
More conventional for a server install. `/opt` is root-owned, so both install paths now create the dir with **`sudo` + `chown`** to the invoking user when the parent isn't writable, then run everything unprivileged:
- `hola bootstrap` — the download step creates the dir (plain `mkdir` if the parent is writable, `sudo mkdir && sudo chown` if not, and aborts with a clear one-line pre-create instruction when there's no write access **and** no passwordless sudo).
- root `install.sh` — same `ensure-dir` logic before the clone.

**Implications (verified on a live host):**
- **Data is safe** — server/app state lives in named volumes (`hola_hola-data`, …) scoped to the compose project, not the directory, so the dir default change doesn't lose anything.
- An unprivileged `--dir` (e.g. `--dir ~/hola`) skips sudo entirely.
- Migrating an *existing* install to a new dir re-issues TLS (ACME store is a dir-relative bind — see #149); carry `traefik/acme/acme.json` over, or stay on the same dir.

### 2. Release 0.4.1
Bump published packages `0.4.0 → 0.4.1` + `CLI_VERSION` (web `0.0.0`, root `0.2.0` unchanged). **0.4.1 binaries include the multi-word-flag fix (#152)** that the 0.4.0 binaries shipped without (`--env-file`, `--dry-run`, `--tarball-url`, …).

## Verification
- `bun run lint` ✓ · `bun run test` ✓ (server 249, web 127, CLI 47) · `bun run build` ✓
- Dry-run shows `/opt/hola` default + the sudo-create command.
- Sudo-create logic exercised on a real host (`/opt` root-owned, passwordless sudo): created + chowned + writable + cleaned up.

After merge I'll tag `cli-v0.4.1` (builds binaries, pushes `ghcr.io/try-hola/{server,web}:0.4.1`, attaches `hola-compose-0.4.1.tar.gz`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)