### PR TITLE
fix(cli): prefill masked secrets; live env wins over stale .env

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
         "hola": "./bin/hola",
       },
       "dependencies": {
+        "@clack/core": "^1.4.1",
         "@clack/prompts": "^1.5.1",
         "@hola/sdk": "workspace:*",
         "@hola/shared": "workspace:*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,6 +15,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@clack/core": "^1.4.1",
     "@clack/prompts": "^1.5.1",
     "@hola/sdk": "workspace:*",
     "@hola/shared": "workspace:*",

--- a/packages/cli/src/__tests__/prompter.test.ts
+++ b/packages/cli/src/__tests__/prompter.test.ts
@@ -1,6 +1,10 @@
-import { describe, it, expect } from 'vitest';
+import { PassThrough } from 'node:stream';
 
-import { resultToAnswer, toClackValidate } from '../install/prompter';
+import { describe, it, expect } from 'vitest';
+import * as clack from '@clack/prompts';
+import { PasswordPrompt } from '@clack/core';
+
+import { resultToAnswer, toClackValidate, passwordWithDefault, type PromptSpec } from '../install/prompter';
 
 describe('resultToAnswer', () => {
   it('maps a nullish secret submit to "" so the env-reuse fallback fires', () => {
@@ -25,6 +29,50 @@ describe('resultToAnswer', () => {
   it('renders confirm booleans as "true"/"false"', () => {
     expect(resultToAnswer('confirm', true)).toBe('true');
     expect(resultToAnswer('confirm', false)).toBe('false');
+  });
+});
+
+describe('passwordWithDefault — prefilled masked secret', () => {
+  // Fake TTY streams so the real @clack prompt runs headless.
+  function fakeStdin() {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const s: any = new PassThrough();
+    s.isTTY = true;
+    s.setRawMode = () => {};
+    return s;
+  }
+  function fakeStdout(captured: string[]) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const o: any = new PassThrough();
+    o.isTTY = true;
+    o.columns = 80;
+    o.on('data', (d: Buffer) => captured.push(String(d)));
+    return o;
+  }
+
+  async function run(def: string, keys: string[]) {
+    const input = fakeStdin();
+    const captured: string[] = [];
+    const output = fakeStdout(captured);
+    const spec: PromptSpec = { key: 'AWS_SECRET_ACCESS_KEY', type: 'secret', message: 'AWS secret access key', default: def };
+    const validate = (v: string | undefined) => (v?.trim() ? undefined : 'required');
+    const p = passwordWithDefault(clack, PasswordPrompt, spec, validate, { input, output });
+    setTimeout(() => keys.forEach((k) => input.write(k)), 30);
+    const result = await p;
+    return { result, rendered: captured.join('') };
+  }
+
+  it('submits the real default value (not "undefined" or "") when Enter is pressed', async () => {
+    const secret = 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY';
+    const { result, rendered } = await run(secret, ['\r']);
+    expect(result).toBe(secret);
+    expect(rendered).not.toContain(secret); // shown as dots, never echoed in plaintext
+  });
+
+  it('lets the user edit the prefilled value before submitting', async () => {
+    // Prefill "abc", backspace all three, type "ZY", Enter.
+    const { result } = await run('abc', ['\x7f', '\x7f', '\x7f', 'Z', 'Y', '\r']);
+    expect(result).toBe('ZY');
   });
 });
 

--- a/packages/cli/src/__tests__/wizard.test.ts
+++ b/packages/cli/src/__tests__/wizard.test.ts
@@ -43,6 +43,33 @@ describe('runWizard — AWS credentials from the environment', () => {
     expect(config.AWS_SECRET_ACCESS_KEY).toBe('env-secret');
   });
 
+  it('ignores a corrupt "undefined" AWS secret in an existing .env and uses the env value', async () => {
+    // A prior buggy release could write `AWS_SECRET_ACCESS_KEY=undefined` into .env.
+    // On re-run that parsed value must not shadow the real environment credential.
+    const env = { AWS_ACCESS_KEY_ID: 'AKIAENV', AWS_SECRET_ACCESS_KEY: 'good-secret', AWS_REGION: 'us-east-1' };
+    const { config } = await runWizard({
+      prompter: scriptedPrompter(route53Base), // secret omitted → prompter returns the computed default
+      initial: { AWS_SECRET_ACCESS_KEY: 'undefined' },
+      checks: noChecks,
+      env,
+    });
+    expect(config.AWS_SECRET_ACCESS_KEY).toBe('good-secret');
+  });
+
+  it('lets the live environment win over a stale AWS secret in an existing .env', async () => {
+    // fromEnv fields are environment-sourced; the value the operator just exported
+    // takes precedence over whatever an old .env still holds.
+    const env = { AWS_ACCESS_KEY_ID: 'AKIAENV', AWS_SECRET_ACCESS_KEY: 'fresh-secret', AWS_REGION: 'us-east-1' };
+    const { config } = await runWizard({
+      prompter: scriptedPrompter(route53Base),
+      initial: { AWS_SECRET_ACCESS_KEY: 'stale-old-secret', AWS_ACCESS_KEY_ID: 'AKIASTALE' },
+      checks: noChecks,
+      env,
+    });
+    expect(config.AWS_SECRET_ACCESS_KEY).toBe('fresh-secret');
+    expect(config.AWS_ACCESS_KEY_ID).toBe('AKIAENV');
+  });
+
   it('still prompts (and validates) when nothing is in the environment', async () => {
     await expect(
       runWizard({

--- a/packages/cli/src/install/prompter.ts
+++ b/packages/cli/src/install/prompter.ts
@@ -2,6 +2,8 @@
 // keeping @clack/prompts out of the test path. clackPrompter() is the production
 // implementation; scriptedPrompter() is the test double.
 
+import pc from 'picocolors';
+
 import type { FieldType } from './schema';
 
 export interface PromptSpec {
@@ -55,13 +57,75 @@ export function resultToAnswer(type: FieldType, result: unknown): string {
   return result == null ? '' : String(result);
 }
 
+/**
+ * A masked secret prompt prefilled with `def`, rendered as dots and fully editable.
+ * Pressing Enter submits the real (unmodified) value — so a secret already present
+ * in the environment is reused without retyping or pasting it (which also sidesteps
+ * terminal paste-mangling of `/ + =` in AWS-style secrets).
+ *
+ * clack's high-level `password()` ignores `initialValue`, so we drive @clack/core's
+ * `PasswordPrompt` directly with `initialUserInput` and re-render in clack's house
+ * style (its inline renderer isn't exported). Kept faithful to clack@1's render so
+ * this one field looks identical to every other prompt.
+ */
+export async function passwordWithDefault(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  clack: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  PasswordPrompt: any,
+  spec: PromptSpec,
+  validate: unknown,
+  // Tests inject fake TTY streams; production omits this so the prompt uses process stdio.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  io?: { input?: any; output?: any }
+): Promise<unknown> {
+  const { S_BAR, S_BAR_END, S_STEP_ACTIVE, S_STEP_ERROR, S_STEP_SUBMIT, S_STEP_CANCEL, S_PASSWORD_MASK } = clack;
+  const symbol = (state: string) =>
+    state === 'error'
+      ? pc.yellow(S_STEP_ERROR)
+      : state === 'submit'
+        ? pc.green(S_STEP_SUBMIT)
+        : state === 'cancel'
+          ? pc.red(S_STEP_CANCEL)
+          : pc.cyan(S_STEP_ACTIVE);
+  const prompt = new PasswordPrompt({
+    mask: S_PASSWORD_MASK,
+    initialUserInput: spec.default,
+    validate,
+    input: io?.input,
+    output: io?.output,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    render(this: any) {
+      const head = `${pc.gray(S_BAR)}\n${symbol(this.state)}  ${spec.message}\n`;
+      const masked = this.masked as string;
+      switch (this.state) {
+        case 'error':
+          return `${head.trim()}\n${pc.yellow(S_BAR)}  ${masked ?? ''}\n${pc.yellow(S_BAR_END)}  ${pc.yellow(this.error)}\n`;
+        case 'submit':
+          return `${head}${pc.gray(S_BAR)}  ${masked ? pc.dim(masked) : ''}`;
+        case 'cancel':
+          return `${head}${pc.gray(S_BAR)}  ${masked ? pc.strikethrough(pc.dim(masked)) : ''}`;
+        default:
+          return `${head}${pc.cyan(S_BAR)}  ${this.userInputWithCursor}\n${pc.cyan(S_BAR_END)}\n`;
+      }
+    },
+  });
+  return prompt.prompt();
+}
+
 /** Production prompter backed by @clack/prompts. Lazily imported so tests never load it. */
 export function clackPrompter(): Prompter {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let p: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let core: any;
   const load = async () => {
     if (!p) p = await import('@clack/prompts');
     return p;
+  };
+  const loadCore = async () => {
+    if (!core) core = await import('@clack/core');
+    return core;
   };
   return {
     async prompt(spec) {
@@ -70,7 +134,11 @@ export function clackPrompter(): Prompter {
       let result: unknown;
       switch (spec.type) {
         case 'secret':
-          result = await clack.password({ message: spec.message, validate });
+          // Prefill with the detected value (e.g. a fromEnv secret) so Enter submits
+          // it as dots; fall back to an empty masked prompt when there's nothing to reuse.
+          result = spec.default
+            ? await passwordWithDefault(clack, (await loadCore()).PasswordPrompt, spec, validate)
+            : await clack.password({ message: spec.message, validate });
           break;
         case 'select':
           result = await clack.select({

--- a/packages/cli/src/install/wizard.ts
+++ b/packages/cli/src/install/wizard.ts
@@ -35,12 +35,25 @@ export async function runWizard(opts: WizardOptions): Promise<WizardResult> {
   for (const field of INSTALL_SCHEMA) {
     if (field.requiredWhen && !field.requiredWhen(config)) continue;
 
-    // A `fromEnv` field offers a value already set in the environment (AWS_*),
-    // so the user accepts it instead of pasting. For a masked secret we can't
-    // prefill the prompt, so a blank answer means "use the detected value" and
-    // is not rejected by the field's validator.
+    // A `fromEnv` field offers a value already set in the environment (AWS_*); the
+    // prompt prefills with it (masked secrets render as dots) so the user just
+    // presses Enter. A blank answer still means "use the detected value" and is
+    // not rejected by the field's validator.
     const envVal = field.fromEnv ? env[field.key]?.trim() || undefined : undefined;
-    const fallback = initial[field.key] ?? envVal ?? defaultFor(field, config);
+
+    // A literal "undefined"/"null" in `initial` is corruption, not a real prior
+    // value — earlier releases could mis-collect a masked secret and write
+    // `AWS_SECRET_ACCESS_KEY=undefined` into .env. Never let that shadow a good value.
+    const prior = initial[field.key];
+    const priorVal = prior === 'undefined' || prior === 'null' ? undefined : prior;
+
+    // For env-sourced fields the live environment is authoritative: a stale value
+    // in an existing .env must not override what the operator just exported. Other
+    // fields prefer the existing .env so host-generated secrets (HOLA_API_KEY)
+    // survive a `hola init --force` re-run.
+    const fallback = field.fromEnv
+      ? envVal ?? priorVal ?? defaultFor(field, config)
+      : priorVal ?? envVal ?? defaultFor(field, config);
 
     let message = field.help ? `${field.prompt}\n  ${field.help}` : field.prompt;
     if (envVal && field.secret) message = `${field.prompt} (found in your environment — press Enter to use it)`;


### PR DESCRIPTION
## Why 0.6.11 still failed

0.6.10's error-message fix made the failure legible (`SignatureDoesNotMatch`), and 0.6.11 fixed the empty-submit fallback — but a route53 install could **still** fail with valid AWS credentials, because the value the wizard collected differed from the one the shell's `aws` used. Two root causes, both fixed here.

### 1. Masked secret now prefilled (the requested behavior)

`clack.password()` resolves to `undefined` on an empty Enter (its `PasswordPrompt` has no finalize/default handler), and its high-level wrapper **ignores `initialValue`** — so the env value could never be shown in the field. We now drive `@clack/core`'s `PasswordPrompt` directly with `initialUserInput`, re-rendering in clack's house style. The detected secret renders as dots, is editable, and **Enter submits the real value** — no retyping/pasting, which also sidesteps terminal paste-mangling of `/ + =`.

(`@clack/core` is added as a direct dependency — it was previously only transitive.)

### 2. Live environment wins over a stale `.env`

`hola init --force` parses an existing `.env` into `initial`, and `fallback = initial[key] ?? envVal` meant **`.env` overrode the environment**. So a stale (or `undefined`) `AWS_SECRET_ACCESS_KEY` left in `.env` by an earlier run shadowed the good value the operator just exported, and the preflight signed with the wrong secret.

- For `fromEnv` fields (the `AWS_*` group, which are environment-sourced by definition) the **live environment is now authoritative**.
- Non-`fromEnv` fields still prefer the existing `.env` so host-generated secrets (`HOLA_API_KEY`) survive a re-run.
- A literal `"undefined"`/`"null"` in `initial` is filtered out — earlier releases (≤0.6.10) could mis-collect a masked secret and write `AWS_SECRET_ACCESS_KEY=undefined` into `.env`, re-poisoning the value on the next run.

## Tests

- Real-prompt headless coverage (injected TTY streams): Enter submits the prefilled secret, shown as dots and never echoed in plaintext; backspace/edit produces the edited value.
- Wizard coverage: env value wins over both a `"undefined"` and a stale real secret in `.env`.
- `bun --cwd packages/cli test` (111), `typecheck`, `lint`, `build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)