### PR TITLE
fix(cli): masked secret accepts env value instead of literal "undefined"

### DIFF
--- a/packages/cli/src/__tests__/prompter.test.ts
+++ b/packages/cli/src/__tests__/prompter.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+
+import { resultToAnswer, toClackValidate } from '../install/prompter';
+
+describe('resultToAnswer', () => {
+  it('maps a nullish secret submit to "" so the env-reuse fallback fires', () => {
+    // clack.password() resolves to `undefined` on an empty submit. A naive
+    // String(undefined) === "undefined" would be truthy and shadow the env value,
+    // sending the literal "undefined" to AWS (→ SignatureDoesNotMatch).
+    expect(resultToAnswer('secret', undefined)).toBe('');
+    expect(resultToAnswer('secret', null)).toBe('');
+  });
+
+  it('passes a real secret through unchanged', () => {
+    expect(resultToAnswer('secret', 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY')).toBe(
+      'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
+    );
+  });
+
+  it('stringifies text answers', () => {
+    expect(resultToAnswer('text', 'apps.example.com')).toBe('apps.example.com');
+    expect(resultToAnswer('text', '')).toBe('');
+  });
+
+  it('renders confirm booleans as "true"/"false"', () => {
+    expect(resultToAnswer('confirm', true)).toBe('true');
+    expect(resultToAnswer('confirm', false)).toBe('false');
+  });
+});
+
+describe('toClackValidate', () => {
+  it('coerces a nullish blank submit to "" before validating', () => {
+    const validate = toClackValidate((v) => (v.trim() ? undefined : 'required'));
+    expect(validate?.(undefined)).toBe('required');
+    expect(validate?.('ok')).toBeUndefined();
+  });
+
+  it('returns undefined when there is no validator', () => {
+    expect(toClackValidate(undefined)).toBeUndefined();
+  });
+});

--- a/packages/cli/src/install/prompter.ts
+++ b/packages/cli/src/install/prompter.ts
@@ -39,6 +39,22 @@ export function toClackValidate(
   return validate ? (v) => validate(v ?? '') : undefined;
 }
 
+/**
+ * Coerce a clack prompt result to the string the wizard expects. Exported for testing.
+ *
+ * `clack.password()` resolves to `undefined` on an empty submit — unlike `text()`,
+ * the PasswordPrompt has no finalize/default handler, so an untouched field never
+ * sets `value`. A naive `String(result)` would turn that into the literal string
+ * `"undefined"`, which is truthy and so poisons the wizard's `!value` env-reuse
+ * fallback (the masked `fromEnv` secret silently becomes `"undefined"`, and AWS
+ * later rejects it as `SignatureDoesNotMatch`). Mapping nullish → '' lets the
+ * fallback fire.
+ */
+export function resultToAnswer(type: FieldType, result: unknown): string {
+  if (type === 'confirm') return result ? 'true' : 'false';
+  return result == null ? '' : String(result);
+}
+
 /** Production prompter backed by @clack/prompts. Lazily imported so tests never load it. */
 export function clackPrompter(): Prompter {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -70,8 +86,7 @@ export function clackPrompter(): Prompter {
           result = await clack.text({ message: spec.message, initialValue: spec.default, validate });
       }
       if (clack.isCancel(result)) throw new PromptCancelled();
-      if (spec.type === 'confirm') return result ? 'true' : 'false';
-      return String(result);
+      return resultToAnswer(spec.type, result);
     },
     note(message) {
       // clack.log.message keeps the framed output consistent.


### PR DESCRIPTION
## The bug

Running the install wizard with valid AWS credentials **in the environment** still failed the route53 preflight:

```
✗  AWS credentials — aws: [ERROR]: An error occurred (SignatureDoesNotMatch) when calling the
   GetCallerIdentity operation: The request signature we calculated does not match the signature
   you provided. ...
```

…even though `aws sts get-caller-identity` succeeded in the same shell with the same creds. The 0.6.10 error-message fix (#204) is what made this legible — it surfaced the real AWS reason instead of `aws exited 254`.

## Root cause

`clack.password()` resolves to **`undefined`** on an empty submit. Unlike `text()`, the clack `PasswordPrompt` has no `finalize`/default handler, so an untouched masked field never assigns `value`. `clackPrompter` then did `String(result)` → the literal string `"undefined"`.

That string is truthy, so the wizard's env-reuse fallback (`if (!value && envVal) value = envVal`) was **skipped**, and `config.AWS_SECRET_ACCESS_KEY` became `"undefined"`. The preflight set that as `AWS_SECRET_ACCESS_KEY` and ran `aws sts get-caller-identity` → AWS rejected the signature.

So the masked `fromEnv` "press Enter to use it" path was broken for *every* secret, AWS being where it surfaced.

## Fix

Extract the result coercion to a pure, exported `resultToAnswer(type, result)` and map nullish → `''` so the fallback fires. New `prompter.test.ts` covers the nullish-secret regression, real secrets, text answers, confirm booleans, and `toClackValidate`.

## Verification

- New `resultToAnswer('secret', undefined) === ''` test fails on `main`, passes here.
- Reproduced the original symptom from the live env: the wizard `fromEnv` config path (which bypasses the prompter) already returned `pass`, isolating the defect to the prompter boundary.
- `bun --cwd packages/cli test` (107 passed), `bun run typecheck`, `bun run lint` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)