### PR TITLE
feat(auth): dashboard sign-in — OIDC (PKCE) + admin-key fallback

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -61,6 +61,7 @@
       "version": "0.4.1",
       "dependencies": {
         "@hola/shared": "workspace:*",
+        "jose": "^5.9.6",
         "yaml": "^2.9.0",
       },
       "devDependencies": {
@@ -92,6 +93,7 @@
         "@hola/sdk": "workspace:*",
         "@hola/shared": "workspace:*",
         "lucide-react": "^1.18.0",
+        "oidc-client-ts": "^3.5.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-router-dom": "^7.17.0",
@@ -658,6 +660,8 @@
 
     "jiti": ["jiti@1.21.6", "", { "bin": "bin/jiti.js" }, "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w=="],
 
+    "jose": ["jose@5.10.0", "", {}, "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="],
+
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "jsdom": ["jsdom@29.1.1", "", { "dependencies": { "@asamuzakjp/css-color": "^5.1.11", "@asamuzakjp/dom-selector": "^7.1.1", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.3", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.3.5", "parse5": "^8.0.1", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.25.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q=="],
@@ -671,6 +675,8 @@
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
     "json5": ["json5@2.2.3", "", { "bin": "lib/cli.js" }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "jwt-decode": ["jwt-decode@4.0.0", "", {}, "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA=="],
 
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
@@ -739,6 +745,8 @@
     "object.assign": ["object.assign@4.1.7", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0", "has-symbols": "^1.1.0", "object-keys": "^1.1.1" } }, "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw=="],
 
     "obug": ["obug@2.1.3", "", {}, "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg=="],
+
+    "oidc-client-ts": ["oidc-client-ts@3.5.0", "", { "dependencies": { "jwt-decode": "^4.0.0" } }, "sha512-l2q8l9CTCTOlbX+AnK4p3M+4CEpKpyQhle6blQkdFhm0IsBqsxm15bYaSa11G7pWdsYr6epdsRZxJpCyCRbT8A=="],
 
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -52,6 +52,25 @@ docker compose exec server cat /data/config/admin-api-key
 Send it as `Authorization: Bearer <key>` (or `X-API-Key: <key>`); for the CLI/SDK
 set `HOLA_TOKEN`. Development and test run with auth disabled. See ADR 0001.
 
+#### Dashboard sign-in
+
+The web dashboard reads `GET /api/auth/config` (unauthenticated) at load to pick a
+login flow:
+
+- **SSO (recommended).** With `HOLA_AUTH_MODE=authentik`, the server self-provisions
+  a public OIDC client for the dashboard at startup (registered at
+  `https://<HOLA_DOMAIN>/auth/callback`) and the login screen shows **Sign in with
+  SSO** — an Authorization Code + PKCE flow against Authentik. The browser sends the
+  resulting access-token JWT as a Bearer header; the server validates it against
+  Authentik's JWKS. Set `HOLA_OIDC_ISSUER` + `HOLA_OIDC_CLIENT_ID` to point at an
+  external IdP instead, and `HOLA_OIDC_ADMIN_GROUP` to restrict write access to a
+  group.
+- **Admin-key fallback.** Without OIDC, the login screen accepts the admin API key;
+  the server validates it and sets an `HttpOnly` session cookie, so the key is never
+  stored in the browser.
+
+When `HOLA_USE_AUTH=false` (dev/test) the dashboard loads with no login.
+
 ## Deploy an app
 
 The web dashboard browses a remote **catalog** of installable apps, set via

--- a/packages/compose/.env.example
+++ b/packages/compose/.env.example
@@ -59,9 +59,23 @@ HOLA_DEFAULT_TZ=
 # --- Admin API auth (see docs/adr/0001-authentication.md) ---
 # Auth is on by default in production. Set a fixed admin API key here, or leave
 # it blank to have the server generate one on first boot and write it to
-# /data/config/admin-api-key inside the hola-data volume.
+# /data/config/admin-api-key inside the hola-data volume. The admin key is the
+# CLI/SDK credential and the dashboard's fallback login when SSO is off.
 HOLA_USE_AUTH=true
 HOLA_API_KEY=
+
+# --- Dashboard sign-in (SSO) ---
+# With HOLA_AUTH_MODE=authentik (below), the server self-provisions a public OIDC
+# client for the web dashboard and the login screen becomes "Sign in with SSO" —
+# no extra config needed. To point the dashboard at an EXTERNAL IdP instead, set
+# the issuer + client id here (register https://${HOLA_DOMAIN}/auth/callback as the
+# client's redirect URI). HOLA_OIDC_ADMIN_GROUP, when set, limits write access to
+# members of that group (others get read-only). Leave blank to use SSO auto-config
+# or the admin-key login.
+HOLA_OIDC_ISSUER=
+HOLA_OIDC_CLIENT_ID=
+HOLA_OIDC_AUDIENCE=
+HOLA_OIDC_ADMIN_GROUP=
 
 # --- Authentication & SSO for catalog apps (Authentik) ---
 # `none` (default): no SSO platform; catalog apps deploy without auth wiring.

--- a/packages/compose/docker-compose.yml
+++ b/packages/compose/docker-compose.yml
@@ -99,6 +99,14 @@ services:
       # service account. Set HOLA_AUTHENTIK_API_TOKEN to pin a pre-made scoped token instead.
       - HOLA_AUTHENTIK_BOOTSTRAP_TOKEN=${AUTHENTIK_BOOTSTRAP_TOKEN:-}
       - HOLA_AUTHENTIK_API_TOKEN=${HOLA_AUTHENTIK_API_TOKEN:-}
+      # Dashboard SSO: with HOLA_AUTH_MODE=authentik the server self-provisions a
+      # public OIDC client for the dashboard and validates its access tokens. To
+      # use an external IdP instead, set HOLA_OIDC_ISSUER + HOLA_OIDC_CLIENT_ID
+      # (and the client's redirect URI must be https://${HOLA_DOMAIN}/auth/callback).
+      - HOLA_OIDC_ISSUER=${HOLA_OIDC_ISSUER:-}
+      - HOLA_OIDC_CLIENT_ID=${HOLA_OIDC_CLIENT_ID:-}
+      - HOLA_OIDC_AUDIENCE=${HOLA_OIDC_AUDIENCE:-}
+      - HOLA_OIDC_ADMIN_GROUP=${HOLA_OIDC_ADMIN_GROUP:-}
       # Base DN of the shared LDAP directory (for native-ldap apps); host/port
       # default to the authentik-ldap outpost service.
       - HOLA_AUTHENTIK_LDAP_BASE_DN=${HOLA_AUTHENTIK_LDAP_BASE_DN:-dc=hola,dc=internal}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@hola/shared": "workspace:*",
+    "jose": "^5.9.6",
     "yaml": "^2.9.0"
   },
   "devDependencies": {

--- a/packages/server/src/__tests__/auth/oidc-provider.test.ts
+++ b/packages/server/src/__tests__/auth/oidc-provider.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { SignJWT, exportJWK, generateKeyPair, type KeyLike } from 'jose';
+
+import { OidcAuthProvider } from '../../services/auth/oidc-provider';
+import { clearProvisionedOidc, resolveOidcConfig } from '../../config/oidc';
+
+const ISSUER = 'https://idp.test/application/o/hola-dashboard/';
+const JWKS_URI = 'https://idp.test/jwks';
+const CLIENT_ID = 'dashboard-client-123';
+const KID = 'test-key-1';
+
+let privateKey: KeyLike;
+let publicJwk: Record<string, unknown>;
+let realFetch: typeof globalThis.fetch;
+
+/** A fetch stub serving the OIDC discovery doc and the JWKS. */
+function installFetchStub() {
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    if (url.endsWith('/.well-known/openid-configuration')) {
+      return new Response(JSON.stringify({ issuer: ISSUER, jwks_uri: JWKS_URI }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    if (url === JWKS_URI) {
+      return new Response(JSON.stringify({ keys: [publicJwk] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    return new Response('not found', { status: 404 });
+  }) as typeof globalThis.fetch;
+}
+
+async function signToken(claims: {
+  iss?: string;
+  aud?: string | string[];
+  azp?: string;
+  expSecondsFromNow?: number;
+  sub?: string;
+  extra?: Record<string, unknown>;
+}): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  const exp = now + (claims.expSecondsFromNow ?? 300);
+  const builder = new SignJWT({ azp: claims.azp, ...claims.extra })
+    .setProtectedHeader({ alg: 'RS256', kid: KID })
+    .setIssuedAt(now)
+    .setExpirationTime(exp)
+    .setSubject(claims.sub ?? 'user-1');
+  if (claims.iss !== undefined) builder.setIssuer(claims.iss);
+  if (claims.aud !== undefined) builder.setAudience(claims.aud);
+  return builder.sign(privateKey);
+}
+
+describe('OidcAuthProvider', () => {
+  beforeEach(async () => {
+    const pair = await generateKeyPair('RS256');
+    privateKey = pair.privateKey;
+    publicJwk = { ...(await exportJWK(pair.publicKey)), kid: KID, alg: 'RS256', use: 'sig' };
+    realFetch = globalThis.fetch;
+    installFetchStub();
+    process.env.HOLA_OIDC_ISSUER = ISSUER;
+    process.env.HOLA_OIDC_CLIENT_ID = CLIENT_ID;
+    delete process.env.HOLA_OIDC_AUDIENCE;
+    delete process.env.HOLA_OIDC_ADMIN_GROUP;
+    clearProvisionedOidc();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    delete process.env.HOLA_OIDC_ISSUER;
+    delete process.env.HOLA_OIDC_CLIENT_ID;
+    delete process.env.HOLA_OIDC_AUDIENCE;
+    delete process.env.HOLA_OIDC_ADMIN_GROUP;
+    clearProvisionedOidc();
+  });
+
+  it('resolves config as enabled from env (issuer normalized with trailing slash)', () => {
+    process.env.HOLA_OIDC_ISSUER = 'https://idp.test/application/o/hola-dashboard';
+    const cfg = resolveOidcConfig();
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.issuer).toBe(ISSUER);
+    expect(cfg.audience).toBe(CLIENT_ID); // defaults to clientId
+  });
+
+  it('accepts a valid token (aud = clientId) and maps an admin principal', async () => {
+    const provider = new OidcAuthProvider();
+    const token = await signToken({ iss: ISSUER, aud: CLIENT_ID, sub: 'abc', extra: { email: 'a@b.c', name: 'Ada' } });
+    const res = await provider.authenticate(token);
+    expect(res.success).toBe(true);
+    expect(res.principal?.id).toBe('abc');
+    expect(res.principal?.email).toBe('a@b.c');
+    expect(res.principal?.capabilities).toContain('*');
+  });
+
+  it('accepts a token whose audience is in an array', async () => {
+    const provider = new OidcAuthProvider();
+    const token = await signToken({ iss: ISSUER, aud: ['other', CLIENT_ID] });
+    expect((await provider.authenticate(token)).success).toBe(true);
+  });
+
+  it('accepts a token that names the client only via azp', async () => {
+    const provider = new OidcAuthProvider();
+    const token = await signToken({ iss: ISSUER, aud: 'someone-else', azp: CLIENT_ID });
+    expect((await provider.authenticate(token)).success).toBe(true);
+  });
+
+  it('rejects a token whose audience/azp does not match the client', async () => {
+    const provider = new OidcAuthProvider();
+    const token = await signToken({ iss: ISSUER, aud: 'wrong-client' });
+    const res = await provider.authenticate(token);
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/audience/);
+  });
+
+  it('rejects a token with the wrong issuer', async () => {
+    const provider = new OidcAuthProvider();
+    const token = await signToken({ iss: 'https://evil.test/', aud: CLIENT_ID });
+    expect((await provider.authenticate(token)).success).toBe(false);
+  });
+
+  it('rejects an expired token', async () => {
+    const provider = new OidcAuthProvider();
+    const token = await signToken({ iss: ISSUER, aud: CLIENT_ID, expSecondsFromNow: -60 });
+    expect((await provider.authenticate(token)).success).toBe(false);
+  });
+
+  it('fails fast (not a JWT) for an opaque admin key, leaving it to other providers', async () => {
+    const provider = new OidcAuthProvider();
+    const res = await provider.authenticate('deadbeefcafe1234567890');
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/not a JWT/);
+  });
+
+  it('is disabled (fails closed) when no issuer/clientId is configured', async () => {
+    delete process.env.HOLA_OIDC_ISSUER;
+    delete process.env.HOLA_OIDC_CLIENT_ID;
+    const provider = new OidcAuthProvider();
+    const token = await signToken({ iss: ISSUER, aud: CLIENT_ID });
+    const res = await provider.authenticate(token);
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/not configured/);
+  });
+
+  it('maps a read-only principal when an admin group is required and absent', async () => {
+    process.env.HOLA_OIDC_ADMIN_GROUP = 'hola-admins';
+    const provider = new OidcAuthProvider();
+    const token = await signToken({ iss: ISSUER, aud: CLIENT_ID, extra: { groups: ['users'] } });
+    const res = await provider.authenticate(token);
+    expect(res.success).toBe(true);
+    expect(res.principal?.capabilities).not.toContain('*');
+    expect(res.principal?.capabilities).toContain('read:deployments');
+  });
+
+  it('maps an admin principal when the user is in the required admin group', async () => {
+    process.env.HOLA_OIDC_ADMIN_GROUP = 'hola-admins';
+    const provider = new OidcAuthProvider();
+    const token = await signToken({ iss: ISSUER, aud: CLIENT_ID, extra: { groups: ['hola-admins'] } });
+    const res = await provider.authenticate(token);
+    expect(res.principal?.capabilities).toContain('*');
+  });
+});

--- a/packages/server/src/__tests__/auth/session-cookie.test.ts
+++ b/packages/server/src/__tests__/auth/session-cookie.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'bun:test';
+
+import { readCookie, SESSION_COOKIE } from '../../middleware/auth';
+
+function reqWithCookie(cookie: string | null): Request {
+  const headers = new Headers();
+  if (cookie !== null) headers.set('cookie', cookie);
+  return new Request('https://app.example.com/api/deployments', { headers });
+}
+
+describe('readCookie', () => {
+  it('returns null when there is no Cookie header', () => {
+    expect(readCookie(reqWithCookie(null), SESSION_COOKIE)).toBeNull();
+  });
+
+  it('reads a single cookie value', () => {
+    expect(readCookie(reqWithCookie(`${SESSION_COOKIE}=abc123`), SESSION_COOKIE)).toBe('abc123');
+  });
+
+  it('reads the right cookie among several', () => {
+    const req = reqWithCookie(`theme=dark; ${SESSION_COOKIE}=secret-key; other=1`);
+    expect(readCookie(req, SESSION_COOKIE)).toBe('secret-key');
+  });
+
+  it('URL-decodes the cookie value', () => {
+    expect(readCookie(reqWithCookie(`${SESSION_COOKIE}=a%20b%3Dc`), SESSION_COOKIE)).toBe('a b=c');
+  });
+
+  it('returns null for an absent cookie name', () => {
+    expect(readCookie(reqWithCookie('theme=dark'), SESSION_COOKIE)).toBeNull();
+  });
+});

--- a/packages/server/src/__tests__/deployments/auth-provisioning.test.ts
+++ b/packages/server/src/__tests__/deployments/auth-provisioning.test.ts
@@ -28,6 +28,8 @@ import type {
   ProvisionInput,
   ProvisionResult,
   DeprovisionInput,
+  PlatformOidcInput,
+  PlatformOidcResult,
 } from '../../services/core/provisioner';
 import type { AppAuthConfig } from '@hola/shared';
 
@@ -125,6 +127,16 @@ class SpyProvisioner implements ProvisionerService {
 
   async deprovision(input: DeprovisionInput): Promise<void> {
     this.deprovisions.push(input);
+  }
+
+  async provisionPlatformOidc(input: PlatformOidcInput): Promise<PlatformOidcResult> {
+    const clientId = 'dashboard-cid';
+    return {
+      issuer: 'https://auth.example.com/application/o/hola-dashboard/',
+      clientId,
+      redirectUri: `https://${input.host}${input.redirectPath}`,
+      audience: clientId,
+    };
   }
 }
 

--- a/packages/server/src/config/oidc.ts
+++ b/packages/server/src/config/oidc.ts
@@ -1,0 +1,99 @@
+// OIDC configuration for the **dashboard's own** login (ADR 0001 follow-up).
+//
+// This is distinct from the per-app auth the ProvisionerService wires for catalog
+// apps: here the Hola web SPA is itself an OAuth2 public client (Authorization Code
+// + PKCE) against Authentik, and the server validates the resulting access-token
+// JWT (see services/auth/oidc-provider.ts).
+//
+// Config has two sources, merged with **env winning** so an operator can always
+// point the dashboard at an external IdP:
+//   1. Explicit env (HOLA_OIDC_*) — set by an operator or installer.
+//   2. Self-provisioned values — when HOLA_AUTH_MODE=authentik, the server creates
+//      a public OIDC client for the dashboard at startup and calls
+//      setProvisionedOidc() with the issuer/clientId it read back.
+// When neither yields an issuer+clientId, OIDC is disabled and the dashboard falls
+// back to the admin-key login.
+
+function stripTrailingSlash(url: string | undefined): string | undefined {
+  if (!url) return undefined;
+  return url.replace(/\/+$/, '');
+}
+
+/** Ensure an OIDC issuer ends with exactly one trailing slash (Authentik issuers do). */
+function normalizeIssuer(url: string | undefined): string | undefined {
+  const s = stripTrailingSlash(url);
+  return s ? `${s}/` : undefined;
+}
+
+export interface OidcConfig {
+  /** True when a usable issuer + clientId are resolved. */
+  enabled: boolean;
+  issuer?: string;
+  clientId?: string;
+  /** Expected token audience; defaults to clientId when unset. */
+  audience?: string;
+  /** Browser callback URL registered with the IdP. */
+  redirectUri?: string;
+  scopes: string[];
+  /**
+   * Optional Authentik group that grants full (write) capabilities. When set,
+   * users outside it authenticate as read-only. When unset, any user who obtains
+   * a valid token for the dashboard client is treated as admin (Authentik's
+   * application-access policy is then the sole gate).
+   */
+  adminGroup?: string;
+}
+
+/** Values discovered by self-provisioning the dashboard's OIDC client at startup. */
+export interface ProvisionedOidc {
+  issuer: string;
+  clientId: string;
+  redirectUri: string;
+  audience?: string;
+}
+
+let provisioned: ProvisionedOidc | undefined;
+
+/** Record the self-provisioned dashboard client so resolveOidcConfig() can use it. */
+export function setProvisionedOidc(values: ProvisionedOidc): void {
+  provisioned = {
+    ...values,
+    issuer: normalizeIssuer(values.issuer) ?? values.issuer,
+  };
+}
+
+/** Test/reset hook. */
+export function clearProvisionedOidc(): void {
+  provisioned = undefined;
+}
+
+function defaultScopes(): string[] {
+  const raw = process.env.HOLA_OIDC_SCOPES?.trim();
+  if (raw) return raw.split(/[,\s]+/).filter(Boolean);
+  return ['openid', 'profile', 'email'];
+}
+
+/**
+ * Resolve the effective dashboard OIDC config, env overriding self-provisioned.
+ * Reads process.env on each call so startup provisioning and tests are reflected
+ * without a process restart.
+ */
+export function resolveOidcConfig(): OidcConfig {
+  const issuer = normalizeIssuer(process.env.HOLA_OIDC_ISSUER) ?? provisioned?.issuer;
+  const clientId = process.env.HOLA_OIDC_CLIENT_ID?.trim() || provisioned?.clientId;
+  const redirectUri =
+    stripTrailingSlash(process.env.HOLA_OIDC_REDIRECT_URI) || provisioned?.redirectUri;
+  const audience =
+    process.env.HOLA_OIDC_AUDIENCE?.trim() || provisioned?.audience || clientId;
+  const adminGroup = process.env.HOLA_OIDC_ADMIN_GROUP?.trim() || undefined;
+
+  return {
+    enabled: Boolean(issuer && clientId),
+    issuer,
+    clientId,
+    audience,
+    redirectUri,
+    scopes: defaultScopes(),
+    adminGroup,
+  };
+}

--- a/packages/server/src/middleware/auth.ts
+++ b/packages/server/src/middleware/auth.ts
@@ -40,14 +40,38 @@ function extractToken(req: Request): string | null {
   if (apiKeyHeader) {
     return apiKeyHeader;
   }
-  
+
+  // Try the dashboard session cookie (admin-key fallback login sets this HttpOnly
+  // cookie so the SPA never holds the raw key in JS-readable storage).
+  const sessionCookie = readCookie(req, SESSION_COOKIE);
+  if (sessionCookie) {
+    return sessionCookie;
+  }
+
   // Try query parameter (less secure, for development)
   const url = new URL(req.url);
   const queryToken = url.searchParams.get('token') || url.searchParams.get('api_key');
   if (queryToken) {
     return queryToken;
   }
-  
+
+  return null;
+}
+
+/** Name of the HttpOnly session cookie used by the admin-key login fallback. */
+export const SESSION_COOKIE = 'hola_session';
+
+/** Read a single cookie value from the request's Cookie header. */
+export function readCookie(req: Request, name: string): string | null {
+  const header = req.headers.get('cookie');
+  if (!header) return null;
+  for (const part of header.split(';')) {
+    const eq = part.indexOf('=');
+    if (eq < 0) continue;
+    if (part.slice(0, eq).trim() === name) {
+      return decodeURIComponent(part.slice(eq + 1).trim());
+    }
+  }
   return null;
 }
 
@@ -62,6 +86,11 @@ function isPublicEndpoint(path: string, method: string): boolean {
     { path: '/api/system/health', method: 'GET' },
     { path: '/api/system/status', method: 'GET' },
     { path: '/api/echo', method: 'POST' }, // For testing
+    // Auth bootstrap: the SPA reads its login config and logs in before it has a
+    // credential, so these must be reachable without one.
+    { path: '/api/auth/config', method: 'GET' },
+    { path: '/api/auth/login', method: 'POST' },
+    { path: '/api/auth/logout', method: 'POST' },
   ];
   
   return publicEndpoints.some(endpoint => 

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -2,6 +2,8 @@ import {
   API,
   AUTH_API,
   type GetAuthMeResponse,
+  type AuthConfigResponse,
+  type AuthLoginResponse,
   type HealthResponse,
   type HelloResponse,
   type GetMeResponse,
@@ -61,7 +63,9 @@ import { createSSEStream, createSSEHeaders } from './utils/sse';
 import { mapErrorToResponse } from './middleware/error-mapping';
 
 // Phase 3: Authentication imports
-import { createAuthMiddleware, getPrincipal } from './middleware/auth';
+import { createAuthMiddleware, getPrincipal, SESSION_COOKIE } from './middleware/auth';
+import { resolveOidcConfig, setProvisionedOidc } from './config/oidc';
+import { authConfig } from './config/auth';
 
 // Import enhanced mock data
 import {
@@ -182,6 +186,13 @@ function withCors(res: Response) {
   headers.set('access-control-allow-origin', '*');
   headers.set('access-control-allow-methods', 'GET,POST,PATCH,PUT,DELETE,OPTIONS');
   headers.set('access-control-allow-headers', 'content-type,authorization,x-request-id');
+  // Re-copying headers via the Headers constructor can drop Set-Cookie on some
+  // runtimes; restore it explicitly so the login/logout cookie survives.
+  const setCookies = typeof res.headers.getSetCookie === 'function' ? res.headers.getSetCookie() : [];
+  if (setCookies.length > 0) {
+    headers.delete('set-cookie');
+    for (const c of setCookies) headers.append('set-cookie', c);
+  }
   return new Response(res.body, { status: res.status, statusText: res.statusText, headers });
 }
 
@@ -317,6 +328,65 @@ async function route(url: URL, req: Request): Promise<Response> {
     const me = getIdentity(req);
     if (!me) return json({ error: { code: 'UNAUTHORIZED', message: 'Authentication required' } }, { status: 401 });
     return json(me);
+  }
+
+  // Public: tell the dashboard how to authenticate (OIDC vs admin-key vs none).
+  if (pathname === AUTH_API.config && req.method === 'GET') {
+    const authRequired = featureFlags.useAuth;
+    if (!authRequired) {
+      return json({ authRequired: false, mode: 'none' } satisfies AuthConfigResponse);
+    }
+    const oidc = resolveOidcConfig();
+    if (oidc.enabled && oidc.issuer && oidc.clientId && oidc.redirectUri) {
+      return json({
+        authRequired: true,
+        mode: 'oidc',
+        oidc: {
+          issuer: oidc.issuer,
+          clientId: oidc.clientId,
+          redirectUri: oidc.redirectUri,
+          audience: oidc.audience ?? oidc.clientId,
+          scopes: oidc.scopes,
+        },
+      } satisfies AuthConfigResponse);
+    }
+    return json({ authRequired: true, mode: 'apikey' } satisfies AuthConfigResponse);
+  }
+
+  // Public: admin-key login fallback. Validates the key via the auth service and,
+  // on success, sets an HttpOnly session cookie so the SPA never stores the raw key.
+  if (pathname === AUTH_API.login && req.method === 'POST') {
+    if (!featureFlags.useAuth) {
+      // Nothing to log into; report success so the SPA proceeds.
+      return json({ ok: true, principal: getPrincipal(req) } as AuthLoginResponse);
+    }
+    let body: { key?: string };
+    try {
+      body = (await req.json()) as { key?: string };
+    } catch {
+      return json({ error: { code: 'BAD_JSON', message: 'Invalid JSON' } }, { status: 400 });
+    }
+    const key = body.key?.trim();
+    if (!key) {
+      return json({ error: { code: 'BAD_REQUEST', message: 'key is required' } }, { status: 400 });
+    }
+    const { auth } = getServices();
+    const result = await auth.authenticate(key, { path: pathname, method: req.method });
+    if (!result.success || !result.principal) {
+      return json({ error: { code: 'UNAUTHORIZED', message: 'Invalid key' } }, { status: 401 });
+    }
+    // Session cookie carries the key itself; it's HttpOnly+Secure+SameSite=Strict
+    // and same-origin with /api, so it can't be read by JS or sent cross-site.
+    const cookie = `${SESSION_COOKIE}=${encodeURIComponent(key)}; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=2592000`;
+    return json({ ok: true, principal: result.principal } satisfies AuthLoginResponse, {
+      headers: { 'set-cookie': cookie },
+    });
+  }
+
+  // Public: clear the admin-key session cookie.
+  if (pathname === AUTH_API.logout && req.method === 'POST') {
+    const cookie = `${SESSION_COOKIE}=; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=0`;
+    return json({ ok: true }, { headers: { 'set-cookie': cookie } });
   }
 
   // Summary
@@ -1610,6 +1680,49 @@ export async function createInProcessApp(options: InProcessAppOptions = {}): Pro
   };
 }
 
+/**
+ * Self-provision the dashboard's own OIDC client (best-effort, background).
+ *
+ * Only runs in production with auth on and HOLA_AUTH_MODE=authentik. Skips when
+ * the operator supplied explicit HOLA_OIDC_* env (external IdP). Authentik may
+ * still be migrating at first boot, so this retries with backoff and never blocks
+ * serving — until it succeeds, /api/auth/config reports the admin-key fallback.
+ */
+async function initializePlatformAuth(): Promise<void> {
+  if (!featureFlags.useAuth || authConfig.mode !== 'authentik') return;
+  if (process.env.HOLA_OIDC_ISSUER && process.env.HOLA_OIDC_CLIENT_ID) {
+    logger.info('Dashboard OIDC configured via env; skipping self-provision');
+    return;
+  }
+  const host = process.env.HOLA_DOMAIN?.trim();
+  if (!host) {
+    logger.warn('HOLA_DOMAIN unset; cannot self-provision the dashboard OIDC client');
+    return;
+  }
+
+  const { provisioner } = getServices();
+  const delaysMs = [0, 5_000, 15_000, 30_000, 60_000];
+  for (let i = 0; i < delaysMs.length; i++) {
+    if (delaysMs[i]) await new Promise((r) => setTimeout(r, delaysMs[i]));
+    try {
+      const result = await provisioner.provisionPlatformOidc({
+        host,
+        redirectPath: '/auth/callback',
+        scopes: resolveOidcConfig().scopes,
+      });
+      setProvisionedOidc(result);
+      logger.info('Dashboard OIDC client ready', { issuer: result.issuer, clientId: result.clientId });
+      return;
+    } catch (error) {
+      logger.warn('Dashboard OIDC provisioning attempt failed; will retry', {
+        attempt: i + 1,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+  logger.error('Gave up self-provisioning the dashboard OIDC client; using admin-key login until configured');
+}
+
 // Phase 0: Start background tasks
 async function startBackgroundTasks() {
   logger.info('Starting background tasks');
@@ -1652,7 +1765,10 @@ process.on('SIGTERM', () => {
 if (shouldAutoStart) {
   await initializeDevelopmentEnvironment();
   await startBackgroundTasks();
-  
+
+  // Self-provision the dashboard OIDC client in the background (best-effort).
+  void initializePlatformAuth();
+
   const server = Bun.serve({
     port: PORT,
     fetch: handleRequest,

--- a/packages/server/src/services/auth/oidc-provider.ts
+++ b/packages/server/src/services/auth/oidc-provider.ts
@@ -1,0 +1,156 @@
+/**
+ * OIDC auth provider — validates dashboard access-token JWTs (ADR 0001 follow-up).
+ *
+ * The web dashboard runs an Authorization Code + PKCE flow against Authentik and
+ * sends the resulting access token as `Authorization: Bearer <jwt>`. This provider
+ * verifies that JWT against the IdP's published JWKS:
+ *   - signature (RS256/ES256) via the issuer's discovery → jwks_uri
+ *   - `iss` exact match + `exp`/`nbf` (enforced by jose)
+ *   - audience: `aud` contains, or `azp`/`client_id` equals, the expected value
+ *     (Authentik's access-token audience shape varies, so we accept either)
+ *
+ * Config is resolved per-call from resolveOidcConfig(), so the provider can be
+ * registered once at startup and lights up when issuer/clientId become available
+ * (e.g. after self-provisioning). When OIDC is disabled it fails closed, letting
+ * the api-key provider handle the token instead.
+ */
+
+import { createRemoteJWKSet, jwtVerify, type JWTPayload, type JWTVerifyGetKey } from 'jose';
+
+import { getLogger } from '../../lib/logger';
+import { resolveOidcConfig, type OidcConfig } from '../../config/oidc';
+import type { AuthProvider, AuthResult, Principal } from './auth-service';
+
+/** Read-only capability set for authenticated-but-non-admin OIDC users. */
+const READONLY_CAPABILITIES = [
+  'read:system',
+  'read:deployments',
+  'read:logs',
+  'read:backups',
+  'read:catalog',
+];
+
+interface OidcClaims extends JWTPayload {
+  email?: string;
+  name?: string;
+  preferred_username?: string;
+  given_name?: string;
+  groups?: string[];
+  azp?: string;
+  client_id?: string;
+}
+
+export class OidcAuthProvider implements AuthProvider {
+  readonly name = 'oidc';
+  private logger = getLogger().child({ service: 'OidcAuthProvider' });
+
+  // Cache a remote JWKS per issuer; createRemoteJWKSet handles its own key caching
+  // and rotation. Keyed by jwks_uri so an issuer/config change rebuilds it.
+  private jwksByUri = new Map<string, JWTVerifyGetKey>();
+  // Cache discovered jwks_uri per issuer to avoid a discovery fetch on every token.
+  private jwksUriByIssuer = new Map<string, string>();
+
+  /** Allow tests/config changes to drop cached discovery + key sets. */
+  resetCache(): void {
+    this.jwksByUri.clear();
+    this.jwksUriByIssuer.clear();
+  }
+
+  async authenticate(token: string): Promise<AuthResult> {
+    const cfg = resolveOidcConfig();
+    if (!cfg.enabled || !cfg.issuer || !cfg.clientId) {
+      return { success: false, error: 'OIDC not configured' };
+    }
+    // Cheap pre-filter: only compact JWTs (header.payload.signature) are ours.
+    // Anything else (e.g. the admin API key) is left to other providers.
+    if (token.split('.').length !== 3) {
+      return { success: false, error: 'not a JWT' };
+    }
+
+    try {
+      const jwks = await this.getJwks(cfg.issuer);
+      const { payload } = await jwtVerify(token, jwks, { issuer: cfg.issuer });
+      const claims = payload as OidcClaims;
+
+      if (!this.audienceMatches(claims, cfg.audience ?? cfg.clientId)) {
+        this.logger.warn('OIDC token audience mismatch', { aud: claims.aud, azp: claims.azp });
+        return { success: false, error: 'token audience mismatch' };
+      }
+
+      return { success: true, principal: this.toPrincipal(claims, cfg) };
+    } catch (error) {
+      // Expired/invalid/wrong-issuer tokens land here; not an error worth raising.
+      this.logger.debug('OIDC token verification failed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return { success: false, error: 'invalid OIDC token' };
+    }
+  }
+
+  hasCapability(principal: Principal, capability: string): boolean {
+    return principal.capabilities.includes('*') || principal.capabilities.includes(capability);
+  }
+
+  async healthCheck(): Promise<boolean> {
+    return resolveOidcConfig().enabled;
+  }
+
+  private async getJwks(issuer: string): Promise<JWTVerifyGetKey> {
+    const jwksUri = await this.discoverJwksUri(issuer);
+    let set = this.jwksByUri.get(jwksUri);
+    if (!set) {
+      set = createRemoteJWKSet(new URL(jwksUri));
+      this.jwksByUri.set(jwksUri, set);
+    }
+    return set;
+  }
+
+  /** Resolve jwks_uri from the issuer's OIDC discovery document (cached). */
+  private async discoverJwksUri(issuer: string): Promise<string> {
+    const cached = this.jwksUriByIssuer.get(issuer);
+    if (cached) return cached;
+
+    // issuer is normalized to a trailing slash; the well-known path joins cleanly.
+    const discoveryUrl = `${issuer}.well-known/openid-configuration`;
+    const res = await fetch(discoveryUrl, { headers: { Accept: 'application/json' } });
+    if (!res.ok) throw new Error(`OIDC discovery failed: ${res.status} ${discoveryUrl}`);
+    const doc = (await res.json()) as { jwks_uri?: string };
+    if (!doc.jwks_uri) throw new Error('OIDC discovery document has no jwks_uri');
+
+    this.jwksUriByIssuer.set(issuer, doc.jwks_uri);
+    return doc.jwks_uri;
+  }
+
+  /** Accept the token if its audience, azp, or client_id names our client. */
+  private audienceMatches(claims: OidcClaims, expected: string): boolean {
+    const aud = claims.aud;
+    if (typeof aud === 'string' && aud === expected) return true;
+    if (Array.isArray(aud) && aud.includes(expected)) return true;
+    if (claims.azp === expected) return true;
+    if (claims.client_id === expected) return true;
+    return false;
+  }
+
+  private toPrincipal(claims: OidcClaims, cfg: OidcConfig): Principal {
+    const groups = Array.isArray(claims.groups) ? claims.groups : [];
+    // Admin unless an admin group is configured and the user isn't in it.
+    const isAdmin = !cfg.adminGroup || groups.includes(cfg.adminGroup);
+    const name =
+      claims.name || claims.preferred_username || claims.given_name || claims.email || 'OIDC User';
+
+    return {
+      id: String(claims.sub ?? name),
+      type: 'user',
+      name,
+      email: claims.email,
+      roles: isAdmin ? ['admin'] : ['user'],
+      capabilities: isAdmin ? ['*'] : [...READONLY_CAPABILITIES],
+      metadata: { provider: 'oidc', groups },
+    };
+  }
+}
+
+/** Factory mirroring createAdminApiKeyProvider for symmetric wiring. */
+export function createOidcAuthProvider(): OidcAuthProvider {
+  return new OidcAuthProvider();
+}

--- a/packages/server/src/services/core/provisioner.ts
+++ b/packages/server/src/services/core/provisioner.ts
@@ -63,11 +63,40 @@ export interface DeprovisionInput {
   ref?: ProvisionedAuthRef;
 }
 
+/** Input for provisioning the Hola dashboard's OWN OIDC client (not a deployed app). */
+export interface PlatformOidcInput {
+  /** The dashboard's external host (HOLA_DOMAIN), e.g. `app.example.com`. */
+  host: string;
+  /** Browser callback path the SPA handles, e.g. `/auth/callback`. */
+  redirectPath: string;
+  /** OIDC scopes to grant, e.g. ['openid','profile','email']. */
+  scopes: string[];
+}
+
+/** The dashboard OIDC client details, read back for the server + SPA to use. */
+export interface PlatformOidcResult {
+  issuer: string;
+  clientId: string;
+  redirectUri: string;
+  audience: string;
+}
+
 export interface ProvisionerService extends HealthCheckable {
   provision(input: ProvisionInput): Promise<ProvisionResult>;
   deprovision(input: DeprovisionInput): Promise<void>;
+  /**
+   * Idempotently ensure a PUBLIC (PKCE) OIDC client for the dashboard itself and
+   * return its issuer/clientId. Stable across restarts (keyed on a fixed slug), so
+   * re-running reuses the same client. The dashboard is a public SPA client, so no
+   * client secret is issued.
+   */
+  provisionPlatformOidc(input: PlatformOidcInput): Promise<PlatformOidcResult>;
   healthCheck(): Promise<ServiceHealth>;
 }
+
+// Fixed identifiers for the dashboard's own OIDC client (stable → idempotent).
+const DASHBOARD_SLUG = 'hola-dashboard';
+const DASHBOARD_NAME = 'Hola Dashboard';
 
 // ---------------------------------------------------------------------------
 // Authentik REST backend
@@ -110,6 +139,8 @@ const PROVISIONER_PERMISSIONS = [
   'authentik_outposts.view_outpost',
   'authentik_outposts.change_outpost',
   'authentik_flows.view_flow',
+  // Read certificate-keypairs to pick a signing key for the dashboard OIDC client.
+  'authentik_crypto.view_certificatekeypair',
 ];
 
 /** Sanitize a string into an Authentik slug (lowercase, alnum + hyphen). */
@@ -259,6 +290,92 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
   private issuerUrl(slug: string): string {
     const base = this.config.authentikPublicUrl || this.config.authentikUrl || '';
     return `${base}/application/o/${slug}/`;
+  }
+
+  // ---- platform (dashboard) OIDC ----------------------------------------
+
+  async provisionPlatformOidc(input: PlatformOidcInput): Promise<PlatformOidcResult> {
+    const redirectUri = `https://${input.host}${input.redirectPath}`;
+    const issuer = this.issuerUrl(DASHBOARD_SLUG);
+
+    // Idempotent: if the dashboard application already exists, reuse its provider
+    // (keeping a stable client_id across restarts) and just refresh the redirect URI.
+    const existing = await this.findApplication(DASHBOARD_SLUG);
+    if (existing?.provider != null) {
+      const provider = await this.api<AuthentikOAuth2Provider>('GET', `/api/v3/providers/oauth2/${existing.provider}/`);
+      await this.api('PATCH', `/api/v3/providers/oauth2/${existing.provider}/`, {
+        redirect_uris: [{ matching_mode: 'strict', url: redirectUri }],
+      });
+      this.logger.info('Reused dashboard OIDC client', { clientId: provider.client_id });
+      return { issuer, clientId: provider.client_id, redirectUri, audience: provider.client_id };
+    }
+
+    // Fresh provision: a PUBLIC client (PKCE, no usable secret) with an asymmetric
+    // signing key so access tokens are verifiable JWTs (RS256) via JWKS.
+    const clientId = randomUUID();
+    const [authFlow, invalidationFlow, propertyMappings, signingKey] = await Promise.all([
+      this.resolveFlowPk(AUTHZ_FLOW_SLUG, 'authorization'),
+      this.resolveFlowPk(INVALIDATION_FLOW_SLUG, 'invalidation'),
+      this.resolveScopeMappingPks(input.scopes),
+      this.resolveSigningKeyPk(),
+    ]);
+
+    const provider = await this.api<AuthentikOAuth2Provider>('POST', '/api/v3/providers/oauth2/', {
+      name: DASHBOARD_NAME,
+      authorization_flow: authFlow,
+      invalidation_flow: invalidationFlow,
+      client_type: 'public',
+      client_id: clientId,
+      redirect_uris: [{ matching_mode: 'strict', url: redirectUri }],
+      property_mappings: propertyMappings,
+      sub_mode: 'hashed_user_id',
+      ...(signingKey ? { signing_key: signingKey } : {}),
+    });
+
+    try {
+      await this.api('POST', '/api/v3/core/applications/', {
+        name: DASHBOARD_NAME,
+        slug: DASHBOARD_SLUG,
+        provider: provider.pk,
+        meta_launch_url: `https://${input.host}/`,
+      });
+    } catch (error) {
+      await this.apiDeleteIgnoreMissing(`/api/v3/providers/oauth2/${provider.pk}/`);
+      throw new ProvisioningError('failed to create dashboard Authentik application', error);
+    }
+
+    this.logger.info('Provisioned dashboard OIDC client', { clientId, providerPk: provider.pk });
+    return { issuer, clientId, redirectUri, audience: clientId };
+  }
+
+  /** Look up an application by slug, returning null when absent (404). */
+  private async findApplication(slug: string): Promise<{ provider: number | null } | null> {
+    try {
+      return await this.api<{ provider: number | null }>(
+        'GET',
+        `/api/v3/core/applications/${encodeURIComponent(slug)}/`,
+      );
+    } catch (error) {
+      const status = error instanceof ProvisioningError ? (error.details as { status?: number })?.status : undefined;
+      if (status === 404) return null;
+      throw error;
+    }
+  }
+
+  /** Pick a certificate-keypair to sign tokens with (Authentik ships a default). */
+  private async resolveSigningKeyPk(): Promise<string | undefined> {
+    try {
+      const res = await this.api<{ results: Array<{ pk: string }> }>(
+        'GET',
+        '/api/v3/crypto/certificatekeypairs/?has_key=true&ordering=name',
+      );
+      return res.results?.[0]?.pk;
+    } catch (error) {
+      this.logger.warn('Could not resolve a signing key for the dashboard client; tokens may be opaque', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return undefined;
+    }
   }
 
   // ---- forward-auth ------------------------------------------------------
@@ -646,5 +763,15 @@ export class MockProvisionerService implements ProvisionerService {
 
   async deprovision(input: DeprovisionInput): Promise<void> {
     this.logger.debug('Mock deprovision', { deploymentId: input.deploymentId, mode: input.ref?.mode });
+  }
+
+  async provisionPlatformOidc(input: PlatformOidcInput): Promise<PlatformOidcResult> {
+    const clientId = 'mock-dashboard-client';
+    return {
+      issuer: `https://auth.mock/application/o/${DASHBOARD_SLUG}/`,
+      clientId,
+      redirectUri: `https://${input.host}${input.redirectPath}`,
+      audience: clientId,
+    };
   }
 }

--- a/packages/server/src/services/core/provisioner.ts
+++ b/packages/server/src/services/core/provisioner.ts
@@ -119,6 +119,10 @@ const PROVISIONER_PERMISSIONS = [
   'authentik_providers_oauth2.view_oauth2provider',
   'authentik_providers_oauth2.change_oauth2provider',
   'authentik_providers_oauth2.delete_oauth2provider',
+  // Read OAuth2 scope mappings to attach openid/profile/email to provisioned
+  // clients (the generic core.view_propertymapping is insufficient for the
+  // provider/scope subclass endpoint — Authentik returns 403 without this).
+  'authentik_providers_oauth2.view_scopemapping',
   'authentik_providers_proxy.add_proxyprovider',
   'authentik_providers_proxy.view_proxyprovider',
   'authentik_providers_proxy.change_proxyprovider',
@@ -303,8 +307,17 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
     const existing = await this.findApplication(DASHBOARD_SLUG);
     if (existing?.provider != null) {
       const provider = await this.api<AuthentikOAuth2Provider>('GET', `/api/v3/providers/oauth2/${existing.provider}/`);
+      // Self-heal on every startup: refresh the redirect URI, and (re)attach the
+      // scope mappings + signing key so a client created before a permission/config
+      // fix converges without manual deletion.
+      const [propertyMappings, signingKey] = await Promise.all([
+        this.resolveScopeMappingPks(input.scopes),
+        this.resolveSigningKeyPk(),
+      ]);
       await this.api('PATCH', `/api/v3/providers/oauth2/${existing.provider}/`, {
         redirect_uris: [{ matching_mode: 'strict', url: redirectUri }],
+        ...(propertyMappings.length ? { property_mappings: propertyMappings } : {}),
+        ...(signingKey ? { signing_key: signingKey } : {}),
       });
       this.logger.info('Reused dashboard OIDC client', { clientId: provider.client_id });
       return { issuer, clientId: provider.client_id, redirectUri, audience: provider.client_id };

--- a/packages/server/src/services/simple-factory.ts
+++ b/packages/server/src/services/simple-factory.ts
@@ -13,6 +13,7 @@ import { RealDatabaseService, MockDatabaseService, type DatabaseService } from '
 import { RealDatabaseConfigService, type DatabaseConfigService } from './core/database-config';
 import { RealAuthService, MockAuthService, type AuthService } from './auth/auth-service';
 import { resolveAdminApiKey, createAdminApiKeyProvider } from './auth/api-key-config';
+import { createOidcAuthProvider } from './auth/oidc-provider';
 import { RealDockerService, MockDockerService, type DockerService } from './core/docker';
 import { RealSystemMonitoringService, MockSystemMonitoringService, type SystemMonitoringService } from './core/system-monitoring';
 import { RealLoggingService, MockLoggingService, type LoggingService } from './core/logging';
@@ -151,9 +152,13 @@ export function createServices(env: ServiceEnvironment): Services {
   
   const catalog = new RealCatalogService();
   
-  // Set up auth provider for real auth service
-  // Register the admin API-key provider with a usable credential (env or generated+persisted).
+  // Set up auth providers for real auth service. Order matters: the api-key
+  // provider runs first (cheap map lookup for the admin key / CLI tokens); the
+  // OIDC provider runs second and validates dashboard Bearer JWTs. The OIDC
+  // provider self-disables until an issuer/clientId is configured (e.g. after
+  // startup self-provisioning), so registering it unconditionally is safe.
   authService.registerProvider(createAdminApiKeyProvider(resolveAdminApiKey()));
+  authService.registerProvider(createOidcAuthProvider());
   
   // Shared routing service owns Traefik rule generation/validation/emission.
   const routing = new RealRoutingService(storage);

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -157,13 +157,41 @@ export const CAPABILITIES = {
 export type Capability = typeof CAPABILITIES[keyof typeof CAPABILITIES];
 
 // Auth API endpoints.
-// pt.1 (control-plane API keys) implements `me`. Session/SSO endpoints
-// (login/logout/refresh) arrive with application SSO in MVP pt.2 (ADR 0001).
+// `me` returns the current principal. `config` is an UNAUTHENTICATED endpoint the
+// web dashboard reads at boot to learn how to log in (OIDC vs admin-key). `login`/
+// `logout` back the admin-key session fallback (sets/clears an HttpOnly cookie);
+// the OIDC path exchanges codes in the browser and sends a Bearer JWT instead.
 export const AUTH_API = {
   me: '/api/auth/me',
+  config: '/api/auth/config',
+  login: '/api/auth/login',
+  logout: '/api/auth/logout',
 } as const;
 
 export type GetAuthMeResponse = Principal;
+
+/**
+ * GET /api/auth/config — tells the dashboard how to authenticate. Served without
+ * auth so the SPA can fetch it before it has a credential.
+ *  - `mode: 'none'`   — auth disabled (HOLA_USE_AUTH=false); the SPA loads directly.
+ *  - `mode: 'oidc'`   — run the Authorization Code + PKCE flow against `oidc`.
+ *  - `mode: 'apikey'` — auth on but no OIDC; the SPA shows an admin-key login.
+ */
+export type AuthConfigResponse = {
+  authRequired: boolean;
+  mode: 'none' | 'oidc' | 'apikey';
+  oidc?: {
+    issuer: string;
+    clientId: string;
+    redirectUri: string;
+    audience: string;
+    scopes: string[];
+  };
+};
+
+// POST /api/auth/login — admin-key session fallback.
+export type AuthLoginRequest = { key: string };
+export type AuthLoginResponse = { ok: true; principal: Principal };
 
 // GET /api/me
 export type GetMeResponse = Principal;

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -17,6 +17,7 @@
     "@hola/sdk": "workspace:*",
     "@hola/shared": "workspace:*",
     "lucide-react": "^1.18.0",
+    "oidc-client-ts": "^3.5.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-router-dom": "^7.17.0"

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,6 +1,8 @@
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import { AppShell } from './components/layout/AppShell';
+import { RequireAuth } from './components/auth/RequireAuth';
 import { ThemeProvider } from './hooks/useTheme';
+import { AuthProvider } from './hooks/useAuth';
 import { Dashboard } from './pages/Dashboard';
 import { Apps } from './pages/Apps';
 import { Catalog } from './pages/Catalog';
@@ -10,27 +12,45 @@ import { InstallWizard } from './pages/InstallWizard';
 import { Backups } from './pages/Backups';
 import { Notifications } from './pages/Notifications';
 import { Settings } from './pages/Settings';
+import { Login } from './pages/Login';
+import { AuthCallback } from './pages/AuthCallback';
 
 function App() {
   return (
     <ThemeProvider>
       <Router>
-        <div className="min-h-screen bg-surface-0 text-text-strong">
-          <AppShell>
-            <Routes>
-              <Route path="/" element={<Navigate to="/apps" replace />} />
-              <Route path="/apps" element={<Apps />} />
-              <Route path="/dashboard" element={<Dashboard />} />
-              <Route path="/catalog" element={<Catalog />} />
-              <Route path="/catalog/:appId/install" element={<InstallWizard />} />
-              <Route path="/deployments" element={<Deployments />} />
-              <Route path="/deployments/:deploymentId" element={<DeploymentDetail />} />
-              <Route path="/backups" element={<Backups />} />
-              <Route path="/notifications" element={<Notifications />} />
-              <Route path="/settings" element={<Settings />} />
-            </Routes>
-          </AppShell>
-        </div>
+        <AuthProvider>
+          <Routes>
+            {/* Public auth routes (outside the guard). */}
+            <Route path="/login" element={<Login />} />
+            <Route path="/auth/callback" element={<AuthCallback />} />
+
+            {/* Everything else requires authentication. */}
+            <Route
+              path="/*"
+              element={
+                <RequireAuth>
+                  <div className="min-h-screen bg-surface-0 text-text-strong">
+                    <AppShell>
+                      <Routes>
+                        <Route path="/" element={<Navigate to="/apps" replace />} />
+                        <Route path="/apps" element={<Apps />} />
+                        <Route path="/dashboard" element={<Dashboard />} />
+                        <Route path="/catalog" element={<Catalog />} />
+                        <Route path="/catalog/:appId/install" element={<InstallWizard />} />
+                        <Route path="/deployments" element={<Deployments />} />
+                        <Route path="/deployments/:deploymentId" element={<DeploymentDetail />} />
+                        <Route path="/backups" element={<Backups />} />
+                        <Route path="/notifications" element={<Notifications />} />
+                        <Route path="/settings" element={<Settings />} />
+                      </Routes>
+                    </AppShell>
+                  </div>
+                </RequireAuth>
+              }
+            />
+          </Routes>
+        </AuthProvider>
       </Router>
     </ThemeProvider>
   );

--- a/packages/web/src/components/auth/RequireAuth.tsx
+++ b/packages/web/src/components/auth/RequireAuth.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { Loader2 } from 'lucide-react';
+
+import { useAuth } from '../../hooks/useAuth';
+
+/**
+ * Gate for the authenticated app. Shows a spinner while the auth mode/session is
+ * resolving, redirects to /login when unauthenticated (remembering where the user
+ * was headed), and renders the app once authenticated.
+ */
+export const RequireAuth: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { status } = useAuth();
+  const location = useLocation();
+
+  if (status === 'loading') {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-surface-0">
+        <Loader2 className="w-6 h-6 text-primary animate-spin" />
+      </div>
+    );
+  }
+
+  if (status === 'unauthenticated') {
+    return <Navigate to="/login" replace state={{ from: location.pathname + location.search }} />;
+  }
+
+  return <>{children}</>;
+};
+
+export default RequireAuth;

--- a/packages/web/src/components/layout/Topbar.tsx
+++ b/packages/web/src/components/layout/Topbar.tsx
@@ -1,7 +1,16 @@
 import React from 'react';
 import { useLocation } from 'react-router-dom';
-import { Search, Moon, Sun } from 'lucide-react';
+import { Search, Moon, Sun, LogOut } from 'lucide-react';
 import { useTheme } from '../../hooks/useTheme';
+import { useAuth } from '../../hooks/useAuth';
+
+/** Two-letter initials from a name/email for the avatar. */
+function initials(label: string | undefined): string {
+  if (!label) return 'av';
+  const parts = label.split(/[\s@.]+/).filter(Boolean);
+  const chars = (parts[0]?.[0] ?? '') + (parts[1]?.[0] ?? '');
+  return (chars || label.slice(0, 2)).toLowerCase();
+}
 
 const TITLES: Record<string, { title: string; crumb: string }> = {
   '/apps': { title: 'Your apps', crumb: 'Installed applications' },
@@ -24,7 +33,10 @@ function pageInfo(pathname: string): { title: string; crumb: string } {
 export const Topbar: React.FC = () => {
   const location = useLocation();
   const { applied, toggle } = useTheme();
+  const { user, mode, logout } = useAuth();
   const { title, crumb } = pageInfo(location.pathname);
+  const showAccount = mode !== null && mode !== 'none';
+  const label = user?.name || user?.email;
 
   return (
     <header className="h-[60px] flex-none flex items-center gap-4 px-[22px] border-b border-border bg-surface-0/80 backdrop-blur-md z-[5]">
@@ -60,10 +72,22 @@ export const Topbar: React.FC = () => {
         {applied === 'dark' ? <Sun className="w-[18px] h-[18px]" /> : <Moon className="w-[18px] h-[18px]" />}
       </button>
 
-      {/* Avatar */}
-      <div className="w-9 h-9 flex-none flex items-center justify-center bg-surface-2 border border-border rounded-[9px] text-text-strong font-semibold text-[13px] cursor-pointer">
-        av
+      {/* Avatar + sign out (only when auth is enabled) */}
+      <div
+        className="w-9 h-9 flex-none flex items-center justify-center bg-surface-2 border border-border rounded-[9px] text-text-strong font-semibold text-[13px]"
+        title={label ?? 'Account'}
+      >
+        {initials(label)}
       </div>
+      {showAccount && (
+        <button
+          onClick={() => { void logout(); }}
+          title="Sign out"
+          className="w-9 h-9 flex-none flex items-center justify-center bg-surface-1 border border-border rounded-[9px] text-text-muted cursor-pointer hover:text-danger hover:border-danger transition-colors"
+        >
+          <LogOut className="w-[18px] h-[18px]" />
+        </button>
+      )}
     </header>
   );
 };

--- a/packages/web/src/hooks/useAuth.tsx
+++ b/packages/web/src/hooks/useAuth.tsx
@@ -1,0 +1,208 @@
+/* eslint-disable react-refresh/only-export-components -- provider + hook are intentionally colocated */
+import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
+import { UserManager, WebStorageStateStore, type User } from 'oidc-client-ts';
+import type { AuthConfigResponse, Principal } from '@hola/shared';
+
+import { getWebBaseUrl } from '../utils/sdk-adapter';
+import { setAuthTokenGetter, setUnauthorizedHandler } from '../utils/auth-token';
+
+/**
+ * Dashboard authentication. Reads /api/auth/config at boot to learn the mode:
+ *   - none   → auth disabled; the app loads directly.
+ *   - oidc   → Authorization Code + PKCE against Authentik (oidc-client-ts); the
+ *              access token is sent as a Bearer header by the fetch layer.
+ *   - apikey → admin-key fallback; login posts the key, the server sets an
+ *              HttpOnly session cookie, and we authenticate by cookie thereafter.
+ */
+
+export type AuthStatus = 'loading' | 'authenticated' | 'unauthenticated';
+export type AuthMode = 'none' | 'oidc' | 'apikey';
+
+export interface AuthUser {
+  name?: string;
+  email?: string;
+}
+
+interface AuthContextValue {
+  status: AuthStatus;
+  mode: AuthMode | null;
+  user: AuthUser | null;
+  /** OIDC: start the redirect. apikey: pass the admin key. */
+  login: (key?: string) => Promise<void>;
+  logout: () => Promise<void>;
+  /** Last login error (e.g. wrong admin key), cleared on the next attempt. */
+  loginError: string | null;
+  /** Completes the OIDC redirect; called by the /auth/callback route. */
+  completeOidcLogin: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+/** Same-origin in prod (nginx) / via the Vite proxy in dev; absolute only in tests. */
+function apiUrl(path: string): string {
+  return `${getWebBaseUrl()}${path}`;
+}
+
+function buildUserManager(oidc: NonNullable<AuthConfigResponse['oidc']>): UserManager {
+  return new UserManager({
+    // oidc-client-ts appends /.well-known/openid-configuration; strip the trailing
+    // slash the Authentik issuer carries so we don't get a doubled slash.
+    authority: oidc.issuer.replace(/\/$/, ''),
+    client_id: oidc.clientId,
+    redirect_uri: oidc.redirectUri,
+    response_type: 'code',
+    scope: oidc.scopes.join(' '),
+    automaticSilentRenew: true,
+    userStore: new WebStorageStateStore({ store: window.localStorage }),
+    post_logout_redirect_uri: `${window.location.origin}/login`,
+  });
+}
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [status, setStatus] = useState<AuthStatus>('loading');
+  const [mode, setMode] = useState<AuthMode | null>(null);
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [loginError, setLoginError] = useState<string | null>(null);
+
+  const managerRef = useRef<UserManager | null>(null);
+  const accessTokenRef = useRef<string | undefined>(undefined);
+
+  // Keep the fetch layer's token getter pointed at the current OIDC access token.
+  useEffect(() => {
+    setAuthTokenGetter(() => accessTokenRef.current);
+    return () => setAuthTokenGetter(undefined);
+  }, []);
+
+  const applyOidcUser = useCallback((u: User | null) => {
+    if (u && !u.expired) {
+      accessTokenRef.current = u.access_token;
+      setUser({ name: u.profile?.name, email: u.profile?.email });
+      setStatus('authenticated');
+    } else {
+      accessTokenRef.current = undefined;
+      setStatus('unauthenticated');
+    }
+  }, []);
+
+  // Boot: discover the auth mode and resolve the initial session.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      let config: AuthConfigResponse;
+      try {
+        const res = await fetch(apiUrl('/api/auth/config'), { credentials: 'include' });
+        config = (await res.json()) as AuthConfigResponse;
+      } catch {
+        // Can't reach the server — treat as unauthenticated so the UI can show an error.
+        if (!cancelled) { setMode('apikey'); setStatus('unauthenticated'); }
+        return;
+      }
+      if (cancelled) return;
+      setMode(config.mode);
+
+      if (config.mode === 'none') {
+        setStatus('authenticated');
+        return;
+      }
+
+      if (config.mode === 'oidc' && config.oidc) {
+        const manager = buildUserManager(config.oidc);
+        managerRef.current = manager;
+        // Refresh the in-memory token when silent-renew issues a new one.
+        manager.events.addUserLoaded((u) => applyOidcUser(u));
+        manager.events.addUserUnloaded(() => applyOidcUser(null));
+        try {
+          applyOidcUser(await manager.getUser());
+        } catch {
+          if (!cancelled) setStatus('unauthenticated');
+        }
+        return;
+      }
+
+      // apikey: probe whether the session cookie already authenticates us.
+      try {
+        const me = await fetch(apiUrl('/api/auth/me'), { credentials: 'include' });
+        if (!cancelled) {
+          if (me.ok) {
+            const principal = (await me.json()) as Principal;
+            setUser({ name: principal.name, email: principal.email });
+            setStatus('authenticated');
+          } else {
+            setStatus('unauthenticated');
+          }
+        }
+      } catch {
+        if (!cancelled) setStatus('unauthenticated');
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [applyOidcUser]);
+
+  // On a 401 from any API call, drop to unauthenticated so the guard shows login.
+  useEffect(() => {
+    setUnauthorizedHandler(() => {
+      accessTokenRef.current = undefined;
+      // 'none' mode can't 401; ignore so we never trap a no-auth dev server.
+      setStatus((s) => (mode === 'none' ? s : 'unauthenticated'));
+    });
+    return () => setUnauthorizedHandler(undefined);
+  }, [mode]);
+
+  const login = useCallback(async (key?: string) => {
+    setLoginError(null);
+    if (mode === 'oidc') {
+      await managerRef.current?.signinRedirect();
+      return;
+    }
+    if (mode === 'apikey') {
+      if (!key) { setLoginError('Enter your admin key.'); return; }
+      try {
+        const res = await fetch(apiUrl('/api/auth/login'), {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ key }),
+        });
+        if (!res.ok) { setLoginError('That key was not accepted.'); return; }
+        const data = (await res.json()) as { principal?: Principal };
+        setUser({ name: data.principal?.name, email: data.principal?.email });
+        setStatus('authenticated');
+      } catch {
+        setLoginError('Could not reach the server.');
+      }
+    }
+  }, [mode]);
+
+  const logout = useCallback(async () => {
+    if (mode === 'oidc') {
+      const m = managerRef.current;
+      accessTokenRef.current = undefined;
+      try { await m?.signoutRedirect(); }
+      catch { await m?.removeUser(); setStatus('unauthenticated'); }
+      return;
+    }
+    if (mode === 'apikey') {
+      try { await fetch(apiUrl('/api/auth/logout'), { method: 'POST', credentials: 'include' }); }
+      finally { setUser(null); setStatus('unauthenticated'); }
+    }
+  }, [mode]);
+
+  const completeOidcLogin = useCallback(async () => {
+    const m = managerRef.current;
+    if (!m) throw new Error('OIDC is not configured');
+    const u = await m.signinRedirectCallback();
+    applyOidcUser(u);
+  }, [applyOidcUser]);
+
+  return (
+    <AuthContext.Provider value={{ status, mode, user, login, logout, loginError, completeOidcLogin }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within an AuthProvider');
+  return ctx;
+}

--- a/packages/web/src/pages/AuthCallback.tsx
+++ b/packages/web/src/pages/AuthCallback.tsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useState } from 'react';
+import { Navigate, useNavigate } from 'react-router-dom';
+import { Loader2 } from 'lucide-react';
+
+import { useAuth } from '../hooks/useAuth';
+
+/**
+ * OIDC redirect landing page (/auth/callback). Once the AuthProvider has built
+ * its UserManager (mode resolves to 'oidc'), exchange the authorization code and
+ * return to the app. Any other mode means we shouldn't be here — go home.
+ */
+export const AuthCallback: React.FC = () => {
+  const { mode, completeOidcLogin } = useAuth();
+  const navigate = useNavigate();
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+
+  useEffect(() => {
+    if (mode !== 'oidc') return;
+    let cancelled = false;
+    (async () => {
+      try {
+        await completeOidcLogin();
+        if (!cancelled) { setDone(true); navigate('/', { replace: true }); }
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Sign-in failed.');
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [mode, completeOidcLogin, navigate]);
+
+  // Server isn't using OIDC (or auth is off) — nothing to complete here.
+  if (mode && mode !== 'oidc') return <Navigate to="/" replace />;
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-surface-0 text-text-strong px-4">
+      <div className="flex flex-col items-center gap-3 animate-fadein">
+        {error ? (
+          <>
+            <p className="text-danger text-sm" role="alert">{error}</p>
+            <button
+              onClick={() => navigate('/login', { replace: true })}
+              className="h-9 px-4 bg-surface-2 border border-border rounded-[9px] text-sm hover:border-primary transition"
+            >
+              Back to sign in
+            </button>
+          </>
+        ) : (
+          <>
+            <Loader2 className="w-6 h-6 text-primary animate-spin" />
+            <p className="text-text-muted text-sm">{done ? 'Signed in.' : 'Completing sign-in…'}</p>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default AuthCallback;

--- a/packages/web/src/pages/Login.tsx
+++ b/packages/web/src/pages/Login.tsx
@@ -1,0 +1,115 @@
+import React, { useState } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { KeyRound, ShieldCheck, LogIn } from 'lucide-react';
+
+import { useAuth } from '../hooks/useAuth';
+
+/**
+ * Login screen. Adapts to the server's auth mode:
+ *  - oidc   → a single "Sign in with SSO" button (redirects to Authentik).
+ *  - apikey → an admin-key field that posts to the session-login endpoint.
+ * Already-authenticated users (or auth-disabled servers) are bounced to the app.
+ */
+export const Login: React.FC = () => {
+  const { status, mode, login, loginError } = useAuth();
+  const location = useLocation();
+  const [key, setKey] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  if (status === 'authenticated') {
+    const from = (location.state as { from?: string } | null)?.from ?? '/';
+    return <Navigate to={from} replace />;
+  }
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    try {
+      await login(key);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const onSso = async () => {
+    setSubmitting(true);
+    try {
+      await login();
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-surface-0 text-text-strong px-4">
+      <div className="w-full max-w-[380px] animate-fadein">
+        <div className="flex items-center gap-3 mb-7 justify-center">
+          <div className="w-10 h-10 rounded-[11px] bg-primary/15 border border-primary/30 flex items-center justify-center">
+            <ShieldCheck className="w-5 h-5 text-primary" />
+          </div>
+          <div className="font-semibold text-[20px] tracking-[-0.01em]">Hola</div>
+        </div>
+
+        <div className="bg-surface-1 border border-border rounded-[15px] p-7 shadow-xl">
+          <h1 className="text-[17px] font-semibold mb-1">Sign in</h1>
+          <p className="text-text-muted text-[13px] mb-6">
+            {mode === 'oidc'
+              ? 'Continue with your single sign-on provider.'
+              : 'Enter the admin API key for this deployment.'}
+          </p>
+
+          {mode === 'oidc' ? (
+            <button
+              onClick={onSso}
+              disabled={submitting}
+              className="w-full flex items-center justify-center gap-2 h-11 px-4 bg-primary text-white rounded-[10px] text-sm font-semibold shadow-primary-glow hover:brightness-110 transition disabled:opacity-60"
+            >
+              <LogIn className="w-[18px] h-[18px]" />
+              {submitting ? 'Redirecting…' : 'Sign in with SSO'}
+            </button>
+          ) : (
+            <form onSubmit={onSubmit} className="flex flex-col gap-3">
+              <label className="text-[12px] font-medium text-text-muted" htmlFor="adminKey">
+                Admin key
+              </label>
+              <div className="relative">
+                <KeyRound className="w-4 h-4 text-text-faint absolute left-3 top-1/2 -translate-y-1/2" />
+                <input
+                  id="adminKey"
+                  type="password"
+                  autoFocus
+                  autoComplete="current-password"
+                  value={key}
+                  onChange={(e) => setKey(e.target.value)}
+                  placeholder="hola admin key"
+                  className="w-full h-11 bg-surface-0 border border-border rounded-[9px] text-text-strong pl-9 pr-3 text-[13px] font-mono outline-none focus:border-primary"
+                />
+              </div>
+              <button
+                type="submit"
+                disabled={submitting || !key}
+                className="w-full flex items-center justify-center gap-2 h-11 px-4 bg-primary text-white rounded-[10px] text-sm font-semibold shadow-primary-glow hover:brightness-110 transition disabled:opacity-60"
+              >
+                {submitting ? 'Signing in…' : 'Sign in'}
+              </button>
+            </form>
+          )}
+
+          {loginError && (
+            <p className="mt-4 text-[12px] text-danger" role="alert">
+              {loginError}
+            </p>
+          )}
+        </div>
+
+        <p className="text-center text-text-faint text-[11px] mt-5">
+          {mode === 'apikey'
+            ? 'Find the key on the host: docker compose exec server cat /data/config/admin-api-key'
+            : 'Authenticated by your organization’s identity provider.'}
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default Login;

--- a/packages/web/src/utils/auth-token.ts
+++ b/packages/web/src/utils/auth-token.ts
@@ -1,0 +1,35 @@
+/**
+ * Bridge between the React auth layer (useAuth) and the non-React fetch layer.
+ *
+ * The API clients (sdk-adapter, api.ts) both funnel through safeFetchEnhanced,
+ * which lives outside React. This module lets the AuthProvider register:
+ *   - a token getter — returns the current OIDC access token (Bearer), if any;
+ *     the admin-key fallback uses an HttpOnly cookie instead, so it returns none.
+ *   - an unauthorized handler — invoked when an API call returns 401 so the app
+ *     can drop to the login screen (e.g. a token expired and refresh failed).
+ */
+
+type TokenGetter = () => string | undefined;
+
+let tokenGetter: TokenGetter | undefined;
+let unauthorizedHandler: (() => void) | undefined;
+
+/** Register (or clear) the source of the current Bearer access token. */
+export function setAuthTokenGetter(getter: TokenGetter | undefined): void {
+  tokenGetter = getter;
+}
+
+/** The current Bearer access token, or undefined (cookie/no-auth modes). */
+export function getAuthToken(): string | undefined {
+  return tokenGetter?.();
+}
+
+/** Register (or clear) the handler invoked when an API call returns 401. */
+export function setUnauthorizedHandler(handler: (() => void) | undefined): void {
+  unauthorizedHandler = handler;
+}
+
+/** Signal that an authenticated request was rejected (token expired/invalid). */
+export function notifyUnauthorized(): void {
+  unauthorizedHandler?.();
+}

--- a/packages/web/src/utils/error-enhanced.ts
+++ b/packages/web/src/utils/error-enhanced.ts
@@ -3,6 +3,8 @@
 
 import type { ErrorResponse as SharedErrorResponse } from '@hola/shared';
 
+import { getAuthToken, notifyUnauthorized } from './auth-token';
+
 export type ErrorResponse = SharedErrorResponse;
 
 // Error classification for different handling strategies
@@ -326,14 +328,38 @@ export async function enhancedFetch(
   throw lastError;
 }
 
+/** True for our own auth bootstrap endpoints, which must not trigger re-auth loops. */
+function isAuthEndpoint(input: RequestInfo | URL): boolean {
+  const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+  return url.includes('/api/auth/');
+}
+
 // Enhanced safeFetch replacement with retry support
 export async function safeFetchEnhanced(
   input: RequestInfo | URL,
   init?: RequestInit,
   retryConfig?: Partial<RetryConfig>
 ): Promise<Response> {
+  // Attach auth: a Bearer access token for the OIDC flow (cookie auth needs none),
+  // and always send same-origin credentials so the admin-key session cookie rides
+  // along. The token getter is registered by the React AuthProvider.
+  const token = getAuthToken();
+  const withAuth: RequestInit = { credentials: 'include', ...init };
+  if (token) {
+    const headers = new Headers(withAuth.headers);
+    if (!headers.has('Authorization')) headers.set('Authorization', `Bearer ${token}`);
+    withAuth.headers = headers;
+  }
+
   try {
-    return await enhancedFetch(input, init, retryConfig);
+    const res = await enhancedFetch(input, withAuth, retryConfig);
+    // A 401 on a real API call means our credential is gone/expired — let the app
+    // drop to login. Ignore the auth endpoints themselves (login returning 401 is
+    // a normal "wrong key", not a session expiry).
+    if (res.status === 401 && !isAuthEndpoint(input)) {
+      notifyUnauthorized();
+    }
+    return res;
   } catch (err) {
     // Ensure we always throw an EnhancedError
     if (err instanceof Error && !(err as EnhancedError).type) {

--- a/packages/web/src/utils/sdk-adapter.ts
+++ b/packages/web/src/utils/sdk-adapter.ts
@@ -32,7 +32,7 @@ import { globalCache, CacheTTL } from './cache';
 import { safeFetchEnhanced, createEnhancedError, type EnhancedError } from './error-enhanced';
 
 // Environment-based configuration for SDK
-function getWebBaseUrl(): string {
+export function getWebBaseUrl(): string {
   // Check for explicit Vite environment variable first
   if (typeof import.meta !== 'undefined' && import.meta.env?.VITE_API_BASE_URL) {
     return import.meta.env.VITE_API_BASE_URL;


### PR DESCRIPTION
## Why

The web dashboard sent **no credential** while the server enforced auth (`HOLA_USE_AUTH=true`), so every `/api` call returned `401 Authentication required` in production. The dashboard only worked with auth disabled (dev). This adds a real login path.

The SPA reads `GET /api/auth/config` (unauthenticated) at boot and picks one of three modes: `none` (auth off), `oidc`, or `apikey`.

## Phase 1 — admin-key fallback (works on any install, no Authentik)

- `GET /api/auth/config` advertises the mode.
- `POST /api/auth/login` validates the admin key and sets an `HttpOnly; Secure; SameSite=Strict` **session cookie**; `extractToken` reads it; `POST /api/auth/logout` clears it. The raw key never lives in browser-readable storage.
- SPA: `AuthProvider` + `RequireAuth` guard + `Login` screen. Closes the production 401 gap immediately.

## Phase 2 — full OIDC Authorization Code + PKCE (Authentik)

- **`OidcAuthProvider`** (jose): discovery → JWKS signature verify, `iss`/`exp` enforcement, resilient audience matching (`aud` / `azp` / `client_id`), optional `HOLA_OIDC_ADMIN_GROUP` → capability mapping. Registered after the api-key provider; fails closed when unconfigured (so the admin key still works).
- **Self-provisioning**: `provisionPlatformOidc()` idempotently creates a **public PKCE** OIDC client + app for the dashboard in Authentik (stable `hola-dashboard` slug, RS256 signing key), read back at startup and fed to `/api/auth/config`. Background retry with backoff for Authentik's first-boot migrations.
- **SPA**: `oidc-client-ts` `UserManager`, `/auth/callback` route, in-memory access token injected as `Bearer` through the shared fetch layer, silent renew, Topbar sign-out. External IdP supported via `HOLA_OIDC_ISSUER` / `HOLA_OIDC_CLIENT_ID`.

The two phases share one config endpoint, so the default install stops 401-ing in Phase 1 and SSO layers on without SPA rework.

## Config

Compose passthrough + `.env.example` + `docs/OPERATIONS.md` updated. With `HOLA_AUTH_MODE=authentik` the dashboard SSO client is auto-provisioned (login becomes "Sign in with SSO"); set `HOLA_OIDC_ISSUER`/`HOLA_OIDC_CLIENT_ID` to point at an external IdP instead.

## Tests

New unit tests (17) cover JWT validation — valid, expired, wrong-issuer, audience-via-`azp`, non-JWT pass-through, disabled-fails-closed — plus group→capability mapping and cookie parsing, using **real RS256 signing against a mocked JWKS**. Full suite green: 265 server + 127 web, typecheck, lint, build. (The one remaining `tsc` error in `authentik-provision.it.ts` is a pre-existing bun/vitest typing mismatch, identical on `main`.)

## Notes / follow-ups

- **Needs a live check:** Authentik must emit CORS on its token endpoint for the dashboard origin (it derives allowed origins from the client's redirect URIs, so this should work for a public client) and issue JWT access tokens. Verified everything offline; the true end-to-end against a running Authentik still needs a test-host run.
- **Default authz:** an authenticated OIDC user is admin unless `HOLA_OIDC_ADMIN_GROUP` is set (Authentik's app-access policy is then the gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)