### PR TITLE
feat(logs): surface real container logs in the deployment Logs tab

### DIFF
--- a/packages/server/src/__tests__/docker/compose-logs-parser.test.ts
+++ b/packages/server/src/__tests__/docker/compose-logs-parser.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Compose log parser tests
+ *
+ * `parseComposeLogs` turns `docker compose logs --timestamps` output (each line
+ * prefixed `<service>-<replica>  | <rfc3339> message`) into structured,
+ * service-labelled, timestamp-sorted entries. See #167.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseComposeLogs } from '../../services/core/docker';
+
+describe('parseComposeLogs', () => {
+  it('parses service-prefixed, --timestamps lines', () => {
+    const out = [
+      'gitea-1  | 2024-01-01T00:00:01.000000000Z Starting Gitea',
+      'gitea-1  | 2024-01-01T00:00:02.500000000Z [E] database error: boom',
+    ].join('\n');
+
+    const entries = parseComposeLogs(out);
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toEqual({
+      timestamp: '2024-01-01T00:00:01.000000000Z',
+      service: 'gitea',
+      level: 'info',
+      message: 'Starting Gitea',
+    });
+    // "error" in the body → error level.
+    expect(entries[1].level).toBe('error');
+    expect(entries[1].message).toBe('[E] database error: boom');
+  });
+
+  it('drops the -<replica> suffix and keeps hyphenated service names', () => {
+    const out = [
+      'temporal-postgres-1  | 2024-01-01T00:00:00.000000000Z db ready',
+      'postiz-1  | 2024-01-01T00:00:00.100000000Z app up',
+    ].join('\n');
+
+    const entries = parseComposeLogs(out);
+    expect(entries.map(e => e.service)).toEqual(['temporal-postgres', 'postiz']);
+  });
+
+  it('merges multiple services and sorts by timestamp', () => {
+    // Interleaved/out-of-order across services should come back chronological.
+    const out = [
+      'postgres-1  | 2024-01-01T00:00:03.000000000Z later',
+      'redis-1  | 2024-01-01T00:00:01.000000000Z earliest',
+      'postiz-1  | 2024-01-01T00:00:02.000000000Z middle',
+    ].join('\n');
+
+    const entries = parseComposeLogs(out);
+    expect(entries.map(e => e.message)).toEqual(['earliest', 'middle', 'later']);
+    expect(entries.map(e => e.service)).toEqual(['redis', 'postiz', 'postgres']);
+  });
+
+  it('labels prefix-less lines (e.g. "Attaching to …") as system', () => {
+    const out = 'Attaching to gitea-1, postgres-1';
+    const entries = parseComposeLogs(out);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].service).toBe('system');
+    expect(entries[0].message).toBe('Attaching to gitea-1, postgres-1');
+  });
+
+  it('keeps a prefixed line that has no docker timestamp', () => {
+    const out = 'gitea-1  | plain line without timestamp';
+    const entries = parseComposeLogs(out);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].service).toBe('gitea');
+    expect(entries[0].message).toBe('plain line without timestamp');
+  });
+
+  it('ignores blank lines and trailing carriage returns', () => {
+    const out = 'gitea-1  | 2024-01-01T00:00:01.000000000Z hello\r\n\n';
+    const entries = parseComposeLogs(out);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].message).toBe('hello');
+  });
+
+  it('returns an empty array for empty output', () => {
+    expect(parseComposeLogs('')).toEqual([]);
+  });
+});

--- a/packages/server/src/__tests__/jobs/structured-logs.test.ts
+++ b/packages/server/src/__tests__/jobs/structured-logs.test.ts
@@ -60,6 +60,22 @@ describe('Jobs and Structured Logs', () => {
       expect(body).toEqual({ items: [] });
     }, TEST_TIMEOUT);
 
+    it('GET /api/deployments/:id/logs returns a real container-log snapshot as JSON', async () => {
+      // Mock mode has no Docker engine, so the snapshot is honestly empty —
+      // never the fabricated sample data the endpoint used to emit (#166/#167).
+      const services = getServices();
+      const list = await services.deployments.listDeployments({ page: 1, limit: 1 });
+      const deploymentId = list.items[0]?.id ?? 'seed-nextcloud';
+
+      const res = await fetch(`${BASE_URL}${API.deployments.logs(deploymentId)}`);
+      expect(res.ok).toBe(true);
+      expect(res.status).toBe(200);
+      expect(res.headers.get('content-type')).toContain('application/json');
+      const body = await res.json() as { items: unknown[] };
+      expect(Array.isArray(body.items)).toBe(true);
+      expect(body.items).toEqual([]);
+    }, TEST_TIMEOUT);
+
     it('GET /api/jobs/:id/logs/stream has SSE headers and supports job_update events', async () => {
       const services = getServices();
   const job = await services.jobs.createJob({ type: 'install', deploymentId: 'grafana-monitoring' });

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -935,14 +935,22 @@ async function route(url: URL, req: Request): Promise<Response> {
     }
   }
 
-  // Logs SSE (deployment)
-  // Snapshot of prior logs. Live logs are served by the dedicated SSE endpoint
-  // `/logs/stream` below; historical container-log retrieval is not implemented
-  // yet (tracked separately), so this returns an empty snapshot rather than the
-  // fabricated sample data it used to emit.
+  // Logs snapshot (deployment): the app's real recent container output across
+  // every compose service. Live logs stream from `/logs/stream` below. On any
+  // docker error the service returns an empty snapshot — never fabricated data.
   const deploymentLogsMatch = pathname.match(/^\/api\/deployments\/([^/]+)\/logs$/);
   if (deploymentLogsMatch && req.method === 'GET') {
-    return json({ items: [] });
+    const deploymentId = deploymentLogsMatch[1];
+    const url = new URL(req.url);
+    const tailParam = parseInt(url.searchParams.get('tail') ?? '', 10);
+    const tail = Number.isFinite(tailParam) && tailParam > 0 ? tailParam : undefined;
+    try {
+      const services = getServices();
+      const payload = await services.deployments.getDeploymentLogs(deploymentId, { tail });
+      return json(payload);
+    } catch (err) {
+      return errorResponse(req, err);
+    }
   }
 
   // Logs SSE Stream (deployment) - new endpoint for real-time logs
@@ -954,7 +962,10 @@ async function route(url: URL, req: Request): Promise<Response> {
       logger,
       onSubscribe(controller) {
         controller.heartbeat();
-        // Stream real deployment lifecycle/Compose logs emitted by the deployment service.
+        // Two sources, merged: (1) Hola lifecycle/Compose events (deploy,
+        // provision) from the logging bus, and (2) the app's real container
+        // stdout via `docker compose logs -f`, so the tab shows what the app
+        // is actually doing.
         const sub = services.logging.onLog({ kind: 'deployment', id: deploymentId }, entry => {
           controller.send({
             type: 'log',
@@ -967,8 +978,36 @@ async function route(url: URL, req: Request): Promise<Response> {
           });
         });
 
+        // The container stream starts async; guard against the client
+        // disconnecting before the stop handle resolves (else it would leak the
+        // `docker compose logs -f` child).
+        let closed = false;
+        let containerStop = () => {};
+        services.deployments
+          .streamDeploymentLogs(deploymentId, entry => {
+            if (closed) return;
+            controller.send({
+              type: 'log',
+              data: {
+                timestamp: entry.timestamp,
+                service: entry.service,
+                level: entry.level,
+                message: entry.message,
+              },
+            });
+          })
+          .then(handle => {
+            if (closed) handle.stop();
+            else containerStop = handle.stop;
+          })
+          .catch(error => {
+            logger.warn('Failed to start container log stream', { deploymentId, error: String(error) });
+          });
+
         return () => {
+          closed = true;
           sub.unsubscribe();
+          containerStop();
         };
       },
     });

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -32,7 +32,9 @@ import type {
   DeploymentDirectoryLayout,
   Job,
   DeploymentListItem,
-  ProvisionedAuthRef
+  ProvisionedAuthRef,
+  GetLogsResponse,
+  LogEntry
 } from '@hola/shared';
 
 import { getLogger } from '../../lib/logger';
@@ -97,6 +99,12 @@ export interface DeploymentService extends HealthCheckable {
   getDeploymentHistory(deploymentId: string, options?: { page?: number; limit?: number }): Promise<GetDeploymentHistoryResponse>;
   getReleases(deploymentId: string): Promise<Release[]>;
   getRelease(deploymentId: string, releaseId: string): Promise<Release>;
+
+  // Container logs (the app's real stdout, distinct from lifecycle/job logs)
+  /** Recent container logs for the deployment's compose project (snapshot). */
+  getDeploymentLogs(deploymentId: string, options?: { tail?: number }): Promise<GetLogsResponse>;
+  /** Live container log stream; returns a stop handle. No-op when unsupported. */
+  streamDeploymentLogs(deploymentId: string, callback: (entry: LogEntry) => void): Promise<{ stop: () => void }>;
 
   // Internal management
   getDirectoryLayout(deploymentId: string): Promise<DeploymentDirectoryLayout>;
@@ -713,6 +721,27 @@ abstract class InMemoryDeploymentService implements DeploymentService {
     return release;
   }
 
+  /**
+   * Container-log snapshot. The base store has no Docker engine, so it returns
+   * an honest empty snapshot; RealDeploymentService overrides this to read the
+   * app's actual compose-project logs.
+   */
+  async getDeploymentLogs(deploymentId: string, options?: { tail?: number }): Promise<GetLogsResponse> {
+    void deploymentId;
+    void options;
+    return { items: [] };
+  }
+
+  /** No-op container stream for the base store; RealDeploymentService overrides. */
+  async streamDeploymentLogs(
+    deploymentId: string,
+    callback: (entry: LogEntry) => void
+  ): Promise<{ stop: () => void }> {
+    void deploymentId;
+    void callback;
+    return { stop: () => {} };
+  }
+
   async getDirectoryLayout(deploymentId: string): Promise<DeploymentDirectoryLayout> {
     const deploymentPath = `deployments/${deploymentId}`;
     return {
@@ -770,6 +799,40 @@ export class RealDeploymentService extends InMemoryDeploymentService {
   /** Absolute working directory that holds the materialized docker-compose.yml. */
   private runtimeDir(deploymentId: string): string {
     return this.storageService.resolveHolaPath('deployments', deploymentId, 'runtime');
+  }
+
+  /**
+   * Real container logs for a deployment: read the compose project's recent
+   * stdout across every service. Returns an empty snapshot for an unknown
+   * deployment (never throws/fabricates); docker errors are absorbed by the
+   * docker service.
+   */
+  override async getDeploymentLogs(
+    deploymentId: string,
+    options?: { tail?: number }
+  ): Promise<GetLogsResponse> {
+    await this.ensureLoaded();
+    if (!this.deployments.has(deploymentId)) return { items: [] };
+    const { entries } = await this.dockerService.composeLogs(
+      this.runtimeDir(deploymentId),
+      this.projectName(deploymentId),
+      options
+    );
+    return { items: entries };
+  }
+
+  /** Live stream of the deployment's compose-project container stdout. */
+  override async streamDeploymentLogs(
+    deploymentId: string,
+    callback: (entry: LogEntry) => void
+  ): Promise<{ stop: () => void }> {
+    await this.ensureLoaded();
+    if (!this.deployments.has(deploymentId)) return { stop: () => {} };
+    return this.dockerService.streamComposeLogs(
+      this.runtimeDir(deploymentId),
+      this.projectName(deploymentId),
+      callback
+    );
   }
 
   /** Write the active release's compose file into the deployment runtime dir. */

--- a/packages/server/src/services/core/docker.ts
+++ b/packages/server/src/services/core/docker.ts
@@ -71,7 +71,15 @@ export interface DockerService {
   // Log operations
   getContainerLogs(containerName: string, since?: string, tail?: number): Promise<DockerLogs>;
   streamContainerLogs(containerName: string, callback: (log: DockerLogs['entries'][0]) => void): Promise<{ stop: () => void }>;
-  
+  /** Recent logs across every service in a compose project, merged + timestamp-sorted. */
+  composeLogs(projectPath: string, projectName: string, options?: { tail?: number }): Promise<DockerLogs>;
+  /** Live stream of every service's stdout in a compose project (`docker compose logs -f`). */
+  streamComposeLogs(
+    projectPath: string,
+    projectName: string,
+    callback: (log: DockerLogs['entries'][0]) => void
+  ): Promise<{ stop: () => void }>;
+
   // Health checking
   healthCheck(): Promise<ServiceHealth>;
 }
@@ -394,6 +402,70 @@ export class RealDockerService implements DockerService, HealthCheckable {
     };
   }
 
+  async composeLogs(
+    projectPath: string,
+    projectName: string,
+    options?: { tail?: number }
+  ): Promise<DockerLogs> {
+    const tail = options?.tail ?? 200;
+    try {
+      this.logger.debug('Getting compose project logs', { projectPath, projectName, tail });
+      const composeFile = join(projectPath, 'docker-compose.yml');
+      const { stdout } = await execFileAsync(
+        'docker',
+        ['compose', '-f', composeFile, '-p', projectName, 'logs', '--no-color', '--timestamps', '--tail', String(tail)],
+        { cwd: projectPath, maxBuffer: 16 * 1024 * 1024 }
+      );
+      return { entries: parseComposeLogs(stdout), hasMore: false };
+    } catch (error) {
+      // Honest empty snapshot on any failure (project down, no daemon, etc.) —
+      // never fabricate log data.
+      this.logger.error('Failed to get compose project logs', error instanceof Error ? error : undefined, {
+        projectPath,
+        projectName,
+      });
+      return { entries: [], hasMore: false };
+    }
+  }
+
+  async streamComposeLogs(
+    projectPath: string,
+    projectName: string,
+    callback: (log: DockerLogs['entries'][0]) => void
+  ): Promise<{ stop: () => void }> {
+    this.logger.info('Starting compose log stream', { projectPath, projectName });
+    const composeFile = join(projectPath, 'docker-compose.yml');
+    const { spawn } = await import('child_process');
+    // `--tail 0`: the snapshot endpoint already serves history, so the live
+    // stream only carries new lines (no duplicate flood on connect).
+    const proc = spawn('docker', [
+      'compose', '-f', composeFile, '-p', projectName,
+      'logs', '-f', '--no-color', '--timestamps', '--tail', '0',
+    ], { cwd: projectPath });
+
+    let stopped = false;
+    const onData = (data: Buffer) => {
+      if (stopped) return;
+      parseComposeLogs(data.toString()).forEach(callback);
+    };
+    proc.stdout?.on('data', onData);
+    proc.stderr?.on('data', onData);
+    proc.on('error', (error) => {
+      this.logger.error('Compose log stream error', error, { projectName });
+    });
+    proc.on('exit', (code) => {
+      this.logger.info('Compose log stream ended', { projectName, code });
+    });
+
+    return {
+      stop: () => {
+        stopped = true;
+        proc.kill();
+        this.logger.info('Compose log stream stopped', { projectName });
+      },
+    };
+  }
+
   async healthCheck(): Promise<ServiceHealth> {
     try {
       const info = await this.getDockerInfo();
@@ -472,20 +544,66 @@ export class RealDockerService implements DockerService, HealthCheckable {
   }
 
   private detectLogLevel(message: string): 'info' | 'warn' | 'error' | 'debug' {
-    const lowerMessage = message.toLowerCase();
-    
-    if (lowerMessage.includes('error') || lowerMessage.includes('fatal') || lowerMessage.includes('critical')) {
-      return 'error';
-    }
-    if (lowerMessage.includes('warn') || lowerMessage.includes('warning')) {
-      return 'warn';
-    }
-    if (lowerMessage.includes('debug') || lowerMessage.includes('trace')) {
-      return 'debug';
-    }
-    
-    return 'info';
+    return detectLogLevel(message);
   }
+}
+
+/** Heuristic log-level classification from a message body (shared by both parsers). */
+function detectLogLevel(message: string): DockerLogs['entries'][0]['level'] {
+  const lowerMessage = message.toLowerCase();
+
+  if (lowerMessage.includes('error') || lowerMessage.includes('fatal') || lowerMessage.includes('critical')) {
+    return 'error';
+  }
+  if (lowerMessage.includes('warn') || lowerMessage.includes('warning')) {
+    return 'warn';
+  }
+  if (lowerMessage.includes('debug') || lowerMessage.includes('trace')) {
+    return 'debug';
+  }
+
+  return 'info';
+}
+
+// A `docker logs --timestamps` line: RFC3339Nano timestamp then the message.
+const LOG_TIMESTAMP_RE = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z)\s+(.*)$/;
+// A `docker compose logs` line prefixes each line with `<service>-<replica>  | `.
+const COMPOSE_PREFIX_RE = /^([^|]+?)\s*\|\s?(.*)$/;
+
+/**
+ * Parse `docker compose logs --timestamps` output into structured entries.
+ *
+ * Each line looks like `gitea-1  | 2024-01-01T00:00:00.000000000Z message`: a
+ * service prefix (service name + replica index), then a docker-logs line. The
+ * service label drops the `-<n>` replica suffix so multi-service apps (e.g.
+ * Postiz) are grouped by compose service. Entries are timestamp-sorted so the
+ * merged multi-service view reads chronologically. Exported for unit testing.
+ */
+export function parseComposeLogs(output: string): DockerLogs['entries'] {
+  const entries: DockerLogs['entries'] = [];
+
+  for (const raw of output.split('\n')) {
+    const line = raw.replace(/\r$/, '');
+    if (!line.trim()) continue;
+
+    const prefixed = line.match(COMPOSE_PREFIX_RE);
+    // Lines without a `service |` prefix (e.g. compose's own "Attaching to …"
+    // notices) are labelled `system` rather than dropped or misattributed.
+    const service = prefixed ? prefixed[1].trim().replace(/-\d+$/, '') : 'system';
+    const rest = prefixed ? prefixed[2] : line;
+
+    const tsMatch = rest.match(LOG_TIMESTAMP_RE);
+    if (tsMatch) {
+      const [, timestamp, message] = tsMatch;
+      entries.push({ timestamp, service, level: detectLogLevel(message), message: message.trim() });
+    } else {
+      // No docker timestamp (rare: a notice line) — keep the text, stamp now.
+      entries.push({ timestamp: new Date().toISOString(), service, level: detectLogLevel(rest), message: rest.trim() });
+    }
+  }
+
+  entries.sort((a, b) => (a.timestamp < b.timestamp ? -1 : a.timestamp > b.timestamp ? 1 : 0));
+  return entries;
 }
 
 /**
@@ -557,6 +675,16 @@ export class MockDockerService implements DockerService {
     callback: (log: DockerLogs['entries'][0]) => void
   ): Promise<{ stop: () => void }> {
     callback({ timestamp: new Date().toISOString(), service: containerName, level: 'info', message: '[mock] streaming log line' });
+    return { stop: () => {} };
+  }
+
+  // No real containers in mock mode: return an honest empty snapshot / no-op
+  // stream rather than fabricating app output (see #166/#167).
+  async composeLogs(): Promise<DockerLogs> {
+    return { entries: [], hasMore: false };
+  }
+
+  async streamComposeLogs(): Promise<{ stop: () => void }> {
     return { stop: () => {} };
   }
 


### PR DESCRIPTION
## What

The deployment **Logs** tab now shows the app's **real container stdout**, not just Hola lifecycle events. Follow-up to #166 (which removed the fabricated sample data) — closes #167.

## How

- **`DockerService`** — new `composeLogs` (snapshot via `docker compose logs --no-color --timestamps --tail N`, merged + timestamp-sorted across every service) and `streamComposeLogs` (live `-f` follow, `--tail 0` so it doesn't re-emit the snapshot). A new exported pure `parseComposeLogs` turns the `<service>-<replica>  | <rfc3339> message` format into structured `LogEntry`s, drops the replica suffix (so multi-service apps like Postiz group by service), and labels prefix-less notice lines (`Attaching to …`) as `system`.
- **`DeploymentService`** — `getDeploymentLogs` / `streamDeploymentLogs` resolve a deployment to its compose project (`hola-<id>` + runtime dir) and read real logs. The base in-memory/mock store returns an honest empty snapshot (no Docker engine).
- **server** — `GET /api/deployments/:id/logs` returns the real snapshot (`?tail=` honoured); the `/logs/stream` SSE merges lifecycle events **and** live container stdout, guarding against a client disconnect before the stop handle resolves so the `logs -f` child never leaks.
- **Defensive** — any docker error → `{ items: [] }` / a closed stream. Never fabricated data.

## Tests

- `compose-logs-parser.test.ts`: service-prefixed `--timestamps` parsing, replica-suffix stripping, multi-service merge/sort, `system` fallback, blank-line/CR handling.
- `structured-logs.test.ts`: `GET /api/deployments/:id/logs` returns a JSON `{ items: [] }` snapshot in mock mode (no fabricated data).

`typecheck` · `lint` · `build` · server (282) + web (127) suites all green.

## Acceptance criteria
- [x] Opening Logs for a running deployment shows that app's real container output (snapshot + live).
- [x] Multi-service apps (e.g. Postiz) show logs labelled per service.
- [x] No fabricated data on error; honest empty/error states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)