### PR TITLE
fix: deliver a usable recovery link (public URL + JSON-log extraction + mm:ss)

### DIFF
--- a/packages/cli/src/__tests__/credentials.test.ts
+++ b/packages/cli/src/__tests__/credentials.test.ts
@@ -3,9 +3,21 @@ import { mkdtemp, readFile, rm } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
-import { runCredentials } from '../commands/credentials/credentials';
+import { runCredentials, formatElapsed } from '../commands/credentials/credentials';
 import { scriptedPrompter } from '../install/prompter';
 import type { Runner } from '../lib/runner';
+
+describe('formatElapsed', () => {
+  it('shows seconds under a minute', () => {
+    expect(formatElapsed(0)).toBe('0s');
+    expect(formatElapsed(59_000)).toBe('59s');
+  });
+  it('shows minutes and seconds at or above 60s', () => {
+    expect(formatElapsed(60_000)).toBe('1m 0s');
+    expect(formatElapsed(125_000)).toBe('2m 5s');
+    expect(formatElapsed(318_000)).toBe('5m 18s');
+  });
+});
 
 // A fake runner that serves the host's .env on `cat`, then canned values for the
 // credential-retrieval commands. Records every command so we can assert behavior.

--- a/packages/cli/src/commands/credentials/credentials.ts
+++ b/packages/cli/src/commands/credentials/credentials.ts
@@ -154,6 +154,13 @@ export async function handoffCredentials(config: ConfigMap, ctx: HandoffContext)
 
 const PROVISION_FAILED = '__HOLA_PROVISION_FAILED__';
 
+/** Human elapsed time: seconds under a minute, "Xm Ys" at or above 60s. */
+export function formatElapsed(ms: number): string {
+  const total = Math.round(ms / 1000);
+  if (total < 60) return `${total}s`;
+  return `${Math.floor(total / 60)}m ${total % 60}s`;
+}
+
 /**
  * Poll the server log for the one-time recovery link, waiting through first-boot
  * provisioning with a spinner. By default it waits **indefinitely** (the user can
@@ -172,11 +179,14 @@ async function pollRecoveryLink(
   const { host, composeDir, runner } = ctx;
   const maxAttempts = ctx.linkAttempts ?? Infinity; // default: never give up
   const intervalMs = ctx.linkIntervalMs ?? 3000;
-  // One read of the server log per poll: emit the line after the setup marker (the
-  // link), plus a sentinel if the server has logged that provisioning gave up.
+  // One read of the server log per poll. The server logs structured JSON, so the
+  // marker and the link sit on the SAME physical line ("…setup ===\\n<url>"); a
+  // naive "line after the marker" grep misses it. Match the marker line + the one
+  // after, then extract the recovery URL itself (it carries a `flow_token`). Also
+  // emit a sentinel if the server logged that it gave up.
   const grab =
     `cd ${composeDir} && logs=$(docker compose logs --no-color --no-log-prefix server 2>&1); ` +
-    `printf '%s\\n' "$logs" | grep -A1 'Hola admin setup' | tail -1 | tr -d '\\r'; ` +
+    `printf '%s\\n' "$logs" | grep -A1 'Hola admin setup' | grep -oE 'https?://[^" ]*flow_token=[^" ]+' | tail -1; ` +
     `printf '%s' "$logs" | grep -qE 'Could not mint admin recovery link|Gave up self-provisioning' && echo ${PROVISION_FAILED}`;
   const spin = createSpinner('Waiting for SSO provisioning to finish…');
   let elapsedMs = 0;
@@ -192,7 +202,7 @@ async function pollRecoveryLink(
       return { failed: true };
     }
     elapsedMs += intervalMs;
-    spin.update(`Waiting for SSO provisioning… (${Math.round(elapsedMs / 1000)}s elapsed)`);
+    spin.update(`Waiting for SSO provisioning… (${formatElapsed(elapsedMs)} elapsed)`);
     if (i < maxAttempts - 1) await wait(intervalMs);
   }
   spin.fail('Password-setup link not available yet.');

--- a/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
+++ b/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
@@ -484,6 +484,25 @@ describe('RealAuthentikProvisionerService — scoped-token bootstrap', () => {
       && (c.body as { flow_recovery: string }).flow_recovery === 'hola-recovery-pk')).toBe(true);
   });
 
+  test('ensureBootstrapAdmin rewrites the recovery link to the public Authentik URL', async () => {
+    installFetch((call) => {
+      if (call.method === 'GET' && call.path.startsWith('/api/v3/core/users/?email=')) return json({ results: [] });
+      if (call.method === 'POST' && call.path === '/api/v3/core/users/') return json({ pk: 101, last_login: null }, 201);
+      if (call.method === 'GET' && call.path.startsWith('/api/v3/core/groups/?name=')) return json({ results: [{ pk: 'g1', users: [] }] });
+      if (call.method === 'PATCH' && call.path === '/api/v3/core/groups/g1/') return json({ pk: 'g1' });
+      if (call.method === 'GET' && call.path.startsWith('/api/v3/flows/instances/?designation=recovery')) return json({ results: [{ pk: 'recovery-flow' }] });
+      if (call.method === 'GET' && call.path.startsWith('/api/v3/core/brands/')) return json({ results: [{ brand_uuid: 'b1', flow_recovery: null }] });
+      // Authentik returns the link on the INTERNAL host the API was called on.
+      if (call.method === 'POST' && call.path === '/api/v3/core/users/101/recovery/') return json({ link: 'http://authentik-server:9000/if/flow/hola-recovery/?flow_token=tok' });
+      return undefined;
+    });
+    calls.length = 0;
+    // CONFIG.authentikPublicUrl is https://auth.example.com.
+    const svc = new RealAuthentikProvisionerService({ ...CONFIG, adminEmail: 'me@example.com' });
+    const result = await svc.ensureBootstrapAdmin('hola-admins');
+    expect(result.recoveryLink).toBe('https://auth.example.com/if/flow/hola-recovery/?flow_token=tok');
+  });
+
   test('ensureBootstrapAdmin no-ops without HOLA_ADMIN_EMAIL', async () => {
     installFetch();
     calls.length = 0;

--- a/packages/server/src/services/core/provisioner.ts
+++ b/packages/server/src/services/core/provisioner.ts
@@ -583,7 +583,10 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
       if (!(await this.ensureBrandRecoveryFlow())) continue;
       try {
         const res = await this.api<{ link: string }>('POST', `/api/v3/core/users/${userPk}/recovery/`);
-        return res.link;
+        // Authentik builds the link from the host the API was called on — which is
+        // the internal `authentik-server:9000` for us, unreachable from a browser.
+        // Rewrite the origin to the public Authentik URL so the operator can open it.
+        return this.toPublicUrl(res.link);
       } catch (error) {
         this.logger.warn('Recovery link generation attempt failed; will retry', {
           attempt: i + 1,
@@ -592,6 +595,27 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
       }
     }
     return undefined;
+  }
+
+  /**
+   * Rewrite a link's origin to the public Authentik URL. Authentik builds links
+   * (e.g. recovery) from the host the request arrived on, which for us is the
+   * internal `authentik-server:9000` — not browser-reachable. Swap in the
+   * configured public origin (HOLA_AUTHENTIK_PUBLIC_URL). No-op if unset/unparseable.
+   */
+  private toPublicUrl(link: string): string {
+    const pub = this.config.authentikPublicUrl;
+    if (!pub) return link;
+    try {
+      const u = new URL(link);
+      const p = new URL(pub);
+      u.protocol = p.protocol;
+      u.hostname = p.hostname;
+      u.port = p.port; // clears the internal :9000 when the public URL has no port
+      return u.toString();
+    } catch {
+      return link;
+    }
   }
 
   /**


### PR DESCRIPTION
0.6.5 started *minting* the named-admin recovery link, but two bugs kept it from reaching the operator (surfaced by a real install hanging ~5 min with no URL):

## Bug 1 — server mints the link with the internal URL
Authentik builds the recovery link from the host the API was called on, which for us is the internal `http://authentik-server:9000` — not browser-reachable. **Fix:** rewrite the link origin to `HOLA_AUTHENTIK_PUBLIC_URL` (`toPublicUrl`). Contract test asserts `http://authentik-server:9000/if/flow/…` → `https://auth.example.com/if/flow/…` (the internal `:9000` is cleared).

## Bug 2 — CLI can't extract the link from JSON logs
The server logs structured JSON, so the marker and link share **one physical line** (`"…setup ===\n<url>"`, an escaped `\n`). The poll's `grep -A1 … | tail -1` grabbed the *next* log line, never matched, and waited forever. **Fix:** match the marker line + the one after and extract the recovery URL itself (it carries `flow_token`). **Verified live** against the real JSON log on the affected host — it now pulls the URL correctly.

## Plus
- Spinner elapsed time formats as `Xm Ys` past 60s (was a raw second count), per request. New `formatElapsed` unit tests.

Server: **285 pass**. CLI: **91 pass**. Typecheck + lint + build clean across both.

> Releasing as 0.6.6 — the server change needs the new image; the CLI change ships in the binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)