### PR TITLE
feat(cli): smooth init→bootstrap handoff and .env reuse

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -31,8 +31,8 @@ Commands are registered in `src/index.tsx` with lazy loaders and implemented und
 ## Commands
 
 ### Setup
-- `hola init` — interactively generate a validated Hola `.env` (runs locally; no server needed).
-- `hola bootstrap --host user@vm` — set up Hola on a remote host over SSH (wizard + install).
+- `hola bootstrap --host user@vm` — **the one-step install.** Walks the setup wizard and installs Hola on the host over SSH. This is all most people need.
+- `hola init` — *optional.* Just generate a validated `.env` locally (no server/SSH) — for reviewing/editing config before install, keeping it in a secrets manager, reusing it across hosts, or CI. It then offers to hand off to `bootstrap`, and `bootstrap` reuses an init-produced `.env` rather than re-asking. Options: `--out`, `--compose-dir`, `--force`, `--keep-env`, `--skip-checks`, `--json`.
 
 ### Catalog & install
 - `hola catalog [query]` — browse/search the app catalog. Options: `--category`, `--limit`, `--json`.

--- a/packages/cli/src/__tests__/bootstrap.test.ts
+++ b/packages/cli/src/__tests__/bootstrap.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, writeFile, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
 import { runBootstrap } from '../commands/bootstrap/bootstrap';
 import { scriptedPrompter } from '../install/prompter';
@@ -117,5 +120,30 @@ describe('hola bootstrap', () => {
     const res = await runBootstrap({ skipChecks: true, json: true }, { prompter: scriptedPrompter(answers), runner: makeRunner() });
     expect(res).toBeUndefined();
     expect(process.exitCode).toBe(1);
+  });
+
+  it('detects an init-produced .env and reuses it instead of re-asking the wizard', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'hola-boot-'));
+    const envPath = join(tmp, '.env');
+    // A marker value the wizard would never produce, proving the file was reused.
+    await writeFile(envPath, 'HOLA_DOMAIN=reused.example.com\nHOLA_API_KEY=from-the-file\n');
+    const runner = makeRunner();
+    try {
+      const res = await runBootstrap(
+        { host: 'me@vm', skipChecks: true }, // interactive: detection runs
+        {
+          // Empty answers: if the wizard ran, its required fields would throw.
+          prompter: scriptedPrompter({}),
+          runner,
+          findEnvFile: async () => envPath,
+        }
+      );
+      expect(res?.host).toBe('me@vm');
+      const writeCall = runner.calls.find((c) => c.cmd.includes('cat >'))!;
+      expect(writeCall.input).toContain('HOLA_DOMAIN=reused.example.com');
+      expect(writeCall.input).toContain('HOLA_API_KEY=from-the-file');
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/cli/src/__tests__/init.test.ts
+++ b/packages/cli/src/__tests__/init.test.ts
@@ -92,6 +92,66 @@ describe('hola init', () => {
     expect(process.exitCode).toBe(1);
   });
 
+  it('offers to install, hands the .env to bootstrap, and deletes it on success', async () => {
+    const out = join(dir, '.env');
+    const calls: Array<{ host?: string; envFile?: string }> = [];
+    const res = await runInit(
+      { out, skipChecks: true }, // interactive (no json) → the install offer runs
+      {
+        prompter: scriptedPrompter({ ...baseAnswers, _bootstrap: 'true', _host: 'paul@vm' }),
+        checks: noChecks,
+        bootstrap: async (o) => { calls.push(o); return { host: o.host!, dir: '/opt/hola', ref: 'cli-v9', steps: [] }; },
+      }
+    );
+
+    expect(res?.target).toBe(out);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ host: 'paul@vm', envFile: out });
+    // .env removed once its secrets are on the host.
+    await expect(readFile(out, 'utf8')).rejects.toThrow();
+  });
+
+  it('keeps the .env with --keep-env after a successful install', async () => {
+    const out = join(dir, '.env');
+    await runInit(
+      { out, skipChecks: true, keepEnv: true },
+      {
+        prompter: scriptedPrompter({ ...baseAnswers, _bootstrap: 'true', _host: 'paul@vm' }),
+        checks: noChecks,
+        bootstrap: async (o) => ({ host: o.host!, dir: '/opt/hola', ref: 'cli-v9', steps: [] }),
+      }
+    );
+    expect(await readFile(out, 'utf8')).toContain('HOLA_BASE_DOMAIN=hola.example.com'); // still there
+  });
+
+  it('keeps the .env when bootstrap fails so the user can retry', async () => {
+    const out = join(dir, '.env');
+    await runInit(
+      { out, skipChecks: true },
+      {
+        prompter: scriptedPrompter({ ...baseAnswers, _bootstrap: 'true', _host: 'paul@vm' }),
+        checks: noChecks,
+        bootstrap: async () => undefined, // bootstrap reported an error
+      }
+    );
+    expect(await readFile(out, 'utf8')).toContain('HOLA_BASE_DOMAIN='); // preserved
+  });
+
+  it('does not call bootstrap when the install offer is declined', async () => {
+    const out = join(dir, '.env');
+    let called = false;
+    await runInit(
+      { out, skipChecks: true },
+      {
+        prompter: scriptedPrompter({ ...baseAnswers, _bootstrap: 'false', _host: 'paul@vm' }),
+        checks: noChecks,
+        bootstrap: async () => { called = true; return undefined; },
+      }
+    );
+    expect(called).toBe(false);
+    expect(await readFile(out, 'utf8')).toContain('HOLA_BASE_DOMAIN='); // kept for later
+  });
+
   it('skips conditional fields when not applicable (none/http-01)', async () => {
     const out = join(dir, '.env');
     await runInit(

--- a/packages/cli/src/commands/bootstrap/bootstrap.ts
+++ b/packages/cli/src/commands/bootstrap/bootstrap.ts
@@ -51,9 +51,32 @@ function releaseBase(repo: string): string {
  * pulls the published images), and verify. Returns the result, or undefined on
  * failure (after setting a non-zero exit code).
  */
+/** First existing `.env` a freshly-run `hola init` would have written, or null. */
+async function defaultFindEnvFile(): Promise<string | null> {
+  const candidates = [
+    path.resolve(process.cwd(), 'packages/compose/.env'),
+    path.resolve(process.cwd(), '.env'),
+  ];
+  for (const c of candidates) {
+    try {
+      await fs.access(c);
+      return c;
+    } catch {
+      // try the next candidate
+    }
+  }
+  return null;
+}
+
 export async function runBootstrap(
   opts: BootstrapOptions,
-  injected?: { prompter?: Prompter; runner?: Runner; checks?: (c: ConfigMap) => Promise<CheckResult[]> }
+  injected?: {
+    prompter?: Prompter;
+    runner?: Runner;
+    checks?: (c: ConfigMap) => Promise<CheckResult[]>;
+    /** Locate a reusable .env (defaults to the init-produced compose/.env); injectable for tests. */
+    findEnvFile?: () => Promise<string | null>;
+  }
 ): Promise<BootstrapResult | undefined> {
   const prompter = injected?.prompter ?? clackPrompter();
   const runner = injected?.runner ?? systemRunner();
@@ -74,14 +97,28 @@ export async function runBootstrap(
   try {
     if (!host) throw new BootstrapAbort('--host user@vm is required.');
 
-    // 1) Config → rendered .env (reuse an init-produced file, or run the wizard).
+    // 1) Config → rendered .env: an explicit --env-file, else a detected
+    //    init-produced .env we offer to reuse, else the wizard. Detection only
+    //    runs interactively (skipped under --json, which is for scripted use).
     let rendered: string;
     let config: ConfigMap;
-    if (opts.envFile) {
-      const p = path.resolve(process.cwd(), opts.envFile);
-      rendered = await fs.readFile(p, 'utf8');
+    let reuse: string | null = opts.envFile ? path.resolve(process.cwd(), opts.envFile) : null;
+    if (!reuse && !opts.json) {
+      const found = await (injected?.findEnvFile ?? defaultFindEnvFile)();
+      if (found) {
+        const ans = await prompter.prompt({
+          key: '_use_env',
+          type: 'confirm',
+          message: `Found ${found} — use it (skip the questions)?`,
+          default: 'true',
+        });
+        if (ans === 'true') reuse = found;
+      }
+    }
+    if (reuse) {
+      rendered = await fs.readFile(reuse, 'utf8');
       config = parseEnv(rendered);
-      out(`Using ${p}`);
+      out(`Using ${reuse}`);
     } else {
       out('Hola setup — answer a few questions, then I will install on the host.\n');
       const wiz = await runWizard({ prompter, skipChecks: opts.skipChecks, checks: injected?.checks });

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -6,6 +6,7 @@ import { parseEnv, renderEnv, schemaTemplate } from '../../install/render-env';
 import { secretKeys, type ConfigMap } from '../../install/schema';
 import { runWizard, WizardError } from '../../install/wizard';
 import type { CheckResult } from '../../install/checks';
+import type { BootstrapOptions, BootstrapResult } from '../bootstrap/bootstrap';
 
 export interface InitOptions {
   out?: string;
@@ -13,7 +14,15 @@ export interface InitOptions {
   force?: boolean;
   skipChecks?: boolean;
   json?: boolean;
+  /** Keep the local .env after a successful remote install (default: delete it). */
+  keepEnv?: boolean;
 }
+
+/** The bootstrap entrypoint, narrowed to what the init handoff needs; injectable for tests. */
+type BootstrapFn = (
+  opts: BootstrapOptions,
+  injected?: { prompter?: Prompter }
+) => Promise<BootstrapResult | undefined>;
 
 export interface InitResult {
   target: string;
@@ -47,7 +56,7 @@ async function resolveComposeDir(opts: InitOptions): Promise<string> {
  */
 export async function runInit(
   opts: InitOptions,
-  injected?: { prompter?: Prompter; checks?: (c: ConfigMap) => Promise<CheckResult[]> }
+  injected?: { prompter?: Prompter; checks?: (c: ConfigMap) => Promise<CheckResult[]>; bootstrap?: BootstrapFn }
 ): Promise<InitResult | undefined> {
   const prompter = injected?.prompter ?? clackPrompter();
   const out = (msg: string) => { if (!opts.json) console.log(msg); };
@@ -86,13 +95,54 @@ export async function runInit(
     await fs.chmod(target, 0o600); // ensure 0600 even if the file pre-existed
 
     const result: InitResult = { target, config };
+
+    // JSON / non-interactive mode: emit the result and stop (no prompts).
     if (opts.json) {
       console.log(JSON.stringify({ target, config: redact(config) }, null, 2));
+      return result;
+    }
+
+    out(`\nWrote ${target}`);
+    out('  Note: this file holds the values you entered, including any secrets (it is chmod 600).');
+
+    // Offer the one-step remote install so the freshly written .env is reused
+    // (no re-answering the wizard), then prompt for the target host.
+    const wantsInstall = await prompter.prompt({
+      key: '_bootstrap',
+      type: 'confirm',
+      message: 'Install Hola on a host now over SSH?',
+      default: 'true',
+    });
+    if (wantsInstall !== 'true') {
+      out('\nWhen you are ready, install on a host with:');
+      out(`  hola bootstrap --host user@your-vm --env-file ${target}`);
+      return result;
+    }
+
+    const host = (await prompter.prompt({
+      key: '_host',
+      type: 'text',
+      message: 'Target host to install on (user@host)',
+      validate: (v: string) => (v.trim() ? undefined : 'A host is required'),
+    })).trim();
+
+    // Lazily load bootstrap so `hola init` stays light when not installing.
+    const bootstrap = injected?.bootstrap ?? (await import('../bootstrap/bootstrap')).runBootstrap;
+    const bootRes = await bootstrap({ host, envFile: target, skipChecks: opts.skipChecks }, { prompter });
+    if (!bootRes) {
+      // bootstrap already reported the error + set the exit code; keep the .env
+      // so the user can retry without re-entering everything.
+      out(`\nKept ${target} so you can retry:  hola bootstrap --host ${host} --env-file ${target}`);
+      return result;
+    }
+
+    // Installed — the secrets now live on the host, so remove the local copy by
+    // default (it's a sensitive artifact). `--keep-env` opts out.
+    if (opts.keepEnv) {
+      out(`\nKept ${target} (--keep-env).`);
     } else {
-      out(`\nWrote ${target}`);
-      out('Next steps:');
-      out('  • On the host (in your Hola checkout): cd packages/compose && ./scripts/install.sh');
-      out('  • Or from here, all at once:           hola bootstrap --host user@your-vm');
+      await fs.rm(target, { force: true });
+      out(`\nRemoved ${target} — its secrets now live only on ${host}.`);
     }
     return result;
   } catch (err) {

--- a/packages/cli/src/index.tsx
+++ b/packages/cli/src/index.tsx
@@ -21,6 +21,7 @@ prog
   .option('--compose-dir', 'Path to the packages/compose directory')
   .option('--force', 'Update an existing .env in place', false)
   .option('--skip-checks', 'Skip live DNS/credential/catalog validation', false)
+  .option('--keep-env', 'Keep the local .env after a successful remote install', false)
   .option('--json', 'Print the resolved config as JSON (secrets redacted)', false)
   .action(async (opts) => {
     const { runInit } = await load(import('./commands/init/init'));

--- a/packages/cli/src/index.tsx
+++ b/packages/cli/src/index.tsx
@@ -14,9 +14,11 @@ prog
   .describe('Hola CLI — install, deployments, and the bundle developer workflow');
 
 // init — guided first-time setup (writes .env on this machine; no server needed)
+// Optional: `hola bootstrap` does the wizard + install in one step. init is for
+// when you want the validated .env on its own (review/edit, secrets manager, CI).
 prog
   .command('init')
-  .describe('Interactively generate a Hola .env (validated, runs locally)')
+  .describe('Optional: generate a validated .env locally (bootstrap does this + installs)')
   .option('--out', 'Path to write the .env (default <compose-dir>/.env)')
   .option('--compose-dir', 'Path to the packages/compose directory')
   .option('--force', 'Update an existing .env in place', false)
@@ -31,7 +33,7 @@ prog
 // bootstrap — wizard + SSH into the host and run the full install
 prog
   .command('bootstrap')
-  .describe('Set up Hola on a remote host over SSH (wizard + install)')
+  .describe('Install Hola on a host over SSH — the one-step setup (wizard + install)')
   .option('--host', 'Target host, e.g. user@vm (required)')
   .option('--repo', 'Hola repo to download release assets from', 'https://github.com/try-hola/hola.git')
   .option('--ref', `Release tag to install (default cli-v${CLI_VERSION})`)
@@ -171,8 +173,10 @@ prog
 
 // Fallback banner when no args
 if (process.argv.length <= 2) {
-  // Minimal banner when no args
-  console.log('Hola CLI ready. Try: hola catalog · hola install <app> · hola deployments');
+  // Minimal banner when no args. Lead with setup for first-time users, then the
+  // day-to-day commands for an installed server.
+  console.log('Hola CLI. New here? Set up a server: hola bootstrap --host user@vm');
+  console.log('Installed? Try: hola catalog · hola install <app> · hola deployments');
 } else {
   prog.parse(process.argv);
 }


### PR DESCRIPTION
Addresses the "why am I answering the wizard twice?" papercut: `hola init` then `hola bootstrap` re-prompted everything.

## `hola init` — offer to install, then chain into bootstrap
After writing the `.env`:
1. Warns that the file holds the secrets you entered (it's `chmod 600`).
2. Offers **"Install Hola on a host now over SSH?"** and prompts for `user@host`, handing the freshly written `.env` straight to `bootstrap` via `--env-file` (no re-asking).
3. On a successful install, **deletes the local `.env` by default** — its secrets now live only on the host. `--keep-env` opts out; if bootstrap fails, the file is kept so you can retry.
4. Drops the stale `cd packages/compose && ./scripts/install.sh` hint.

## `hola bootstrap` — detect and reuse an init `.env`
When `--env-file` isn't given, bootstrap now looks for an init-produced `.env` (`packages/compose/.env`, then `./.env`) and offers **"Found <path> — use it (skip the questions)?"** instead of blindly re-running the wizard. Detection is interactive-only (skipped under `--json`, which is for scripted use — pass `--env-file` there).

## Notes
- The two commands stay separable (init = produce a config artifact locally; bootstrap = provision a host). This just makes the common path one smooth flow and removes the double-wizard.
- `bootstrap --host user@vm` on its own still does wizard→install in one step.

## Test
New coverage: init offers→hands off→deletes (and `--keep-env` / failure / declined paths); bootstrap detects+reuses a `.env` without re-asking. `bun --cwd packages/cli test` → 62 passed; typecheck + lint + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)