### PR TITLE
fix(web): Deployments freeze, hardcoded domain pill, wizard Next blocker

### DIFF
--- a/packages/web/src/components/layout/Topbar.tsx
+++ b/packages/web/src/components/layout/Topbar.tsx
@@ -60,7 +60,7 @@ export const Topbar: React.FC = () => {
           <span className="absolute inset-0 rounded-full bg-success" />
           <span className="absolute inset-0 rounded-full bg-success animate-ping-slow" />
         </span>
-        <span className="text-[12.5px] text-text-muted">home.example.com</span>
+        <span className="text-[12.5px] text-text-muted">{window.location.hostname}</span>
       </div>
 
       {/* Theme toggle */}

--- a/packages/web/src/hooks/useCatalogApi.ts
+++ b/packages/web/src/hooks/useCatalogApi.ts
@@ -55,7 +55,13 @@ export function useCatalogAppsApi(params: GetCatalogAppsRequest) {
         error: error instanceof Error ? error.message : 'Unknown error',
       });
     }
-  }, [cacheKey, params]); // Include params in dependency to refetch when they change
+    // Only depend on cacheKey, not the `params` object: callers often pass an inline
+    // object literal (e.g. `useCatalogAppsApi({ page: 1, limit: 100 })`), whose identity
+    // changes every render. Including `params` here would recreate fetchData each render,
+    // re-fire the effect, setState, and loop forever — freezing the tab. cacheKey is a
+    // stable string derived from the param values, and `params` is read via closure.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cacheKey]);
 
   React.useEffect(() => {
     fetchData();

--- a/packages/web/src/pages/Deployments.tsx
+++ b/packages/web/src/pages/Deployments.tsx
@@ -34,6 +34,10 @@ const STATUS_FILTERS: { value: DeploymentStatus | 'all'; label: string }[] = [
 const GRID_COLS =
   'grid grid-cols-[2.4fr_1.1fr_0.9fr_1.9fr_0.9fr_130px] gap-[14px] px-[18px]';
 
+// Module-level constant so its identity is stable across renders (matches Apps.tsx).
+// A fresh object literal here would change every render and re-fetch the catalog.
+const CATALOG_PARAMS = { page: 1, limit: 100 };
+
 export const Deployments: React.FC = () => {
   const navigate = useNavigate();
   const [searchTerm, setSearchTerm] = useState('');
@@ -64,7 +68,7 @@ export const Deployments: React.FC = () => {
 
   // Join app id -> catalog product name + glyph so the "App" column shows the
   // real app (e.g. "Uptime Kuma" 📈), not a "deployment-<id>" placeholder.
-  const { data: catalogData } = useCatalogAppsApi({ page: 1, limit: 100 });
+  const { data: catalogData } = useCatalogAppsApi(CATALOG_PARAMS);
   const appMeta = React.useMemo(() => {
     const map = new Map<string, { name: string; icon: string }>();
     for (const app of catalogData?.items ?? []) map.set(app.id, { name: app.name, icon: app.icon });

--- a/packages/web/src/pages/InstallWizard.tsx
+++ b/packages/web/src/pages/InstallWizard.tsx
@@ -168,8 +168,14 @@ export const InstallWizard: React.FC = () => {
 
   const canProceed = () => {
     switch (currentStep) {
-      case 0: // Environment Variables
-        return !isLoading && envVars.every(env => env.key && (env.value || !env.isSecret));
+      case 0: {
+        // Environment Variables. A completely empty row is an unused placeholder
+        // (e.g. a default trailing row or one added via "Add variable") — it must
+        // not block Next. Only rows the user actually started filling in are
+        // validated: a populated row needs a key, and a secret also needs a value.
+        const meaningful = envVars.filter(env => env.key || env.value);
+        return !isLoading && meaningful.every(env => env.key && (env.value || !env.isSecret));
+      }
       case 4: // Validate & Preflight
         // Allow proceeding if not loading, and either checks haven't run yet OR both have passed
         return !isLoading && (!validationResult || (validationResult?.ok && preflightResult?.ok));


### PR DESCRIPTION
Three dashboard bugs surfaced while testing a fresh install.

## 1. Deployments page froze the browser tab
`useCatalogAppsApi`'s `fetchData` listed the **`params` object** in its `useCallback` deps. The Deployments page passed a fresh `{ page: 1, limit: 100 }` literal on every render, so `fetchData` was recreated each render → the `useEffect(…, [fetchData])` re-fired → `setState` (a new state object even on a cache hit) → re-render → **infinite loop** pegging the main thread. `Apps.tsx` was unaffected only because it passes a stable module-level constant.

`useDeploymentsApi` already guards against this (`fetchData` depends on `cacheKey` only, with a comment). Applied the same fix to `useCatalogAppsApi`, and made the Deployments call site use a module-level `CATALOG_PARAMS` constant matching `Apps.tsx`.

## 2. Topbar health pill hardcoded to `home.example.com`
It was a literal string. Now renders `window.location.hostname`, so it reflects the host you're actually on instead of a placeholder.

## 3. Install wizard "Next" disabled with default env vars
`canProceed` (env step) required **every** row to have a key, so a single empty placeholder row (a default trailing row, or one added via "Add variable") blocked the step. Now empty rows are ignored; only rows the user actually populated are validated (a populated row still needs a key, and a secret still needs a value).

## Verification
`bun --cwd packages/web test` (127), `typecheck`, `lint` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)