### PR TITLE
chore(release): 0.6.3

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.6.2';
+export const CLI_VERSION = '0.6.3';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Release 0.6.3.

## Included
- **#183** `feat`: `hola teardown --host user@vm` — the inverse of bootstrap; removes containers (platform + apps), the `hola` network, volumes, and data/install dirs over SSH, with typed-host confirmation. `--keep-data`, `--images`, `--dry-run`.
- **#182** `feat`: bootstrap credential handoff — saves the generated admin API key to a local `hola-<host>.env`, and surfaces the one-time SSO recovery link (named admin) or offers the akadmin password once (fallback). `install.sh` stays quiet under `HOLA_BOOTSTRAP=1`.

## Mechanics
Bumps the 5 published package versions + `packages/cli/src/version.ts` to `0.6.3`. After merge, tag `cli-v0.6.3` to trigger the CLI Release workflow (binaries + `ghcr.io/try-hola/{server,web}:0.6.3`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)