### PR TITLE
fix(cli): surface the real AWS error in the route53 credential check

### DIFF
--- a/packages/cli/src/__tests__/checks.test.ts
+++ b/packages/cli/src/__tests__/checks.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+
+import { runChecks, type CheckDeps, type CheckResult } from '../install/checks';
+
+// A CheckDeps whose DNS/fetch are inert; only `exec` matters for the route53 path.
+function deps(over: Partial<CheckDeps>): CheckDeps {
+  return {
+    lookup: async () => [],
+    fetchImpl: (async () => new Response('{}', { status: 200 })) as typeof fetch,
+    exec: async () => ({ code: 0, stderr: '' }),
+    ...over,
+  };
+}
+
+const ROUTE53 = {
+  ACME_DNS_PROVIDER: 'route53',
+  AWS_ACCESS_KEY_ID: 'AKIATESTTESTTEST1234',
+  AWS_SECRET_ACCESS_KEY: 'shhh',
+  AWS_REGION: 'us-east-1',
+} as Record<string, string>;
+
+const awsCheck = (results: CheckResult[]) => results.find((r) => r.name === 'AWS credentials');
+
+describe('runChecks — route53 AWS credentials', () => {
+  it('passes when the aws CLI exits 0', async () => {
+    const results = await runChecks(ROUTE53, deps({ exec: async () => ({ code: 0, stderr: '' }) }));
+    expect(awsCheck(results)).toEqual({ name: 'AWS credentials', status: 'pass' });
+  });
+
+  it('surfaces the real AWS error even when stderr has leading blank lines', async () => {
+    // The aws CLI writes `\n\naws: [ERROR]: An error occurred (SignatureDoesNotMatch) ...`.
+    // The detail must be that line, not the useless "aws exited 254" fallback.
+    const stderr = '\n\naws: [ERROR]: An error occurred (SignatureDoesNotMatch) when calling the GetCallerIdentity operation: ...\n';
+    const results = await runChecks(ROUTE53, deps({ exec: async () => ({ code: 254, stderr }) }));
+    const aws = awsCheck(results)!;
+    expect(aws.status).toBe('fail');
+    expect(aws.detail).toContain('SignatureDoesNotMatch');
+    expect(aws.detail).not.toBe('aws exited 254');
+  });
+
+  it('falls back to the exit code only when stderr is truly empty', async () => {
+    const results = await runChecks(ROUTE53, deps({ exec: async () => ({ code: 254, stderr: '' }) }));
+    expect(awsCheck(results)!.detail).toBe('aws exited 254');
+  });
+
+  it('warns (not fails) when the aws CLI is missing', async () => {
+    const results = await runChecks(ROUTE53, deps({
+      exec: async () => { throw Object.assign(new Error('spawn aws ENOENT'), { code: 'ENOENT' }); },
+    }));
+    expect(awsCheck(results)!.status).toBe('warn');
+  });
+});

--- a/packages/cli/src/install/checks.ts
+++ b/packages/cli/src/install/checks.ts
@@ -141,6 +141,9 @@ async function runWithEnv(
   }
 }
 
+// First NON-EMPTY line. The aws CLI prefixes its error with blank lines
+// (`\n\naws: [ERROR]: An error occurred (SignatureDoesNotMatch) ...`), so taking
+// line[0] would drop the actual reason and leave only "aws exited <code>".
 function firstLine(s: string): string {
-  return s.split('\n')[0]?.trim() ?? '';
+  return s.split('\n').map((l) => l.trim()).find(Boolean) ?? '';
 }


### PR DESCRIPTION
## What you saw
```
✗  AWS credentials — aws exited 254
```

## What it means (verified)
- **Valid local-env creds ARE picked up correctly.** The wizard captures `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION` from the environment into the config, and the check passes — confirmed by running the exact check command (`aws sts get-caller-identity` → exit 0) and reproducing the full wizard → check (pass).
- **Exit 254 = AWS *rejected* the credentials** used at that moment (signature/token mismatch or expired), not a pickup failure.

## The bug this fixes
The check threw away the *reason*. The aws CLI prefixes its error with blank lines:
```
\n\naws: [ERROR]: An error occurred (SignatureDoesNotMatch) when calling the GetCallerIdentity operation: ...
```
…and `firstLine` took `split('\n')[0]` — the empty first line — so the detail fell back to the useless `aws exited 254`. An operator couldn't tell an expired key, a wrong secret, or a typo apart.

**Fix:** return the first **non-empty** line, so the detail now reads e.g. `An error occurred (SignatureDoesNotMatch) ...` or `The security token included in the request is invalid` (ExpiredToken).

## Changes
- `install/checks.ts` — `firstLine` returns the first non-empty trimmed line.
- `__tests__/checks.test.ts` (new) — covers pass, blank-line-prefixed error (real reason surfaced), truly-empty-stderr fallback, and aws-not-found → warn.

## Test
`bun --cwd packages/cli test` → 101 pass · typecheck · lint ✅
Verified live: a deliberately-wrong secret now reports `An error occurred (SignatureDoesNotMatch) ...` instead of `aws exited 254`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)