### PR TITLE
fix(auth): drop the recovery-flow dashboard redirect (Authentik denies cross-origin next)

### DIFF
--- a/packages/server/src/__tests__/integration/authentik-provision.it.ts
+++ b/packages/server/src/__tests__/integration/authentik-provision.it.ts
@@ -272,7 +272,6 @@ describe.skipIf(!dockerOk)('Authentik provisioner (real daemon)', () => {
     // also verifies the scoped permission set can add the flow + stage bindings.
     const svc = new RealAuthentikProvisionerService({
       ...config, authentikApiToken: undefined, authentikBootstrapToken: BOOTSTRAP_TOKEN, adminEmail: 'recovery-it@example.com',
-      dashboardUrl: 'https://hola.example.com',
     });
 
     // Precondition: confirm Authentik really ships no recovery flow out of the box.
@@ -286,8 +285,6 @@ describe.skipIf(!dockerOk)('Authentik provisioner (real daemon)', () => {
 
     expect(result.recoveryLink).toBeTruthy();
     expect(result.recoveryLink).toContain('/if/flow/');
-    // The link carries the dashboard as its post-success redirect.
-    expect(new URL(result.recoveryLink!).searchParams.get('next')).toBe('https://hola.example.com');
 
     // The recovery flow now exists, is bound to the default brand, and has the two
     // reused stages (prompt + user-write) PLUS the appended Login stage so setting

--- a/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
+++ b/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
@@ -487,27 +487,6 @@ describe('RealAuthentikProvisionerService — scoped-token bootstrap', () => {
       && (c.body as { flow_recovery: string }).flow_recovery === 'hola-recovery-pk')).toBe(true);
   });
 
-  test('ensureBootstrapAdmin appends the dashboard redirect (next=) to the recovery link', async () => {
-    installFetch((call) => {
-      if (call.method === 'GET' && call.path.startsWith('/api/v3/core/users/?email=')) return json({ results: [] });
-      if (call.method === 'POST' && call.path === '/api/v3/core/users/') return json({ pk: 101, last_login: null }, 201);
-      if (call.method === 'GET' && call.path.startsWith('/api/v3/core/groups/?name=')) return json({ results: [{ pk: 'g1', users: [] }] });
-      if (call.method === 'PATCH' && call.path === '/api/v3/core/groups/g1/') return json({ pk: 'g1' });
-      if (call.method === 'GET' && call.path.startsWith('/api/v3/flows/instances/?designation=recovery')) return json({ results: [{ pk: 'recovery-flow' }] });
-      if (call.method === 'GET' && call.path.startsWith('/api/v3/core/brands/')) return json({ results: [{ brand_uuid: 'b1', flow_recovery: 'recovery-flow' }] });
-      if (call.method === 'POST' && call.path === '/api/v3/core/users/101/recovery/') return json({ link: 'http://authentik-server:9000/if/flow/hola-recovery/?flow_token=tok' });
-      return undefined;
-    });
-    calls.length = 0;
-    const svc = new RealAuthentikProvisionerService({ ...CONFIG, adminEmail: 'me@example.com', dashboardUrl: 'https://app.example.com' });
-    const result = await svc.ensureBootstrapAdmin('hola-admins');
-    // Origin rewritten to the public Authentik URL AND ?next= points at the dashboard.
-    const url = new URL(result.recoveryLink!);
-    expect(url.origin).toBe('https://auth.example.com');
-    expect(url.searchParams.get('next')).toBe('https://app.example.com');
-    expect(url.searchParams.get('flow_token')).toBe('tok');
-  });
-
   test('ensureBootstrapAdmin rewrites the recovery link to the public Authentik URL', async () => {
     installFetch((call) => {
       if (call.method === 'GET' && call.path.startsWith('/api/v3/core/users/?email=')) return json({ results: [] });

--- a/packages/server/src/config/auth.ts
+++ b/packages/server/src/config/auth.ts
@@ -57,24 +57,11 @@ export interface AuthConfig {
   adminUsername?: string;
   /** Optional display name for the provisioned admin. */
   adminName?: string;
-  /**
-   * Browser-facing URL of the Hola dashboard (derived from HOLA_DOMAIN). Used as
-   * the recovery flow's post-success redirect (`?next=`) so setting a password +
-   * auto-login lands the operator on the dashboard, not Authentik's app launcher.
-   */
-  dashboardUrl?: string;
 }
 
 function stripTrailingSlash(url: string | undefined): string | undefined {
   if (!url) return undefined;
   return url.replace(/\/+$/, '');
-}
-
-/** Normalize a host or URL into a browser URL (https:// unless a scheme is given). */
-function toBrowserUrl(value: string | undefined): string | undefined {
-  const v = value?.trim();
-  if (!v) return undefined;
-  return stripTrailingSlash(/^https?:\/\//.test(v) ? v : `https://${v}`);
 }
 
 export const defaultAuthConfig: AuthConfig = {
@@ -92,7 +79,6 @@ export const defaultAuthConfig: AuthConfig = {
   adminEmail: process.env.HOLA_ADMIN_EMAIL?.trim() || undefined,
   adminUsername: process.env.HOLA_ADMIN_USERNAME?.trim() || undefined,
   adminName: process.env.HOLA_ADMIN_NAME?.trim() || undefined,
-  dashboardUrl: toBrowserUrl(process.env.HOLA_DOMAIN),
 };
 
 export function loadAuthConfig(): AuthConfig {

--- a/packages/server/src/services/core/provisioner.ts
+++ b/packages/server/src/services/core/provisioner.ts
@@ -588,10 +588,8 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
         const res = await this.api<{ link: string }>('POST', `/api/v3/core/users/${userPk}/recovery/`);
         // Authentik builds the link from the host the API was called on — which is
         // the internal `authentik-server:9000` for us, unreachable from a browser.
-        // Rewrite the origin to the public Authentik URL so the operator can open it,
-        // then attach the dashboard as the post-flow redirect so a successful set +
-        // auto-login lands them on Hola, not Authentik's app launcher.
-        return this.withDashboardRedirect(this.toPublicUrl(res.link));
+        // Rewrite the origin to the public Authentik URL so the operator can open it.
+        return this.toPublicUrl(res.link);
       } catch (error) {
         this.logger.warn('Recovery link generation attempt failed; will retry', {
           attempt: i + 1,
@@ -617,24 +615,6 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
       u.protocol = p.protocol;
       u.hostname = p.hostname;
       u.port = p.port; // clears the internal :9000 when the public URL has no port
-      return u.toString();
-    } catch {
-      return link;
-    }
-  }
-
-  /**
-   * Attach the Hola dashboard as the recovery flow's post-success redirect via the
-   * `next` query param, so once the operator sets a password (and the appended
-   * Login stage signs them in) they land on the dashboard instead of Authentik's
-   * single-tile app launcher. No-op when no dashboard URL is configured.
-   */
-  private withDashboardRedirect(link: string): string {
-    const dash = this.config.dashboardUrl;
-    if (!dash) return link;
-    try {
-      const u = new URL(link);
-      u.searchParams.set('next', dash);
       return u.toString();
     } catch {
       return link;


### PR DESCRIPTION
## Symptom
After following the password-setup link and setting a password, the operator hits Authentik's **"Request has been denied — Invalid next URL"** error screen (screenshot from a live 0.6.8 host).

## Cause
The `?next=<dashboard>` redirect added in #197 points at `https://apps.<base>` while the flow runs on `https://auth.<base>`. Authentik's open-redirect protection rejects that cross-subdomain `next` outright. The password **is** saved (the User Write stage commits first — confirmed via `password_change_date`), but the final redirect fails, so the flow ends on an error instead of the dashboard. This was the exact risk flagged in #197 ("if Authentik tightens open-redirect handling and drops it…") — except it hard-fails rather than degrading.

## Fix
Remove the `next=` redirect and the now-unused `dashboardUrl` config. The **auto-login Login stage from #195 stays** — setting a password still signs the operator in; they land on Authentik's app launcher (the single "hola" tile) and click through to the dashboard (one click, no second password entry).

Landing *directly* on the dashboard needs an Authentik-validated redirect target (e.g. the application's launch URL on the auth origin) and is left as a follow-up rather than shipping a broken cross-origin `next`.

## Changes
- `provisioner.ts` — drop `withDashboardRedirect`; `mintRecoveryLink` returns `toPublicUrl(link)` only.
- `config/auth.ts` — remove `dashboardUrl` + the unused `toBrowserUrl` helper.
- Tests — drop the `next=` contract test and the integration `next=` assertion (login-stage coverage retained).

## Test
`bun run typecheck` · `bun run lint` · `bun --cwd packages/server test` → 288 pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)