### PR TITLE
fix(ci): cli-release compile path after index.tsx → index.ts rename

### DIFF
--- a/.github/instructions/cli.instructions.md
+++ b/.github/instructions/cli.instructions.md
@@ -19,7 +19,7 @@ Node/TS CLI orchestrating server APIs and streaming real-time feedback.
 
 ## Core Rules
 - Build requests with `@hola/shared` constants/types.
-- Commands under `src/commands/*`; top-level `src/index.tsx` dispatches.
+- Commands under `src/commands/*`; top-level `src/index.ts` dispatches.
 - SSE: reuse `src/lib/sse.ts`; handle reconnects, SIGINT cleanup, and graceful termination messages.
 - Output: human-friendly by default; `--json` for machine output.
 - **Use Draft workflow for validation**: Validate compose files by creating drafts, uploading files, and using SDK validation methods.

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -110,8 +110,8 @@ jobs:
           mkdir -p dist-bin
           for t in linux-x64 linux-arm64 darwin-x64 darwin-arm64; do
             echo "Building hola-$t"
-            bun build packages/cli/src/index.tsx --compile \
-              --target="bun-$t" --external react-devtools-core \
+            bun build packages/cli/src/index.ts --compile \
+              --target="bun-$t" \
               --outfile "dist-bin/hola-$t"
           done
           ls -lh dist-bin

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ packages/*/coverage
 # TypeScript build info
 **/tsconfig.tsbuildinfo
 .tsbuildinfo
+
+# Bun compile scratch artifacts
+*.bun-build

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -24,9 +24,9 @@ hola --help
 ## Usage
 - From repo root: `bun --filter @hola/cli dev` (interactive dev)
 - Directly in package: `bun --cwd packages/cli dev`
-- Built standalone binary: `bun build packages/cli/src/index.tsx --compile --external react-devtools-core --outfile hola`
+- Built standalone binary: `bun build packages/cli/src/index.ts --compile --outfile hola`
 
-Commands are registered in `src/index.tsx` with lazy loaders and implemented under `src/commands/`. Run `hola --help` (or `hola <command> --help`) for the authoritative, always-current list.
+Commands are registered in `src/index.ts` with lazy loaders and implemented under `src/commands/`. Run `hola --help` (or `hola <command> --help`) for the authoritative, always-current list.
 
 ## Commands
 


### PR DESCRIPTION
The 0.6.4 release (#186) failed in the `release` job's **Compile binaries (cross-target)** step: it still built `packages/cli/src/index.tsx --external react-devtools-core`, but #185 renamed the entry to `src/index.ts` and removed the ink/React deps → `error: ModuleNotFound resolving "packages/cli/src/index.tsx"`.

(The `images` job succeeded, so `ghcr.io/try-hola/{server,web}:0.6.4` are already published; only the binaries + GitHub release were blocked.)

Fixes the workflow compile command and the stale doc/instruction references; also gitignores Bun's `*.bun-build` compile scratch files.

Verified locally:
```
bun build packages/cli/src/index.ts --compile --target=bun-darwin-arm64  # → binary reports 0.6.4
```

After merge I'll re-point the `cli-v0.6.4` tag to include this fix so the release re-runs with the corrected workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)