### PR TITLE
chore(release): 0.6.6

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "packages/cli": {
       "name": "@hola/cli",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "bin": {
         "hola": "./bin/hola",
       },
@@ -35,11 +35,11 @@
     },
     "packages/compose": {
       "name": "@hola/compose",
-      "version": "0.6.5",
+      "version": "0.6.6",
     },
     "packages/sdk": {
       "name": "@hola/sdk",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "dependencies": {
         "@hola/shared": "workspace:*",
       },
@@ -53,7 +53,7 @@
     },
     "packages/server": {
       "name": "@hola/server",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "dependencies": {
         "@hola/shared": "workspace:*",
         "jose": "^5.9.6",
@@ -69,7 +69,7 @@
     },
     "packages/shared": {
       "name": "@hola/shared",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "dependencies": {
         "yaml": "^2.9.0",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.6.5';
+export const CLI_VERSION = '0.6.6';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Release **0.6.6**.

## Highlights (#191)
- **server** — the minted recovery link now uses `HOLA_AUTHENTIK_PUBLIC_URL` instead of the internal `authentik-server:9000`, so it's actually openable in a browser.
- **cli** — `bootstrap`/`hola credentials` extract the link from the server's **JSON** logs (the marker + link share one physical line, which the old `grep -A1 | tail -1` missed → indefinite hang). Verified live against a real log.
- **cli** — spinner elapsed time shows `Xm Ys` past 60s.

Together with 0.6.5 (creates the recovery flow Authentik ships none of), the named-admin password-setup link now works end-to-end with no manual steps.

Bumps `cli`/`compose`/`sdk`/`server`/`shared` to 0.6.6 (`web` unversioned). Tag `cli-v0.6.6` publishes binaries + `ghcr.io/try-hola/{server,web}:0.6.6`.

**Upgrade:** `cd /opt/hola && docker compose pull && docker compose up -d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)