### PR TITLE
chore(release): 0.6.8

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "packages/cli": {
       "name": "@hola/cli",
-      "version": "0.6.7",
+      "version": "0.6.8",
       "bin": {
         "hola": "./bin/hola",
       },
@@ -35,11 +35,11 @@
     },
     "packages/compose": {
       "name": "@hola/compose",
-      "version": "0.6.7",
+      "version": "0.6.8",
     },
     "packages/sdk": {
       "name": "@hola/sdk",
-      "version": "0.6.7",
+      "version": "0.6.8",
       "dependencies": {
         "@hola/shared": "workspace:*",
       },
@@ -53,7 +53,7 @@
     },
     "packages/server": {
       "name": "@hola/server",
-      "version": "0.6.7",
+      "version": "0.6.8",
       "dependencies": {
         "@hola/shared": "workspace:*",
         "jose": "^5.9.6",
@@ -69,7 +69,7 @@
     },
     "packages/shared": {
       "name": "@hola/shared",
-      "version": "0.6.7",
+      "version": "0.6.8",
       "dependencies": {
         "yaml": "^2.9.0",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.6.7';
+export const CLI_VERSION = '0.6.8';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Release 0.6.8.

## Included
- **#199** `fix(compose)`: a `traefik-init` oneshot now creates `/data/runtime/traefik` before Traefik starts (`depends_on … service_completed_successfully`). Fixes a startup race where Traefik booting before the server created that dir left its read-only file provider permanently failed → zero routers → 404 on every host (dashboard/app/auth). Restart-breaker; should reach hosts via `hola bootstrap`.
- **#200** `feat(cli)`: install validation renders as one compact, colorized block (`✓`/`!`/`✗` + summary) instead of a framed note per check.

## Version bump
`cli`, `compose`, `sdk`, `server`, `shared` → `0.6.8` (+ `cli/src/version.ts`); `web` stays `0.0.0`.

Tag `cli-v0.6.8` on the squash-merge commit publishes the CLI binaries and `ghcr.io/try-hola/{server,web}:0.6.8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)