### PR TITLE
feat(cli): hola init wizard polish — Note: hints, timezone & plural-host defaults

### DIFF
--- a/packages/cli/src/__tests__/install-schema.test.ts
+++ b/packages/cli/src/__tests__/install-schema.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 
-import { INSTALL_SCHEMA, defaultFor, secretKeys } from '../install/schema';
+import { INSTALL_SCHEMA, defaultFor, secretKeys, systemTimeZone } from '../install/schema';
 import { parseEnv, renderEnv, schemaTemplate } from '../install/render-env';
 import { interdependencyErrors, isDomain, isEmail, isEmailOrEmpty, optionalSecret } from '../install/validate';
 import { toClackValidate } from '../install/prompter';
@@ -35,6 +35,13 @@ describe('install schema', () => {
   it('marks the AWS credential fields as reusable from the environment', () => {
     const fromEnv = INSTALL_SCHEMA.filter((f) => f.fromEnv).map((f) => f.key);
     expect(fromEnv).toEqual(['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_REGION', 'AWS_HOSTED_ZONE_ID']);
+  });
+
+  it("defaults the timezone to this machine's timezone", () => {
+    const tz = INSTALL_SCHEMA.find((f) => f.key === 'HOLA_DEFAULT_TZ')!;
+    expect(defaultFor(tz, {})).toBe(systemTimeZone());
+    // Intl resolves a real IANA zone on any CI host, so the default is non-empty there.
+    expect(defaultFor(tz, {})).toMatch(/^[A-Za-z]+\/[A-Za-z]/);
   });
 
   it('gates conditional fields with requiredWhen', () => {

--- a/packages/cli/src/install/schema.ts
+++ b/packages/cli/src/install/schema.ts
@@ -44,6 +44,15 @@ const isRoute53 = (c: ConfigMap) => c.ACME_DNS_PROVIDER === 'route53';
 const isCloudflare = (c: ConfigMap) => c.ACME_DNS_PROVIDER === 'cloudflare';
 const isAuthentik = (c: ConfigMap) => c.HOLA_AUTH_MODE === 'authentik';
 
+/** IANA timezone of the machine running the wizard (e.g. America/New_York), or '' if undetectable. Honors $TZ. */
+export function systemTimeZone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || '';
+  } catch {
+    return '';
+  }
+}
+
 export const INSTALL_SCHEMA: InstallField[] = [
   {
     key: 'HOLA_BASE_DOMAIN',
@@ -139,14 +148,15 @@ export const INSTALL_SCHEMA: InstallField[] = [
     key: 'HOLA_DEFAULT_TZ',
     type: 'text',
     prompt: 'Default timezone for deployed apps (TZ, blank to leave unset)',
-    help: 'e.g. UTC or America/New_York; applied to apps that do not set TZ',
-    default: '',
+    help: 'Applied to apps that do not set TZ; defaults to this machine\'s timezone',
+    // Prefill the timezone of the machine running `hola init`.
+    default: () => systemTimeZone(),
   },
   {
     key: 'HOLA_AUTH_MODE',
     type: 'select',
     prompt: 'SSO platform for catalog apps',
-    help: 'authentik brings up the bundled Authentik stack (~2 GB RAM)',
+    help: 'Note: authentik brings up the bundled Authentik stack (~2 GB RAM)',
     // Secure by default: provision per-app SSO unless the operator opts out.
     default: 'authentik',
     options: [

--- a/packages/cli/src/install/schema.ts
+++ b/packages/cli/src/install/schema.ts
@@ -78,7 +78,7 @@ export const INSTALL_SCHEMA: InstallField[] = [
     key: 'ACME_DNS_PROVIDER',
     type: 'select',
     prompt: 'TLS certificate challenge',
-    help: 'DNS-01 is required for private/homelab hosts not reachable on :80',
+    help: 'Note: DNS-01 is required for private/homelab hosts not reachable on :80',
     default: '',
     options: [
       { value: '', label: 'HTTP-01 (host is internet-reachable on port 80)' },


### PR DESCRIPTION
A few small `hola init` wizard refinements:

## "Note:" prefixes on select hints
Two `select` hints started with a word that looked like a fourth choice in the list. Prefixed both with `Note:`:

```
TLS certificate challenge
│    Note: DNS-01 is required for private/homelab hosts not reachable on :80
│  ○ HTTP-01 …

SSO platform for catalog apps
│    Note: authentik brings up the bundled Authentik stack (~2 GB RAM)
│  ● authentik — …
```

## Default the timezone to the host
`HOLA_DEFAULT_TZ` now prefills the IANA timezone of the machine running `hola init` (`Intl.DateTimeFormat().resolvedOptions().timeZone`, which honors `$TZ`). Blank still leaves it unset.

## Test
`bun --cwd packages/cli test` → 58 passed; typecheck + lint + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)