### PR TITLE
fix: one admin identity (drop akadmin email collision) + revert dashboard-landing

### DIFF
--- a/packages/cli/src/__tests__/install-schema.test.ts
+++ b/packages/cli/src/__tests__/install-schema.test.ts
@@ -22,14 +22,17 @@ describe('install schema', () => {
     expect(authMode.options?.[0]?.value).toBe('authentik');
   });
 
-  it('reuses the first email (Let\'s Encrypt) as the default for later email questions', () => {
-    const bootstrap = INSTALL_SCHEMA.find((f) => f.key === 'AUTHENTIK_BOOTSTRAP_EMAIL')!;
+  it('reuses the first email (Let\'s Encrypt) as the default for the admin email', () => {
     const adminEmail = INSTALL_SCHEMA.find((f) => f.key === 'HOLA_ADMIN_EMAIL')!;
-    expect(defaultFor(bootstrap, { LETSENCRYPT_EMAIL: 'me@x.io' })).toBe('me@x.io');
     expect(defaultFor(adminEmail, { LETSENCRYPT_EMAIL: 'me@x.io' })).toBe('me@x.io');
-    // Falls back to the static placeholder / blank when no email was given yet.
-    expect(defaultFor(bootstrap, {})).toBe('admin@example.com');
+    // Blank when no email was given yet.
     expect(defaultFor(adminEmail, {})).toBe('');
+  });
+
+  it('does NOT prompt for the akadmin (break-glass) email — it stays internal', () => {
+    // Asking for it led operators to reuse one email for akadmin AND their named
+    // admin, which collapsed "you" into akadmin. akadmin's address is a compose default.
+    expect(INSTALL_SCHEMA.find((f) => f.key === 'AUTHENTIK_BOOTSTRAP_EMAIL')).toBeUndefined();
   });
 
   it('marks the AWS credential fields as reusable from the environment', () => {

--- a/packages/cli/src/__tests__/wizard.test.ts
+++ b/packages/cli/src/__tests__/wizard.test.ts
@@ -82,7 +82,7 @@ describe('runWizard — AWS credentials from the environment', () => {
 });
 
 describe('runWizard — new defaults flow through', () => {
-  it('defaults the Authentik + admin emails to the first email and signs you in as yourself', async () => {
+  it('defaults your admin email to the first email and signs you in as yourself', async () => {
     // Provide only the base domain + first email; accept every other default.
     const { config } = await runWizard({
       prompter: scriptedPrompter({
@@ -95,8 +95,10 @@ describe('runWizard — new defaults flow through', () => {
     });
     expect(config.HOLA_AUTH_MODE).toBe('authentik'); // secure by default
     expect(config.HOLA_DOMAIN).toBe('apps.hola.example.com'); // plural dashboard host
-    expect(config.AUTHENTIK_BOOTSTRAP_EMAIL).toBe('paul@example.com');
     expect(config.HOLA_ADMIN_EMAIL).toBe('paul@example.com');
     expect(config.HOLA_ADMIN_USERNAME).toBe('paul'); // local part of the admin email
+    // The wizard does NOT set akadmin's email — it stays a separate internal account,
+    // so your personal email never collides with the break-glass superuser.
+    expect(config.AUTHENTIK_BOOTSTRAP_EMAIL).toBeUndefined();
   });
 });

--- a/packages/cli/src/install/schema.ts
+++ b/packages/cli/src/install/schema.ts
@@ -172,20 +172,17 @@ export const INSTALL_SCHEMA: InstallField[] = [
     requiredWhen: isAuthentik,
     validate: isDomain,
   },
-  {
-    key: 'AUTHENTIK_BOOTSTRAP_EMAIL',
-    type: 'text',
-    prompt: 'Authentik admin email',
-    // Reuse the first email the operator gave (Let's Encrypt contact) as the default.
-    default: (c) => c.LETSENCRYPT_EMAIL || 'admin@example.com',
-    requiredWhen: isAuthentik,
-    validate: isEmail,
-  },
+  // Note: we deliberately do NOT prompt for the built-in `akadmin` superuser's
+  // email — it stays an internal break-glass account (AUTHENTIK_BOOTSTRAP_EMAIL
+  // defaults to akadmin@example.com in compose). Asking for it caused operators to
+  // reuse their personal email for BOTH akadmin and their named admin; the server
+  // then found akadmin by that email and never created a distinct named admin, so
+  // "you" silently became akadmin. One email — yours — is all the wizard needs.
   {
     key: 'HOLA_ADMIN_EMAIL',
     type: 'text',
-    prompt: 'Your admin email (sign in as yourself)',
-    help: 'Blank to just use the built-in akadmin account',
+    prompt: 'Your admin email (you sign in as yourself)',
+    help: 'akadmin stays as a separate internal break-glass account; blank to use only that.',
     // Default to the first email given, so you sign in as yourself out of the box.
     default: (c) => c.LETSENCRYPT_EMAIL || '',
     requiredWhen: isAuthentik,

--- a/packages/compose/.env.example
+++ b/packages/compose/.env.example
@@ -87,14 +87,17 @@ HOLA_AUTH_MODE=none
 # Browser-facing domain for the Authentik login UI (needs DNS + TLS, like HOLA_DOMAIN).
 HOLA_AUTHENTIK_DOMAIN=auth.local.hola
 
-# Optional: provision a named admin so you sign in as yourself instead of the
-# generic `akadmin`. When set (with HOLA_AUTH_MODE=authentik), the server ensures
-# this user exists, adds them to the `hola-admins` group (platform admin), and —
-# until they've logged in once — logs a ONE-TIME recovery link at startup that you
-# open to set your own password. No password is stored here.
+# Your admin account: set HOLA_ADMIN_EMAIL to YOUR email so you sign in as yourself.
+# When set (with HOLA_AUTH_MODE=authentik), the server ensures this user exists, adds
+# them to the `hola-admins` group (platform admin), and — until they've logged in once —
+# logs a ONE-TIME recovery link at startup that you open to set your own password. No
+# password is stored here.
 #   docker logs hola-server | grep -A1 "Hola admin setup"
-# Leave HOLA_ADMIN_EMAIL blank to just use akadmin. Username defaults to the email
-# local part; display name is optional. `hola init` prompts for these.
+# Keep this DIFFERENT from AUTHENTIK_BOOTSTRAP_EMAIL below: `akadmin` is a separate
+# internal break-glass superuser. If they share an email the server finds akadmin first
+# and never creates a distinct "you" account. Leave HOLA_ADMIN_EMAIL blank to use only
+# akadmin. Username defaults to the email local part; display name is optional. `hola
+# init` prompts for this.
 HOLA_ADMIN_EMAIL=
 HOLA_ADMIN_USERNAME=
 HOLA_ADMIN_NAME=
@@ -108,7 +111,9 @@ AUTHENTIK_SECRET_KEY=
 AUTHENTIK_PG_PASS=
 AUTHENTIK_BOOTSTRAP_PASSWORD=
 AUTHENTIK_BOOTSTRAP_TOKEN=
-AUTHENTIK_BOOTSTRAP_EMAIL=admin@example.com
+# akadmin (break-glass superuser) email — internal only; keep it NON-personal and
+# distinct from HOLA_ADMIN_EMAIL above. Not prompted by `hola init`.
+AUTHENTIK_BOOTSTRAP_EMAIL=akadmin@example.com
 HOLA_AUTHENTIK_API_TOKEN=
 # Internal API URL the server uses to reach Authentik (compose service DNS).
 # Override only if you point Hola at an external Authentik.

--- a/packages/compose/docker-compose.yml
+++ b/packages/compose/docker-compose.yml
@@ -220,7 +220,7 @@ services:
       # The token doubles as HOLA_AUTHENTIK_API_TOKEN for the server's provisioner.
       AUTHENTIK_BOOTSTRAP_PASSWORD: ${AUTHENTIK_BOOTSTRAP_PASSWORD:-}
       AUTHENTIK_BOOTSTRAP_TOKEN: ${AUTHENTIK_BOOTSTRAP_TOKEN:-}
-      AUTHENTIK_BOOTSTRAP_EMAIL: ${AUTHENTIK_BOOTSTRAP_EMAIL:-admin@example.com}
+      AUTHENTIK_BOOTSTRAP_EMAIL: ${AUTHENTIK_BOOTSTRAP_EMAIL:-akadmin@example.com}
     depends_on:
       authentik-postgres:
         condition: service_healthy
@@ -248,7 +248,7 @@ services:
       # by Authentik (403), failing every SSO deploy. Must match authentik-server.
       AUTHENTIK_BOOTSTRAP_PASSWORD: ${AUTHENTIK_BOOTSTRAP_PASSWORD:-}
       AUTHENTIK_BOOTSTRAP_TOKEN: ${AUTHENTIK_BOOTSTRAP_TOKEN:-}
-      AUTHENTIK_BOOTSTRAP_EMAIL: ${AUTHENTIK_BOOTSTRAP_EMAIL:-admin@example.com}
+      AUTHENTIK_BOOTSTRAP_EMAIL: ${AUTHENTIK_BOOTSTRAP_EMAIL:-akadmin@example.com}
     depends_on:
       authentik-postgres:
         condition: service_healthy

--- a/packages/server/src/__tests__/integration/authentik-provision.it.ts
+++ b/packages/server/src/__tests__/integration/authentik-provision.it.ts
@@ -285,8 +285,6 @@ describe.skipIf(!dockerOk)('Authentik provisioner (real daemon)', () => {
 
     expect(result.recoveryLink).toBeTruthy();
     expect(result.recoveryLink).toContain('/if/flow/');
-    // Lands on the dashboard after set-password via a same-origin app-launch `next`.
-    expect(result.recoveryLink).toContain('next=%2Fapplication%2Flaunch%2Fhola-dashboard%2F');
 
     // The recovery flow now exists, is bound to the default brand, and has the two
     // reused stages (prompt + user-write) PLUS the appended Login stage so setting

--- a/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
+++ b/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
@@ -413,12 +413,7 @@ describe('RealAuthentikProvisionerService — scoped-token bootstrap', () => {
     const result = await svc.ensureBootstrapAdmin('hola-admins');
 
     expect(result.created).toBe(true);
-    // The recovery link carries a relative `next` that lands the user on the dashboard
-    // (via the same-origin application-launch view) after they set their password,
-    // instead of Authentik's default "My applications" page.
-    expect(result.recoveryLink).toBe(
-      'https://auth.example.com/recovery/abc?next=%2Fapplication%2Flaunch%2Fhola-dashboard%2F'
-    );
+    expect(result.recoveryLink).toBe('https://auth.example.com/recovery/abc');
     expect(patchedGroupUsers).toEqual([101]);
     // Bound a recovery flow to the default brand so /recovery/ works.
     expect(calls.some(c => c.method === 'PATCH' && c.path === '/api/v3/core/brands/b1/')).toBe(true);
@@ -451,9 +446,7 @@ describe('RealAuthentikProvisionerService — scoped-token bootstrap', () => {
     const result = await svc.ensureBootstrapAdmin('hola-admins');
 
     expect(flowQueries).toBeGreaterThanOrEqual(3); // kept polling until the flow appeared
-    expect(result.recoveryLink).toBe(
-      'https://auth.example.com/recovery/late?next=%2Fapplication%2Flaunch%2Fhola-dashboard%2F'
-    );
+    expect(result.recoveryLink).toBe('https://auth.example.com/recovery/late');
     expect(calls.some((c) => c.method === 'PATCH' && c.path === '/api/v3/core/brands/b1/')).toBe(true);
   });
 
@@ -486,8 +479,6 @@ describe('RealAuthentikProvisionerService — scoped-token bootstrap', () => {
     const result = await svc.ensureBootstrapAdmin('hola-admins');
 
     expect(result.recoveryLink).toContain('hola-recovery');
-    // ...and lands on the dashboard after the flow via a relative app-launch `next`.
-    expect(result.recoveryLink).toContain('next=%2Fapplication%2Flaunch%2Fhola-dashboard%2F');
     // It created the flow, rebound the two reused stages, then appended the Login
     // stage as the final binding (order after the reused stages) for auto-login.
     expect(created).toEqual(['flow', 'bind:prompt-stage@0', 'bind:write-stage@1', 'bind:login-stage@2']);
@@ -512,10 +503,7 @@ describe('RealAuthentikProvisionerService — scoped-token bootstrap', () => {
     // CONFIG.authentikPublicUrl is https://auth.example.com.
     const svc = new RealAuthentikProvisionerService({ ...CONFIG, adminEmail: 'me@example.com' });
     const result = await svc.ensureBootstrapAdmin('hola-admins');
-    // Origin rewritten to the public host AND the dashboard-landing `next` appended.
-    expect(result.recoveryLink).toBe(
-      'https://auth.example.com/if/flow/hola-recovery/?flow_token=tok&next=%2Fapplication%2Flaunch%2Fhola-dashboard%2F'
-    );
+    expect(result.recoveryLink).toBe('https://auth.example.com/if/flow/hola-recovery/?flow_token=tok');
   });
 
   test('ensureBootstrapAdmin no-ops without HOLA_ADMIN_EMAIL', async () => {

--- a/packages/server/src/services/core/provisioner.ts
+++ b/packages/server/src/services/core/provisioner.ts
@@ -588,10 +588,8 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
         const res = await this.api<{ link: string }>('POST', `/api/v3/core/users/${userPk}/recovery/`);
         // Authentik builds the link from the host the API was called on — which is
         // the internal `authentik-server:9000` for us, unreachable from a browser.
-        // Rewrite the origin to the public Authentik URL so the operator can open it,
-        // then point the post-recovery redirect at the dashboard instead of Authentik's
-        // default "My applications" page.
-        return this.withDashboardLanding(this.toPublicUrl(res.link));
+        // Rewrite the origin to the public Authentik URL so the operator can open it.
+        return this.toPublicUrl(res.link);
       } catch (error) {
         this.logger.warn('Recovery link generation attempt failed; will retry', {
           attempt: i + 1,
@@ -600,29 +598,6 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
       }
     }
     return undefined;
-  }
-
-  /**
-   * Append a `next` that sends the user to the Hola dashboard after the recovery
-   * flow (set-password + auto-login) completes, instead of Authentik's default
-   * "My applications" library page.
-   *
-   * It MUST be a relative path: Authentik's flow executor rejects any absolute
-   * `next` (different host than Authentik) as "Invalid next URL" — `is_url_absolute`
-   * returns true for anything with a netloc, so the cross-origin dashboard URL is
-   * refused. The core `application/launch/<slug>/` view is same-origin and, for an
-   * already-authenticated user (the recovery flow's Login stage signs them in),
-   * 302s straight to the application's launch URL — i.e. the dashboard. No-op if
-   * the link can't be parsed.
-   */
-  private withDashboardLanding(link: string): string {
-    try {
-      const u = new URL(link);
-      u.searchParams.set('next', `/application/launch/${DASHBOARD_SLUG}/`);
-      return u.toString();
-    } catch {
-      return link;
-    }
   }
 
   /**


### PR DESCRIPTION
Bundles two related changes to the bootstrap-admin / recovery model.

## 1. One admin identity — stop the akadmin/named-admin email collision
The wizard asked for **two** admin emails — `AUTHENTIK_BOOTSTRAP_EMAIL` (the built-in `akadmin` superuser) and `HOLA_ADMIN_EMAIL` (your named admin) — both defaulting to your Let's Encrypt email. Accepting defaults made them identical, so the server (which finds the admin **by email**, `provisioner.ts:520`) found akadmin, reused it, and minted a "set your password" recovery link for **akadmin** — which already has a bootstrap password. "You" silently became akadmin.

Fix: **drop the akadmin-email prompt.** akadmin keeps a separate internal break-glass address (compose default, now `akadmin@example.com`); the wizard asks only for **your** email. Your personal email can no longer collide with the superuser, so you always get a distinct named admin and the recovery link is genuinely yours.

- `schema.ts`: removed the `AUTHENTIK_BOOTSTRAP_EMAIL` field; clarified `HOLA_ADMIN_EMAIL`.
- `.env.example` + `docker-compose.yml`: akadmin default → `akadmin@example.com`, with guidance to keep it distinct from `HOLA_ADMIN_EMAIL`.
- Tests assert akadmin's email is no longer a wizard field.

## 2. Revert the dashboard-landing redirect (#212)
With the collision in place, #212's `next=/application/launch/hola-dashboard/` sent the akadmin session to the app-launch endpoint, which dead-ended at akadmin's "Set your password" — worse than the prior "My applications" landing. Reverted; once #1 yields a proper distinct named admin we can revisit a direct-to-dashboard redirect separately.

## Verification
Full suite green: server 288, web 127, cli 112; typecheck + lint across all packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)