### PR TITLE
docs(cli): clarify post-install hint for first-time users

### DIFF
--- a/cli-install.sh
+++ b/cli-install.sh
@@ -99,7 +99,10 @@ case ":$PATH:" in
      warn "  export PATH=\"$INSTALL_DIR:\$PATH\"" ;;
 esac
 
-info "Point the CLI at your server:"
-info "  export HOLA_API_URL=https://<your-hola-domain>"
-info "  export HOLA_TOKEN=<admin-api-key>"
-info "Then: $BIN_NAME --help"
+info "Next steps:"
+info "  • No server yet?  Set one up on a host:   $BIN_NAME bootstrap --host user@your-vm"
+info "    (or generate a .env locally first with:  $BIN_NAME init)"
+info "  • Already have a server?  Point the CLI at it:"
+info "      export HOLA_API_URL=https://<your-hola-domain>"
+info "      export HOLA_TOKEN=<admin-api-key>"
+info "Run '$BIN_NAME --help' to see all commands."


### PR DESCRIPTION
## What

The CLI installer's post-install message jumped straight to:

```
[hola] Point the CLI at your server:
[hola]   export HOLA_API_URL=https://<your-hola-domain>
[hola]   export HOLA_TOKEN=<admin-api-key>
```

For a first-time user who **doesn't have a server yet**, this is confusing — there's no domain or admin key to point at.

## Change

Branch the next-steps hint by situation:

```
[hola] Next steps:
[hola]   • No server yet?  Set one up on a host:   hola bootstrap --host user@your-vm
[hola]     (or generate a .env locally first with:  hola init)
[hola]   • Already have a server?  Point the CLI at it:
[hola]       export HOLA_API_URL=https://<your-hola-domain>
[hola]       export HOLA_TOKEN=<admin-api-key>
[hola] Run 'hola --help' to see all commands.
```

Docs-only change to `cli-install.sh`; no code paths affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)