### PR TITLE
chore(release): 0.6.9

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "packages/cli": {
       "name": "@hola/cli",
-      "version": "0.6.8",
+      "version": "0.6.9",
       "bin": {
         "hola": "./bin/hola",
       },
@@ -35,11 +35,11 @@
     },
     "packages/compose": {
       "name": "@hola/compose",
-      "version": "0.6.8",
+      "version": "0.6.9",
     },
     "packages/sdk": {
       "name": "@hola/sdk",
-      "version": "0.6.8",
+      "version": "0.6.9",
       "dependencies": {
         "@hola/shared": "workspace:*",
       },
@@ -53,7 +53,7 @@
     },
     "packages/server": {
       "name": "@hola/server",
-      "version": "0.6.8",
+      "version": "0.6.9",
       "dependencies": {
         "@hola/shared": "workspace:*",
         "jose": "^5.9.6",
@@ -69,7 +69,7 @@
     },
     "packages/shared": {
       "name": "@hola/shared",
-      "version": "0.6.8",
+      "version": "0.6.9",
       "dependencies": {
         "yaml": "^2.9.0",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.6.8';
+export const CLI_VERSION = '0.6.9';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Release 0.6.9.

## Included
- **#202** `fix(auth)`: drop the recovery-flow `?next=` dashboard redirect. Authentik rejects the cross-subdomain `next` ("Request has been denied — Invalid next URL"), which ended the password-setup flow on an error screen even though the password was saved. The auto-login Login stage (#195) is retained — set password → signed in → app launcher → dashboard. Recovery links were broken on 0.6.7–0.6.8; this restores them.

## Version bump
`cli`, `compose`, `sdk`, `server`, `shared` → `0.6.9` (+ `cli/src/version.ts`); `web` stays `0.0.0`.

Tag `cli-v0.6.9` on the squash-merge commit publishes the CLI binaries and `ghcr.io/try-hola/{server,web}:0.6.9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)