### PR TITLE
chore(release): 0.6.4

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "packages/cli": {
       "name": "@hola/cli",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "bin": {
         "hola": "./bin/hola",
       },
@@ -35,11 +35,11 @@
     },
     "packages/compose": {
       "name": "@hola/compose",
-      "version": "0.6.3",
+      "version": "0.6.4",
     },
     "packages/sdk": {
       "name": "@hola/sdk",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "dependencies": {
         "@hola/shared": "workspace:*",
       },
@@ -53,7 +53,7 @@
     },
     "packages/server": {
       "name": "@hola/server",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "dependencies": {
         "@hola/shared": "workspace:*",
         "jose": "^5.9.6",
@@ -69,7 +69,7 @@
     },
     "packages/shared": {
       "name": "@hola/shared",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "dependencies": {
         "yaml": "^2.9.0",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.6.3';
+export const CLI_VERSION = '0.6.4';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Release **0.6.4**.

## Highlights (from #185)
- **Better bootstrap streaming output (no TUI):** the install step shows a single live spinner with the latest cleaned compose line, then a colorized table of running containers — instead of scrolling `docker compose` noise.
- **`hola credentials --host user@vm`:** the supported "come back later" command to retrieve the CLI API key and wait for / print the SSO admin password-setup link. The CLI no longer ever tells you to SSH in and grep logs.
- **Dropped the unused ink/React dependencies** (the CLI uses clack + picocolors).
- gitignore `hola-*.env` (the per-host creds file was a latent leak).

Bumps `cli`/`compose`/`sdk`/`server`/`shared` to 0.6.4 (`web` stays unversioned). Tagging `cli-v0.6.4` after merge publishes the CLI binaries and `ghcr.io/try-hola/{server,web}:0.6.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)