### PR TITLE
fix(compose): create Traefik file-provider dir before Traefik starts (startup race)

### DIFF
--- a/packages/compose/docker-compose.yml
+++ b/packages/compose/docker-compose.yml
@@ -15,10 +15,28 @@
 #   # or: docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d
 
 services:
+  # Ensure the Traefik file-provider directory exists in the shared data volume
+  # BEFORE Traefik starts. Traefik mounts hola-data READ-ONLY and its file provider
+  # fails permanently if the watched directory is missing at boot — it cannot watch
+  # a nonexistent path and never retries. On a cold start where Traefik wins the race
+  # against the server (which creates the dir), Traefik would load ZERO routers and
+  # 404 every host until manually restarted. This oneshot creates the dir read-write
+  # and exits; it reuses the traefik image so it adds no extra pull.
+  traefik-init:
+    image: traefik:v3.5
+    container_name: traefik-init
+    entrypoint: ["/bin/sh", "-c", "mkdir -p /data/runtime/traefik"]
+    restart: "no"
+    volumes:
+      - hola-data:/data
+
   traefik:
     image: traefik:v3.5
     container_name: traefik
     restart: unless-stopped
+    depends_on:
+      traefik-init:
+        condition: service_completed_successfully
     command:
       # --api enables the built-in api@internal service; the Hola server emits a
       # file-provider router for it (core.yml) at TRAEFIK_DASHBOARD_DOMAIN.


### PR DESCRIPTION
## Symptom
After a full `docker compose` restart on a real deployment, **every** host 404'd — the dashboard, the app, and the Authentik login UI — even though the cert still served and Authentik was healthy. The recovery/password-setup link 404'd as a result.

## Root cause
Traefik mounts the shared `hola-data` volume **read-only** and watches `/data/runtime/traefik` for the server-emitted routers (`core.yml` + per-app routes). Traefik's file provider **fails permanently if that directory is missing at boot** — it cannot watch a nonexistent path and never retries. On a cold start Traefik and the server start in parallel; when Traefik wins the race (the server hasn't created the dir yet), Traefik loads **zero routers** and returns its default 404 for everything until manually restarted.

The single Traefik log line confirmed it:
```
ERR Cannot start the provider *file.Provider
error="unable to read directory /data/runtime/traefik: no such file or directory"
```

(The read-only mount means Traefik can't create the dir itself, so it can never self-heal.)

## Fix
Add a `traefik-init` oneshot that creates `/data/runtime/traefik` read-write and exits; Traefik now `depends_on` it with `condition: service_completed_successfully`, guaranteeing the watched directory exists before Traefik boots. It reuses the `traefik:v3.5` image (no extra pull), and the `depends_on` merges cleanly under the dns01 overlay (verified with `docker compose config`).

## Test
- `docker compose config` renders `traefik-init` + the `service_completed_successfully` dependency in both base-only and base+dns01.
- Verified live: the broken host had the file-provider error and 404'd all hosts; recreating Traefik after the dir existed restored routing (`auth`→302, `apps`→200, `traefik`→302).

🤖 Generated with [Claude Code](https://claude.com/claude-code)