### PR TITLE
feat(cli): smarter hola init defaults

### DIFF
--- a/packages/cli/src/__tests__/install-schema.test.ts
+++ b/packages/cli/src/__tests__/install-schema.test.ts
@@ -10,8 +10,30 @@ describe('install schema', () => {
   it('derives HOLA_DOMAIN/AUTHENTIK domains from the base domain', () => {
     const holaDomain = INSTALL_SCHEMA.find((f) => f.key === 'HOLA_DOMAIN')!;
     const authDomain = INSTALL_SCHEMA.find((f) => f.key === 'HOLA_AUTHENTIK_DOMAIN')!;
-    expect(defaultFor(holaDomain, { HOLA_BASE_DOMAIN: 'hola.example.com' })).toBe('app.hola.example.com');
+    // The dashboard lists the collection of apps → plural `apps.<base>`.
+    expect(defaultFor(holaDomain, { HOLA_BASE_DOMAIN: 'hola.example.com' })).toBe('apps.hola.example.com');
     expect(defaultFor(authDomain, { HOLA_BASE_DOMAIN: 'hola.example.com' })).toBe('auth.hola.example.com');
+  });
+
+  it('defaults SSO to authentik (secure by default) with it listed first', () => {
+    const authMode = INSTALL_SCHEMA.find((f) => f.key === 'HOLA_AUTH_MODE')!;
+    expect(defaultFor(authMode, {})).toBe('authentik');
+    expect(authMode.options?.[0]?.value).toBe('authentik');
+  });
+
+  it('reuses the first email (Let\'s Encrypt) as the default for later email questions', () => {
+    const bootstrap = INSTALL_SCHEMA.find((f) => f.key === 'AUTHENTIK_BOOTSTRAP_EMAIL')!;
+    const adminEmail = INSTALL_SCHEMA.find((f) => f.key === 'HOLA_ADMIN_EMAIL')!;
+    expect(defaultFor(bootstrap, { LETSENCRYPT_EMAIL: 'me@x.io' })).toBe('me@x.io');
+    expect(defaultFor(adminEmail, { LETSENCRYPT_EMAIL: 'me@x.io' })).toBe('me@x.io');
+    // Falls back to the static placeholder / blank when no email was given yet.
+    expect(defaultFor(bootstrap, {})).toBe('admin@example.com');
+    expect(defaultFor(adminEmail, {})).toBe('');
+  });
+
+  it('marks the AWS credential fields as reusable from the environment', () => {
+    const fromEnv = INSTALL_SCHEMA.filter((f) => f.fromEnv).map((f) => f.key);
+    expect(fromEnv).toEqual(['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_REGION', 'AWS_HOSTED_ZONE_ID']);
   });
 
   it('gates conditional fields with requiredWhen', () => {

--- a/packages/cli/src/__tests__/wizard.test.ts
+++ b/packages/cli/src/__tests__/wizard.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+
+import { runWizard } from '../install/wizard';
+import { scriptedPrompter } from '../install/prompter';
+
+const noChecks = async () => [];
+
+// Minimal answers for a route53 run; AWS_* are intentionally omitted so the
+// wizard's env-reuse path supplies them.
+const route53Base: Record<string, string> = {
+  HOLA_BASE_DOMAIN: 'hola.example.com',
+  HOLA_DOMAIN: 'apps.hola.example.com',
+  TRAEFIK_DASHBOARD_DOMAIN: 'traefik.hola.example.com',
+  LETSENCRYPT_EMAIL: 'me@example.com',
+  ACME_DNS_PROVIDER: 'route53',
+  HOLA_CATALOG_URL: 'https://example.com/catalog.json',
+  HOLA_AUTH_MODE: 'none',
+  HOLA_USE_AUTH: 'true',
+  HOLA_API_KEY: '',
+};
+
+describe('runWizard — AWS credentials from the environment', () => {
+  it('reuses AWS_* from the environment when the fields are accepted (left to default)', async () => {
+    const env = { AWS_ACCESS_KEY_ID: 'AKIAENV', AWS_SECRET_ACCESS_KEY: 'env-secret', AWS_REGION: 'eu-west-1' };
+    const { config } = await runWizard({
+      prompter: scriptedPrompter(route53Base),
+      checks: noChecks,
+      env,
+    });
+    expect(config.AWS_ACCESS_KEY_ID).toBe('AKIAENV');
+    expect(config.AWS_SECRET_ACCESS_KEY).toBe('env-secret');
+    expect(config.AWS_REGION).toBe('eu-west-1'); // env wins over the static us-east-1 default
+  });
+
+  it('accepts a blank answer for the masked secret as "use the detected value"', async () => {
+    const env = { AWS_ACCESS_KEY_ID: 'AKIAENV', AWS_SECRET_ACCESS_KEY: 'env-secret', AWS_REGION: 'us-east-1' };
+    const { config } = await runWizard({
+      // Explicitly submit the secret blank — the validator must not reject it.
+      prompter: scriptedPrompter({ ...route53Base, AWS_SECRET_ACCESS_KEY: '' }),
+      checks: noChecks,
+      env,
+    });
+    expect(config.AWS_SECRET_ACCESS_KEY).toBe('env-secret');
+  });
+
+  it('still prompts (and validates) when nothing is in the environment', async () => {
+    await expect(
+      runWizard({
+        prompter: scriptedPrompter({ ...route53Base, AWS_ACCESS_KEY_ID: '', AWS_SECRET_ACCESS_KEY: '' }),
+        checks: noChecks,
+        env: {},
+      })
+    ).rejects.toThrow(/AWS access key ID is required/);
+  });
+});
+
+describe('runWizard — new defaults flow through', () => {
+  it('defaults the Authentik + admin emails to the first email and signs you in as yourself', async () => {
+    // Provide only the base domain + first email; accept every other default.
+    const { config } = await runWizard({
+      prompter: scriptedPrompter({
+        HOLA_BASE_DOMAIN: 'hola.example.com',
+        LETSENCRYPT_EMAIL: 'paul@example.com',
+        ACME_DNS_PROVIDER: '',
+      }),
+      checks: noChecks,
+      env: {},
+    });
+    expect(config.HOLA_AUTH_MODE).toBe('authentik'); // secure by default
+    expect(config.HOLA_DOMAIN).toBe('apps.hola.example.com'); // plural dashboard host
+    expect(config.AUTHENTIK_BOOTSTRAP_EMAIL).toBe('paul@example.com');
+    expect(config.HOLA_ADMIN_EMAIL).toBe('paul@example.com');
+    expect(config.HOLA_ADMIN_USERNAME).toBe('paul'); // local part of the admin email
+  });
+});

--- a/packages/cli/src/install/schema.ts
+++ b/packages/cli/src/install/schema.ts
@@ -21,12 +21,19 @@ export interface InstallField {
   prompt: string;
   /** Extra one-line guidance. */
   help?: string;
-  /** Static default, or one derived from answers so far (e.g. `app.<base>`). */
+  /** Static default, or one derived from answers so far (e.g. `apps.<base>`). */
   default?: string | ((c: ConfigMap) => string);
   /** Choices for `select`. */
   options?: { value: string; label: string }[];
   /** Mask input and redact in JSON/dry-run output. */
   secret?: boolean;
+  /**
+   * Offer a value already present in the process environment (read from the env
+   * var named by this field's `key`) so the user can accept it instead of
+   * pasting it in. For a `secret` field a blank answer means "use the detected
+   * value". Used for the AWS_* credentials.
+   */
+  fromEnv?: boolean;
   /** Returns an error message, or undefined when valid. */
   validate?: (v: string, c: ConfigMap) => string | undefined;
   /** When present and false for the current answers, the field is skipped. */
@@ -48,8 +55,10 @@ export const INSTALL_SCHEMA: InstallField[] = [
   {
     key: 'HOLA_DOMAIN',
     type: 'text',
-    prompt: 'Domain for the Hola UI/API',
-    default: (c) => (c.HOLA_BASE_DOMAIN ? `app.${c.HOLA_BASE_DOMAIN}` : ''),
+    prompt: 'Domain for the Hola dashboard/API',
+    // The dashboard lists the collection of installed apps, so default to the
+    // plural `apps.<base>` rather than the singular `app.<base>`.
+    default: (c) => (c.HOLA_BASE_DOMAIN ? `apps.${c.HOLA_BASE_DOMAIN}` : ''),
     validate: isDomain,
   },
   {
@@ -81,6 +90,7 @@ export const INSTALL_SCHEMA: InstallField[] = [
     key: 'AWS_ACCESS_KEY_ID',
     type: 'text',
     prompt: 'AWS access key ID',
+    fromEnv: true,
     requiredWhen: isRoute53,
     validate: required('AWS access key ID'),
   },
@@ -89,6 +99,7 @@ export const INSTALL_SCHEMA: InstallField[] = [
     type: 'secret',
     prompt: 'AWS secret access key',
     secret: true,
+    fromEnv: true,
     requiredWhen: isRoute53,
     validate: required('AWS secret access key'),
   },
@@ -97,6 +108,7 @@ export const INSTALL_SCHEMA: InstallField[] = [
     type: 'text',
     prompt: 'AWS region',
     default: 'us-east-1',
+    fromEnv: true,
     requiredWhen: isRoute53,
     validate: required('AWS region'),
   },
@@ -104,6 +116,7 @@ export const INSTALL_SCHEMA: InstallField[] = [
     key: 'AWS_HOSTED_ZONE_ID',
     type: 'text',
     prompt: 'AWS hosted zone ID (optional — blank to auto-detect)',
+    fromEnv: true,
     requiredWhen: isRoute53,
     // optional: empty is allowed.
   },
@@ -134,10 +147,11 @@ export const INSTALL_SCHEMA: InstallField[] = [
     type: 'select',
     prompt: 'SSO platform for catalog apps',
     help: 'authentik brings up the bundled Authentik stack (~2 GB RAM)',
-    default: 'none',
+    // Secure by default: provision per-app SSO unless the operator opts out.
+    default: 'authentik',
     options: [
-      { value: 'none', label: 'none — apps use their own auth' },
       { value: 'authentik', label: 'authentik — auto-provision per-app SSO' },
+      { value: 'none', label: 'none — apps use their own auth' },
     ],
   },
   {
@@ -152,7 +166,8 @@ export const INSTALL_SCHEMA: InstallField[] = [
     key: 'AUTHENTIK_BOOTSTRAP_EMAIL',
     type: 'text',
     prompt: 'Authentik admin email',
-    default: 'admin@example.com',
+    // Reuse the first email the operator gave (Let's Encrypt contact) as the default.
+    default: (c) => c.LETSENCRYPT_EMAIL || 'admin@example.com',
     requiredWhen: isAuthentik,
     validate: isEmail,
   },
@@ -161,6 +176,8 @@ export const INSTALL_SCHEMA: InstallField[] = [
     type: 'text',
     prompt: 'Your admin email (sign in as yourself)',
     help: 'Blank to just use the built-in akadmin account',
+    // Default to the first email given, so you sign in as yourself out of the box.
+    default: (c) => c.LETSENCRYPT_EMAIL || '',
     requiredWhen: isAuthentik,
     validate: isEmailOrEmpty,
   },

--- a/packages/cli/src/install/wizard.ts
+++ b/packages/cli/src/install/wizard.ts
@@ -15,6 +15,8 @@ export interface WizardOptions {
   skipChecks?: boolean;
   /** Injectable for tests; defaults to the real network/host checks. */
   checks?: (config: ConfigMap) => Promise<CheckResult[]>;
+  /** Process environment, for fields that offer to reuse a value already set (AWS_*). Injectable for tests. */
+  env?: Record<string, string | undefined>;
 }
 
 export interface WizardResult {
@@ -26,22 +28,35 @@ export interface WizardResult {
 export class WizardError extends Error {}
 
 export async function runWizard(opts: WizardOptions): Promise<WizardResult> {
-  const { prompter, initial = {} } = opts;
+  const { prompter, initial = {}, env = process.env } = opts;
   const config: ConfigMap = {};
 
   for (const field of INSTALL_SCHEMA) {
     if (field.requiredWhen && !field.requiredWhen(config)) continue;
 
-    const fallback = initial[field.key] ?? defaultFor(field, config);
-    const message = field.help ? `${field.prompt}\n  ${field.help}` : field.prompt;
-    const value = await prompter.prompt({
+    // A `fromEnv` field offers a value already set in the environment (AWS_*),
+    // so the user accepts it instead of pasting. For a masked secret we can't
+    // prefill the prompt, so a blank answer means "use the detected value" and
+    // is not rejected by the field's validator.
+    const envVal = field.fromEnv ? env[field.key]?.trim() || undefined : undefined;
+    const fallback = initial[field.key] ?? envVal ?? defaultFor(field, config);
+
+    let message = field.help ? `${field.prompt}\n  ${field.help}` : field.prompt;
+    if (envVal && field.secret) message = `${field.prompt} (found in your environment — press Enter to use it)`;
+
+    const validate = field.validate
+      ? (v: string) => (!v && envVal ? undefined : field.validate!(v, config))
+      : undefined;
+
+    let value = await prompter.prompt({
       key: field.key,
       type: field.type,
       message,
       default: fallback,
       options: field.options,
-      validate: field.validate ? (v: string) => field.validate!(v, config) : undefined,
+      validate,
     });
+    if (!value && envVal) value = envVal; // accept the detected environment value
     config[field.key] = value;
   }
 

--- a/packages/compose/.env.example
+++ b/packages/compose/.env.example
@@ -36,8 +36,8 @@ CF_DNS_API_TOKEN=
 # aren't directly reachable. Leave blank to use the default (1.1.1.1, 9.9.9.9).
 ACME_DNS_RESOLVERS=
 
-# --- Hola UI/API (single origin: web serves the SPA and proxies /api) ---
-HOLA_DOMAIN=app.local.hola
+# --- Hola dashboard/API (single origin: web serves the SPA and proxies /api) ---
+HOLA_DOMAIN=apps.local.hola
 
 # Base domain that DEPLOYED apps are exposed under, e.g. gitea.local.hola.
 HOLA_BASE_DOMAIN=local.hola


### PR DESCRIPTION
Four quality-of-life improvements to the `hola init` / `hola bootstrap` wizard, all in `INSTALL_SCHEMA` + the wizard loop.

## 1. Reuse the first email for later email prompts
The first email you enter (Let's Encrypt contact) becomes the default for the **Authentik admin email** and **your named-admin email**, so you don't retype it. Falls back to the old placeholder / blank when no email was given yet.

## 2. Authentik is the default SSO mode (secure by default)
`HOLA_AUTH_MODE` now defaults to `authentik` and is listed first in the picker; `none` is still selectable.

## 3. Offer AWS credentials from the environment
If `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION` / `AWS_HOSTED_ZONE_ID` are already exported, the wizard offers them instead of making you paste:
- Text fields (access key id, region, zone id) prefill the detected value — press Enter to accept.
- The **masked** secret can't be prefilled, so a blank answer means "use the detected value" and the validator won't reject blank in that case.

Implemented with a new `fromEnv` field flag and an injectable `env` on `runWizard` (defaults to `process.env`; tests pass a fake). Nothing new is written to `.env` beyond the actual `AWS_*` keys.

## 4. Plural dashboard host
The dashboard lists the **collection** of installed apps, so the default `HOLA_DOMAIN` is now `apps.<base>` instead of `app.<base>`. `packages/compose/.env.example` updated to match.

## Test
- New `wizard.test.ts` covers AWS env-reuse (accept-default, blank-secret, and still-prompts-when-absent) and the new defaults flowing end-to-end.
- `install-schema.test.ts` updated/extended for the plural host, authentik default, email chaining, and `fromEnv` fields.
- `bun --cwd packages/cli test` → 56 passed; typecheck + lint + build clean.

> Note: independent of #174 (the init crash fix) — touches different files / test regions, merges cleanly alongside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)