### PR TITLE
feat(cli): compact, colorized install validation output

### DIFF
--- a/packages/cli/src/__tests__/ui.test.ts
+++ b/packages/cli/src/__tests__/ui.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { formatComposeLine, parseComposePs, renderContainerTable } from '../lib/ui';
+import { formatComposeLine, parseComposePs, renderContainerTable, renderChecks } from '../lib/ui';
 
 // picocolors auto-disables ANSI off a TTY (as under vitest), so the rendered
 // strings here are plain text and assert cleanly.
@@ -68,5 +68,40 @@ describe('renderContainerTable', () => {
 
   it('returns an empty string when there are no rows', () => {
     expect(renderContainerTable([])).toBe('');
+  });
+});
+
+describe('renderChecks', () => {
+  it('renders one compact block: a heading, a line per check, and a summary', () => {
+    const out = renderChecks([
+      { name: 'DNS: apps.example.com', status: 'pass' },
+      { name: 'AWS credentials', status: 'pass' },
+      { name: 'Catalog URL', status: 'warn', detail: 'HTTP 503' },
+    ]);
+    const lines = out.split('\n');
+    // One heading + 3 check rows + 1 summary, with NO blank lines between rows.
+    expect(lines).toHaveLength(5);
+    expect(lines[0]).toContain('Validation');
+    expect(lines[1]).toContain('DNS: apps.example.com');
+    expect(lines[3]).toContain('Catalog URL');
+    expect(lines[3]).toContain('— HTTP 503'); // detail rendered inline
+    expect(lines[4]).toContain('2 passed');
+    expect(lines[4]).toContain('1 warning');
+  });
+
+  it('pluralizes and surfaces failures in the summary', () => {
+    const summary = renderChecks([
+      { name: 'a', status: 'pass' },
+      { name: 'b', status: 'warn' },
+      { name: 'c', status: 'warn' },
+      { name: 'd', status: 'fail' },
+    ]).split('\n').at(-1)!;
+    expect(summary).toContain('1 passed');
+    expect(summary).toContain('2 warnings');
+    expect(summary).toContain('1 failed');
+  });
+
+  it('returns an empty string when there are no checks', () => {
+    expect(renderChecks([])).toBe('');
   });
 });

--- a/packages/cli/src/install/wizard.ts
+++ b/packages/cli/src/install/wizard.ts
@@ -7,6 +7,7 @@ import { runChecks, type CheckResult } from './checks';
 import type { Prompter } from './prompter';
 import { INSTALL_SCHEMA, defaultFor, type ConfigMap } from './schema';
 import { interdependencyErrors } from './validate';
+import { renderChecks } from '../lib/ui';
 
 export interface WizardOptions {
   prompter: Prompter;
@@ -68,8 +69,8 @@ export async function runWizard(opts: WizardOptions): Promise<WizardResult> {
     const run = opts.checks ?? runChecks;
     checks = await run(config);
     if (checks.length) {
-      prompter.note('Validation:');
-      for (const c of checks) prompter.note(`  ${c.status.toUpperCase()}  ${c.name}${c.detail ? ` — ${c.detail}` : ''}`);
+      // One compact, colorized block — not a framed line per check.
+      prompter.note(renderChecks(checks));
     }
   }
 

--- a/packages/cli/src/lib/ui.ts
+++ b/packages/cli/src/lib/ui.ts
@@ -166,3 +166,38 @@ export function renderContainerTable(rows: PsRow[]): string {
   );
   return [headerLine, ...body].join('\n');
 }
+
+export interface CheckLine {
+  name: string;
+  status: 'pass' | 'warn' | 'fail';
+  detail?: string;
+}
+
+const CHECK_GLYPH: Record<CheckLine['status'], string> = {
+  pass: colors.green('✓'),
+  warn: colors.yellow('!'),
+  fail: colors.red('✗'),
+};
+
+/**
+ * Render install validation checks as ONE compact block (a single note), instead
+ * of one framed line per check. Each row is `<glyph> <name> — <detail>` with the
+ * glyph colorized by status, followed by a one-line summary. Returns '' for no
+ * checks. picocolors drops the ANSI off-TTY, so tests see plain text.
+ */
+export function renderChecks(checks: CheckLine[]): string {
+  if (!checks.length) return '';
+  const rows = checks.map((c) => {
+    const name = c.status === 'fail' ? colors.red(c.name) : c.name;
+    const detail = c.detail ? ` ${colors.dim(`— ${c.detail}`)}` : '';
+    return `  ${CHECK_GLYPH[c.status]}  ${name}${detail}`;
+  });
+  const count = (s: CheckLine['status']) => checks.filter((c) => c.status === s).length;
+  const pass = count('pass');
+  const warn = count('warn');
+  const fail = count('fail');
+  const parts = [`${pass} passed`];
+  if (warn) parts.push(colors.yellow(`${warn} warning${warn === 1 ? '' : 's'}`));
+  if (fail) parts.push(colors.red(`${fail} failed`));
+  return [colors.bold('Validation'), ...rows, colors.dim(parts.join('  ·  '))].join('\n');
+}


### PR DESCRIPTION
## Why
The install wizard rendered each validation check as its own framed clack note, producing a tall, gutter-spaced list with a blank line between every entry and a flat uppercase `PASS`/`WARN`/`FAIL` label:

```
│  Validation:
│
│    PASS  DNS: apps.hola.get2know.io
│
│    PASS  DNS: traefik.hola.get2know.io
│
│    PASS  Catalog URL
│
│    PASS  AWS credentials
```

## After
One compact note — a heading, a colorized glyph per check, inline details, and a summary:

```
│  Validation
│    ✓  DNS: apps.hola.get2know.io
│    ✓  DNS: traefik.hola.get2know.io
│    ✓  Catalog URL
│    ✓  AWS credentials
│    4 passed
```

(✓ green / ! yellow / ✗ red; warnings/failures get their counts in the summary, e.g. `3 passed · 1 warning`.)

## Changes
- `lib/ui.ts` — new pure `renderChecks(checks)` formatter (colorized glyphs + summary; picocolors drops ANSI off-TTY).
- `install/wizard.ts` — emit one `prompter.note(renderChecks(checks))` instead of a note per line.
- `__tests__/ui.test.ts` — cover the block layout, inline detail, pluralized summary, and the empty case.

## Test
`bun --cwd packages/cli test` → 97 pass · typecheck · lint ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)