### PR TITLE
feat(cli): hola teardown — remove a deployment from a host over SSH

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -33,6 +33,7 @@ Commands are registered in `src/index.tsx` with lazy loaders and implemented und
 ### Setup
 - `hola bootstrap --host user@vm` — **the one-step install.** Walks the setup wizard and installs Hola on the host over SSH. This is all most people need.
 - `hola init` — *optional.* Just generate a validated `.env` locally (no server/SSH) — for reviewing/editing config before install, keeping it in a secrets manager, reusing it across hosts, or CI. It then offers to hand off to `bootstrap`, and `bootstrap` reuses an init-produced `.env` rather than re-asking. Options: `--out`, `--compose-dir`, `--force`, `--keep-env`, `--skip-checks`, `--json`.
+- `hola teardown --host user@vm` — the inverse of `bootstrap`. **Destructive**: stops/removes the platform + app containers, the `hola` network, named volumes (incl. the Authentik DB), and the data/install directories. Requires typing the host to confirm (unless `--yes`). `--keep-data` stops containers but preserves volumes and directories; `--images` also removes the `ghcr.io/try-hola/*` images. Options: `--host`, `--dir`, `--keep-data`, `--images`, `--yes`/`-y`, `--dry-run`, `--json`.
 
 ### Catalog & install
 - `hola catalog [query]` — browse/search the app catalog. Options: `--category`, `--limit`, `--json`.

--- a/packages/cli/src/__tests__/teardown.test.ts
+++ b/packages/cli/src/__tests__/teardown.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { runTeardown } from '../commands/teardown/teardown';
+import { scriptedPrompter } from '../install/prompter';
+import type { Runner } from '../lib/runner';
+
+function makeRunner(): Runner & { calls: string[] } {
+  const calls: string[] = [];
+  return {
+    calls,
+    ssh: vi.fn(async (_host: string, cmd: string) => {
+      calls.push(cmd);
+      if (cmd.includes('command -v docker')) return { code: 0, stdout: 'ok', stderr: '' };
+      return { code: 0, stdout: '', stderr: '' };
+    }),
+    local: vi.fn(async () => ({ code: 0, stdout: '', stderr: '' })),
+  } as Runner & { calls: string[] };
+}
+
+const has = (calls: string[], re: RegExp) => calls.some((c) => re.test(c));
+
+describe('hola teardown', () => {
+  beforeEach(() => { process.exitCode = 0; });
+  afterEach(() => { process.exitCode = 0; });
+
+  it('requires --host', async () => {
+    const res = await runTeardown({ yes: true }, { prompter: scriptedPrompter({}), runner: makeRunner() });
+    expect(res).toBeUndefined();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('full teardown removes containers, network, volumes, dirs (with --yes)', async () => {
+    const runner = makeRunner();
+    const res = await runTeardown({ host: 'me@vm', yes: true }, { prompter: scriptedPrompter({}), runner });
+    expect(res?.host).toBe('me@vm');
+    expect(has(runner.calls, /docker compose down -v --remove-orphans/)).toBe(true);
+    expect(has(runner.calls, /docker rm -f/)).toBe(true);
+    expect(has(runner.calls, /docker network rm hola/)).toBe(true);
+    expect(has(runner.calls, /docker volume ls .*hola.*docker volume rm/)).toBe(true);
+    expect(has(runner.calls, /rm -rf \/opt\/hola/)).toBe(true);
+    // No image removal unless --images.
+    expect(has(runner.calls, /docker rmi/)).toBe(false);
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('--keep-data stops containers but preserves volumes and dirs', async () => {
+    const runner = makeRunner();
+    await runTeardown({ host: 'me@vm', keepData: true, yes: true }, { prompter: scriptedPrompter({}), runner });
+    // down WITHOUT -v
+    expect(has(runner.calls, /docker compose down\s+--remove-orphans/)).toBe(true);
+    expect(has(runner.calls, /docker compose down -v/)).toBe(false);
+    expect(has(runner.calls, /docker volume rm/)).toBe(false);
+    expect(has(runner.calls, /rm -rf/)).toBe(false);
+  });
+
+  it('--images also removes the try-hola images', async () => {
+    const runner = makeRunner();
+    await runTeardown({ host: 'me@vm', images: true, yes: true }, { prompter: scriptedPrompter({}), runner });
+    expect(has(runner.calls, /ghcr\.io\/try-hola\/.*docker rmi -f/)).toBe(true);
+  });
+
+  it('--dry-run prints the plan and connects to nothing', async () => {
+    const runner = makeRunner();
+    const res = await runTeardown({ host: 'me@vm', dryRun: true }, { prompter: scriptedPrompter({}), runner });
+    expect(runner.calls).toHaveLength(0);
+    expect(res?.steps.length).toBeGreaterThan(0);
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('full teardown requires typing the host to confirm', async () => {
+    const runner = makeRunner();
+    // Wrong confirmation → scriptedPrompter throws via the validator → abort, no ssh.
+    const res = await runTeardown(
+      { host: 'me@vm' },
+      { prompter: scriptedPrompter({ _confirm: 'nope' }), runner }
+    );
+    expect(res).toBeUndefined();
+    expect(runner.calls).toHaveLength(0);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('proceeds when the typed host matches', async () => {
+    const runner = makeRunner();
+    const res = await runTeardown(
+      { host: 'me@vm' },
+      { prompter: scriptedPrompter({ _confirm: 'me@vm' }), runner }
+    );
+    expect(res?.host).toBe('me@vm');
+    expect(has(runner.calls, /docker compose down -v/)).toBe(true);
+  });
+
+  it('aborts when --keep-data confirmation is declined', async () => {
+    const runner = makeRunner();
+    const res = await runTeardown(
+      { host: 'me@vm', keepData: true },
+      { prompter: scriptedPrompter({ _confirm: 'false' }), runner }
+    );
+    expect(res).toBeUndefined();
+    expect(runner.calls).toHaveLength(0);
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/packages/cli/src/commands/teardown/teardown.ts
+++ b/packages/cli/src/commands/teardown/teardown.ts
@@ -1,0 +1,160 @@
+import { clackPrompter, PromptCancelled, type Prompter } from '../../install/prompter';
+import { systemRunner, type Runner } from '../../lib/runner';
+
+export interface TeardownOptions {
+  host?: string;
+  /** Install directory on the host (default /opt/hola). */
+  dir?: string;
+  /** Preserve volumes and the data/install directories — only stop + remove containers. */
+  keepData?: boolean;
+  /** Also remove the ghcr.io/try-hola/* images. */
+  images?: boolean;
+  /** Skip the confirmation prompt. */
+  yes?: boolean;
+  /** Print the plan without connecting. */
+  dryRun?: boolean;
+  json?: boolean;
+}
+
+export interface TeardownResult {
+  host: string;
+  dir: string;
+  steps: string[];
+}
+
+class TeardownAbort extends Error {}
+
+const DEFAULT_DIR = '/opt/hola';
+
+/**
+ * Tear down a Hola deployment on a host over SSH — the inverse of `bootstrap`.
+ * By default this is destructive (removes containers, the `hola` network, named
+ * volumes, and the data/install directories); `--keep-data` preserves volumes and
+ * directories. Returns the result, or undefined on failure/cancel (after setting
+ * a non-zero exit code).
+ */
+export async function runTeardown(
+  opts: TeardownOptions,
+  injected?: { prompter?: Prompter; runner?: Runner }
+): Promise<TeardownResult | undefined> {
+  const prompter = injected?.prompter ?? clackPrompter();
+  const runner = injected?.runner ?? systemRunner();
+  const out = (msg: string) => { if (!opts.json) console.log(msg); };
+
+  const host = opts.host;
+  const dir = opts.dir ?? DEFAULT_DIR;
+  const vol = opts.keepData ? '' : '-v';
+
+  // The remote steps. Force-removing by name/label keeps this robust even if the
+  // compose files are already gone. App deployments are separate `hola-<id>`
+  // projects whose containers/volumes also match the `hola` prefix.
+  const steps: { title: string; cmd: string }[] = [
+    {
+      title: 'Stop the platform stack',
+      cmd: `[ -d ${dir} ] && (cd ${dir} && docker compose down ${vol} --remove-orphans) 2>/dev/null || true`,
+    },
+    {
+      title: 'Remove remaining Hola containers',
+      cmd: `docker ps -a --format '{{.Names}}' | grep -E '^hola-' | xargs -r docker rm -f 2>/dev/null || true`,
+    },
+    {
+      title: 'Remove the hola network',
+      cmd: `docker network rm hola 2>/dev/null || true`,
+    },
+  ];
+  if (!opts.keepData) {
+    steps.push({
+      title: 'Remove Hola volumes',
+      cmd: `docker volume ls -q | grep -E '^hola(_|-)' | xargs -r docker volume rm -f 2>/dev/null || true`,
+    });
+    steps.push({
+      title: 'Remove data and install directories',
+      // Derive the app data root from the host .env (falls back to the default),
+      // and also remove the default /srv/hola parent. App data is written by
+      // containers as root, so try sudo -n first.
+      cmd:
+        `apps=$(grep -E '^HOLA_APPS_BIND_ROOT=' ${dir}/.env 2>/dev/null | cut -d= -f2- | xargs); apps="\${apps:-/srv/hola/apps}"; ` +
+        `rm -rf ${dir} 2>/dev/null; ` +
+        `sudo -n rm -rf "$apps" /srv/hola 2>/dev/null || rm -rf "$apps" /srv/hola 2>/dev/null || true`,
+    });
+  }
+  if (opts.images) {
+    steps.push({
+      title: 'Remove Hola images',
+      cmd: `docker images --format '{{.Repository}}:{{.Tag}}' | grep -E '^ghcr.io/try-hola/' | xargs -r docker rmi -f 2>/dev/null || true`,
+    });
+  }
+
+  try {
+    if (!host) throw new TeardownAbort('--host user@vm is required.');
+
+    // Plan (always shown — this is destructive).
+    out(`Teardown plan for ${host}${opts.keepData ? ' (data kept)' : ''}:`);
+    for (const s of steps) out(`  • ${s.title}`);
+    if (!opts.keepData) {
+      out('\nThis PERMANENTLY DELETES all Hola data on the host: named volumes');
+      out(`(incl. the Authentik database), the app data root, and ${dir} (compose, .env, TLS certs).`);
+    }
+
+    if (opts.dryRun) {
+      out('\nDry run — the remote commands that WOULD run:');
+      for (const s of steps) out(`  # ${s.title}\n  ssh ${host} ${s.cmd}`);
+      out('\nNo connection was made. Re-run without --dry-run to execute.');
+      return { host, dir, steps: steps.map((s) => s.title) };
+    }
+
+    // Confirmation. Full teardown requires typing the host (guards against data
+    // loss); --keep-data is a simpler yes/no. `--yes` skips either.
+    if (!opts.yes) {
+      if (opts.keepData) {
+        const ok = await prompter.prompt({
+          key: '_confirm',
+          type: 'confirm',
+          message: `Stop Hola on ${host} (containers only; data kept)?`,
+          default: 'false',
+        });
+        if (ok !== 'true') throw new TeardownAbort('Cancelled.');
+      } else {
+        const typed = await prompter.prompt({
+          key: '_confirm',
+          type: 'text',
+          message: `Type the host (${host}) to confirm permanent deletion`,
+          validate: (v: string) => (v.trim() === host ? undefined : `Enter "${host}" to confirm, or Ctrl-C to cancel`),
+        });
+        if (typed.trim() !== host) throw new TeardownAbort('Cancelled.');
+      }
+    }
+
+    const ssh = async (title: string, cmd: string) => {
+      out(`==> ${title}`);
+      const r = await runner.ssh(host, cmd, { stream: (l) => out(`  ${l}`) });
+      return r;
+    };
+
+    // Connectivity probe — fail fast with a clear message.
+    const probe = await runner.ssh(host, 'command -v docker >/dev/null 2>&1 && echo ok || echo nodocker');
+    if (probe.code !== 0) throw new TeardownAbort(`Could not connect to ${host} (ssh exit ${probe.code}).`);
+    if (!probe.stdout.includes('ok')) out('Note: docker was not found on the host — there may be nothing to remove.');
+
+    for (const s of steps) await ssh(s.title, s.cmd);
+
+    const result: TeardownResult = { host, dir, steps: steps.map((s) => s.title) };
+    if (opts.json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      out(`\nDone. Hola has been torn down on ${host}${opts.keepData ? ' (data preserved)' : ''}.`);
+    }
+    return result;
+  } catch (err) {
+    if (err instanceof TeardownAbort || err instanceof PromptCancelled) {
+      console.error(err.message);
+      process.exitCode = 1;
+      return undefined;
+    }
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`teardown failed: ${msg}`);
+    if (/ENOENT|spawn ssh/i.test(msg)) console.error('Hint: the `ssh` client must be installed and on PATH.');
+    process.exitCode = 1;
+    return undefined;
+  }
+}

--- a/packages/cli/src/index.tsx
+++ b/packages/cli/src/index.tsx
@@ -48,6 +48,22 @@ prog
     await runBootstrap(camelKeys(opts));
   });
 
+// teardown — remove a Hola deployment from a host over SSH (inverse of bootstrap)
+prog
+  .command('teardown')
+  .describe('Tear down Hola on a host over SSH — destructive (removes containers, volumes, data)')
+  .option('--host', 'Target host, e.g. user@vm (required)')
+  .option('--dir', 'Install directory on the host', '/opt/hola')
+  .option('--keep-data', 'Only stop/remove containers; keep volumes and the data/install dirs', false)
+  .option('--images', 'Also remove the ghcr.io/try-hola/* images', false)
+  .option('--yes, -y', 'Skip the confirmation prompt', false)
+  .option('--dry-run', 'Print the plan without connecting', false)
+  .option('--json', 'Print the result as JSON', false)
+  .action(async (opts) => {
+    const { runTeardown } = await load(import('./commands/teardown/teardown'));
+    await runTeardown(camelKeys(opts));
+  });
+
 // catalog — browse the app catalog
 prog
   .command('catalog [query]')


### PR DESCRIPTION
The inverse of `hola bootstrap`: SSH into a host and tear Hola down so you can re-install clean or decommission. (Replaces the by-hand teardown we'd otherwise do over SSH.)

## Behavior
**Destructive by default** — removes, in order:
1. The platform stack (`docker compose down -v --remove-orphans` in the install dir).
2. Any remaining `hola-*` containers — this covers **app deployments**, which are separate `hola-<id>` compose projects on the `hola` network.
3. The `hola` network.
4. Named volumes (`hola_*` — `hola-data`, `authentik-postgres`, `authentik-media/templates/certs`, plus any app volumes).
5. The data + install directories — the app data root read from the host `.env` (`HOLA_APPS_BIND_ROOT`, default `/srv/hola/apps`) plus `/srv/hola`, and the install dir (`/opt/hola`: compose, `.env`, TLS certs). Uses `sudo -n` for container-written root-owned paths, falling back to a plain `rm`.

Force-removing by name/label keeps it robust even when the compose files are already gone.

## Flags & guards
- **Confirmation**: a full teardown requires **typing the host** to confirm (guards against accidental data loss); `--keep-data` uses a simple yes/no. `--yes`/`-y` skips either.
- `--keep-data` — stop/remove containers only; preserve volumes and the data/install dirs.
- `--images` — also remove the `ghcr.io/try-hola/*` images.
- `--dir` — install dir (default `/opt/hola`).
- `--dry-run` — print the exact remote commands and connect to nothing.
- `--json`.

## Why
Re-running `bootstrap` over an existing Authentik install rotates host-generated secrets and breaks the Authentik DB (the Postgres volume keeps its original password). A clean `teardown` → `bootstrap` is the safe reset. (A separate fix to make `bootstrap` merge-preserve the host `.env` is worth doing too — noted for follow-up.)

## Test
8 cases: requires `--host`; full removal command set; `--keep-data` preserves volumes/dirs; `--images`; `--dry-run` touches nothing; typed-host confirmation (match proceeds, mismatch aborts); `--keep-data` decline aborts. `bun --cwd packages/cli test` → 67 passed; typecheck + lint + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)