### PR TITLE
fix(server): recovery flow binds a real user_login stage (not a password stage)

### DIFF
--- a/packages/server/src/__tests__/integration/authentik-provision.it.ts
+++ b/packages/server/src/__tests__/integration/authentik-provision.it.ts
@@ -304,11 +304,17 @@ describe.skipIf(!dockerOk)('Authentik provisioner (real daemon)', () => {
       status: number; body: { results: Array<{ stage: string; order: number }> };
     };
     expect(bindings.body.results.length).toBe(3);
-    // The final (highest-order) binding is Authentik's Login stage.
+    // The final (highest-order) binding is Authentik's user_login stage, so
+    // setting the password also signs the operator in. Resolve it via the TYPED
+    // user_login endpoint — /api/v3/stages/all/ ignores name__iexact and returns
+    // every stage (results[0] is a password stage), which is exactly the bug that
+    // left the flow without a login stage.
     const lastStage = [...bindings.body.results].sort((a, b) => b.order - a.order)[0].stage;
-    const loginStages = (await akGet('/api/v3/stages/all/?name__iexact=default-authentication-login')) as {
-      status: number; body: { results: Array<{ pk: string }> };
+    const loginStages = (await akGet('/api/v3/stages/user_login/')) as {
+      status: number; body: { results: Array<{ pk: string; name: string }> };
     };
-    expect(lastStage).toBe(loginStages.body.results[0].pk);
+    const expectedLogin = loginStages.body.results.find((s) => s.name === 'default-authentication-login');
+    expect(expectedLogin).toBeDefined();
+    expect(lastStage).toBe(expectedLogin!.pk);
   }, 180_000);
 });

--- a/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
+++ b/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
@@ -403,6 +403,12 @@ describe('RealAuthentikProvisionerService — scoped-token bootstrap', () => {
         return json({ pk: 'g1' });
       }
       if (call.method === 'GET' && call.path.startsWith('/api/v3/flows/instances/?designation=recovery')) return json({ results: [{ pk: 'recovery-flow' }] });
+      // Self-heal check: the flow already ends with a user_login stage → no repair.
+      if (call.method === 'GET' && call.path.startsWith('/api/v3/flows/bindings/?target=recovery-flow')) return json({ results: [
+        { pk: 'b0', order: 0, stage_obj: { component: 'ak-stage-prompt-form' } },
+        { pk: 'b1', order: 1, stage_obj: { component: 'ak-stage-user-write-form' } },
+        { pk: 'b2', order: 2, stage_obj: { component: 'ak-stage-user-login-form' } },
+      ] });
       if (call.method === 'GET' && call.path.startsWith('/api/v3/core/brands/')) return json({ results: [{ brand_uuid: 'b1', flow_recovery: null }] });
       if (call.method === 'POST' && call.path === '/api/v3/core/users/101/recovery/') return json({ link: 'https://auth.example.com/recovery/abc' });
       return undefined;
@@ -436,6 +442,11 @@ describe('RealAuthentikProvisionerService — scoped-token bootstrap', () => {
         flowQueries += 1;
         return json({ results: flowQueries >= 3 ? [{ pk: 'recovery-flow' }] : [] }); // empty until the 3rd poll
       }
+      if (call.method === 'GET' && call.path.startsWith('/api/v3/flows/bindings/?target=recovery-flow')) return json({ results: [
+        { pk: 'b0', order: 0, stage_obj: { component: 'ak-stage-prompt-form' } },
+        { pk: 'b1', order: 1, stage_obj: { component: 'ak-stage-user-write-form' } },
+        { pk: 'b2', order: 2, stage_obj: { component: 'ak-stage-user-login-form' } },
+      ] });
       if (call.method === 'GET' && call.path.startsWith('/api/v3/core/brands/')) return json({ results: [{ brand_uuid: 'b1', flow_recovery: null }] });
       if (call.method === 'POST' && call.path === '/api/v3/core/users/101/recovery/') return json({ link: 'https://auth.example.com/recovery/late' });
       return undefined;
@@ -471,8 +482,18 @@ describe('RealAuthentikProvisionerService — scoped-token bootstrap', () => {
       // default-password-change exists with two stages to reuse.
       if (call.method === 'GET' && call.path.startsWith('/api/v3/flows/instances/?slug=default-password-change')) return json({ results: [{ pk: 'pw-flow' }] });
       if (call.method === 'GET' && call.path.startsWith('/api/v3/flows/bindings/?target=pw-flow')) return json({ results: [{ stage: 'prompt-stage', order: 0 }, { stage: 'write-stage', order: 1 }] });
-      // The built-in Login stage we append so the operator is signed in on success.
-      if (call.method === 'GET' && call.path.startsWith('/api/v3/stages/all/?name__iexact=default-authentication-login')) return json({ results: [{ pk: 'login-stage' }] });
+      // Self-heal reads the new flow's bindings (prompt + write, no login yet)…
+      if (call.method === 'GET' && call.path.startsWith('/api/v3/flows/bindings/?target=hola-recovery-pk')) return json({ results: [
+        { pk: 'rb0', order: 0, stage_obj: { component: 'ak-stage-prompt-form' } },
+        { pk: 'rb1', order: 1, stage_obj: { component: 'ak-stage-user-write-form' } },
+      ] });
+      // …then resolves the Login stage via the TYPED user_login endpoint (the
+      // polymorphic /stages/all/ endpoint ignores name__iexact and would return a
+      // password stage as results[0]).
+      if (call.method === 'GET' && call.path.startsWith('/api/v3/stages/user_login/')) return json({ results: [
+        { pk: 'pw-login-decoy', name: 'default-source-enrollment-login' },
+        { pk: 'login-stage', name: 'default-authentication-login' },
+      ] });
       if (call.method === 'POST' && call.path === '/api/v3/flows/instances/') { created.push('flow'); return json({ pk: 'hola-recovery-pk' }, 201); }
       if (call.method === 'POST' && call.path === '/api/v3/flows/bindings/') { const b = call.body as { stage: string; order: number }; created.push(`bind:${b.stage}@${b.order}`); return json({ pk: 'b' }, 201); }
       if (call.method === 'GET' && call.path.startsWith('/api/v3/core/brands/')) return json({ results: [{ brand_uuid: 'b1', flow_recovery: null }] });
@@ -501,6 +522,11 @@ describe('RealAuthentikProvisionerService — scoped-token bootstrap', () => {
       if (call.method === 'GET' && call.path.startsWith('/api/v3/core/groups/?name=')) return json({ results: [{ pk: 'g1', users: [] }] });
       if (call.method === 'PATCH' && call.path === '/api/v3/core/groups/g1/') return json({ pk: 'g1' });
       if (call.method === 'GET' && call.path.startsWith('/api/v3/flows/instances/?designation=recovery')) return json({ results: [{ pk: 'recovery-flow' }] });
+      if (call.method === 'GET' && call.path.startsWith('/api/v3/flows/bindings/?target=recovery-flow')) return json({ results: [
+        { pk: 'b0', order: 0, stage_obj: { component: 'ak-stage-prompt-form' } },
+        { pk: 'b1', order: 1, stage_obj: { component: 'ak-stage-user-write-form' } },
+        { pk: 'b2', order: 2, stage_obj: { component: 'ak-stage-user-login-form' } },
+      ] });
       if (call.method === 'GET' && call.path.startsWith('/api/v3/core/brands/')) return json({ results: [{ brand_uuid: 'b1', flow_recovery: null }] });
       // Authentik returns the link on the INTERNAL host the API was called on.
       if (call.method === 'POST' && call.path === '/api/v3/core/users/101/recovery/') return json({ link: 'http://authentik-server:9000/if/flow/hola-recovery/?flow_token=tok' });
@@ -516,6 +542,42 @@ describe('RealAuthentikProvisionerService — scoped-token bootstrap', () => {
     expect(publicLink.origin + publicLink.pathname).toBe('https://auth.example.com/if/flow/hola-recovery/');
     expect(publicLink.searchParams.get('flow_token')).toBe('tok');
     expect(publicLink.searchParams.get('next')).toBe('/application/launch/hola-dashboard/');
+  });
+
+  test('ensureBootstrapAdmin repairs a legacy recovery flow that lacks the login stage', async () => {
+    // Reproduces the host bug: an existing flow ends with a stray PASSWORD stage
+    // (mis-bound by the old /stages/all/ filter) instead of a user_login stage,
+    // so the operator was never signed in. Self-heal must drop the password
+    // binding and append a real user_login stage.
+    const deleted: string[] = [];
+    const bound: Array<{ target: string; stage: string; order: number }> = [];
+    installFetch((call) => {
+      if (call.method === 'GET' && call.path.startsWith('/api/v3/core/users/?email=')) return json({ results: [] });
+      if (call.method === 'POST' && call.path === '/api/v3/core/users/') return json({ pk: 101, last_login: null }, 201);
+      if (call.method === 'GET' && call.path.startsWith('/api/v3/core/groups/?name=')) return json({ results: [{ pk: 'g1', users: [] }] });
+      if (call.method === 'PATCH' && call.path === '/api/v3/core/groups/g1/') return json({ pk: 'g1' });
+      if (call.method === 'GET' && call.path.startsWith('/api/v3/flows/instances/?designation=recovery')) return json({ results: [{ pk: 'broken-flow' }] });
+      if (call.method === 'GET' && call.path.startsWith('/api/v3/flows/bindings/?target=broken-flow')) return json({ results: [
+        { pk: 'b0', order: 0, stage_obj: { component: 'ak-stage-prompt-form' } },
+        { pk: 'b1', order: 1, stage_obj: { component: 'ak-stage-user-write-form' } },
+        { pk: 'bpw', order: 2, stage_obj: { component: 'ak-stage-password-form' } }, // the bug
+      ] });
+      if (call.method === 'DELETE' && call.path.startsWith('/api/v3/flows/bindings/')) { deleted.push(call.path); return new Response(null, { status: 204 }); }
+      if (call.method === 'GET' && call.path.startsWith('/api/v3/stages/user_login/')) return json({ results: [{ pk: 'login-stage', name: 'default-authentication-login' }] });
+      if (call.method === 'POST' && call.path === '/api/v3/flows/bindings/') { bound.push(call.body as { target: string; stage: string; order: number }); return json({ pk: 'nb' }, 201); }
+      // Brand already bound to this flow → no re-patch needed.
+      if (call.method === 'GET' && call.path.startsWith('/api/v3/core/brands/')) return json({ results: [{ brand_uuid: 'b1', flow_recovery: 'broken-flow' }] });
+      if (call.method === 'POST' && call.path === '/api/v3/core/users/101/recovery/') return json({ link: 'https://auth.example.com/if/flow/hola-recovery/?flow_token=t' });
+      return undefined;
+    });
+    calls.length = 0;
+    const svc = new RealAuthentikProvisionerService({ ...CONFIG, adminEmail: 'me@example.com' });
+    await svc.ensureBootstrapAdmin('hola-admins');
+
+    // Deleted exactly the stray password binding…
+    expect(deleted).toEqual(['/api/v3/flows/bindings/bpw/']);
+    // …and appended the user_login stage after the two kept stages (order 2).
+    expect(bound).toEqual([{ target: 'broken-flow', stage: 'login-stage', order: 2 }]);
   });
 
   test('ensureBootstrapAdmin no-ops without HOLA_ADMIN_EMAIL', async () => {

--- a/packages/server/src/services/core/provisioner.ts
+++ b/packages/server/src/services/core/provisioner.ts
@@ -662,6 +662,10 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
       )).results?.[0]?.pk;
       if (!flowPk) flowPk = await this.createRecoveryFlow();
       if (!flowPk) return false; // couldn't find or create one yet — retry later
+      // Self-heal: make sure the flow ends by logging the user in. Runs for an
+      // existing flow too (found by designation above), so legacy installs whose
+      // flow was built with the wrong terminal stage converge without a rebuild.
+      await this.ensureRecoveryFlowAutoLogin(flowPk);
       const brands = await this.api<{ results: Array<{ brand_uuid: string; flow_recovery: string | null }> }>(
         'GET', '/api/v3/core/brands/?default=true'
       );
@@ -715,34 +719,87 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
     for (const b of bindings) {
       await this.api('POST', '/api/v3/flows/bindings/', { target: flow.pk, stage: b.stage, order: b.order });
     }
-    // Append the Login stage as the final binding so the operator is signed in on
-    // success. Degrade gracefully (warn, no auto-login) if none is found — the
-    // password-set part still works.
-    const loginStagePk = await this.resolveLoginStagePk();
-    if (loginStagePk) {
-      const lastOrder = bindings.reduce((max, b) => Math.max(max, b.order), -1);
-      await this.api('POST', '/api/v3/flows/bindings/', { target: flow.pk, stage: loginStagePk, order: lastOrder + 1 });
-    } else {
-      this.logger.warn('No Login stage found; recovery flow will set the password but not auto-sign-in', { slug });
-    }
-    this.logger.info('Created a recovery flow (Authentik ships none)', { flowPk: flow.pk, slug, autoLogin: !!loginStagePk });
+    // The terminal Login stage (so set-password ALSO signs the operator in) is
+    // added by ensureRecoveryFlowAutoLogin, which the caller runs for both fresh
+    // and pre-existing flows.
+    this.logger.info('Created a recovery flow (Authentik ships none)', { flowPk: flow.pk, slug });
     return flow.pk;
   }
 
+  /** Admin-form `component` of a bound stage, identifying its type. */
+  private static readonly LOGIN_STAGE_COMPONENT = 'ak-stage-user-login-form';
+  /** Stages that must never be in the recovery flow — they re-prompt for credentials. */
+  private static readonly STRAY_RECOVERY_STAGE_COMPONENTS = new Set([
+    'ak-stage-password-form',
+    'ak-stage-identification-form',
+  ]);
+
   /**
-   * Resolve the pk of Authentik's built-in Login stage (the one the default
-   * authentication flow ends with). The `stages/all` endpoint lists every stage
-   * type; match the default name and fall back to the first Login-component stage.
+   * Ensure a recovery flow ends by logging the user in: the reused Prompt +
+   * User Write stages, then a `user_login` stage. Removes any stray credential
+   * stages and appends the login stage if missing. Idempotent.
+   *
+   * This repairs flows built by earlier releases that bound the WRONG terminal
+   * stage: `resolveLoginStagePk` used `/api/v3/stages/all/?name__iexact=…`, but
+   * that polymorphic endpoint IGNORES the filter and returns every stage, so
+   * `results[0]` was whatever sorted first (a password stage) — leaving the
+   * operator unauthenticated after set-password and bounced to a login screen.
+   */
+  private async ensureRecoveryFlowAutoLogin(flowPk: string): Promise<void> {
+    const bindings = (await this.api<{
+      results: Array<{ pk: string; order: number; stage_obj?: { component?: string } }>;
+    }>('GET', `/api/v3/flows/bindings/?target=${flowPk}&ordering=order`)).results ?? [];
+
+    let changed = false;
+    // Drop stray credential stages (e.g. the mis-bound password stage).
+    for (const b of bindings) {
+      if (RealAuthentikProvisionerService.STRAY_RECOVERY_STAGE_COMPONENTS.has(b.stage_obj?.component ?? '')) {
+        await this.apiDeleteIgnoreMissing(`/api/v3/flows/bindings/${b.pk}/`);
+        changed = true;
+      }
+    }
+
+    const hasLogin = bindings.some(
+      (b) => b.stage_obj?.component === RealAuthentikProvisionerService.LOGIN_STAGE_COMPONENT,
+    );
+    if (!hasLogin) {
+      const loginStagePk = await this.resolveLoginStagePk();
+      if (loginStagePk) {
+        const keptMaxOrder = bindings
+          .filter((b) => !RealAuthentikProvisionerService.STRAY_RECOVERY_STAGE_COMPONENTS.has(b.stage_obj?.component ?? ''))
+          .reduce((max, b) => Math.max(max, b.order), -1);
+        await this.api('POST', '/api/v3/flows/bindings/', {
+          target: flowPk,
+          stage: loginStagePk,
+          order: keptMaxOrder + 1,
+        });
+        changed = true;
+      } else {
+        this.logger.warn('No Login stage found; recovery flow will set the password but not auto-sign-in', { flowPk });
+      }
+    }
+
+    if (changed) this.logger.info('Repaired recovery flow auto-login bindings', { flowPk });
+  }
+
+  /**
+   * Resolve the pk of Authentik's built-in Login (`user_login`) stage — the one
+   * the default authentication flow ends with, which attaches the pending user
+   * to a session.
+   *
+   * Uses the TYPED `/api/v3/stages/user_login/` endpoint, NOT the polymorphic
+   * `/api/v3/stages/all/`: the latter ignores `name__iexact` and returns every
+   * stage type, so taking `results[0]` there hands back whatever sorts first
+   * (often a password stage). `/stages/user_login/` only ever returns user_login
+   * stages, so even the fallback is a valid login stage.
    */
   private async resolveLoginStagePk(): Promise<string | undefined> {
-    const byName = (await this.api<{ results: Array<{ pk: string }> }>(
-      'GET', '/api/v3/stages/all/?name__iexact=default-authentication-login'
-    )).results?.[0]?.pk;
-    if (byName) return byName;
-    const all = (await this.api<{ results: Array<{ pk: string; component?: string }> }>(
-      'GET', '/api/v3/stages/all/'
+    const stages = (await this.api<{ results: Array<{ pk: string; name?: string }> }>(
+      'GET', '/api/v3/stages/user_login/'
     )).results ?? [];
-    return all.find((s) => s.component === 'ak-stage-user-login')?.pk;
+    if (!stages.length) return undefined;
+    const preferred = stages.find((s) => (s.name ?? '').toLowerCase() === 'default-authentication-login');
+    return (preferred ?? stages[0]).pk;
   }
 
   /** Add a proxy provider to the embedded outpost; returns the outpost pk. */


### PR DESCRIPTION
## Symptom

After setting a password via the recovery link, the operator was prompted to **sign in again** ("Login to continue to Hola Dashboard") before reaching the dashboard — i.e. the recovery flow never left them with a session.

## Root cause

`resolveLoginStagePk()` resolved Authentik's Login stage with:

```
GET /api/v3/stages/all/?name__iexact=default-authentication-login   → results[0]
```

But `/api/v3/stages/all/` is a **polymorphic endpoint that ignores `name__iexact`** and returns *every* stage. So `results[0]` was whatever sorted first — `default-authentication-password` — which got bound as the recovery flow's terminal stage. Confirmed on the live host (authentik 2025.10.4): that query returns all 18 stages with the password stage first, and the live `hola-recovery` flow was `[prompt, user_write, **password**]` with **no `user_login` stage**.

The contract test passed only because the mock faithfully honored a query path the real API ignores.

## Fix

- **`resolveLoginStagePk`** now uses the **typed `/api/v3/stages/user_login/`** endpoint (which only ever returns user_login stages) and prefers `default-authentication-login`. Worst case is still a valid login stage.
- **New `ensureRecoveryFlowAutoLogin()`** self-heals the flow on *every* ensure (not just create): drops stray credential stages (password/identification) and appends a `user_login` stage if missing. `ensureBrandRecoveryFlow` runs it for a **pre-existing** flow too, so legacy installs converge without a rebuild.
- Fixed the integration test's assertion, which resolved the login stage the same buggy way.

## Tests

- New contract test: a legacy flow ending in a stray password stage is repaired (password binding deleted, `user_login` appended at the right order).
- Existing recovery tests updated for the typed endpoint + self-heal path; the create-from-scratch test now includes a decoy login stage to prove name-preference (not `results[0]`).
- server tests · typecheck · lint green.

## Note on the second screenshot ("Invalid native challenge element")

Separately, the logs show the dashboard's OIDC silent-renew hitting `/authorize` with a **stale client_id** and `redirect_uri=https://app.hola…` (**singular**, an old pre-"plural-default" host that isn't served) → `400 Invalid client identifier`. The current config is fully consistent (`apps.hola…`, client_id `8dd2cb9e…`). That's **stale browser state** from earlier teardown cycles, not a server bug — cleared by using `https://apps.hola.get2know.io` in a fresh profile / cleared site data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)