### PR TITLE
fix(logs): remove fabricated log data from the Logs tab

### DIFF
--- a/packages/server/src/__tests__/deployments/persistence.test.ts
+++ b/packages/server/src/__tests__/deployments/persistence.test.ts
@@ -187,6 +187,14 @@ describe('Deployment persistence (real service)', () => {
     expect(rollback.previousReleaseId).toBe(promoted.releaseId);
   });
 
+  test('a deployment created without a name defaults to the app slug', async () => {
+    const { drafts, deployments } = makeSystem();
+    const created = await deployments.createFromDraft({ draftId: await finalizedDraft(drafts), options: { autoStart: false } });
+    const detail = await deployments.getDeployment(created.deploymentId);
+    // Not an opaque "deployment-<id>" placeholder — the UI shows the app.
+    expect(detail.name).toBe('gitea');
+  });
+
   test('a failed promotion leaves the previous release active', async () => {
     const { storage, drafts, deployments } = makeSystem();
     const dep = await deployments.createFromDraft({ draftId: await finalizedDraft(drafts), options: { autoStart: false } });

--- a/packages/server/src/__tests__/jobs/structured-logs.test.ts
+++ b/packages/server/src/__tests__/jobs/structured-logs.test.ts
@@ -46,7 +46,7 @@ describe('Jobs and Structured Logs', () => {
   });
 
   describe('Job logs SSE', () => {
-    it('GET /api/jobs/:id/logs has SSE headers', async () => {
+    it('GET /api/jobs/:id/logs returns a JSON snapshot (live logs are on /logs/stream)', async () => {
       const services = getServices();
   // Use a valid JobType ('install' used for generic log stream testing)
   const job = await services.jobs.createJob({ type: 'install', deploymentId: 'homeassistant-main' });
@@ -55,10 +55,9 @@ describe('Jobs and Structured Logs', () => {
       const res = await fetch(`${BASE_URL}${API.jobs.logs(jobId)}`);
       expect(res.ok).toBe(true);
       expect(res.status).toBe(200);
-      expect(res.headers.get('content-type')).toContain('text/event-stream');
-      expect(res.headers.get('cache-control')).toBe('no-cache');
-      expect(res.headers.get('connection')).toBe('keep-alive');
-      // We do not consume the stream to avoid hanging the test
+      expect(res.headers.get('content-type')).toContain('application/json');
+      const body = await res.json();
+      expect(body).toEqual({ items: [] });
     }, TEST_TIMEOUT);
 
     it('GET /api/jobs/:id/logs/stream has SSE headers and supports job_update events', async () => {

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -52,7 +52,6 @@ interface ServiceError extends Error {
 // Phase 0: Infrastructure imports
 import { appConfig, featureFlags } from './config/features';
 import { initializeLogger, getLogger } from './lib/logger';
-import type { LogLevel } from './lib/logger';
 import { initializeMetrics } from './lib/metrics';
 import { createRequestMiddleware, createHealthMiddleware, getRequestContext, type RequestContext } from './middleware/request';
 import { getServices, resetServices } from './services/simple-factory';
@@ -937,40 +936,13 @@ async function route(url: URL, req: Request): Promise<Response> {
   }
 
   // Logs SSE (deployment)
+  // Snapshot of prior logs. Live logs are served by the dedicated SSE endpoint
+  // `/logs/stream` below; historical container-log retrieval is not implemented
+  // yet (tracked separately), so this returns an empty snapshot rather than the
+  // fabricated sample data it used to emit.
   const deploymentLogsMatch = pathname.match(/^\/api\/deployments\/([^/]+)\/logs$/);
   if (deploymentLogsMatch && req.method === 'GET') {
-    const stream = createSSEStream({
-      logger,
-      onSubscribe(controller) {
-        let i = 0;
-        const services = ['nextcloud', 'postgres', 'redis'];
-  const levels: LogLevel[] = ['info', 'warn', 'error', 'debug'];
-        controller.heartbeat();
-        const interval = setInterval(() => {
-          i += 1;
-          controller.send({
-            type: 'log',
-            data: {
-              timestamp: new Date().toISOString(),
-              service: services[i % services.length],
-              level: levels[i % levels.length],
-              message: `Log line ${i}`,
-            },
-          });
-          if (i % 8 === 0) {
-            controller.heartbeat();
-          }
-        }, 1000);
-        const closer = setTimeout(() => {
-          controller.close();
-        }, 60000);
-        return () => {
-          clearInterval(interval);
-          clearTimeout(closer);
-        };
-      },
-    });
-    return new Response(stream, { headers: createSSEHeaders() });
+    return json({ items: [] });
   }
 
   // Logs SSE Stream (deployment) - new endpoint for real-time logs
@@ -1051,68 +1023,12 @@ async function route(url: URL, req: Request): Promise<Response> {
     }
   }
 
+  // Snapshot of prior job logs. Live job logs stream from `/logs/stream` below;
+  // there is no historical log buffer yet, so this returns an empty snapshot
+  // rather than fabricated sample lines.
   const jobLogsMatch = pathname.match(/^\/api\/jobs\/([^/]+)\/logs$/);
   if (jobLogsMatch && req.method === 'GET') {
-    const jobId = jobLogsMatch[1];
-    try {
-      const services = getServices();
-      const stream = createSSEStream({
-        logger,
-        onSubscribe(controller) {
-          controller.heartbeat();
-          const sub = services.logging.onLog({ kind: 'job', id: jobId }, entry => {
-            controller.send({
-              type: 'log',
-              data: {
-                timestamp: entry.timestamp,
-                service: entry.service,
-                level: entry.level,
-                message: entry.message,
-              },
-            });
-          });
-
-          return () => {
-            sub.unsubscribe();
-          };
-        },
-      });
-      return new Response(stream, { headers: createSSEHeaders() });
-    } catch {
-  const levels: LogLevel[] = ['info', 'warn', 'error', 'debug'];
-      const stream = createSSEStream({
-        logger,
-        onSubscribe(controller) {
-          let i = 0;
-          controller.heartbeat();
-          const interval = setInterval(() => {
-            i += 1;
-            controller.send({
-              type: 'log',
-              data: {
-                timestamp: new Date().toISOString(),
-                service: 'job',
-                level: levels[i % levels.length],
-                message: `Job log ${i}`,
-              },
-            });
-            if (i % 8 === 0) {
-              controller.heartbeat();
-            }
-          }, 1000);
-
-          const closer = setTimeout(() => {
-            controller.close();
-          }, 60000);
-
-          return () => {
-            clearInterval(interval);
-            clearTimeout(closer);
-          };
-        },
-      });
-      return new Response(stream, { headers: createSSEHeaders() });
-    }
+    return json({ items: [] });
   }
 
   // Job Logs SSE Stream - new endpoint for real-time job logs and updates
@@ -1156,56 +1072,9 @@ async function route(url: URL, req: Request): Promise<Response> {
         },
       });
       return new Response(stream, { headers: createSSEHeaders() });
-    } catch {
-  const levels: LogLevel[] = ['info', 'warn', 'debug'];
-      const stream = createSSEStream({
-        logger,
-        onSubscribe(controller) {
-          let i = 0;
-          let progress = 0;
-          controller.heartbeat();
-          const interval = setInterval(() => {
-            i += 1;
-            progress = Math.min(progress + 5, 100);
-            controller.send({
-              type: 'log',
-              data: {
-                timestamp: new Date().toISOString(),
-                service: 'job-runner',
-                level: levels[i % levels.length],
-                message: `Job ${jobId} step ${i}`,
-              },
-            });
-            if (i % 5 === 0) {
-              controller.send({
-                type: 'job_update',
-                data: {
-                  jobId,
-                  status: progress >= 100 ? 'completed' : 'running',
-                  progress,
-                  ...(progress >= 100 ? { finishedAt: new Date().toISOString() } : {}),
-                },
-              });
-              if (progress >= 100) {
-                controller.close();
-              }
-            }
-            if (i % 20 === 0) {
-              controller.heartbeat();
-            }
-          }, 1500);
-
-          const closer = setTimeout(() => {
-            controller.close();
-          }, 200000);
-
-          return () => {
-            clearInterval(interval);
-            clearTimeout(closer);
-          };
-        },
-      });
-      return new Response(stream, { headers: createSSEHeaders() });
+    } catch (error) {
+      // Surface the real failure rather than fabricating a fake job log stream.
+      return errorResponse(req, error);
     }
   }
 

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -447,7 +447,9 @@ abstract class InMemoryDeploymentService implements DeploymentService {
 
       const deployment: EnhancedDeploymentDetail = {
         id: deploymentId,
-        name: request.name || `deployment-${deploymentId.slice(0, 8)}`,
+        // Default to the app slug (e.g. "uptime-kuma") so the UI shows the app,
+        // not an opaque "deployment-<id>" placeholder. A caller-supplied name wins.
+        name: request.name || app,
         app,
         icon: '📦',
         status: 'installing',

--- a/packages/web/src/components/LogsViewer.tsx
+++ b/packages/web/src/components/LogsViewer.tsx
@@ -34,57 +34,6 @@ interface LogsViewerProps {
   showJobStatus?: boolean;
 }
 
-const mockLogs: LogEntry[] = [
-  {
-    timestamp: '2024-01-15T14:30:15.123Z',
-    service: 'nextcloud',
-    level: 'info',
-    message: 'Starting Nextcloud instance'
-  },
-  {
-    timestamp: '2024-01-15T14:30:16.456Z',
-    service: 'postgres',
-    level: 'info',
-    message: 'Database connection established'
-  },
-  {
-    timestamp: '2024-01-15T14:30:17.789Z',
-    service: 'nextcloud',
-    level: 'info',
-    message: 'Application ready on port 80'
-  },
-  {
-    timestamp: '2024-01-15T14:32:45.012Z',
-    service: 'nextcloud',
-    level: 'info',
-    message: 'User login: admin'
-  },
-  {
-    timestamp: '2024-01-15T14:35:12.345Z',
-    service: 'nextcloud',
-    level: 'warn',
-    message: 'High memory usage detected: 85% of allocated memory in use'
-  },
-  {
-    timestamp: '2024-01-15T14:40:01.678Z',
-    service: 'nextcloud',
-    level: 'info',
-    message: 'Cron job executed successfully'
-  },
-  {
-    timestamp: '2024-01-15T14:42:33.901Z',
-    service: 'postgres',
-    level: 'error',
-    message: 'Connection timeout from nextcloud service'
-  },
-  {
-    timestamp: '2024-01-15T14:42:34.234Z',
-    service: 'postgres',
-    level: 'info',
-    message: 'Connection restored'
-  },
-];
-
 const getLevelColor = (level: LogLevel) => {
   switch (level) {
     case 'error':
@@ -219,8 +168,7 @@ export const LogsViewer: React.FC<LogsViewerProps> = ({
     } catch (err) {
       console.error('Failed to load initial data:', err);
       setError(err instanceof Error ? err.message : 'Failed to load data');
-      // Fallback to mock data for development
-      setAllLogs(mockLogs);
+      setAllLogs([]);
     } finally {
       setLoading(false);
     }

--- a/packages/web/src/pages/Deployments.tsx
+++ b/packages/web/src/pages/Deployments.tsx
@@ -18,6 +18,7 @@ import type {
 } from '@hola/shared';
 import { api } from '../utils/api';
 import { useDeploymentsApi } from '../hooks/useDeploymentsApi';
+import { useCatalogAppsApi } from '../hooks/useCatalogApi';
 import { AppIcon } from '../components/ui/AppIcon';
 import { StatusBadge } from '../components/ui/StatusBadge';
 
@@ -60,6 +61,15 @@ export const Deployments: React.FC = () => {
 
   const deployments = deploymentsResponse?.items || [];
   const totalDeployments = deploymentsResponse?.total || 0;
+
+  // Join app id -> catalog product name + glyph so the "App" column shows the
+  // real app (e.g. "Uptime Kuma" 📈), not a "deployment-<id>" placeholder.
+  const { data: catalogData } = useCatalogAppsApi({ page: 1, limit: 100 });
+  const appMeta = React.useMemo(() => {
+    const map = new Map<string, { name: string; icon: string }>();
+    for (const app of catalogData?.items ?? []) map.set(app.id, { name: app.name, icon: app.icon });
+    return map;
+  }, [catalogData]);
 
   const handleAction = useCallback(async (deploymentId: string, action: 'start' | 'stop' | 'restart') => {
     try {
@@ -205,15 +215,19 @@ export const Deployments: React.FC = () => {
           </div>
 
           {/* Body rows */}
-          {deployments.map((deployment) => (
+          {deployments.map((deployment) => {
+            const meta = appMeta.get(deployment.app);
+            const displayName = meta?.name || deployment.app || deployment.name;
+            const displayIcon = meta?.icon || deployment.icon;
+            return (
             <div
               key={deployment.id}
               onClick={() => navigate(`/deployments/${deployment.id}`)}
               className={`${GRID_COLS} py-[13px] border-b border-border-soft items-center cursor-pointer hover:bg-surface-2`}
             >
               <div className="flex items-center gap-[11px] min-w-0">
-                <AppIcon name={deployment.name} emoji={deployment.icon} size={34} />
-                <span className="font-semibold text-sm truncate">{deployment.name}</span>
+                <AppIcon name={displayName} emoji={displayIcon} size={34} />
+                <span className="font-semibold text-sm truncate">{displayName}</span>
               </div>
               <div>
                 <StatusBadge status={deployment.status} />
@@ -262,7 +276,8 @@ export const Deployments: React.FC = () => {
                 </button>
               </div>
             </div>
-          ))}
+            );
+          })}
 
           {/* Empty state */}
           {deployments.length === 0 && (


### PR DESCRIPTION
## Why
Opening **Logs** for any deployment (e.g. Gitea) showed hardcoded **Nextcloud/postgres** sample lines — "Starting Nextcloud instance", "User login: admin", etc. — above a "The string did not match the expected pattern / Connection failed" error.

## Root cause (two mock layers)
1. **Client:** `LogsViewer` fell back to a hardcoded `mockLogs` array (Nextcloud/postgres) whenever the initial logs fetch threw.
2. **Server:** the plain `GET /api/deployments/:id/logs` returned a **fabricated SSE stream** (services `nextcloud`/`postgres`/`redis`, `Log line N`). The client calls it expecting JSON `{items}`, so parsing the `text/event-stream` body failed → that's the "did not match the expected pattern" error → which tripped the client mock fallback.

## Fix
- Remove the client `mockLogs` fallback — on error the Logs tab shows the error/empty state, never fake data.
- Both plain `GET …/logs` endpoints (deployment + job) now return a real `{ items: [] }` JSON snapshot. Live logs are served by the dedicated `…/logs/stream` SSE endpoints, which are already real (`services.logging.onLog`). The job stream's fabricated catch-fallback ("job-runner" lines) now surfaces the real error via `errorResponse`.

## Testing
- Updated `structured-logs.test.ts`: `GET /api/jobs/:id/logs` now asserts a JSON `{items: []}` snapshot; `…/logs/stream` still asserts SSE.
- `packages/server` suite: 266 pass. `packages/web`: 127 pass. Lint + typecheck clean (server typecheck clean apart from the pre-existing `authentik-provision.it.ts` arity error on `main`).

## Follow-up
This removes the fake data and fixes the parse error; the snapshot is genuinely empty because there's no historical/container-log retrieval yet, and the live stream currently carries Hola lifecycle logs rather than container stdout. Real container-log retrieval is tracked in a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)