### PR TITLE
chore(release): 0.6.1

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.6.0';
+export const CLI_VERSION = '0.6.1';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Release 0.6.1 — CLI `init`/`bootstrap` fixes and quality-of-life improvements.

## Included
- **#174** `fix(cli)`: `hola init` no longer crashes (`undefined is not an object (evaluating 'v.trim')`) when an optional field is submitted blank.
- **#176** `feat(cli)`: smarter init defaults
  - reuse the first email for later email prompts
  - authentik is the default SSO mode (secure by default)
  - offer AWS_* credentials already set in the environment instead of pasting
  - plural `apps.<base>` dashboard host

## Mechanics
Bumps the 5 published package versions + `packages/cli/src/version.ts` to `0.6.1`. After merge, tag `cli-v0.6.1` on the squash-merge commit to trigger the CLI Release workflow (CLI binaries + `ghcr.io/try-hola/{server,web}:0.6.1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)