### PR TITLE
chore(release): 0.6.17

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "packages/cli": {
       "name": "@hola/cli",
-      "version": "0.6.16",
+      "version": "0.6.17",
       "bin": {
         "hola": "./bin/hola",
       },
@@ -36,11 +36,11 @@
     },
     "packages/compose": {
       "name": "@hola/compose",
-      "version": "0.6.16",
+      "version": "0.6.17",
     },
     "packages/sdk": {
       "name": "@hola/sdk",
-      "version": "0.6.16",
+      "version": "0.6.17",
       "dependencies": {
         "@hola/shared": "workspace:*",
       },
@@ -54,7 +54,7 @@
     },
     "packages/server": {
       "name": "@hola/server",
-      "version": "0.6.16",
+      "version": "0.6.17",
       "dependencies": {
         "@hola/shared": "workspace:*",
         "jose": "^5.9.6",
@@ -70,7 +70,7 @@
     },
     "packages/shared": {
       "name": "@hola/shared",
-      "version": "0.6.16",
+      "version": "0.6.17",
       "dependencies": {
         "yaml": "^2.9.0",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.6.16",
+  "version": "0.6.17",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.6.16';
+export const CLI_VERSION = '0.6.17';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.6.16",
+  "version": "0.6.17",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.6.16",
+  "version": "0.6.17",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.6.16",
+  "version": "0.6.17",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.6.16",
+  "version": "0.6.17",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Release 0.6.17.

Ships the recovery-flow login-stage fix (#219): the recovery flow binds a real `user_login` stage (not a password stage), so set-password actually signs you in. Includes a self-heal that repairs pre-existing broken flows on server boot — so updating the server image fixes the host automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)