### PR TITLE
fix(cli): make bootstrap's .env-reuse a deliberate choice (default no + show config)

### DIFF
--- a/packages/cli/src/__tests__/bootstrap.test.ts
+++ b/packages/cli/src/__tests__/bootstrap.test.ts
@@ -212,7 +212,7 @@ describe('hola bootstrap', () => {
     );
   });
 
-  it('detects an init-produced .env and reuses it instead of re-asking the wizard', async () => {
+  it('detects an init-produced .env and reuses it when the user opts in', async () => {
     const tmp = await mkdtemp(join(tmpdir(), 'hola-boot-'));
     const envPath = join(tmp, '.env');
     // A marker value the wizard would never produce, proving the file was reused.
@@ -222,8 +222,8 @@ describe('hola bootstrap', () => {
       const res = await runBootstrap(
         { host: 'me@vm', skipChecks: true }, // interactive: detection runs
         {
-          // Empty answers: if the wizard ran, its required fields would throw.
-          prompter: scriptedPrompter({}),
+          // Reuse now defaults to NO, so opt in explicitly to skip the wizard.
+          prompter: scriptedPrompter({ _use_env: 'true' }),
           runner,
           findEnvFile: async () => envPath,
         }
@@ -232,6 +232,27 @@ describe('hola bootstrap', () => {
       const writeCall = runner.calls.find((c) => c.cmd.includes('cat >'))!;
       expect(writeCall.input).toContain('HOLA_DOMAIN=reused.example.com');
       expect(writeCall.input).toContain('HOLA_API_KEY=from-the-file');
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('does NOT reuse a detected .env by default — it runs the wizard instead', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'hola-boot-'));
+    const envPath = join(tmp, '.env');
+    await writeFile(envPath, 'HOLA_BASE_DOMAIN=stale.example.com\nHOLA_ADMIN_EMAIL=stale@example.com\n');
+    const runner = makeRunner();
+    try {
+      // Default-no on reuse → the wizard runs; with empty answers a required field
+      // throws (WizardError), so bootstrap aborts rather than shipping the stale file.
+      const res = await runBootstrap(
+        { host: 'me@vm', skipChecks: true },
+        { prompter: scriptedPrompter({}), runner, findEnvFile: async () => envPath }
+      );
+      expect(res).toBeUndefined();
+      expect(process.exitCode).toBe(1);
+      // The stale file was never sent to the host.
+      expect(runner.calls.some((c) => c.input?.includes('stale.example.com'))).toBe(false);
     } finally {
       await rm(tmp, { recursive: true, force: true });
     }

--- a/packages/cli/src/commands/bootstrap/bootstrap.ts
+++ b/packages/cli/src/commands/bootstrap/bootstrap.ts
@@ -110,13 +110,23 @@ export async function runBootstrap(
     if (!reuse && !opts.json) {
       const found = await (injected?.findEnvFile ?? defaultFindEnvFile)();
       if (found) {
+        // Show WHAT the file would deploy (a stale leftover is easy to ship blind),
+        // and default to NO so reuse is a deliberate choice, not an Enter-through.
+        const existing = parseEnv(await fs.readFile(found, 'utf8').catch(() => ''));
+        const summary = [
+          existing.HOLA_BASE_DOMAIN ? `domain ${existing.HOLA_BASE_DOMAIN}` : existing.HOLA_DOMAIN ? `dashboard ${existing.HOLA_DOMAIN}` : null,
+          existing.HOLA_ADMIN_EMAIL ? `admin ${existing.HOLA_ADMIN_EMAIL}` : null,
+        ].filter(Boolean).join(' · ');
+        out(`Found an existing config: ${found}`);
+        if (summary) out(`  it would deploy: ${colors.bold(summary)}`);
         const ans = await prompter.prompt({
           key: '_use_env',
           type: 'confirm',
-          message: `Found ${found} — use it (skip the questions)?`,
-          default: 'true',
+          message: 'Reuse it and skip the setup questions?',
+          default: 'false',
         });
         if (ans === 'true') reuse = found;
+        else out('  Starting fresh — answering the questions below.');
       }
     }
     if (reuse) {


### PR DESCRIPTION
## The footgun
A stale `packages/compose/.env` left over from earlier testing got **silently reused** by `hola bootstrap`. The detection prompt —

> `Found …/packages/compose/.env — use it (skip the questions)?` **(default: yes)**

— defaulted to **yes** and showed only the *path*, not what was inside. So a leftover `hola.example.com` config was shipped to the host and the wizard (including the base-domain question) was skipped entirely. This produced a recovery link on the wrong domain and cost real debugging time — the input-capture path was fine; a stale file just won the race ahead of it.

## The fix
The reuse prompt now:
- **shows what it would deploy** — the base domain + admin email parsed from the file:
  ```
  Found an existing config: /…/packages/compose/.env
    it would deploy: domain hola.example.com · admin paul@example.com
  Reuse it and skip the setup questions? (y/N)
  ```
- **defaults to NO**, so reuse is an explicit opt-in, not an Enter-through. Declining prints "Starting fresh — answering the questions below."

## Tests
- The existing reuse test now opts in explicitly (`_use_env: true`).
- New test: a detected `.env` is **not** reused by default — the wizard runs and the stale file is never sent to the host.

CLI: 92 pass, typecheck + lint + build clean.

> Follow-up worth considering (not in this PR): `hola init` also feeds an existing `.env`'s values back as wizard defaults, so a pre-filled stale base domain can be Enter-accepted there too — at least init shows the question, unlike the silent bootstrap reuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)