### PR TITLE
fix(auth): recovery flow auto-signs-in + lands on the dashboard (closes #195)

### DIFF
--- a/packages/server/src/__tests__/integration/authentik-provision.it.ts
+++ b/packages/server/src/__tests__/integration/authentik-provision.it.ts
@@ -272,6 +272,7 @@ describe.skipIf(!dockerOk)('Authentik provisioner (real daemon)', () => {
     // also verifies the scoped permission set can add the flow + stage bindings.
     const svc = new RealAuthentikProvisionerService({
       ...config, authentikApiToken: undefined, authentikBootstrapToken: BOOTSTRAP_TOKEN, adminEmail: 'recovery-it@example.com',
+      dashboardUrl: 'https://hola.example.com',
     });
 
     // Precondition: confirm Authentik really ships no recovery flow out of the box.
@@ -285,9 +286,12 @@ describe.skipIf(!dockerOk)('Authentik provisioner (real daemon)', () => {
 
     expect(result.recoveryLink).toBeTruthy();
     expect(result.recoveryLink).toContain('/if/flow/');
+    // The link carries the dashboard as its post-success redirect.
+    expect(new URL(result.recoveryLink!).searchParams.get('next')).toBe('https://hola.example.com');
 
     // The recovery flow now exists, is bound to the default brand, and has the two
-    // reused stages (prompt + user-write) so the link can actually set a password.
+    // reused stages (prompt + user-write) PLUS the appended Login stage so setting
+    // the password also signs the operator in.
     const after = (await akGet('/api/v3/flows/instances/?designation=recovery')) as {
       status: number; body: { results: Array<{ pk: string; slug: string }> };
     };
@@ -298,8 +302,14 @@ describe.skipIf(!dockerOk)('Authentik provisioner (real daemon)', () => {
     };
     expect(brand.body.results[0].flow_recovery).toBe(flow!.pk);
     const bindings = (await akGet(`/api/v3/flows/bindings/?target=${flow!.pk}`)) as {
-      status: number; body: { results: unknown[] };
+      status: number; body: { results: Array<{ stage: string; order: number }> };
     };
-    expect(bindings.body.results.length).toBe(2);
+    expect(bindings.body.results.length).toBe(3);
+    // The final (highest-order) binding is Authentik's Login stage.
+    const lastStage = [...bindings.body.results].sort((a, b) => b.order - a.order)[0].stage;
+    const loginStages = (await akGet('/api/v3/stages/all/?name__iexact=default-authentication-login')) as {
+      status: number; body: { results: Array<{ pk: string }> };
+    };
+    expect(lastStage).toBe(loginStages.body.results[0].pk);
   }, 180_000);
 });

--- a/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
+++ b/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
@@ -465,8 +465,10 @@ describe('RealAuthentikProvisionerService — scoped-token bootstrap', () => {
       // default-password-change exists with two stages to reuse.
       if (call.method === 'GET' && call.path.startsWith('/api/v3/flows/instances/?slug=default-password-change')) return json({ results: [{ pk: 'pw-flow' }] });
       if (call.method === 'GET' && call.path.startsWith('/api/v3/flows/bindings/?target=pw-flow')) return json({ results: [{ stage: 'prompt-stage', order: 0 }, { stage: 'write-stage', order: 1 }] });
+      // The built-in Login stage we append so the operator is signed in on success.
+      if (call.method === 'GET' && call.path.startsWith('/api/v3/stages/all/?name__iexact=default-authentication-login')) return json({ results: [{ pk: 'login-stage' }] });
       if (call.method === 'POST' && call.path === '/api/v3/flows/instances/') { created.push('flow'); return json({ pk: 'hola-recovery-pk' }, 201); }
-      if (call.method === 'POST' && call.path === '/api/v3/flows/bindings/') { created.push(`bind:${(call.body as { stage: string }).stage}`); return json({ pk: 'b' }, 201); }
+      if (call.method === 'POST' && call.path === '/api/v3/flows/bindings/') { const b = call.body as { stage: string; order: number }; created.push(`bind:${b.stage}@${b.order}`); return json({ pk: 'b' }, 201); }
       if (call.method === 'GET' && call.path.startsWith('/api/v3/core/brands/')) return json({ results: [{ brand_uuid: 'b1', flow_recovery: null }] });
       if (call.method === 'POST' && call.path === '/api/v3/core/users/101/recovery/') return json({ link: 'https://auth.example.com/if/flow/hola-recovery/?flow_token=abc' });
       return undefined;
@@ -477,11 +479,33 @@ describe('RealAuthentikProvisionerService — scoped-token bootstrap', () => {
     const result = await svc.ensureBootstrapAdmin('hola-admins');
 
     expect(result.recoveryLink).toContain('hola-recovery');
-    // It created the flow and rebound the two reused stages.
-    expect(created).toEqual(['flow', 'bind:prompt-stage', 'bind:write-stage']);
+    // It created the flow, rebound the two reused stages, then appended the Login
+    // stage as the final binding (order after the reused stages) for auto-login.
+    expect(created).toEqual(['flow', 'bind:prompt-stage@0', 'bind:write-stage@1', 'bind:login-stage@2']);
     // And bound the new flow to the default brand.
     expect(calls.some((c) => c.method === 'PATCH' && c.path === '/api/v3/core/brands/b1/'
       && (c.body as { flow_recovery: string }).flow_recovery === 'hola-recovery-pk')).toBe(true);
+  });
+
+  test('ensureBootstrapAdmin appends the dashboard redirect (next=) to the recovery link', async () => {
+    installFetch((call) => {
+      if (call.method === 'GET' && call.path.startsWith('/api/v3/core/users/?email=')) return json({ results: [] });
+      if (call.method === 'POST' && call.path === '/api/v3/core/users/') return json({ pk: 101, last_login: null }, 201);
+      if (call.method === 'GET' && call.path.startsWith('/api/v3/core/groups/?name=')) return json({ results: [{ pk: 'g1', users: [] }] });
+      if (call.method === 'PATCH' && call.path === '/api/v3/core/groups/g1/') return json({ pk: 'g1' });
+      if (call.method === 'GET' && call.path.startsWith('/api/v3/flows/instances/?designation=recovery')) return json({ results: [{ pk: 'recovery-flow' }] });
+      if (call.method === 'GET' && call.path.startsWith('/api/v3/core/brands/')) return json({ results: [{ brand_uuid: 'b1', flow_recovery: 'recovery-flow' }] });
+      if (call.method === 'POST' && call.path === '/api/v3/core/users/101/recovery/') return json({ link: 'http://authentik-server:9000/if/flow/hola-recovery/?flow_token=tok' });
+      return undefined;
+    });
+    calls.length = 0;
+    const svc = new RealAuthentikProvisionerService({ ...CONFIG, adminEmail: 'me@example.com', dashboardUrl: 'https://app.example.com' });
+    const result = await svc.ensureBootstrapAdmin('hola-admins');
+    // Origin rewritten to the public Authentik URL AND ?next= points at the dashboard.
+    const url = new URL(result.recoveryLink!);
+    expect(url.origin).toBe('https://auth.example.com');
+    expect(url.searchParams.get('next')).toBe('https://app.example.com');
+    expect(url.searchParams.get('flow_token')).toBe('tok');
   });
 
   test('ensureBootstrapAdmin rewrites the recovery link to the public Authentik URL', async () => {

--- a/packages/server/src/config/auth.ts
+++ b/packages/server/src/config/auth.ts
@@ -57,11 +57,24 @@ export interface AuthConfig {
   adminUsername?: string;
   /** Optional display name for the provisioned admin. */
   adminName?: string;
+  /**
+   * Browser-facing URL of the Hola dashboard (derived from HOLA_DOMAIN). Used as
+   * the recovery flow's post-success redirect (`?next=`) so setting a password +
+   * auto-login lands the operator on the dashboard, not Authentik's app launcher.
+   */
+  dashboardUrl?: string;
 }
 
 function stripTrailingSlash(url: string | undefined): string | undefined {
   if (!url) return undefined;
   return url.replace(/\/+$/, '');
+}
+
+/** Normalize a host or URL into a browser URL (https:// unless a scheme is given). */
+function toBrowserUrl(value: string | undefined): string | undefined {
+  const v = value?.trim();
+  if (!v) return undefined;
+  return stripTrailingSlash(/^https?:\/\//.test(v) ? v : `https://${v}`);
 }
 
 export const defaultAuthConfig: AuthConfig = {
@@ -79,6 +92,7 @@ export const defaultAuthConfig: AuthConfig = {
   adminEmail: process.env.HOLA_ADMIN_EMAIL?.trim() || undefined,
   adminUsername: process.env.HOLA_ADMIN_USERNAME?.trim() || undefined,
   adminName: process.env.HOLA_ADMIN_NAME?.trim() || undefined,
+  dashboardUrl: toBrowserUrl(process.env.HOLA_DOMAIN),
 };
 
 export function loadAuthConfig(): AuthConfig {

--- a/packages/server/src/services/core/provisioner.ts
+++ b/packages/server/src/services/core/provisioner.ts
@@ -170,6 +170,9 @@ const PROVISIONER_PERMISSIONS = [
   'authentik_flows.add_flow',
   'authentik_flows.view_flowstagebinding',
   'authentik_flows.add_flowstagebinding',
+  // Read stages (stages/all) so the recovery flow can append the built-in Login
+  // stage — setting a password then signs the operator in automatically.
+  'authentik_flows.view_stage',
   // Read certificate-keypairs to pick a signing key for the dashboard OIDC client.
   'authentik_crypto.view_certificatekeypair',
 ];
@@ -585,8 +588,10 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
         const res = await this.api<{ link: string }>('POST', `/api/v3/core/users/${userPk}/recovery/`);
         // Authentik builds the link from the host the API was called on — which is
         // the internal `authentik-server:9000` for us, unreachable from a browser.
-        // Rewrite the origin to the public Authentik URL so the operator can open it.
-        return this.toPublicUrl(res.link);
+        // Rewrite the origin to the public Authentik URL so the operator can open it,
+        // then attach the dashboard as the post-flow redirect so a successful set +
+        // auto-login lands them on Hola, not Authentik's app launcher.
+        return this.withDashboardRedirect(this.toPublicUrl(res.link));
       } catch (error) {
         this.logger.warn('Recovery link generation attempt failed; will retry', {
           attempt: i + 1,
@@ -612,6 +617,24 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
       u.protocol = p.protocol;
       u.hostname = p.hostname;
       u.port = p.port; // clears the internal :9000 when the public URL has no port
+      return u.toString();
+    } catch {
+      return link;
+    }
+  }
+
+  /**
+   * Attach the Hola dashboard as the recovery flow's post-success redirect via the
+   * `next` query param, so once the operator sets a password (and the appended
+   * Login stage signs them in) they land on the dashboard instead of Authentik's
+   * single-tile app launcher. No-op when no dashboard URL is configured.
+   */
+  private withDashboardRedirect(link: string): string {
+    const dash = this.config.dashboardUrl;
+    if (!dash) return link;
+    try {
+      const u = new URL(link);
+      u.searchParams.set('next', dash);
       return u.toString();
     } catch {
       return link;
@@ -652,9 +675,12 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
   /**
    * Create a `recovery`-designation flow, reusing the stages of the shipped
    * `default-password-change` flow (a Prompt + User Write stage) so the recovery
-   * link lets the operator set their own password. Idempotent by slug. Returns the
-   * flow pk, or undefined if the prerequisite `default-password-change` blueprint
-   * has not been applied yet (so the caller retries).
+   * link lets the operator set their own password, then appending the built-in
+   * Login stage so setting the password ALSO signs them in — otherwise the flow
+   * ends unauthenticated and they're bounced to a login screen to re-enter the
+   * password they just set. Idempotent by slug. Returns the flow pk, or undefined
+   * if the prerequisite `default-password-change` blueprint has not been applied
+   * yet (so the caller retries).
    */
   private async createRecoveryFlow(): Promise<string | undefined> {
     const slug = 'hola-recovery';
@@ -681,8 +707,34 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
     for (const b of bindings) {
       await this.api('POST', '/api/v3/flows/bindings/', { target: flow.pk, stage: b.stage, order: b.order });
     }
-    this.logger.info('Created a recovery flow (Authentik ships none)', { flowPk: flow.pk, slug });
+    // Append the Login stage as the final binding so the operator is signed in on
+    // success. Degrade gracefully (warn, no auto-login) if none is found — the
+    // password-set part still works.
+    const loginStagePk = await this.resolveLoginStagePk();
+    if (loginStagePk) {
+      const lastOrder = bindings.reduce((max, b) => Math.max(max, b.order), -1);
+      await this.api('POST', '/api/v3/flows/bindings/', { target: flow.pk, stage: loginStagePk, order: lastOrder + 1 });
+    } else {
+      this.logger.warn('No Login stage found; recovery flow will set the password but not auto-sign-in', { slug });
+    }
+    this.logger.info('Created a recovery flow (Authentik ships none)', { flowPk: flow.pk, slug, autoLogin: !!loginStagePk });
     return flow.pk;
+  }
+
+  /**
+   * Resolve the pk of Authentik's built-in Login stage (the one the default
+   * authentication flow ends with). The `stages/all` endpoint lists every stage
+   * type; match the default name and fall back to the first Login-component stage.
+   */
+  private async resolveLoginStagePk(): Promise<string | undefined> {
+    const byName = (await this.api<{ results: Array<{ pk: string }> }>(
+      'GET', '/api/v3/stages/all/?name__iexact=default-authentication-login'
+    )).results?.[0]?.pk;
+    if (byName) return byName;
+    const all = (await this.api<{ results: Array<{ pk: string; component?: string }> }>(
+      'GET', '/api/v3/stages/all/'
+    )).results ?? [];
+    return all.find((s) => s.component === 'ak-stage-user-login')?.pk;
   }
 
   /** Add a proxy provider to the embedded outpost; returns the outpost pk. */


### PR DESCRIPTION
Closes #195.

## Problem
The recovery flow Hola generates (Authentik 2025.x ships none — #189/#191) reused only `default-password-change`'s **Prompt + User Write** stages. After clicking the one-time admin link and setting a password, two awkward gaps followed:

1. **You had to log in again.** The flow ended unauthenticated, so the operator was bounced to a login screen to re-enter the password they'd *just* set.
2. **You landed on Authentik's app launcher** (a single "hola" tile), not the dashboard, because a bare recovery link has no redirect target.

## Fix
- **Auto-login:** append Authentik's built-in **Login stage** as the final binding of the generated recovery flow, so setting the password also signs the operator in. The stage is resolved via `stages/all` (new `authentik_flows.view_stage` scoped permission) and the binding is ordered after the reused stages. Degrades gracefully (warn, password-set still works) if no Login stage exists.
- **Dashboard redirect:** attach the dashboard as the flow's post-success redirect via `?next=`, derived from a new `dashboardUrl` config (from `HOLA_DOMAIN`). With the Login stage in place, a successful set + auto-login now lands on Hola.

## Changes
- `provisioner.ts` — `createRecoveryFlow` appends the Login stage; new `resolveLoginStagePk` + `withDashboardRedirect`; `authentik_flows.view_stage` added to the scoped permission set.
- `config/auth.ts` — new `dashboardUrl` (normalized from `HOLA_DOMAIN`).
- Contract test — asserts binding order `prompt → write → login` and the `next=` redirect.
- Integration test (`authentik-provision.it.ts`) — asserts 3 bindings, the last being the Login stage, and the minted link carries `next=`.

## Test
- `bun run typecheck` · `bun run lint` ✅
- `bun --cwd packages/server test` → 286 pass ✅
- The real-Authentik integration test (`*.it.ts`) is Docker-gated; it exercises the 3-binding flow + redirect through the scoped token.

> Note: the `?next=` redirect relies on Authentik honoring an absolute cross-subdomain `next` on the flow executor. If a future Authentik build tightens open-redirect handling and drops it, the link simply falls back to today's behavior (app launcher) — the auto-login fix stands on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)