### PR TITLE
chore(release): 0.5.1

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.5.0';
+export const CLI_VERSION = '0.5.1';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Patch release rolling up **#163** (forward-auth embedded-outpost host fix + app-tile product name).

Bumps all published packages `0.5.0` → `0.5.1` (`cli`, `sdk`, `server`, `shared`, `compose`) plus `cli/src/version.ts`. `web` stays unversioned by convention.

Once merged, push `cli-v0.5.1` to trigger the release workflow. No `-` suffix, so it publishes `ghcr.io/try-hola/{server,web}:0.5.1` **and** moves `:latest`, and cuts a non-prerelease GitHub Release.

After it's out, the test host can pull `:0.5.1` and the forward-auth outpost host gets set automatically on the next provision (no manual Authentik edit needed going forward).

🤖 Generated with [Claude Code](https://claude.com/claude-code)