### PR TITLE
fix(server): create the recovery flow Authentik ships none of (named-admin link)

### DIFF
--- a/packages/server/src/__tests__/integration/authentik-provision.it.ts
+++ b/packages/server/src/__tests__/integration/authentik-provision.it.ts
@@ -265,4 +265,41 @@ describe.skipIf(!dockerOk)('Authentik provisioner (real daemon)', () => {
     await svc.deprovision({ deploymentId: 'dep-ldap-0003abcd', ref: result.ref });
     expect((await akGet(`/api/v3/core/users/${result.ref.bindAccountPk}/`)).status).toBe(404);
   }, 120_000);
+
+  test('scoped-token bootstrap admin: creates the missing recovery flow and mints a link', async () => {
+    // Authentik 2025.x ships NO recovery flow, so the provisioner must create one.
+    // Use the self-bootstrapped scoped token (not the superuser admin token) so this
+    // also verifies the scoped permission set can add the flow + stage bindings.
+    const svc = new RealAuthentikProvisionerService({
+      ...config, authentikApiToken: undefined, authentikBootstrapToken: BOOTSTRAP_TOKEN, adminEmail: 'recovery-it@example.com',
+    });
+
+    // Precondition: confirm Authentik really ships no recovery flow out of the box.
+    const before = (await akGet('/api/v3/flows/instances/?designation=recovery')) as {
+      status: number; body: { results: unknown[] };
+    };
+    expect(before.body.results.length).toBe(0);
+
+    await svc.ensureAdminGroup('hola-admins');
+    const result = await svc.ensureBootstrapAdmin('hola-admins');
+
+    expect(result.recoveryLink).toBeTruthy();
+    expect(result.recoveryLink).toContain('/if/flow/');
+
+    // The recovery flow now exists, is bound to the default brand, and has the two
+    // reused stages (prompt + user-write) so the link can actually set a password.
+    const after = (await akGet('/api/v3/flows/instances/?designation=recovery')) as {
+      status: number; body: { results: Array<{ pk: string; slug: string }> };
+    };
+    const flow = after.body.results.find(f => f.slug === 'hola-recovery');
+    expect(flow).toBeDefined();
+    const brand = (await akGet('/api/v3/core/brands/?default=true')) as {
+      status: number; body: { results: Array<{ flow_recovery: string | null }> };
+    };
+    expect(brand.body.results[0].flow_recovery).toBe(flow!.pk);
+    const bindings = (await akGet(`/api/v3/flows/bindings/?target=${flow!.pk}`)) as {
+      status: number; body: { results: unknown[] };
+    };
+    expect(bindings.body.results.length).toBe(2);
+  }, 180_000);
 });

--- a/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
+++ b/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
@@ -440,7 +440,7 @@ describe('RealAuthentikProvisionerService — scoped-token bootstrap', () => {
 
     // Subclass to skip the real backoff delays.
     class FastProvisioner extends RealAuthentikProvisionerService {
-      protected sleep(_ms: number): Promise<void> { return Promise.resolve(); }
+      protected sleep(): Promise<void> { return Promise.resolve(); }
     }
     const svc = new FastProvisioner({ ...CONFIG, adminEmail: 'me@example.com' });
     const result = await svc.ensureBootstrapAdmin('hola-admins');

--- a/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
+++ b/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
@@ -450,6 +450,40 @@ describe('RealAuthentikProvisionerService — scoped-token bootstrap', () => {
     expect(calls.some((c) => c.method === 'PATCH' && c.path === '/api/v3/core/brands/b1/')).toBe(true);
   });
 
+  test('ensureBootstrapAdmin creates a recovery flow when Authentik ships none', async () => {
+    // Authentik 2025.x has no recovery flow, but does ship default-password-change
+    // (a Prompt + User Write stage) we can reuse.
+    const created: string[] = [];
+    installFetch((call) => {
+      if (call.method === 'GET' && call.path.startsWith('/api/v3/core/users/?email=')) return json({ results: [] });
+      if (call.method === 'POST' && call.path === '/api/v3/core/users/') return json({ pk: 101, last_login: null }, 201);
+      if (call.method === 'GET' && call.path.startsWith('/api/v3/core/groups/?name=')) return json({ results: [{ pk: 'g1', users: [] }] });
+      if (call.method === 'PATCH' && call.path === '/api/v3/core/groups/g1/') return json({ pk: 'g1' });
+      // No recovery flow, and our hola-recovery flow doesn't exist yet.
+      if (call.method === 'GET' && call.path.startsWith('/api/v3/flows/instances/?designation=recovery')) return json({ results: [] });
+      if (call.method === 'GET' && call.path.startsWith('/api/v3/flows/instances/?slug=hola-recovery')) return json({ results: [] });
+      // default-password-change exists with two stages to reuse.
+      if (call.method === 'GET' && call.path.startsWith('/api/v3/flows/instances/?slug=default-password-change')) return json({ results: [{ pk: 'pw-flow' }] });
+      if (call.method === 'GET' && call.path.startsWith('/api/v3/flows/bindings/?target=pw-flow')) return json({ results: [{ stage: 'prompt-stage', order: 0 }, { stage: 'write-stage', order: 1 }] });
+      if (call.method === 'POST' && call.path === '/api/v3/flows/instances/') { created.push('flow'); return json({ pk: 'hola-recovery-pk' }, 201); }
+      if (call.method === 'POST' && call.path === '/api/v3/flows/bindings/') { created.push(`bind:${(call.body as { stage: string }).stage}`); return json({ pk: 'b' }, 201); }
+      if (call.method === 'GET' && call.path.startsWith('/api/v3/core/brands/')) return json({ results: [{ brand_uuid: 'b1', flow_recovery: null }] });
+      if (call.method === 'POST' && call.path === '/api/v3/core/users/101/recovery/') return json({ link: 'https://auth.example.com/if/flow/hola-recovery/?flow_token=abc' });
+      return undefined;
+    });
+    calls.length = 0;
+
+    const svc = new RealAuthentikProvisionerService({ ...CONFIG, adminEmail: 'me@example.com' });
+    const result = await svc.ensureBootstrapAdmin('hola-admins');
+
+    expect(result.recoveryLink).toContain('hola-recovery');
+    // It created the flow and rebound the two reused stages.
+    expect(created).toEqual(['flow', 'bind:prompt-stage', 'bind:write-stage']);
+    // And bound the new flow to the default brand.
+    expect(calls.some((c) => c.method === 'PATCH' && c.path === '/api/v3/core/brands/b1/'
+      && (c.body as { flow_recovery: string }).flow_recovery === 'hola-recovery-pk')).toBe(true);
+  });
+
   test('ensureBootstrapAdmin no-ops without HOLA_ADMIN_EMAIL', async () => {
     installFetch();
     calls.length = 0;

--- a/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
+++ b/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
@@ -419,6 +419,37 @@ describe('RealAuthentikProvisionerService — scoped-token bootstrap', () => {
     expect(calls.some(c => c.method === 'PATCH' && c.path === '/api/v3/core/brands/b1/')).toBe(true);
   });
 
+  test('ensureBootstrapAdmin retries the recovery mint until the flow blueprint lands', async () => {
+    // On a fresh Authentik boot the recovery-flow blueprint is applied a little
+    // after the API starts answering, so the flow query is empty at first.
+    let flowQueries = 0;
+    installFetch((call) => {
+      if (call.method === 'GET' && call.path.startsWith('/api/v3/core/users/?email=')) return json({ results: [] });
+      if (call.method === 'POST' && call.path === '/api/v3/core/users/') return json({ pk: 101, last_login: null }, 201);
+      if (call.method === 'GET' && call.path.startsWith('/api/v3/core/groups/?name=')) return json({ results: [{ pk: 'g1', users: [] }] });
+      if (call.method === 'PATCH' && call.path === '/api/v3/core/groups/g1/') return json({ pk: 'g1' });
+      if (call.method === 'GET' && call.path.startsWith('/api/v3/flows/instances/?designation=recovery')) {
+        flowQueries += 1;
+        return json({ results: flowQueries >= 3 ? [{ pk: 'recovery-flow' }] : [] }); // empty until the 3rd poll
+      }
+      if (call.method === 'GET' && call.path.startsWith('/api/v3/core/brands/')) return json({ results: [{ brand_uuid: 'b1', flow_recovery: null }] });
+      if (call.method === 'POST' && call.path === '/api/v3/core/users/101/recovery/') return json({ link: 'https://auth.example.com/recovery/late' });
+      return undefined;
+    });
+    calls.length = 0;
+
+    // Subclass to skip the real backoff delays.
+    class FastProvisioner extends RealAuthentikProvisionerService {
+      protected sleep(_ms: number): Promise<void> { return Promise.resolve(); }
+    }
+    const svc = new FastProvisioner({ ...CONFIG, adminEmail: 'me@example.com' });
+    const result = await svc.ensureBootstrapAdmin('hola-admins');
+
+    expect(flowQueries).toBeGreaterThanOrEqual(3); // kept polling until the flow appeared
+    expect(result.recoveryLink).toBe('https://auth.example.com/recovery/late');
+    expect(calls.some((c) => c.method === 'PATCH' && c.path === '/api/v3/core/brands/b1/')).toBe(true);
+  });
+
   test('ensureBootstrapAdmin no-ops without HOLA_ADMIN_EMAIL', async () => {
     installFetch();
     calls.length = 0;

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1573,7 +1573,10 @@ async function initializePlatformAuth(): Promise<void> {
   }
 
   const { provisioner } = getServices();
-  const delaysMs = [0, 5_000, 15_000, 30_000, 60_000];
+  // Authentik's first boot (image pull + DB migrations + worker bootstrap) can take
+  // several minutes, so keep retrying with capped backoff rather than giving up
+  // after ~2 minutes. Never blocks serving — runs as a background task.
+  const delaysMs = [0, 5_000, 15_000, 30_000, 60_000, 60_000, 60_000, 60_000, 60_000, 60_000];
   for (let i = 0; i < delaysMs.length; i++) {
     if (delaysMs[i]) await new Promise((r) => setTimeout(r, delaysMs[i]));
     try {

--- a/packages/server/src/services/core/provisioner.ts
+++ b/packages/server/src/services/core/provisioner.ts
@@ -165,6 +165,11 @@ const PROVISIONER_PERMISSIONS = [
   'authentik_outposts.view_outpost',
   'authentik_outposts.change_outpost',
   'authentik_flows.view_flow',
+  // Create a recovery flow (Authentik ships none) reusing the password-change
+  // stages, so a named admin can be sent a one-time password-setup link.
+  'authentik_flows.add_flow',
+  'authentik_flows.view_flowstagebinding',
+  'authentik_flows.add_flowstagebinding',
   // Read certificate-keypairs to pick a signing key for the dashboard OIDC client.
   'authentik_crypto.view_certificatekeypair',
 ];
@@ -564,17 +569,17 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
   /**
    * Mint a one-time recovery link, ensuring a recovery flow is bound first.
    *
-   * Authentik applies its default blueprints (including the recovery flow) a short
-   * while AFTER its API starts answering, so on a fresh first boot the flow may not
-   * exist the instant we provision — `ensureBrandRecoveryFlow` then finds nothing to
-   * bind and `/recovery/` returns 400. Rather than give up one-shot, retry the
-   * bind + mint over a short window so the link is minted as soon as the flow lands.
+   * Authentik 2025.x ships NO recovery flow by default, so a fresh install has
+   * nothing to bind and `/recovery/` returns 400 forever. `ensureBrandRecoveryFlow`
+   * now creates one when missing. The default blueprints it depends on (the
+   * password-change stages) are also applied a little after the API starts
+   * answering, so retry the ensure + mint over a short window.
    */
   private async mintRecoveryLink(userPk: number): Promise<string | undefined> {
     const delaysMs = [0, 3_000, 6_000, 10_000, 15_000, 20_000]; // ~54s total
     for (let i = 0; i < delaysMs.length; i++) {
       if (delaysMs[i]) await this.sleep(delaysMs[i]);
-      // Wait for the recovery flow to exist + be bound before attempting the mint.
+      // Ensure a recovery flow exists + is bound to the brand before the mint.
       if (!(await this.ensureBrandRecoveryFlow())) continue;
       try {
         const res = await this.api<{ link: string }>('POST', `/api/v3/core/users/${userPk}/recovery/`);
@@ -590,25 +595,26 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
   }
 
   /**
-   * Best-effort: ensure a recovery flow is bound to the default brand (so
-   * `/recovery/` works). Returns true once a flow exists and is bound, false while
-   * the flow has not been provisioned yet (so the caller can retry).
+   * Ensure a recovery flow exists and is bound to the default brand (so
+   * `/recovery/` works). Authentik ships none, so create one when absent.
+   * Returns true once a flow exists and is bound, false while the prerequisite
+   * default blueprints have not been applied yet (so the caller can retry).
    */
   private async ensureBrandRecoveryFlow(): Promise<boolean> {
     try {
-      const flows = await this.api<{ results: Array<{ pk: string }> }>(
+      let flowPk: string | undefined = (await this.api<{ results: Array<{ pk: string }> }>(
         'GET', '/api/v3/flows/instances/?designation=recovery'
-      );
-      const flowPk = flows.results?.[0]?.pk;
-      if (!flowPk) return false; // recovery-flow blueprint not applied yet
+      )).results?.[0]?.pk;
+      if (!flowPk) flowPk = await this.createRecoveryFlow();
+      if (!flowPk) return false; // couldn't find or create one yet — retry later
       const brands = await this.api<{ results: Array<{ brand_uuid: string; flow_recovery: string | null }> }>(
         'GET', '/api/v3/core/brands/?default=true'
       );
       const brand = brands.results?.[0];
       if (!brand) return false;
-      if (!brand.flow_recovery) {
+      if (brand.flow_recovery !== flowPk) {
         await this.api('PATCH', `/api/v3/core/brands/${brand.brand_uuid}/`, { flow_recovery: flowPk });
-        this.logger.info('Bound a recovery flow to the default brand', { flowPk });
+        this.logger.info('Bound recovery flow to the default brand', { flowPk });
       }
       return true;
     } catch (error) {
@@ -617,6 +623,42 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
       });
       return false;
     }
+  }
+
+  /**
+   * Create a `recovery`-designation flow, reusing the stages of the shipped
+   * `default-password-change` flow (a Prompt + User Write stage) so the recovery
+   * link lets the operator set their own password. Idempotent by slug. Returns the
+   * flow pk, or undefined if the prerequisite `default-password-change` blueprint
+   * has not been applied yet (so the caller retries).
+   */
+  private async createRecoveryFlow(): Promise<string | undefined> {
+    const slug = 'hola-recovery';
+    const existing = (await this.api<{ results: Array<{ pk: string }> }>(
+      'GET', `/api/v3/flows/instances/?slug=${slug}`
+    )).results?.[0]?.pk;
+    if (existing) return existing;
+    // Reuse the password-change flow's stages (prompt for a new password + write it).
+    const pwFlowPk = (await this.api<{ results: Array<{ pk: string }> }>(
+      'GET', '/api/v3/flows/instances/?slug=default-password-change'
+    )).results?.[0]?.pk;
+    if (!pwFlowPk) return undefined; // default blueprints not applied yet
+    const bindings = (await this.api<{ results: Array<{ stage: string; order: number }> }>(
+      'GET', `/api/v3/flows/bindings/?target=${pwFlowPk}`
+    )).results ?? [];
+    if (!bindings.length) return undefined;
+    const flow = await this.api<{ pk: string }>('POST', '/api/v3/flows/instances/', {
+      name: 'Hola Recovery',
+      slug,
+      title: 'Set your password',
+      designation: 'recovery',
+      authentication: 'require_unauthenticated',
+    });
+    for (const b of bindings) {
+      await this.api('POST', '/api/v3/flows/bindings/', { target: flow.pk, stage: b.stage, order: b.order });
+    }
+    this.logger.info('Created a recovery flow (Authentik ships none)', { flowPk: flow.pk, slug });
+    return flow.pk;
   }
 
   /** Add a proxy provider to the embedded outpost; returns the outpost pk. */

--- a/packages/server/src/services/core/provisioner.ts
+++ b/packages/server/src/services/core/provisioner.ts
@@ -556,40 +556,66 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
     }
   }
 
-  /** Mint a one-time recovery link, ensuring a recovery flow is bound first. */
-  private async mintRecoveryLink(userPk: number): Promise<string | undefined> {
-    await this.ensureBrandRecoveryFlow();
-    try {
-      const res = await this.api<{ link: string }>('POST', `/api/v3/core/users/${userPk}/recovery/`);
-      return res.link;
-    } catch (error) {
-      this.logger.warn('Recovery link generation failed', {
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return undefined;
-    }
+  /** Overridable indirection so tests can exercise the retry loop without waiting. */
+  protected sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
   }
 
-  /** Best-effort: bind a recovery flow to the default brand (so /recovery/ works). */
-  private async ensureBrandRecoveryFlow(): Promise<void> {
+  /**
+   * Mint a one-time recovery link, ensuring a recovery flow is bound first.
+   *
+   * Authentik applies its default blueprints (including the recovery flow) a short
+   * while AFTER its API starts answering, so on a fresh first boot the flow may not
+   * exist the instant we provision — `ensureBrandRecoveryFlow` then finds nothing to
+   * bind and `/recovery/` returns 400. Rather than give up one-shot, retry the
+   * bind + mint over a short window so the link is minted as soon as the flow lands.
+   */
+  private async mintRecoveryLink(userPk: number): Promise<string | undefined> {
+    const delaysMs = [0, 3_000, 6_000, 10_000, 15_000, 20_000]; // ~54s total
+    for (let i = 0; i < delaysMs.length; i++) {
+      if (delaysMs[i]) await this.sleep(delaysMs[i]);
+      // Wait for the recovery flow to exist + be bound before attempting the mint.
+      if (!(await this.ensureBrandRecoveryFlow())) continue;
+      try {
+        const res = await this.api<{ link: string }>('POST', `/api/v3/core/users/${userPk}/recovery/`);
+        return res.link;
+      } catch (error) {
+        this.logger.warn('Recovery link generation attempt failed; will retry', {
+          attempt: i + 1,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Best-effort: ensure a recovery flow is bound to the default brand (so
+   * `/recovery/` works). Returns true once a flow exists and is bound, false while
+   * the flow has not been provisioned yet (so the caller can retry).
+   */
+  private async ensureBrandRecoveryFlow(): Promise<boolean> {
     try {
       const flows = await this.api<{ results: Array<{ pk: string }> }>(
         'GET', '/api/v3/flows/instances/?designation=recovery'
       );
       const flowPk = flows.results?.[0]?.pk;
-      if (!flowPk) return; // no recovery flow exists; /recovery/ will 404 and we degrade
+      if (!flowPk) return false; // recovery-flow blueprint not applied yet
       const brands = await this.api<{ results: Array<{ brand_uuid: string; flow_recovery: string | null }> }>(
         'GET', '/api/v3/core/brands/?default=true'
       );
       const brand = brands.results?.[0];
-      if (brand && !brand.flow_recovery) {
+      if (!brand) return false;
+      if (!brand.flow_recovery) {
         await this.api('PATCH', `/api/v3/core/brands/${brand.brand_uuid}/`, { flow_recovery: flowPk });
         this.logger.info('Bound a recovery flow to the default brand', { flowPk });
       }
+      return true;
     } catch (error) {
       this.logger.warn('Could not ensure a brand recovery flow', {
         error: error instanceof Error ? error.message : String(error),
       });
+      return false;
     }
   }
 


### PR DESCRIPTION
## Symptom (real first-boot install)
```
Recovery link generation failed: Authentik POST /api/v3/core/users/4/recovery/ failed: 400
Could not mint admin recovery link; ...
```
The named admin never got a one-time password-setup link.

## Root cause (confirmed live + in CI)
**Authentik 2025.x ships no recovery flow at all.** Verified on a real install and asserted in a new integration test: `GET /flows/instances/?designation=recovery` returns an empty set out of the box. So `ensureBrandRecoveryFlow` had nothing to bind, the brand's `flow_recovery` stayed null, and `POST /core/users/{pk}/recovery/` 400'd on every boot/restart. (My earlier "retry the bind" idea couldn't help — there was never a flow to wait for.)

## Fix
- **`createRecoveryFlow`** — creates a `recovery`-designation flow, reusing the shipped `default-password-change` flow's stages (a Prompt + a User Write stage), so the link actually lets the operator set their own password. Idempotent by slug (`hola-recovery`).
- **`ensureBrandRecoveryFlow`** now creates the flow when absent and rebinds the brand if it points elsewhere; the mint still retries to ride out first-boot blueprint lag (the password-change stages it reuses also land a little after the API answers).
- Grant the scoped provisioning token `authentik_flows.{add_flow, view_flowstagebinding, add_flowstagebinding}` so it can build the flow **without** superuser.
- Also extends `initializePlatformAuth`'s provisioning retry budget (~2→~5 min): in the captured logs OIDC provisioning only succeeded on the last of 5 attempts.

## Validation (three independent ways)
1. **Contract test** (mocked) for the create path: no recovery flow → create flow + rebind stages + bind brand + mint.
2. **Live**: ran the exact API sequence against the affected real Authentik 2025.10 — flow created, stages bound, link minted. ✅
3. **Integration test** (real Authentik 2025.10, Docker-gated): asserts Authentik ships no recovery flow, then self-mints the **scoped** non-superuser token and verifies the flow is created, bound to the default brand with 2 stages, and a link is returned — proving the permission set is sufficient. ✅ (`5 pass`, 88s)

Server suite: **284 pass**, typecheck + lint clean.

> Pairs with #188 (CLI: wait for the link, degrade instead of hanging). Best released together as 0.6.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)