### PR TITLE
chore(release): 0.5.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.5.0-rc.1",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.5.0-rc.1';
+export const CLI_VERSION = '0.5.0';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.5.0-rc.1",
+  "version": "0.5.0",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.5.0-rc.1",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.5.0-rc.1",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.5.0-rc.1",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Promotes `0.5.0-rc.1` to the stable **0.5.0** release.

Bumps the version across all published packages (`cli`, `sdk`, `server`, `shared`, `compose`) plus `cli/src/version.ts`. `web` stays unversioned by convention.

Once merged, push the `cli-v0.5.0` tag to trigger the release workflow. Since the version has no `-` suffix, the workflow will:
- publish `ghcr.io/try-hola/{server,web}:0.5.0` **and** move `:latest` to it
- cut a non-prerelease GitHub Release with the compose bundle + CLI binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.5.0 across the entire package ecosystem, including the CLI, Compose, SDK, Server, and Shared packages. This release marks the graduation from the 0.5.0-rc.1 release candidate to a stable, production-ready final version with all components achieving version parity for enhanced compatibility, stability, and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->