### PR TITLE
fix(tls): DNS-01 wildcard cert issues reliably (router tls.domains + sticky overlay)

### DIFF
--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -153,6 +153,17 @@ principal needs `route53:ChangeResourceRecordSets`, `GetChange`, `ListHostedZone
 `ListResourceRecordSets` on the zone. Note the wildcard is single-level, so deployed apps must
 be one label under the base (they are: `<app>.<HOLA_BASE_DOMAIN>`).
 
+`install.sh` records the active overlay set in `.env` as `COMPOSE_FILE`, so a bare
+`docker compose <cmd>` in this directory (e.g. `docker compose restart traefik`) keeps the
+DNS-01 overlay instead of silently reverting to the base HTTP-01 stack. The wrapper scripts
+still pass explicit `-f` flags either way.
+
+> **Wildcard issuance detail.** Traefik v3 does not proactively request an entrypoint-level
+> `tls.domains`; it only obtains the wildcard when a *router* carries `tls.domains`. So in
+> DNS-01 mode the server stamps the wildcard onto every router it emits, driven by
+> `HOLA_TLS_CERT_RESOLVER` (set on the server by the overlay). If you run a custom stack
+> without that env, routers fall back to `tls: {}` (on-demand per-host issuance).
+
 ## Upgrade
 
 The supported upgrade path is `hola bootstrap` with a newer CLI — it downloads the new bundle

--- a/packages/compose/docker-compose.dns01.yml
+++ b/packages/compose/docker-compose.dns01.yml
@@ -25,9 +25,14 @@ services:
       - --entrypoints.web.address=:80
       - --entrypoints.websecure.address=:443
       - --entrypoints.websecure.http.tls.certresolver=le
-      # One wildcard cert for the whole base domain. Routers (UI, dashboard, auth,
-      # and the server-emitted app routes) inherit this entrypoint default, so they
-      # are all served from the single *.${HOLA_BASE_DOMAIN} cert — no per-host certs.
+      # One wildcard cert for the whole base domain (UI, dashboard, auth, and every
+      # app route — all served from the single *.${HOLA_BASE_DOMAIN} cert).
+      # NOTE: Traefik v3 does NOT proactively request an entrypoint-level
+      # `tls.domains` when routers emit an empty `tls: {}` — it only obtains the
+      # wildcard when a ROUTER carries `tls.domains`. So the actual proactive
+      # request is driven by the server stamping the wildcard on its emitted
+      # routers (HOLA_TLS_CERT_RESOLVER on the server service, below). This
+      # entrypoint default stays as the resolver fallback for any router.
       - --entrypoints.websecure.http.tls.domains[0].main=${HOLA_BASE_DOMAIN}
       - --entrypoints.websecure.http.tls.domains[0].sans=*.${HOLA_BASE_DOMAIN}
       - --entrypoints.web.http.redirections.entrypoint.to=websecure
@@ -56,3 +61,12 @@ services:
       AWS_HOSTED_ZONE_ID: ${AWS_HOSTED_ZONE_ID:-}
       # Cloudflare (ACME_DNS_PROVIDER=cloudflare):
       CF_DNS_API_TOKEN: ${CF_DNS_API_TOKEN:-}
+
+  # In wildcard/DNS-01 mode the server must stamp the wildcard `tls.domains` on
+  # every router it emits — an entrypoint-level `tls.domains` is not proactively
+  # resolved when routers carry `tls: {}` (see the entrypoint note above and
+  # routing.ts `routerTlsBlock`). The value is the ACME resolver name from the
+  # traefik command (`le`). Absent (HTTP-01 path) → routers stay `tls: {}`.
+  server:
+    environment:
+      HOLA_TLS_CERT_RESOLVER: le

--- a/packages/compose/scripts/install.sh
+++ b/packages/compose/scripts/install.sh
@@ -96,6 +96,20 @@ if [[ -n "$ACME_DNS_PROVIDER" ]]; then
   esac
 fi
 
+# Persist the production compose-file set into .env as COMPOSE_FILE so a bare
+# `docker compose <cmd>` in this directory (an operator restart, the orchestrator,
+# or a `docker compose restart traefik`) applies the SAME overlays as scripts/up.sh.
+# Without this, a plain `docker compose up`/`restart` loads only docker-compose.yml
+# and silently drops the DNS-01 overlay — reverting Traefik to HTTP-01 and losing
+# the wildcard cert. Mirrors how COMPOSE_PROFILES is persisted above; the wrapper
+# scripts still pass explicit `-f` flags, which override COMPOSE_FILE. Only the
+# persistent runtime overlays belong here (not the dev/build install-time ones).
+compose_files="docker-compose.yml"
+if [[ -n "$ACME_DNS_PROVIDER" ]]; then
+  compose_files="${compose_files}:docker-compose.dns01.yml"
+fi
+env_set COMPOSE_FILE "$compose_files"
+
 # Create basic data/logs dirs
 mkdir -p "$ROOT_DIR/logs" "$ROOT_DIR/data"
 mkdir -p "$ROOT_DIR/traefik/acme"

--- a/packages/server/src/__tests__/routing/routing-service.test.ts
+++ b/packages/server/src/__tests__/routing/routing-service.test.ts
@@ -74,6 +74,25 @@ describe('RoutingService', () => {
     expect(await storage.readFileAsString('runtime/traefik/dynamic.yml')).toBe(first);
   });
 
+  test('app routers emit empty tls by default (entrypoint-default resolver)', async () => {
+    await routing.activateRoute(routing.generateRule({ deploymentId: 'gitea-dep-a', appName: 'gitea', port: 3000 }));
+    const dynamic = parseYAML(await storage.readFileAsString('runtime/traefik/dynamic.yml'));
+    expect(dynamic.http.routers['gitea-dep-a'].tls).toEqual({});
+  });
+
+  test('wildcard mode stamps the wildcard tls.domains on app routers', async () => {
+    // DNS-01 wildcard mode: the server must carry the wildcard on the router
+    // itself — Traefik v3 won't proactively resolve an entrypoint-level
+    // tls.domains when the router emits tls:{}.
+    const wild = new RealRoutingService(storage, { baseDomain: 'example.com', certResolver: 'le' });
+    await wild.activateRoute(wild.generateRule({ deploymentId: 'gitea-dep-a', appName: 'gitea', port: 3000 }));
+    const dynamic = parseYAML(await storage.readFileAsString('runtime/traefik/dynamic.yml'));
+    expect(dynamic.http.routers['gitea-dep-a'].tls).toEqual({
+      certResolver: 'le',
+      domains: [{ main: 'example.com', sans: ['*.example.com'] }],
+    });
+  });
+
   test('forward-auth rule emits the outpost middleware + path-prefix router', async () => {
     const base = routing.generateRule({ deploymentId: 'grafana-dep-a', appName: 'grafana', port: 3000 });
     const rule = { ...base, forwardAuth: { name: 'ak-grafana-dep-a', outpostUrl: 'http://authentik-server:9000' } };
@@ -176,6 +195,18 @@ describe('RoutingService', () => {
         { name: 'traefik-dashboard', host: 'traefik.example.com', service: 'api@internal' },
       ]);
       expect(await storage.readFileAsString('runtime/traefik/core.yml')).toBe(first);
+    });
+
+    test('wildcard mode stamps the wildcard tls.domains on core routers', async () => {
+      const wild = new RealRoutingService(storage, { baseDomain: 'example.com', certResolver: 'le' });
+      await wild.emitCoreRoutes([
+        { name: 'hola-web', host: 'app.example.com', url: 'http://hola-web:80' },
+        { name: 'traefik-dashboard', host: 'traefik.example.com', service: 'api@internal' },
+      ]);
+      const core = parseYAML(await storage.readFileAsString('runtime/traefik/core.yml'));
+      const wildcardTls = { certResolver: 'le', domains: [{ main: 'example.com', sans: ['*.example.com'] }] };
+      expect(core.http.routers['hola-web'].tls).toEqual(wildcardTls);
+      expect(core.http.routers['traefik-dashboard'].tls).toEqual(wildcardTls);
     });
   });
 });

--- a/packages/server/src/services/core/routing.ts
+++ b/packages/server/src/services/core/routing.ts
@@ -144,8 +144,25 @@ const AUTHENTIK_AUTH_RESPONSE_HEADERS = [
   'X-authentik-jwt',
 ];
 
+/**
+ * The TLS block stamped on every emitted router.
+ *
+ * Empty `tls: {}` keeps the entrypoint's default cert resolver with on-demand,
+ * per-host issuance (the HTTP-01 default). In **wildcard mode** — DNS-01, where
+ * the compose `dns01` overlay sets `HOLA_TLS_CERT_RESOLVER` on the server — every
+ * router must carry the wildcard `tls.domains` itself: Traefik v3 does **not**
+ * proactively resolve an entrypoint-level `tls.domains` when routers emit an
+ * empty `tls: {}`, so without this the `*.<base>` cert is never requested and
+ * Traefik serves its self-signed default. A fresh object per call avoids the
+ * YAML serializer emitting anchor/alias references for the repeated block.
+ */
+function routerTlsBlock(baseDomain: string, certResolver?: string): Record<string, unknown> {
+  if (!certResolver) return {};
+  return { certResolver, domains: [{ main: baseDomain, sans: [`*.${baseDomain}`] }] };
+}
+
 /** Render the Traefik file-provider dynamic config for a routing map (deterministic). */
-function renderDynamicConfig(map: TraefikRoutingMap): string {
+function renderDynamicConfig(map: TraefikRoutingMap, baseDomain: string, certResolver?: string): string {
   const routers: Record<string, unknown> = {};
   const services: Record<string, unknown> = {};
   const middlewares: Record<string, unknown> = {};
@@ -156,7 +173,7 @@ function renderDynamicConfig(map: TraefikRoutingMap): string {
       rule: `Host(\`${host}\`)`,
       service: rule.serviceName,
       entryPoints: ['websecure'],
-      tls: {},
+      tls: routerTlsBlock(baseDomain, certResolver),
     };
 
     if (rule.forwardAuth) {
@@ -180,7 +197,7 @@ function renderDynamicConfig(map: TraefikRoutingMap): string {
         service: outpostService,
         priority: 100,
         entryPoints: ['websecure'],
-        tls: {},
+        tls: routerTlsBlock(baseDomain, certResolver),
       };
       services[outpostService] = {
         loadBalancer: { servers: [{ url: outpost }] },
@@ -201,7 +218,7 @@ function renderDynamicConfig(map: TraefikRoutingMap): string {
 }
 
 /** Render the file-provider config for the platform's core routes (deterministic). */
-function renderCoreConfig(routes: CoreRoute[]): string {
+function renderCoreConfig(routes: CoreRoute[], baseDomain: string, certResolver?: string): string {
   const routers: Record<string, unknown> = {};
   const services: Record<string, unknown> = {};
   for (const route of [...routes].sort((a, b) => a.name.localeCompare(b.name))) {
@@ -211,9 +228,9 @@ function renderCoreConfig(routes: CoreRoute[]): string {
       // gets a load balancer pointing at the upstream URL below.
       service: route.service ?? route.name,
       entryPoints: ['websecure'],
-      // Empty TLS block inherits the entrypoint's default cert resolver (and the
-      // DNS-01 wildcard domains), exactly like the server-emitted app routes.
-      tls: {},
+      // `tls: {}` inherits the entrypoint default resolver (on-demand per-host);
+      // in wildcard mode each router carries the wildcard domains. See routerTlsBlock.
+      tls: routerTlsBlock(baseDomain, certResolver),
     };
     if (!route.service) {
       services[route.name] = { loadBalancer: { servers: [{ url: route.url }] } };
@@ -227,11 +244,16 @@ function renderCoreConfig(routes: CoreRoute[]): string {
 export class RealRoutingService implements RoutingService {
   private logger = getLogger().child({ service: 'RoutingService' });
   private domain: string;
+  private certResolver?: string;
   private map: TraefikRoutingMap = {};
   private loadPromise: Promise<void> | null = null;
 
-  constructor(private storageService: StorageService, options?: { baseDomain?: string }) {
+  constructor(private storageService: StorageService, options?: { baseDomain?: string; certResolver?: string }) {
     this.domain = options?.baseDomain || process.env.HOLA_BASE_DOMAIN?.trim() || DEFAULT_BASE_DOMAIN;
+    // Set (to the resolver name, e.g. `le`) only in wildcard/DNS-01 mode — the
+    // compose dns01 overlay injects HOLA_TLS_CERT_RESOLVER on the server. When
+    // set, emitted routers carry the wildcard `tls.domains` (see routerTlsBlock).
+    this.certResolver = options?.certResolver ?? (process.env.HOLA_TLS_CERT_RESOLVER?.trim() || undefined);
   }
 
   async healthCheck(): Promise<ServiceHealth> {
@@ -317,7 +339,7 @@ export class RealRoutingService implements RoutingService {
 
   async emitCoreRoutes(routes: CoreRoute[]): Promise<void> {
     await this.storageService.ensureDir('runtime/traefik');
-    await this.storageService.writeFile(CORE_CONFIG_PATH, renderCoreConfig(routes));
+    await this.storageService.writeFile(CORE_CONFIG_PATH, renderCoreConfig(routes, this.domain, this.certResolver));
     this.logger.info('Emitted core Traefik routes', {
       count: routes.length,
       hosts: routes.map(r => r.host),
@@ -329,7 +351,7 @@ export class RealRoutingService implements RoutingService {
     await this.storageService.ensureDir('runtime/traefik');
     const ordered = sortedMap(Object.values(this.map));
     await this.storageService.writeFile(ROUTING_MAP_PATH, JSON.stringify(ordered, null, 2));
-    await this.storageService.writeFile(DYNAMIC_CONFIG_PATH, renderDynamicConfig(ordered));
+    await this.storageService.writeFile(DYNAMIC_CONFIG_PATH, renderDynamicConfig(ordered, this.domain, this.certResolver));
   }
 }
 


### PR DESCRIPTION
## What & why

End-to-end testing a homelab (DNS-01) install, the `*.<HOLA_BASE_DOMAIN>` wildcard cert never issued — Traefik served its self-signed default cert, which produced browser warnings **and** broke Authentik OIDC (OAuth over an untrusted cert → "Authentication failed"). Two independent root causes:

### 1. The server's routers never carried the wildcard
The `dns01` overlay set the wildcard on `entrypoints.websecure.http.tls.domains`, and a code comment assumed routers "inherit the entrypoint default". They don't: **Traefik v3 does not proactively resolve an entrypoint-level `tls.domains` when routers emit an empty `tls: {}`** — it only obtains the wildcard when a *router* carries `tls.domains`. So Traefik logged `Testing certificate renew...` and then did nothing; `acme.json` stayed `{}`.

Verified directly on the host: injecting one router with the wildcard `tls.domains` triggered immediate issuance via route53 DNS-01 (`Obtaining bundled SAN certificate` → both domains validated → cert stored), and all three hosts then served the real Let's Encrypt wildcard.

**Fix:** in wildcard mode the server stamps the wildcard `tls.domains` + `certResolver` onto every router it emits (app routes via `renderDynamicConfig`, platform routes via `renderCoreConfig`). It's driven by a new `HOLA_TLS_CERT_RESOLVER` env that the `dns01` overlay sets on the **server** service. Absent (the HTTP-01 default path), routers stay `tls: {}` and get on-demand per-host issuance exactly as before.

### 2. The overlay wasn't sticky
`_common.sh` only adds `-f docker-compose.dns01.yml` when invoked through the wrapper scripts. A bare `docker compose restart traefik` / `up -d` in the install dir loads **only** `docker-compose.yml` and silently reverts Traefik to HTTP-01 (dropping the wildcard) — which is exactly how the cert got lost during debugging.

**Fix:** `install.sh` now writes the active overlay set into `.env` as `COMPOSE_FILE` (mirroring how `COMPOSE_PROFILES=authentik` is already persisted and honored). A bare `docker compose <cmd>` in the install dir now keeps the DNS-01 overlay; the wrapper scripts still pass explicit `-f` flags, which override it.

## Changes
- `routing.ts` — `routerTlsBlock(baseDomain, certResolver)`; `RealRoutingService` takes an optional `certResolver` (defaults from `HOLA_TLS_CERT_RESOLVER`) and threads it into both render functions.
- `routing-service.test.ts` — default stays `tls: {}`; new tests assert wildcard-mode stamps `tls.domains` on app **and** core routers.
- `docker-compose.dns01.yml` — set `HOLA_TLS_CERT_RESOLVER: le` on the server; corrected the entrypoint comment.
- `install.sh` — persist `COMPOSE_FILE` into `.env`.
- `compose/README.md` — document both.

## Test
- `bun run typecheck` · `bun run lint` ✅
- `bun --cwd packages/server test` → 288 pass ✅
- `bash -n install.sh` ✅
- Mechanism verified live on the homelab host (wildcard cert issued + served on UI/dashboard/auth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)