### PR TITLE
feat(cli): bootstrap hands back credentials after install

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -31,7 +31,7 @@ Commands are registered in `src/index.tsx` with lazy loaders and implemented und
 ## Commands
 
 ### Setup
-- `hola bootstrap --host user@vm` — **the one-step install.** Walks the setup wizard and installs Hola on the host over SSH. This is all most people need.
+- `hola bootstrap --host user@vm` — **the one-step install.** Walks the setup wizard and installs Hola on the host over SSH. This is all most people need. After install it hands you your credentials: it saves the generated admin API key to a local `hola-<host>.env` (`source` it to use the CLI), and for the dashboard it surfaces your one-time SSO password-setup link (when you configured a named admin) or offers to reveal the `akadmin` password once (fallback).
 - `hola init` — *optional.* Just generate a validated `.env` locally (no server/SSH) — for reviewing/editing config before install, keeping it in a secrets manager, reusing it across hosts, or CI. It then offers to hand off to `bootstrap`, and `bootstrap` reuses an init-produced `.env` rather than re-asking. Options: `--out`, `--compose-dir`, `--force`, `--keep-env`, `--skip-checks`, `--json`.
 
 ### Catalog & install

--- a/packages/cli/src/__tests__/bootstrap.test.ts
+++ b/packages/cli/src/__tests__/bootstrap.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdtemp, writeFile, rm } from 'fs/promises';
+import { mkdtemp, writeFile, readFile, rm } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
@@ -31,6 +31,9 @@ function makeRunner(preflight = OK_PREFLIGHT): Runner & { calls: { cmd: string; 
     ssh: vi.fn(async (_host: string, cmd: string, opts?: { input?: string }) => {
       calls.push({ cmd, input: opts?.input });
       if (cmd.includes('command -v')) return { code: 0, stdout: preflight, stderr: '' };
+      if (cmd.includes('admin-api-key')) return { code: 0, stdout: 'generated-key-123', stderr: '' };
+      if (cmd.includes('Hola admin setup')) return { code: 0, stdout: 'https://auth.example.com/if/flow/recovery/abc', stderr: '' };
+      if (cmd.includes('AUTHENTIK_BOOTSTRAP_PASSWORD')) return { code: 0, stdout: 'akadmin-pw-xyz', stderr: '' };
       if (cmd.includes('curl')) return { code: 0, stdout: '200', stderr: '' };
       return { code: 0, stdout: '', stderr: '' };
     }),
@@ -77,7 +80,7 @@ describe('hola bootstrap', () => {
       ),
     ).toBe(true);
     expect(runner.calls.some((c) => c.cmd.includes('cat > /opt/hola/.env'))).toBe(true);
-    expect(runner.calls.some((c) => c.cmd.includes('cd /opt/hola && ./scripts/install.sh'))).toBe(true);
+    expect(runner.calls.some((c) => c.cmd.includes('cd /opt/hola && HOLA_BOOTSTRAP=1 ./scripts/install.sh'))).toBe(true);
     // /opt is root-owned: the fetch step creates the dir with sudo + chown when
     // the parent isn't writable (and plain mkdir when it is).
     const fetch = runner.calls.find((c) => c.cmd.includes('tar xz -C /opt/hola'))!;
@@ -120,6 +123,93 @@ describe('hola bootstrap', () => {
     const res = await runBootstrap({ skipChecks: true, json: true }, { prompter: scriptedPrompter(answers), runner: makeRunner() });
     expect(res).toBeUndefined();
     expect(process.exitCode).toBe(1);
+  });
+
+  // --- Credential handoff (interactive runs) ---------------------------------
+
+  async function withEnv(content: string, run: (tmp: string, envPath: string) => Promise<void>) {
+    const tmp = await mkdtemp(join(tmpdir(), 'hola-creds-'));
+    const envPath = join(tmp, '.env');
+    await writeFile(envPath, content);
+    try { await run(tmp, envPath); } finally { await rm(tmp, { recursive: true, force: true }); }
+  }
+
+  it('saves the fetched admin API key to a local creds file', async () => {
+    await withEnv(
+      'HOLA_DOMAIN=apps.example.com\nHOLA_USE_AUTH=true\nHOLA_API_KEY=\nHOLA_AUTH_MODE=none\n',
+      async (tmp, envPath) => {
+        const runner = makeRunner();
+        await runBootstrap(
+          { host: 'paul@vm', envFile: envPath, skipChecks: true },
+          { prompter: scriptedPrompter({}), runner, credsDir: tmp }
+        );
+        const creds = await readFile(join(tmp, 'hola-paul-vm.env'), 'utf8');
+        expect(creds).toContain('export HOLA_API_URL=https://apps.example.com');
+        expect(creds).toContain('export HOLA_TOKEN=generated-key-123');
+        expect(runner.calls.some((c) => c.cmd.includes('admin-api-key'))).toBe(true);
+      }
+    );
+  });
+
+  it('uses a pinned HOLA_API_KEY without fetching it from the host', async () => {
+    await withEnv(
+      'HOLA_DOMAIN=apps.example.com\nHOLA_USE_AUTH=true\nHOLA_API_KEY=pinned-key\nHOLA_AUTH_MODE=none\n',
+      async (tmp) => {
+        const runner = makeRunner();
+        await runBootstrap(
+          { host: 'paul@vm', envFile: join(tmp, '.env'), skipChecks: true },
+          { prompter: scriptedPrompter({}), runner, credsDir: tmp }
+        );
+        const creds = await readFile(join(tmp, 'hola-paul-vm.env'), 'utf8');
+        expect(creds).toContain('export HOLA_TOKEN=pinned-key');
+        expect(runner.calls.some((c) => c.cmd.includes('admin-api-key'))).toBe(false);
+      }
+    );
+  });
+
+  it('auto-surfaces the named-admin recovery link (no password prompt)', async () => {
+    await withEnv(
+      'HOLA_DOMAIN=apps.example.com\nHOLA_USE_AUTH=true\nHOLA_API_KEY=k\nHOLA_AUTH_MODE=authentik\nHOLA_ADMIN_EMAIL=me@example.com\nHOLA_AUTHENTIK_DOMAIN=auth.example.com\n',
+      async (tmp) => {
+        const runner = makeRunner();
+        await runBootstrap(
+          { host: 'paul@vm', envFile: join(tmp, '.env'), skipChecks: true },
+          { prompter: scriptedPrompter({}), runner, credsDir: tmp }
+        );
+        // Recovery link is fetched; the akadmin password is never read.
+        expect(runner.calls.some((c) => c.cmd.includes('Hola admin setup'))).toBe(true);
+        expect(runner.calls.some((c) => c.cmd.includes('AUTHENTIK_BOOTSTRAP_PASSWORD'))).toBe(false);
+      }
+    );
+  });
+
+  it('reveals the akadmin password only when there is no named admin and the user opts in', async () => {
+    await withEnv(
+      'HOLA_DOMAIN=apps.example.com\nHOLA_USE_AUTH=true\nHOLA_API_KEY=k\nHOLA_AUTH_MODE=authentik\nHOLA_ADMIN_EMAIL=\nHOLA_AUTHENTIK_DOMAIN=auth.example.com\n',
+      async (tmp) => {
+        const runner = makeRunner();
+        await runBootstrap(
+          { host: 'paul@vm', envFile: join(tmp, '.env'), skipChecks: true },
+          { prompter: scriptedPrompter({ _show_akadmin_pw: 'true' }), runner, credsDir: tmp }
+        );
+        expect(runner.calls.some((c) => c.cmd.includes('AUTHENTIK_BOOTSTRAP_PASSWORD'))).toBe(true);
+        expect(runner.calls.some((c) => c.cmd.includes('Hola admin setup'))).toBe(false);
+      }
+    );
+  });
+
+  it('does not read the akadmin password when the reveal is declined', async () => {
+    await withEnv(
+      'HOLA_DOMAIN=apps.example.com\nHOLA_USE_AUTH=true\nHOLA_API_KEY=k\nHOLA_AUTH_MODE=authentik\nHOLA_ADMIN_EMAIL=\nHOLA_AUTHENTIK_DOMAIN=auth.example.com\n',
+      async (tmp) => {
+        const runner = makeRunner();
+        await runBootstrap(
+          { host: 'paul@vm', envFile: join(tmp, '.env'), skipChecks: true },
+          { prompter: scriptedPrompter({ _show_akadmin_pw: 'false' }), runner, credsDir: tmp }
+        );
+        expect(runner.calls.some((c) => c.cmd.includes('AUTHENTIK_BOOTSTRAP_PASSWORD'))).toBe(false);
+      }
+    );
   });
 
   it('detects an init-produced .env and reuses it instead of re-asking the wizard', async () => {

--- a/packages/cli/src/commands/bootstrap/bootstrap.ts
+++ b/packages/cli/src/commands/bootstrap/bootstrap.ts
@@ -51,6 +51,11 @@ function releaseBase(repo: string): string {
  * pulls the published images), and verify. Returns the result, or undefined on
  * failure (after setting a non-zero exit code).
  */
+/** Filesystem-safe slug for a host (paul@vm → paul-vm), for the local creds filename. */
+function hostSlug(host: string): string {
+  return host.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'host';
+}
+
 /** First existing `.env` a freshly-run `hola init` would have written, or null. */
 async function defaultFindEnvFile(): Promise<string | null> {
   const candidates = [
@@ -76,6 +81,8 @@ export async function runBootstrap(
     checks?: (c: ConfigMap) => Promise<CheckResult[]>;
     /** Locate a reusable .env (defaults to the init-produced compose/.env); injectable for tests. */
     findEnvFile?: () => Promise<string | null>;
+    /** Directory the local CLI-credentials file is written to (defaults to cwd); injectable for tests. */
+    credsDir?: string;
   }
 ): Promise<BootstrapResult | undefined> {
   const prompter = injected?.prompter ?? clackPrompter();
@@ -193,8 +200,9 @@ export async function runBootstrap(
     const writeRes = await ssh('Write .env (over stdin)', `cat > ${envPath} && chmod 600 ${envPath}`, { input: rendered });
     if (!opts.dryRun && writeRes.code !== 0) throw new BootstrapAbort(`Writing ${envPath} failed (exit ${writeRes.code}).`);
 
-    // 5) Run the installer, streaming its output.
-    const installRes = await ssh('Run install.sh', `cd ${composeDir} && ./scripts/install.sh`, { stream: true });
+    // 5) Run the installer, streaming its output. HOLA_BOOTSTRAP=1 silences its
+    //    credential hints — the CLI retrieves and presents those itself (step 7).
+    const installRes = await ssh('Run install.sh', `cd ${composeDir} && HOLA_BOOTSTRAP=1 ./scripts/install.sh`, { stream: true });
     if (!opts.dryRun && installRes.code !== 0) throw new BootstrapAbort(`install.sh failed (exit ${installRes.code}).`);
 
     // 6) Best-effort verify (warn-only: DNS/cert may still be settling).
@@ -205,6 +213,75 @@ export async function runBootstrap(
       );
       const codeStr = verify.stdout.trim();
       out(codeStr === '200' ? '  UI is responding (200).' : `  UI not ready yet (got "${codeStr || 'no response'}") — may take a minute for TLS/DNS.`);
+    }
+
+    // 7) Credential handoff (interactive runs only — needs a TTY to prompt and to
+    //    print secrets the operator reads once). install.sh stayed quiet (step 5).
+    if (!opts.dryRun && !opts.json) {
+      // 7a) CLI credential: fetch the generated admin API key and save it locally
+      //     so the CLI is ready to point at this server.
+      if (config.HOLA_USE_AUTH === 'true') {
+        let apiKey = config.HOLA_API_KEY?.trim() || undefined; // a pinned key needs no fetch
+        if (!apiKey) {
+          const fetchKey =
+            `cd ${composeDir} && for i in $(seq 1 10); do ` +
+            `k=$(docker compose exec -T server cat /data/config/admin-api-key 2>/dev/null | tr -d '\\r\\n'); ` +
+            `[ -n "$k" ] && { printf %s "$k"; break; }; sleep 2; done`;
+          apiKey = (await ssh('Retrieve admin API key', fetchKey)).stdout.trim() || undefined;
+        }
+        if (apiKey && config.HOLA_DOMAIN) {
+          const credsPath = path.join(injected?.credsDir ?? process.cwd(), `hola-${hostSlug(host)}.env`);
+          await fs.writeFile(
+            credsPath,
+            `# Hola CLI credentials for ${host}. Source this file (or export the vars) to use the CLI.\n` +
+              `export HOLA_API_URL=https://${config.HOLA_DOMAIN}\n` +
+              `export HOLA_TOKEN=${apiKey}\n`,
+            { mode: 0o600 },
+          );
+          out(`\nSaved CLI credentials to ${credsPath} (chmod 600).`);
+          out(`  Use them:  source ${credsPath}   # then e.g. hola catalog`);
+        } else {
+          out('\nThe admin API key was not ready yet (the server may still be starting). Retrieve it with:');
+          out(`  ssh ${host} "cd ${composeDir} && docker compose exec -T server cat /data/config/admin-api-key"`);
+        }
+      }
+
+      // 7b) Web dashboard admin sign-in.
+      if (config.HOLA_AUTH_MODE === 'authentik') {
+        if (config.HOLA_ADMIN_EMAIL?.trim()) {
+          // Named admin → password-less: surface the one-time recovery link the
+          // server logs on first boot (it sets your own password).
+          out(`\nWeb dashboard admin: sign in as ${config.HOLA_ADMIN_EMAIL} via SSO.`);
+          out('  Fetching your one-time password-setup link (logged on first boot; can take a minute)…');
+          const grabLink =
+            `cd ${composeDir} && for i in $(seq 1 30); do ` +
+            `l=$(docker compose logs --no-color --no-log-prefix server 2>&1 | grep -A1 'Hola admin setup' | tail -1 | tr -d '\\r'); ` +
+            `[ -n "$l" ] && { printf %s "$l"; break; }; sleep 3; done`;
+          const link = (await ssh('Fetch admin recovery link', grabLink)).stdout.trim();
+          if (link) {
+            out(`  Open this one-time link to set your password:\n    ${link}`);
+          } else {
+            out('  Not logged yet. Once SSO provisioning finishes, retrieve it with:');
+            out(`    ssh ${host} 'docker logs hola-server | grep -A1 "Hola admin setup"'`);
+          }
+        } else {
+          // akadmin fallback → offer a one-time password reveal (off by default).
+          const authUrl = config.HOLA_AUTHENTIK_DOMAIN ? `https://${config.HOLA_AUTHENTIK_DOMAIN}` : 'your Authentik domain';
+          out(`\nWeb dashboard admin: akadmin at ${authUrl}.`);
+          const reveal = await prompter.prompt({
+            key: '_show_akadmin_pw',
+            type: 'confirm',
+            message: 'Show the akadmin password once now?',
+            default: 'false',
+          });
+          if (reveal === 'true') {
+            const pw = (await ssh('Read akadmin password', `grep '^AUTHENTIK_BOOTSTRAP_PASSWORD=' ${envPath} | cut -d= -f2-`)).stdout.trim();
+            out(pw ? `  akadmin password: ${pw}` : `  Could not read it; see AUTHENTIK_BOOTSTRAP_PASSWORD in ${envPath} on the host.`);
+          } else {
+            out(`  Retrieve it later:  ssh ${host} 'grep AUTHENTIK_BOOTSTRAP_PASSWORD ${envPath}'`);
+          }
+        }
+      }
     }
 
     const result: BootstrapResult = { host, dir, ref, steps };

--- a/packages/compose/scripts/install.sh
+++ b/packages/compose/scripts/install.sh
@@ -126,18 +126,22 @@ else
   "$SCRIPT_DIR/up.sh"
 fi
 
-cat <<'NEXT'
+# Credential hints. Skipped when invoked by `hola bootstrap` (HOLA_BOOTSTRAP=1):
+# the CLI retrieves the API key and reveals the SSO password itself, client-side.
+if [[ "${HOLA_BOOTSTRAP:-}" != "1" ]]; then
+  cat <<'NEXT'
 [install] Done. If auth is enabled and you did not set HOLA_API_KEY, retrieve the
 generated admin API key with:
   docker compose exec server cat /data/config/admin-api-key
 NEXT
 
-if [[ "$AUTH_MODE" == "authentik" ]]; then
-  cat <<NEXT
+  if [[ "$AUTH_MODE" == "authentik" ]]; then
+    cat <<NEXT
 [install] Authentik SSO is enabled. The login UI is at https://${authentik_domain:-auth.local.hola}
   Admin user: akadmin
   Admin password: AUTHENTIK_BOOTSTRAP_PASSWORD in .env
 First boot takes a minute while Authentik runs migrations. Catalog apps that
 support SSO will have their auth provisioned automatically on install.
 NEXT
+  fi
 fi


### PR DESCRIPTION
Today `install.sh` prints host-side hints and leaves you to SSH in and fetch secrets by hand. Since bootstrap is already on the host over SSH, it can do that for you.

## Changes
**`install.sh`** — the two credential hint blocks are skipped when invoked by bootstrap (gated on `HOLA_BOOTSTRAP=1`, which bootstrap now sets when running the installer). Manual `install.sh` runs are unchanged.

**`bootstrap.ts`** — a new post-install **credential handoff** (interactive runs only; `--json`/`--dry-run` skip it):

1. **CLI API key** → fetch the generated `/data/config/admin-api-key` over SSH and write a local `hola-<host>.env` containing `export HOLA_API_URL=…` / `export HOLA_TOKEN=…` (chmod 600). `source` it and the CLI is pointed at your new server. A pinned `HOLA_API_KEY` is used directly without a fetch.
2. **Web dashboard sign-in:**
   - **Named admin** (`HOLA_ADMIN_EMAIL` set — the wizard default) → poll the server logs and surface the **one-time password-setup recovery link** the server mints on first boot. Password-less: you click it and set your own password. *(This is the flow that was always intended — it just wasn't wired into bootstrap.)*
   - **`akadmin` fallback** (no named admin) → **offer** to reveal the generated `AUTHENTIK_BOOTSTRAP_PASSWORD` once (defaults to **No**; if declined, prints how to fetch it later).

## Why
- The API key lands locally so you can immediately run `hola catalog` / `hola install` against the new server.
- The recovery-link path means you never see or store a dashboard password — you set your own via the one-time link.
- Secrets are presented client-side, by you, in your terminal — not left echoed in host install output.

## Test
New bootstrap coverage: API-key save, pinned-key (no fetch), named-admin recovery link (no password read), akadmin opt-in reveal, and declined reveal. `bun --cwd packages/cli test` → 64 passed; `bash -n install.sh` clean; typecheck + lint + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)