### PR TITLE
fix: name deployments after the app, not "deployment-<id>"

### DIFF
--- a/packages/server/src/__tests__/deployments/persistence.test.ts
+++ b/packages/server/src/__tests__/deployments/persistence.test.ts
@@ -187,6 +187,14 @@ describe('Deployment persistence (real service)', () => {
     expect(rollback.previousReleaseId).toBe(promoted.releaseId);
   });
 
+  test('a deployment created without a name defaults to the app slug', async () => {
+    const { drafts, deployments } = makeSystem();
+    const created = await deployments.createFromDraft({ draftId: await finalizedDraft(drafts), options: { autoStart: false } });
+    const detail = await deployments.getDeployment(created.deploymentId);
+    // Not an opaque "deployment-<id>" placeholder — the UI shows the app.
+    expect(detail.name).toBe('gitea');
+  });
+
   test('a failed promotion leaves the previous release active', async () => {
     const { storage, drafts, deployments } = makeSystem();
     const dep = await deployments.createFromDraft({ draftId: await finalizedDraft(drafts), options: { autoStart: false } });

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -447,7 +447,9 @@ abstract class InMemoryDeploymentService implements DeploymentService {
 
       const deployment: EnhancedDeploymentDetail = {
         id: deploymentId,
-        name: request.name || `deployment-${deploymentId.slice(0, 8)}`,
+        // Default to the app slug (e.g. "uptime-kuma") so the UI shows the app,
+        // not an opaque "deployment-<id>" placeholder. A caller-supplied name wins.
+        name: request.name || app,
         app,
         icon: '📦',
         status: 'installing',

--- a/packages/web/src/pages/Deployments.tsx
+++ b/packages/web/src/pages/Deployments.tsx
@@ -18,6 +18,7 @@ import type {
 } from '@hola/shared';
 import { api } from '../utils/api';
 import { useDeploymentsApi } from '../hooks/useDeploymentsApi';
+import { useCatalogAppsApi } from '../hooks/useCatalogApi';
 import { AppIcon } from '../components/ui/AppIcon';
 import { StatusBadge } from '../components/ui/StatusBadge';
 
@@ -60,6 +61,15 @@ export const Deployments: React.FC = () => {
 
   const deployments = deploymentsResponse?.items || [];
   const totalDeployments = deploymentsResponse?.total || 0;
+
+  // Join app id -> catalog product name + glyph so the "App" column shows the
+  // real app (e.g. "Uptime Kuma" 📈), not a "deployment-<id>" placeholder.
+  const { data: catalogData } = useCatalogAppsApi({ page: 1, limit: 100 });
+  const appMeta = React.useMemo(() => {
+    const map = new Map<string, { name: string; icon: string }>();
+    for (const app of catalogData?.items ?? []) map.set(app.id, { name: app.name, icon: app.icon });
+    return map;
+  }, [catalogData]);
 
   const handleAction = useCallback(async (deploymentId: string, action: 'start' | 'stop' | 'restart') => {
     try {
@@ -205,15 +215,19 @@ export const Deployments: React.FC = () => {
           </div>
 
           {/* Body rows */}
-          {deployments.map((deployment) => (
+          {deployments.map((deployment) => {
+            const meta = appMeta.get(deployment.app);
+            const displayName = meta?.name || deployment.app || deployment.name;
+            const displayIcon = meta?.icon || deployment.icon;
+            return (
             <div
               key={deployment.id}
               onClick={() => navigate(`/deployments/${deployment.id}`)}
               className={`${GRID_COLS} py-[13px] border-b border-border-soft items-center cursor-pointer hover:bg-surface-2`}
             >
               <div className="flex items-center gap-[11px] min-w-0">
-                <AppIcon name={deployment.name} emoji={deployment.icon} size={34} />
-                <span className="font-semibold text-sm truncate">{deployment.name}</span>
+                <AppIcon name={displayName} emoji={displayIcon} size={34} />
+                <span className="font-semibold text-sm truncate">{displayName}</span>
               </div>
               <div>
                 <StatusBadge status={deployment.status} />
@@ -262,7 +276,8 @@ export const Deployments: React.FC = () => {
                 </button>
               </div>
             </div>
-          ))}
+            );
+          })}
 
           {/* Empty state */}
           {deployments.length === 0 && (


### PR DESCRIPTION
## Why
The app tiles / Deployments table showed names like **`deployment-uptime-k`** and **`deployment-gitea-f4`**.

Root cause: a deployment created without an explicit name defaults to `` `deployment-${deploymentId.slice(0, 8)}` `` (`deployment.ts:450`). The deployment id is `<app-slug>-<hash>`, so its first 8 chars (`uptime-k`, `gitea-f4`) get that `deployment-` prefix — and the install wizard never passes a name, so every install hit the placeholder.

## Fix
- **Server:** default the name to the **app slug** (`uptime-kuma`) instead of `deployment-<id>`. A caller-supplied name still wins. New test asserts the default.
- **Web (Deployments table):** the **App** column now joins the catalog to show the product name + glyph (e.g. "Uptime Kuma" 📈), falling back to the app id, then the deployment name — so even already-installed deployments display correctly regardless of their stored name. Mirrors the Apps-tile fix from #163.

## Testing
- `bun --cwd packages/server test deployments/persistence` — 9 pass (incl. new default-name case).
- `packages/web` typecheck + tests clean (127 pass); `packages/server` typecheck clean apart from the pre-existing `authentik-provision.it.ts` arity error on `main`.

Note: existing deployments keep their stored `deployment-…` name in data, but the Deployments table now shows the catalog product name regardless. New installs get the app-slug name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)