### PR TITLE
chore(release): 0.6.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.5.1';
+export const CLI_VERSION = '0.6.0';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Minor version bump `0.5.1 → 0.6.0` across published packages (cli, sdk, server, shared, compose; `web` stays unversioned) plus `cli/src/version.ts`. Tag `cli-v0.6.0` on the squash-merge commit triggers `cli-release.yml` to publish `ghcr.io/try-hola/{server,web}:0.6.0`.

### Since 0.5.1
- **feat(auth):** named-admin bootstrap with a one-time recovery link + wizard prompts for admin email/username/display name (#169)
- **feat(auth):** platform-owned `hola-admins` group, seeded with superusers, shared by the dashboard and catalog apps (#168)
- **feat(logs):** real container logs in the deployment Logs tab (#171)
- **fix(logs):** remove fabricated log data from the Logs tab (#166)
- **fix:** name deployments after the app, not `deployment-<id>` (#165)

🤖 Generated with [Claude Code](https://claude.com/claude-code)