### PR TITLE
chore: release candidate 0.5.0-rc.1

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -32,7 +32,18 @@ jobs:
 
       - name: Resolve version
         id: ver
-        run: echo "version=${GITHUB_REF_NAME#cli-v}" >> "$GITHUB_OUTPUT"
+        run: |
+          VERSION="${GITHUB_REF_NAME#cli-v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          # A pre-release version (e.g. 0.5.0-rc.1) must not move the :latest tag —
+          # only stable releases become the default a fresh `docker compose up` pulls.
+          if [[ "$VERSION" == *-* ]]; then
+            echo "server_tags=ghcr.io/try-hola/server:$VERSION" >> "$GITHUB_OUTPUT"
+            echo "web_tags=ghcr.io/try-hola/web:$VERSION" >> "$GITHUB_OUTPUT"
+          else
+            echo "server_tags=ghcr.io/try-hola/server:$VERSION,ghcr.io/try-hola/server:latest" >> "$GITHUB_OUTPUT"
+            echo "web_tags=ghcr.io/try-hola/web:$VERSION,ghcr.io/try-hola/web:latest" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -54,9 +65,7 @@ jobs:
           file: packages/server/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            ghcr.io/try-hola/server:${{ steps.ver.outputs.version }}
-            ghcr.io/try-hola/server:latest
+          tags: ${{ steps.ver.outputs.server_tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -67,9 +76,7 @@ jobs:
           file: packages/web/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            ghcr.io/try-hola/web:${{ steps.ver.outputs.version }}
-            ghcr.io/try-hola/web:latest
+          tags: ${{ steps.ver.outputs.web_tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -92,7 +99,11 @@ jobs:
 
       - name: Resolve version
         id: ver
-        run: echo "version=${GITHUB_REF_NAME#cli-v}" >> "$GITHUB_OUTPUT"
+        run: |
+          VERSION="${GITHUB_REF_NAME#cli-v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          # Pre-release versions (e.g. 0.5.0-rc.1) are published as GitHub prereleases.
+          [[ "$VERSION" == *-* ]] && echo "prerelease=true" >> "$GITHUB_OUTPUT" || echo "prerelease=false" >> "$GITHUB_OUTPUT"
 
       - name: Compile binaries (cross-target)
         run: |
@@ -123,6 +134,7 @@ jobs:
           # Create the release if it does not exist, then upload (clobbering) the assets.
           if ! gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
             gh release create "$GITHUB_REF_NAME" \
+              ${{ steps.ver.outputs.prerelease == 'true' && '--prerelease' || '' }} \
               --title "Hola CLI $GITHUB_REF_NAME" \
               --notes "Standalone \`hola\` CLI binaries. Install with:
           \`\`\`

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.4.1",
+  "version": "0.5.0-rc.1",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.4.1';
+export const CLI_VERSION = '0.5.0-rc.1';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.4.1",
+  "version": "0.5.0-rc.1",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.4.1",
+  "version": "0.5.0-rc.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.4.1",
+  "version": "0.5.0-rc.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.4.1",
+  "version": "0.5.0-rc.1",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
First release candidate for **0.5.0**, cutting the install-wizard + mock-data-removal work from #158.

## Changes
- Bump synced packages (cli, sdk, server, compose, shared) and the CLI `--version` banner to `0.5.0-rc.1`.
- Make `cli-release.yml` prerelease-aware: an `-rc` tag pushes the server/web images **only** under their version tag (not `:latest`, so a fresh `docker compose up` still pulls the last stable), and the GitHub Release is marked as a prerelease.

## Release
After merge, tag `cli-v0.5.0-rc.1` on `main` to trigger the release workflow (multi-arch GHCR images `ghcr.io/try-hola/{server,web}:0.5.0-rc.1` + CLI binaries + a prerelease GitHub Release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)