### PR TITLE
chore(release): 0.6.10

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "packages/cli": {
       "name": "@hola/cli",
-      "version": "0.6.9",
+      "version": "0.6.10",
       "bin": {
         "hola": "./bin/hola",
       },
@@ -35,11 +35,11 @@
     },
     "packages/compose": {
       "name": "@hola/compose",
-      "version": "0.6.9",
+      "version": "0.6.10",
     },
     "packages/sdk": {
       "name": "@hola/sdk",
-      "version": "0.6.9",
+      "version": "0.6.10",
       "dependencies": {
         "@hola/shared": "workspace:*",
       },
@@ -53,7 +53,7 @@
     },
     "packages/server": {
       "name": "@hola/server",
-      "version": "0.6.9",
+      "version": "0.6.10",
       "dependencies": {
         "@hola/shared": "workspace:*",
         "jose": "^5.9.6",
@@ -69,7 +69,7 @@
     },
     "packages/shared": {
       "name": "@hola/shared",
-      "version": "0.6.9",
+      "version": "0.6.10",
       "dependencies": {
         "yaml": "^2.9.0",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.6.9';
+export const CLI_VERSION = '0.6.10';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Release 0.6.10.

## Included
- **#204** `fix(cli)`: the route53 AWS credential check now surfaces the real AWS error (e.g. `SignatureDoesNotMatch`, `ExpiredToken`, `InvalidClientTokenId`) instead of a bare `aws exited 254`. The aws CLI prefixes its error with blank lines, so `firstLine` was dropping the reason.

## Version bump
`cli`, `compose`, `sdk`, `server`, `shared` → `0.6.10` (+ `cli/src/version.ts`); `web` stays `0.0.0`.

Tag `cli-v0.6.10` on the squash-merge commit publishes the CLI binaries and `ghcr.io/try-hola/{server,web}:0.6.10`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)