### PR TITLE
feat(auth): land on the dashboard authenticated after recovery — no clicks

### DIFF
--- a/packages/server/src/__tests__/integration/authentik-provision.it.ts
+++ b/packages/server/src/__tests__/integration/authentik-provision.it.ts
@@ -285,6 +285,8 @@ describe.skipIf(!dockerOk)('Authentik provisioner (real daemon)', () => {
 
     expect(result.recoveryLink).toBeTruthy();
     expect(result.recoveryLink).toContain('/if/flow/');
+    // Lands on the dashboard after set-password+login, not Authentik's app library.
+    expect(new URL(result.recoveryLink!).searchParams.get('next')).toBe('/application/launch/hola-dashboard/');
 
     // The recovery flow now exists, is bound to the default brand, and has the two
     // reused stages (prompt + user-write) PLUS the appended Login stage so setting

--- a/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
+++ b/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
@@ -413,7 +413,11 @@ describe('RealAuthentikProvisionerService — scoped-token bootstrap', () => {
     const result = await svc.ensureBootstrapAdmin('hola-admins');
 
     expect(result.created).toBe(true);
-    expect(result.recoveryLink).toBe('https://auth.example.com/recovery/abc');
+    // The link points at the recovery flow, with a `next` that lands the operator
+    // on the dashboard (not Authentik's "My applications") once they're signed in.
+    const link = new URL(result.recoveryLink!);
+    expect(link.origin + link.pathname).toBe('https://auth.example.com/recovery/abc');
+    expect(link.searchParams.get('next')).toBe('/application/launch/hola-dashboard/');
     expect(patchedGroupUsers).toEqual([101]);
     // Bound a recovery flow to the default brand so /recovery/ works.
     expect(calls.some(c => c.method === 'PATCH' && c.path === '/api/v3/core/brands/b1/')).toBe(true);
@@ -446,7 +450,9 @@ describe('RealAuthentikProvisionerService — scoped-token bootstrap', () => {
     const result = await svc.ensureBootstrapAdmin('hola-admins');
 
     expect(flowQueries).toBeGreaterThanOrEqual(3); // kept polling until the flow appeared
-    expect(result.recoveryLink).toBe('https://auth.example.com/recovery/late');
+    const lateLink = new URL(result.recoveryLink!);
+    expect(lateLink.origin + lateLink.pathname).toBe('https://auth.example.com/recovery/late');
+    expect(lateLink.searchParams.get('next')).toBe('/application/launch/hola-dashboard/');
     expect(calls.some((c) => c.method === 'PATCH' && c.path === '/api/v3/core/brands/b1/')).toBe(true);
   });
 
@@ -479,6 +485,7 @@ describe('RealAuthentikProvisionerService — scoped-token bootstrap', () => {
     const result = await svc.ensureBootstrapAdmin('hola-admins');
 
     expect(result.recoveryLink).toContain('hola-recovery');
+    expect(new URL(result.recoveryLink!).searchParams.get('next')).toBe('/application/launch/hola-dashboard/');
     // It created the flow, rebound the two reused stages, then appended the Login
     // stage as the final binding (order after the reused stages) for auto-login.
     expect(created).toEqual(['flow', 'bind:prompt-stage@0', 'bind:write-stage@1', 'bind:login-stage@2']);
@@ -503,7 +510,12 @@ describe('RealAuthentikProvisionerService — scoped-token bootstrap', () => {
     // CONFIG.authentikPublicUrl is https://auth.example.com.
     const svc = new RealAuthentikProvisionerService({ ...CONFIG, adminEmail: 'me@example.com' });
     const result = await svc.ensureBootstrapAdmin('hola-admins');
-    expect(result.recoveryLink).toBe('https://auth.example.com/if/flow/hola-recovery/?flow_token=tok');
+    // Origin rewritten to the public host; the existing flow_token query is preserved
+    // and the dashboard-landing `next` is appended alongside it.
+    const publicLink = new URL(result.recoveryLink!);
+    expect(publicLink.origin + publicLink.pathname).toBe('https://auth.example.com/if/flow/hola-recovery/');
+    expect(publicLink.searchParams.get('flow_token')).toBe('tok');
+    expect(publicLink.searchParams.get('next')).toBe('/application/launch/hola-dashboard/');
   });
 
   test('ensureBootstrapAdmin no-ops without HOLA_ADMIN_EMAIL', async () => {

--- a/packages/server/src/services/core/provisioner.ts
+++ b/packages/server/src/services/core/provisioner.ts
@@ -588,8 +588,10 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
         const res = await this.api<{ link: string }>('POST', `/api/v3/core/users/${userPk}/recovery/`);
         // Authentik builds the link from the host the API was called on — which is
         // the internal `authentik-server:9000` for us, unreachable from a browser.
-        // Rewrite the origin to the public Authentik URL so the operator can open it.
-        return this.toPublicUrl(res.link);
+        // Rewrite the origin to the public Authentik URL so the operator can open it,
+        // then point the post-recovery redirect at the dashboard instead of Authentik's
+        // default "My applications" page.
+        return this.withDashboardLanding(this.toPublicUrl(res.link));
       } catch (error) {
         this.logger.warn('Recovery link generation attempt failed; will retry', {
           attempt: i + 1,
@@ -598,6 +600,32 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
       }
     }
     return undefined;
+  }
+
+  /**
+   * Append a `next` that sends the user to the Hola dashboard after the recovery
+   * flow (set-password + auto-login) completes, instead of Authentik's default
+   * "My applications" library page.
+   *
+   * It MUST be a relative path: Authentik's flow executor rejects any absolute
+   * `next` (different host than Authentik) as "Invalid next URL" — `is_url_absolute`
+   * returns true for anything with a netloc, so the cross-origin dashboard URL is
+   * refused. The core `application/launch/<slug>/` view is same-origin and, for an
+   * already-authenticated user (the recovery flow's Login stage signs them in),
+   * 302s straight to the application's launch URL — i.e. the dashboard. The
+   * dashboard SPA then auto-initiates its OIDC login (see Login.tsx), which
+   * completes silently against the live Authentik session — so the user lands on
+   * the Hola apps page authenticated, with no intermediate clicks. No-op if the
+   * link can't be parsed.
+   */
+  private withDashboardLanding(link: string): string {
+    try {
+      const u = new URL(link);
+      u.searchParams.set('next', `/application/launch/${DASHBOARD_SLUG}/`);
+      return u.toString();
+    } catch {
+      return link;
+    }
   }
 
   /**

--- a/packages/web/src/__tests__/pages/Login.test.tsx
+++ b/packages/web/src/__tests__/pages/Login.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+
+import { Login } from '../../pages/Login';
+import { SSO_ATTEMPTED_KEY, SSO_SIGNED_OUT_KEY } from '../../hooks/useAuth';
+
+// Control the auth context per test; keep the real flag-key constants.
+const login = vi.fn();
+let authState: { status: string; mode: string | null; loginError: string | null };
+
+vi.mock('../../hooks/useAuth', async (importActual) => {
+  const actual = await importActual<typeof import('../../hooks/useAuth')>();
+  return {
+    ...actual,
+    useAuth: () => ({
+      ...authState,
+      user: null,
+      login,
+      logout: vi.fn(),
+      completeOidcLogin: vi.fn(),
+    }),
+  };
+});
+
+const renderLogin = () => render(<MemoryRouter><Login /></MemoryRouter>);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.sessionStorage.clear();
+  authState = { status: 'unauthenticated', mode: 'oidc', loginError: null };
+});
+
+describe('Login — OIDC auto sign-in', () => {
+  it('auto-starts the SSO redirect when unauthenticated with no guard flags', async () => {
+    renderLogin();
+    await waitFor(() => expect(login).toHaveBeenCalledTimes(1));
+    // Shows the quiet "signing you in" state, not the manual button.
+    expect(screen.getByText('Signing you in…')).toBeInTheDocument();
+    expect(screen.queryByText('Sign in with SSO')).not.toBeInTheDocument();
+  });
+
+  it('does NOT auto-redirect right after an explicit logout — shows the manual button', async () => {
+    window.sessionStorage.setItem(SSO_SIGNED_OUT_KEY, '1');
+    renderLogin();
+    expect(await screen.findByText('Sign in with SSO')).toBeInTheDocument();
+    expect(login).not.toHaveBeenCalled();
+    // The guard is consumed so a later visit can auto-redirect again.
+    expect(window.sessionStorage.getItem(SSO_SIGNED_OUT_KEY)).toBeNull();
+  });
+
+  it('does NOT loop when a prior attempt returned us here unauthenticated', async () => {
+    window.sessionStorage.setItem(SSO_ATTEMPTED_KEY, '1');
+    renderLogin();
+    expect(await screen.findByText('Sign in with SSO')).toBeInTheDocument();
+    expect(login).not.toHaveBeenCalled();
+    expect(window.sessionStorage.getItem(SSO_ATTEMPTED_KEY)).toBeNull();
+  });
+
+  it('shows the admin-key form (no auto-redirect) in apikey mode', async () => {
+    authState = { status: 'unauthenticated', mode: 'apikey', loginError: null };
+    renderLogin();
+    expect(await screen.findByPlaceholderText('hola admin key')).toBeInTheDocument();
+    expect(login).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/hooks/useAuth.tsx
+++ b/packages/web/src/hooks/useAuth.tsx
@@ -38,6 +38,29 @@ interface AuthContextValue {
 
 const AuthContext = createContext<AuthContextValue | null>(null);
 
+/**
+ * sessionStorage markers that let the login screen auto-start SSO without
+ * looping (see Login.tsx):
+ *  - SSO_ATTEMPTED is set just before a signin redirect and cleared once we're
+ *    authenticated. If we land back on /login with it still set, the silent
+ *    sign-in failed — show the manual button instead of bouncing again.
+ *  - SSO_SIGNED_OUT is set on an explicit logout so we don't immediately shove
+ *    the user back into the IdP after they asked to leave.
+ */
+export const SSO_ATTEMPTED_KEY = 'hola.sso.attempted';
+export const SSO_SIGNED_OUT_KEY = 'hola.sso.signedout';
+
+function setSessionFlag(key: string): void {
+  try { window.sessionStorage.setItem(key, '1'); } catch { /* private mode / disabled storage */ }
+}
+function takeSessionFlag(key: string): boolean {
+  try {
+    const had = window.sessionStorage.getItem(key) === '1';
+    if (had) window.sessionStorage.removeItem(key);
+    return had;
+  } catch { return false; }
+}
+
 /** Same-origin in prod (nginx) / via the Vite proxy in dev; absolute only in tests. */
 function apiUrl(path: string): string {
   return `${getWebBaseUrl()}${path}`;
@@ -78,6 +101,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       accessTokenRef.current = u.access_token;
       setUser({ name: u.profile?.name, email: u.profile?.email });
       setStatus('authenticated');
+      // Sign-in succeeded — drop the auto-redirect guard so a future visit can
+      // silently bounce again.
+      takeSessionFlag(SSO_ATTEMPTED_KEY);
     } else {
       accessTokenRef.current = undefined;
       setStatus('unauthenticated');
@@ -151,6 +177,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const login = useCallback(async (key?: string) => {
     setLoginError(null);
     if (mode === 'oidc') {
+      // Mark the attempt so the login screen falls back to a manual button if the
+      // redirect round-trip returns us here still unauthenticated (a broken callback).
+      setSessionFlag(SSO_ATTEMPTED_KEY);
       await managerRef.current?.signinRedirect();
       return;
     }
@@ -177,6 +206,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     if (mode === 'oidc') {
       const m = managerRef.current;
       accessTokenRef.current = undefined;
+      // Suppress the login screen's auto-redirect once, so logging out doesn't
+      // immediately bounce the user back into the IdP.
+      setSessionFlag(SSO_SIGNED_OUT_KEY);
       try { await m?.signoutRedirect(); }
       catch { await m?.removeUser(); setStatus('unauthenticated'); }
       return;

--- a/packages/web/src/pages/Login.tsx
+++ b/packages/web/src/pages/Login.tsx
@@ -1,12 +1,23 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
-import { KeyRound, ShieldCheck, LogIn } from 'lucide-react';
+import { KeyRound, ShieldCheck, LogIn, Loader2 } from 'lucide-react';
 
-import { useAuth } from '../hooks/useAuth';
+import { useAuth, SSO_ATTEMPTED_KEY, SSO_SIGNED_OUT_KEY } from '../hooks/useAuth';
+
+/** Read and clear a sessionStorage marker; false if absent or storage is blocked. */
+function takeFlag(key: string): boolean {
+  try {
+    const had = window.sessionStorage.getItem(key) === '1';
+    if (had) window.sessionStorage.removeItem(key);
+    return had;
+  } catch { return false; }
+}
 
 /**
  * Login screen. Adapts to the server's auth mode:
- *  - oidc   → a single "Sign in with SSO" button (redirects to Authentik).
+ *  - oidc   → auto-starts the SSO redirect so a user who already has an IdP
+ *             session lands in the app with no click; falls back to a manual
+ *             "Sign in with SSO" button after a logout or a failed round-trip.
  *  - apikey → an admin-key field that posts to the session-login endpoint.
  * Already-authenticated users (or auth-disabled servers) are bounced to the app.
  */
@@ -15,10 +26,43 @@ export const Login: React.FC = () => {
   const location = useLocation();
   const [key, setKey] = useState('');
   const [submitting, setSubmitting] = useState(false);
+  // Assume OIDC will auto-redirect so the spinner shows immediately (no button
+  // flash); the effect flips this off if we fall back to the manual button.
+  const [autoRedirecting, setAutoRedirecting] = useState(mode === 'oidc');
+  const decided = useRef(false);
+
+  // OIDC: auto-start the redirect once. We skip (showing the manual button) when
+  // the user just logged out, or when a prior attempt bounced us back here still
+  // unauthenticated — either case would otherwise loop straight back to the IdP.
+  useEffect(() => {
+    if (mode !== 'oidc' || status !== 'unauthenticated' || decided.current) return;
+    decided.current = true;
+    const justSignedOut = takeFlag(SSO_SIGNED_OUT_KEY);
+    const priorAttemptFailed = takeFlag(SSO_ATTEMPTED_KEY);
+    if (justSignedOut || priorAttemptFailed) {
+      setAutoRedirecting(false); // fall through to the manual button
+      return;
+    }
+    setAutoRedirecting(true);
+    void login();
+  }, [mode, status, login]);
 
   if (status === 'authenticated') {
     const from = (location.state as { from?: string } | null)?.from ?? '/';
     return <Navigate to={from} replace />;
+  }
+
+  // While the auto-redirect (or the post-config 'loading' window for OIDC) is in
+  // flight, show a quiet "signing you in" state rather than flashing the button.
+  if (status === 'loading' || autoRedirecting) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-surface-0 text-text-strong px-4">
+        <div className="flex flex-col items-center gap-3 animate-fadein">
+          <Loader2 className="w-6 h-6 text-primary animate-spin" />
+          <p className="text-text-muted text-sm">Signing you in…</p>
+        </div>
+      </div>
+    );
   }
 
   const onSubmit = async (e: React.FormEvent) => {


### PR DESCRIPTION
## What

After the recovery (set-password) flow, two clicks stood between the operator and the dashboard:

1. Authentik dropped them on its **"My applications"** library — they had to click the *Hola Dashboard* tile.
2. The dashboard then showed a **"Sign in with SSO"** button — a manual trigger for a redirect that bounces silently against the live Authentik session anyway.

This removes both, so the flow is: **set password → auto-login → land on `/apps` authenticated**, zero clicks.

## How

**Server** (`provisioner.ts`) — re-apply the dashboard-landing `next` (originally #212, reverted in #215 *only* because of the akadmin email collision, since fixed in #215's other half). The recovery link gets `?next=/application/launch/hola-dashboard/`: a **relative** path Authentik's flow executor accepts (an absolute cross-origin `next` is rejected as *"Invalid next URL"* by `is_url_absolute`), which 302s an already-signed-in user straight to the dashboard's launch URL.

**Web** (`Login.tsx` / `useAuth.tsx`) — the OIDC login screen **auto-starts** the redirect instead of waiting for a click, with loop guards:
- A `sessionStorage` marker set just before the redirect → if the round-trip returns us here still unauthenticated (a broken callback), fall back to the manual button instead of bouncing again.
- An explicit **logout** sets a one-shot suppression flag so signing out doesn't immediately shove the user back into the IdP.
- While redirecting, a quiet "Signing you in…" spinner shows rather than flashing the button.

## Tests

- Contract + integration tests assert the recovery link carries `next=/application/launch/hola-dashboard/`.
- New `Login.test.tsx`: auto-redirects with no flags; falls back to the manual button after logout and after a failed attempt (consuming the flag); shows the admin-key form in apikey mode.
- typecheck · lint · test · build all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)