### PR TITLE
fix(cli): hola init crash on blank optional fields

### DIFF
--- a/packages/cli/src/__tests__/install-schema.test.ts
+++ b/packages/cli/src/__tests__/install-schema.test.ts
@@ -4,7 +4,8 @@ import { join } from 'path';
 
 import { INSTALL_SCHEMA, defaultFor, secretKeys } from '../install/schema';
 import { parseEnv, renderEnv, schemaTemplate } from '../install/render-env';
-import { interdependencyErrors, isDomain, isEmail, isEmailOrEmpty } from '../install/validate';
+import { interdependencyErrors, isDomain, isEmail, isEmailOrEmpty, optionalSecret } from '../install/validate';
+import { toClackValidate } from '../install/prompter';
 
 describe('install schema', () => {
   it('derives HOLA_DOMAIN/AUTHENTIK domains from the base domain', () => {
@@ -79,6 +80,19 @@ describe('validators', () => {
     expect(interdependencyErrors({ ACME_DNS_PROVIDER: 'cloudflare' })).toHaveLength(1);
     expect(interdependencyErrors({ HOLA_AUTH_MODE: 'authentik' })).toHaveLength(1);
     expect(interdependencyErrors({ HOLA_AUTH_MODE: 'none' })).toHaveLength(0);
+  });
+
+  // Regression: clack passes `undefined` (not '') when an optional field is
+  // submitted blank. The prompter's coercion boundary must hand validators a
+  // string so they don't crash on `v.trim()` of undefined.
+  it('coerces a blank (undefined) optional submission before validating', () => {
+    const validator = optionalSecret();
+    const adapted = toClackValidate((v) => validator(v, {}));
+    expect(adapted).toBeDefined();
+    expect(adapted!(undefined)).toBeUndefined();
+    expect(adapted!('')).toBeUndefined();
+    expect(adapted!('secret')).toBeUndefined();
+    expect(adapted!(' padded ')).toBeDefined();
   });
 });
 

--- a/packages/cli/src/install/prompter.ts
+++ b/packages/cli/src/install/prompter.ts
@@ -28,6 +28,17 @@ export class PromptCancelled extends Error {
   }
 }
 
+/**
+ * Adapt a string validator to clack, which passes `undefined` (not `''`) when an
+ * optional field is submitted blank. Our validators all call `v.trim()`, so coerce
+ * the value to a string at this one boundary. Exported for testing.
+ */
+export function toClackValidate(
+  validate?: (v: string) => string | undefined
+): ((v: string | undefined) => string | undefined) | undefined {
+  return validate ? (v) => validate(v ?? '') : undefined;
+}
+
 /** Production prompter backed by @clack/prompts. Lazily imported so tests never load it. */
 export function clackPrompter(): Prompter {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -39,7 +50,7 @@ export function clackPrompter(): Prompter {
   return {
     async prompt(spec) {
       const clack = await load();
-      const validate = spec.validate ? (v: string) => spec.validate!(v) : undefined;
+      const validate = toClackValidate(spec.validate);
       let result: unknown;
       switch (spec.type) {
         case 'secret':


### PR DESCRIPTION
## Bug

Running `hola init` and submitting an **optional** field blank (e.g. the *Fixed admin API key* prompt) crashed:

```
TypeError: undefined is not an object (evaluating 'v.trim')
  function optionalSecret() {
    return (v) => v.trim() === v ? undefined : "Value must not have leading/trailing whitespace";
                  ^
```

`@clack/prompts` passes `undefined` (not `''`) to the `validate` callback when an optional field is submitted empty, and every validator in `install/validate.ts` calls `v.trim()`.

## Fix

Coerce the value to a string at the **single prompter→validator boundary** rather than hardening each validator. Extracted a small `toClackValidate()` helper:

```ts
export function toClackValidate(validate?) {
  return validate ? (v) => validate(v ?? '') : undefined;
}
```

So every validator always receives a string. Added a regression test in `install-schema.test.ts` covering the `undefined` / `''` / valid / leading-whitespace cases.

## Test
- `bun --cwd packages/cli test` → 46 passed
- typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)