### PR TITLE
chore(release): 0.6.2

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.6.1';
+export const CLI_VERSION = '0.6.2';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Release 0.6.2 — CLI `init`/`bootstrap` UX overhaul.

## Included
- **#179** `feat`: smooth init→bootstrap handoff and `.env` reuse; `bootstrap` positioned as the one-step install, `init` as optional.
- **#178** `feat`: init polish — `Note:` prefixes on select hints, default timezone to the host's, plural `apps.<base>` dashboard host.
- **#175** `refactor`: remove the hand-build `bundle` commands.
- **#173** `docs`: clarify the post-install hint for first-time users.

## Mechanics
Bumps the 5 published package versions + `packages/cli/src/version.ts` to `0.6.2`. After merge, tag `cli-v0.6.2` to trigger the CLI Release workflow (binaries + `ghcr.io/try-hola/{server,web}:0.6.2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)