### PR TITLE
chore(release): 0.6.7

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "packages/cli": {
       "name": "@hola/cli",
-      "version": "0.6.6",
+      "version": "0.6.7",
       "bin": {
         "hola": "./bin/hola",
       },
@@ -35,11 +35,11 @@
     },
     "packages/compose": {
       "name": "@hola/compose",
-      "version": "0.6.6",
+      "version": "0.6.7",
     },
     "packages/sdk": {
       "name": "@hola/sdk",
-      "version": "0.6.6",
+      "version": "0.6.7",
       "dependencies": {
         "@hola/shared": "workspace:*",
       },
@@ -53,7 +53,7 @@
     },
     "packages/server": {
       "name": "@hola/server",
-      "version": "0.6.6",
+      "version": "0.6.7",
       "dependencies": {
         "@hola/shared": "workspace:*",
         "jose": "^5.9.6",
@@ -69,7 +69,7 @@
     },
     "packages/shared": {
       "name": "@hola/shared",
-      "version": "0.6.6",
+      "version": "0.6.7",
       "dependencies": {
         "yaml": "^2.9.0",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.6.6';
+export const CLI_VERSION = '0.6.7';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Release 0.6.7.

## Included
- **#196** `fix(tls)`: DNS-01 wildcard cert now issues reliably. The server stamps the wildcard `tls.domains` + `certResolver` on its emitted routers (Traefik v3 does not proactively resolve an entrypoint-level `tls.domains` when routers carry `tls: {}`), driven by `HOLA_TLS_CERT_RESOLVER` from the dns01 overlay. `install.sh` also persists `COMPOSE_FILE` into `.env` so a bare `docker compose restart traefik` keeps the overlay instead of reverting to HTTP-01.
- **#197** `fix(auth)` (closes #195): the generated recovery flow appends a Login stage (auto-sign-in after setting a password) and redirects to the dashboard (`?next=`) instead of Authentik's app launcher.

## Version bump
`cli`, `compose`, `sdk`, `server`, `shared` → `0.6.7` (+ `cli/src/version.ts`); `web` stays `0.0.0`.

Tag `cli-v0.6.7` on the squash-merge commit publishes the CLI binaries and `ghcr.io/try-hola/{server,web}:0.6.7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)