### PR TITLE
fix(auth): pin embedded outpost browser host; show app product name on tiles

### DIFF
--- a/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
+++ b/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
@@ -263,6 +263,13 @@ describe('RealAuthentikProvisionerService (REST contract)', () => {
     expect(patch).toBeDefined();
     expect((patch.body as { providers: number[] }).providers).toContain(55);
 
+    // Outpost's browser host is pinned to the public Authentik URL, otherwise it
+    // defaults to http://0.0.0.0:9000 and forward-auth login redirects 302 to a
+    // host the user's browser can't reach.
+    const cfg = (patch.body as { config?: Record<string, unknown> }).config;
+    expect(cfg?.authentik_host).toBe('https://auth.example.com');
+    expect(cfg?.authentik_host_browser).toBe('https://auth.example.com');
+
     // Returns a middleware descriptor pointing at the internal outpost URL.
     expect(result.middleware?.outpostUrl).toBe('http://authentik-server:9000');
     expect(result.ref).toMatchObject({ mode: 'forward-auth', providerPk: 55, outpostPk: 1 });

--- a/packages/server/src/services/core/provisioner.ts
+++ b/packages/server/src/services/core/provisioner.ts
@@ -448,7 +448,9 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
 
   /** Add a proxy provider to the embedded outpost; returns the outpost pk. */
   private async addProviderToEmbeddedOutpost(providerPk: number): Promise<number | undefined> {
-    const list = await this.api<{ results: Array<{ pk: number; providers: number[] }> }>(
+    const list = await this.api<{
+      results: Array<{ pk: number; providers: number[]; config?: Record<string, unknown> }>;
+    }>(
       'GET',
       `/api/v3/outposts/instances/?name__iexact=${encodeURIComponent('authentik Embedded Outpost')}`
     );
@@ -458,7 +460,26 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
       return undefined;
     }
     const providers = Array.from(new Set([...(outpost.providers ?? []), providerPk]));
-    await this.api('PATCH', `/api/v3/outposts/instances/${outpost.pk}/`, { providers });
+    const patch: Record<string, unknown> = { providers };
+
+    // The embedded outpost defaults its browser-facing host to `http://0.0.0.0:9000`
+    // (Authentik's internal bind address). That value is unroutable from a user's
+    // browser, so every forward-auth app would 302 the OAuth `authorize` redirect to
+    // a dead address. Pin the outpost's host to the public Authentik URL so the login
+    // redirect resolves. Merge into the existing config (PATCH replaces it wholesale).
+    const publicUrl = this.config.authentikPublicUrl;
+    if (publicUrl) {
+      patch.config = {
+        ...(outpost.config ?? {}),
+        authentik_host: publicUrl,
+        authentik_host_browser: publicUrl,
+      };
+    } else {
+      this.logger.warn(
+        'authentikPublicUrl is not set; embedded outpost browser redirects may point at an unroutable host. Set HOLA_AUTHENTIK_PUBLIC_URL.',
+      );
+    }
+    await this.api('PATCH', `/api/v3/outposts/instances/${outpost.pk}/`, patch);
     return outpost.pk;
   }
 

--- a/packages/web/src/__tests__/pages/Apps.test.tsx
+++ b/packages/web/src/__tests__/pages/Apps.test.tsx
@@ -37,9 +37,9 @@ function mockApi(deployments: unknown[], catalog: unknown[]) {
 const renderApps = () => render(<MemoryRouter><Apps /></MemoryRouter>);
 
 describe('Apps landing', () => {
-  it('lists installed apps with a link to the public URL and catalog icon', async () => {
+  it('shows the catalog product name (not the deployment name) and links to the public URL', async () => {
     mockApi(
-      [{ id: 'gitea-abc12345', name: 'Gitea', app: 'gitea', icon: '📦', status: 'running', ports: [], lastUpdated: 'now', url: 'https://gitea.local.hola' }],
+      [{ id: 'gitea-abc12345', name: 'deployment-gitea-abc12345', app: 'gitea', icon: '📦', status: 'running', ports: [], lastUpdated: 'now', url: 'https://gitea.local.hola' }],
       [{ id: 'gitea', name: 'Gitea', description: '', icon: '🍵', category: 'apps', rating: 0, downloads: 0, tags: [], featured: false }],
     );
 
@@ -49,6 +49,8 @@ describe('Apps landing', () => {
     expect(link).toHaveAttribute('href', 'https://gitea.local.hola');
     expect(link).toHaveAttribute('target', '_blank');
     expect(screen.getByText('Gitea')).toBeInTheDocument();
+    // The deployment's internal name must NOT be shown.
+    expect(screen.queryByText('deployment-gitea-abc12345')).not.toBeInTheDocument();
     expect(screen.getByText('🍵')).toBeInTheDocument(); // catalog icon wins over fallback
     expect(screen.getByText('Running')).toBeInTheDocument(); // status pill label
   });
@@ -56,29 +58,35 @@ describe('Apps landing', () => {
   it('renders every installed app, not just running ones', async () => {
     mockApi(
       [
-        { id: 'a-1', name: 'RunningApp', app: 'a', icon: '📦', status: 'running', ports: [], lastUpdated: 'now', url: 'https://a.local.hola' },
-        { id: 'b-1', name: 'StoppedApp', app: 'b', icon: '📦', status: 'stopped', ports: [], lastUpdated: 'now' },
+        { id: 'a-1', name: 'deployment-a-1', app: 'a', icon: '📦', status: 'running', ports: [], lastUpdated: 'now', url: 'https://a.local.hola' },
+        { id: 'b-1', name: 'deployment-b-1', app: 'b', icon: '📦', status: 'stopped', ports: [], lastUpdated: 'now' },
       ],
-      [],
+      [
+        { id: 'a', name: 'Alpha', description: '', icon: '📦', category: 'apps', rating: 0, downloads: 0, tags: [], featured: false },
+        { id: 'b', name: 'Bravo', description: '', icon: '📦', category: 'apps', rating: 0, downloads: 0, tags: [], featured: false },
+      ],
     );
 
     renderApps();
 
-    // Running app opens externally; stopped app links to its detail page.
-    expect(await screen.findByTitle('Open RunningApp')).toHaveAttribute('href', 'https://a.local.hola');
-    expect(screen.getByTitle('StoppedApp')).toHaveAttribute('href', '/deployments/b-1');
+    // Running app opens externally; stopped app links to its detail page. Tiles
+    // show the catalog product name.
+    expect(await screen.findByTitle('Open Alpha')).toHaveAttribute('href', 'https://a.local.hola');
+    expect(screen.getByTitle('Bravo')).toHaveAttribute('href', '/deployments/b-1');
   });
 
-  it('falls back to the deployment detail link when no URL is set', async () => {
+  it('falls back to the app id when the catalog has no match', async () => {
     mockApi(
-      [{ id: 'x-1', name: 'NoUrl', app: 'x', icon: '📦', status: 'installing', ports: [], lastUpdated: 'now' }],
+      [{ id: 'x-1', name: 'deployment-x-1', app: 'uptime-kuma', icon: '📦', status: 'installing', ports: [], lastUpdated: 'now' }],
       [],
     );
 
     renderApps();
 
-    const link = await screen.findByTitle('NoUrl');
+    // No catalog entry → fall back to the app id, never the deployment name.
+    const link = await screen.findByTitle('uptime-kuma');
     expect(link).toHaveAttribute('href', '/deployments/x-1');
+    expect(screen.queryByText('deployment-x-1')).not.toBeInTheDocument();
   });
 
   it('shows an empty state when nothing is installed', async () => {

--- a/packages/web/src/pages/Apps.tsx
+++ b/packages/web/src/pages/Apps.tsx
@@ -24,10 +24,16 @@ export const Apps: React.FC = () => {
   const { data: deploymentsData, loading, error } = useDeploymentsApi(DEPLOYMENTS_PARAMS);
   const { data: catalogData } = useCatalogAppsApi(CATALOG_PARAMS);
 
-  // Join app id -> catalog icon so tiles show the real app glyph, not a fallback.
+  // Join app id -> catalog icon + display name so tiles show the real app glyph
+  // and product name (e.g. "Uptime Kuma"), not the deployment's internal name.
   const iconByApp = React.useMemo(() => {
     const map = new Map<string, string>();
     for (const app of catalogData?.items ?? []) map.set(app.id, app.icon);
+    return map;
+  }, [catalogData]);
+  const nameByApp = React.useMemo(() => {
+    const map = new Map<string, string>();
+    for (const app of catalogData?.items ?? []) map.set(app.id, app.name);
     return map;
   }, [catalogData]);
 
@@ -70,17 +76,20 @@ export const Apps: React.FC = () => {
         <div className="grid gap-4 grid-cols-[repeat(auto-fill,minmax(212px,1fr))]">
           {apps.map((app) => {
             const icon = iconByApp.get(app.app) || app.icon || '';
+            // Prefer the catalog product name; fall back to the app id (always
+            // readable) before the deployment's internal name.
+            const displayName = nameByApp.get(app.app) || app.app || app.name;
             const openable = app.status === 'running' && !!app.url;
 
             const tile = (
               <div className="group relative h-full bg-surface-1 border border-border rounded-[14px] p-[22px] transition hover:-translate-y-[3px] hover:border-primary hover:shadow-elevation-4">
                 <div className="flex items-start justify-between">
-                  <AppIcon name={app.name} emoji={icon} size={54} />
+                  <AppIcon name={displayName} emoji={icon} size={54} />
                   {openable && (
                     <ExternalLink className="w-4 h-4 text-text-faint group-hover:text-primary transition-colors" />
                   )}
                 </div>
-                <div className="mt-4 font-semibold text-base truncate">{app.name}</div>
+                <div className="mt-4 font-semibold text-base truncate">{displayName}</div>
                 <div className="mt-2">
                   <StatusBadge status={app.status} />
                 </div>
@@ -96,13 +105,13 @@ export const Apps: React.FC = () => {
                 href={app.url!}
                 target="_blank"
                 rel="noopener noreferrer"
-                title={`Open ${app.name}`}
+                title={`Open ${displayName}`}
                 className="block"
               >
                 {tile}
               </a>
             ) : (
-              <Link key={app.id} to={`/deployments/${app.id}`} title={app.name} className="block">
+              <Link key={app.id} to={`/deployments/${app.id}`} title={displayName} className="block">
                 {tile}
               </Link>
             );


### PR DESCRIPTION
Both fixes came out of investigating a report that a forward-auth app tile in **Your apps** "doesn't look right, and clicking it doesn't work."

## 1. Forward-auth apps were unreachable (the real "doesn't work")
Probing a running forward-auth app showed it 302s the OAuth flow to:
```
location: http://0.0.0.0:9000/application/o/authorize/?client_id=...
```
`http://0.0.0.0:9000` is Authentik's **internal bind address** — unroutable from a browser. The embedded outpost defaults its browser-facing host to that value, and `addProviderToEmbeddedOutpost` only ever PATCHed `providers`, never the outpost's `config.authentik_host`. So every forward-auth app redirected login to a dead address.

**Fix:** when binding a provider to the embedded outpost, also pin `config.authentik_host` and `config.authentik_host_browser` to the public Authentik URL (`HOLA_AUTHENTIK_PUBLIC_URL`), merged into the existing config (PATCH replaces it wholesale). Idempotent — it self-heals on the next provision — and warns if the public URL is unset. Covered by a new assertion in the provisioner contract test.

## 2. Tiles showed the deployment's internal name
`Apps.tsx` rendered `app.name` (e.g. `deployment-uptime-kuma-…`) instead of the catalog product name. It now joins app id → catalog title (falling back to the app id, then the deployment name) for both the label and the icon.

## Testing
- `bun --cwd packages/server test authentik-contract` — 10 pass (incl. the new outpost-host assertions).
- `packages/web` typecheck clean; `packages/server` typecheck clean apart from a **pre-existing** unrelated error in `authentik-provision.it.ts` (a `beforeAll(fn, timeout)` arity issue present on `main`).

## Live remediation
The code fix applies to future provisions. Existing forward-auth deployments need the embedded outpost's host set once (re-provision, or a one-time Authentik API PATCH) — see PR discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)