### PR TITLE
chore(release): 0.6.5

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "packages/cli": {
       "name": "@hola/cli",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "bin": {
         "hola": "./bin/hola",
       },
@@ -35,11 +35,11 @@
     },
     "packages/compose": {
       "name": "@hola/compose",
-      "version": "0.6.4",
+      "version": "0.6.5",
     },
     "packages/sdk": {
       "name": "@hola/sdk",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "dependencies": {
         "@hola/shared": "workspace:*",
       },
@@ -53,7 +53,7 @@
     },
     "packages/server": {
       "name": "@hola/server",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "dependencies": {
         "@hola/shared": "workspace:*",
         "jose": "^5.9.6",
@@ -69,7 +69,7 @@
     },
     "packages/shared": {
       "name": "@hola/shared",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "dependencies": {
         "yaml": "^2.9.0",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.6.4';
+export const CLI_VERSION = '0.6.5';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Release **0.6.5**.

## Highlights
- **fix(server) #189** — the named-admin SSO **password-setup link now works**. Authentik 2025.x ships no recovery flow, so the provisioner now *creates* one (reusing the password-change stages) and grants the scoped token the permissions to do it. Validated by a contract test, a live run against a real install, and a real-Authentik integration test through the scoped token.
- **feat(cli) #188** — bootstrap/`hola credentials` wait for the link (with an upfront "can take several minutes / Ctrl-C to resume" disclaimer) and **degrade to the akadmin fallback instead of hanging** if the server reports it gave up.
- Carries forward 0.6.4's streaming bootstrap output + container table, the `hola credentials` command, and the ink/React dependency removal.

Bumps `cli`/`compose`/`sdk`/`server`/`shared` to 0.6.5 (`web` stays unversioned). Tagging `cli-v0.6.5` after merge publishes the CLI binaries and `ghcr.io/try-hola/{server,web}:0.6.5`.

**Upgrade:** `cd /opt/hola && docker compose pull && docker compose up -d` — fresh installs then provision the named-admin recovery link automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)