### PR TITLE
feat(server): recovery link lands on the dashboard, not Authentik's app library

### DIFF
--- a/packages/server/src/__tests__/integration/authentik-provision.it.ts
+++ b/packages/server/src/__tests__/integration/authentik-provision.it.ts
@@ -285,6 +285,8 @@ describe.skipIf(!dockerOk)('Authentik provisioner (real daemon)', () => {
 
     expect(result.recoveryLink).toBeTruthy();
     expect(result.recoveryLink).toContain('/if/flow/');
+    // Lands on the dashboard after set-password via a same-origin app-launch `next`.
+    expect(result.recoveryLink).toContain('next=%2Fapplication%2Flaunch%2Fhola-dashboard%2F');
 
     // The recovery flow now exists, is bound to the default brand, and has the two
     // reused stages (prompt + user-write) PLUS the appended Login stage so setting

--- a/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
+++ b/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
@@ -413,7 +413,12 @@ describe('RealAuthentikProvisionerService — scoped-token bootstrap', () => {
     const result = await svc.ensureBootstrapAdmin('hola-admins');
 
     expect(result.created).toBe(true);
-    expect(result.recoveryLink).toBe('https://auth.example.com/recovery/abc');
+    // The recovery link carries a relative `next` that lands the user on the dashboard
+    // (via the same-origin application-launch view) after they set their password,
+    // instead of Authentik's default "My applications" page.
+    expect(result.recoveryLink).toBe(
+      'https://auth.example.com/recovery/abc?next=%2Fapplication%2Flaunch%2Fhola-dashboard%2F'
+    );
     expect(patchedGroupUsers).toEqual([101]);
     // Bound a recovery flow to the default brand so /recovery/ works.
     expect(calls.some(c => c.method === 'PATCH' && c.path === '/api/v3/core/brands/b1/')).toBe(true);
@@ -446,7 +451,9 @@ describe('RealAuthentikProvisionerService — scoped-token bootstrap', () => {
     const result = await svc.ensureBootstrapAdmin('hola-admins');
 
     expect(flowQueries).toBeGreaterThanOrEqual(3); // kept polling until the flow appeared
-    expect(result.recoveryLink).toBe('https://auth.example.com/recovery/late');
+    expect(result.recoveryLink).toBe(
+      'https://auth.example.com/recovery/late?next=%2Fapplication%2Flaunch%2Fhola-dashboard%2F'
+    );
     expect(calls.some((c) => c.method === 'PATCH' && c.path === '/api/v3/core/brands/b1/')).toBe(true);
   });
 
@@ -479,6 +486,8 @@ describe('RealAuthentikProvisionerService — scoped-token bootstrap', () => {
     const result = await svc.ensureBootstrapAdmin('hola-admins');
 
     expect(result.recoveryLink).toContain('hola-recovery');
+    // ...and lands on the dashboard after the flow via a relative app-launch `next`.
+    expect(result.recoveryLink).toContain('next=%2Fapplication%2Flaunch%2Fhola-dashboard%2F');
     // It created the flow, rebound the two reused stages, then appended the Login
     // stage as the final binding (order after the reused stages) for auto-login.
     expect(created).toEqual(['flow', 'bind:prompt-stage@0', 'bind:write-stage@1', 'bind:login-stage@2']);
@@ -503,7 +512,10 @@ describe('RealAuthentikProvisionerService — scoped-token bootstrap', () => {
     // CONFIG.authentikPublicUrl is https://auth.example.com.
     const svc = new RealAuthentikProvisionerService({ ...CONFIG, adminEmail: 'me@example.com' });
     const result = await svc.ensureBootstrapAdmin('hola-admins');
-    expect(result.recoveryLink).toBe('https://auth.example.com/if/flow/hola-recovery/?flow_token=tok');
+    // Origin rewritten to the public host AND the dashboard-landing `next` appended.
+    expect(result.recoveryLink).toBe(
+      'https://auth.example.com/if/flow/hola-recovery/?flow_token=tok&next=%2Fapplication%2Flaunch%2Fhola-dashboard%2F'
+    );
   });
 
   test('ensureBootstrapAdmin no-ops without HOLA_ADMIN_EMAIL', async () => {

--- a/packages/server/src/services/core/provisioner.ts
+++ b/packages/server/src/services/core/provisioner.ts
@@ -588,8 +588,10 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
         const res = await this.api<{ link: string }>('POST', `/api/v3/core/users/${userPk}/recovery/`);
         // Authentik builds the link from the host the API was called on — which is
         // the internal `authentik-server:9000` for us, unreachable from a browser.
-        // Rewrite the origin to the public Authentik URL so the operator can open it.
-        return this.toPublicUrl(res.link);
+        // Rewrite the origin to the public Authentik URL so the operator can open it,
+        // then point the post-recovery redirect at the dashboard instead of Authentik's
+        // default "My applications" page.
+        return this.withDashboardLanding(this.toPublicUrl(res.link));
       } catch (error) {
         this.logger.warn('Recovery link generation attempt failed; will retry', {
           attempt: i + 1,
@@ -598,6 +600,29 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
       }
     }
     return undefined;
+  }
+
+  /**
+   * Append a `next` that sends the user to the Hola dashboard after the recovery
+   * flow (set-password + auto-login) completes, instead of Authentik's default
+   * "My applications" library page.
+   *
+   * It MUST be a relative path: Authentik's flow executor rejects any absolute
+   * `next` (different host than Authentik) as "Invalid next URL" — `is_url_absolute`
+   * returns true for anything with a netloc, so the cross-origin dashboard URL is
+   * refused. The core `application/launch/<slug>/` view is same-origin and, for an
+   * already-authenticated user (the recovery flow's Login stage signs them in),
+   * 302s straight to the application's launch URL — i.e. the dashboard. No-op if
+   * the link can't be parsed.
+   */
+  private withDashboardLanding(link: string): string {
+    try {
+      const u = new URL(link);
+      u.searchParams.set('next', `/application/launch/${DASHBOARD_SLUG}/`);
+      return u.toString();
+    } catch {
+      return link;
+    }
   }
 
   /**


### PR DESCRIPTION
## Problem
After setting their password via the bootstrap recovery link, the operator lands on Authentik's default **"My applications"** page (one tile: Hola Dashboard) instead of being taken straight to the dashboard.

We'd removed the dashboard `?next=` redirect in #202 because Authentik rejects any **absolute, cross-origin** `next` as **"Invalid next URL"**. Confirmed against the live build — `flows/views/executor.py`:
```python
next_param = self.request.session.get(SESSION_KEY_GET, {}).get(NEXT_ARG_NAME, "authentik_core:root-redirect")
if next_param and not is_url_absolute(next_param):
    return to_stage_response(self.request, redirect_with_qs(next_param))
return to_stage_response(self.request, self.stage_invalid(error_message=_("Invalid next URL")))
```
…and `is_url_absolute(url)` is just `bool(urlparse(url).netloc)` — so **anything with a host is refused**; only a relative path is accepted.

## Fix
Append a **relative** `next` to the recovery link: `?next=/application/launch/hola-dashboard/`.

Authentik's core `RedirectToAppLaunch` view (`core/views/apps.py`) is same-origin and, for an already-authenticated user — which the recovery flow's appended **Login stage** makes them — 302s straight to the application's launch URL (the dashboard):
```python
if request.user.is_authenticated:
    return HttpResponseRedirect(app.get_launch_url(request.user))
```
The dashboard SPA's OIDC login then completes silently against the live Authentik session → operator lands on the Hola apps page.

## Verification (against the live Authentik instance)
- Relative-`next` rule confirmed in `executor.py`; `is_url_absolute` rejects cross-origin.
- `GET /application/launch/hola-dashboard/` → **302** to the auth flow (slug + launch URL resolve); a bogus slug → **404**. For an authenticated user the view redirects to the dashboard.
- Contract + integration tests assert the appended `next`. Full server suite (288), typecheck, lint green.

Note: this only changes the *bootstrap admin* recovery link; per-app provisioning is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)