### PR TITLE
fix(server): resolve login stage via /stages/all/ (scoped token 403s on typed endpoint)

### DIFF
--- a/packages/server/src/__tests__/integration/authentik-provision.it.ts
+++ b/packages/server/src/__tests__/integration/authentik-provision.it.ts
@@ -305,15 +305,16 @@ describe.skipIf(!dockerOk)('Authentik provisioner (real daemon)', () => {
     };
     expect(bindings.body.results.length).toBe(3);
     // The final (highest-order) binding is Authentik's user_login stage, so
-    // setting the password also signs the operator in. Resolve it via the TYPED
-    // user_login endpoint — /api/v3/stages/all/ ignores name__iexact and returns
-    // every stage (results[0] is a password stage), which is exactly the bug that
-    // left the flow without a login stage.
+    // setting the password also signs the operator in. Resolve it the same way
+    // the code does: /api/v3/stages/all/ filtered by component (it ignores
+    // name__iexact and lists a password stage first — the original bug).
     const lastStage = [...bindings.body.results].sort((a, b) => b.order - a.order)[0].stage;
-    const loginStages = (await akGet('/api/v3/stages/user_login/')) as {
-      status: number; body: { results: Array<{ pk: string; name: string }> };
+    const allStages = (await akGet('/api/v3/stages/all/')) as {
+      status: number; body: { results: Array<{ pk: string; name: string; component: string }> };
     };
-    const expectedLogin = loginStages.body.results.find((s) => s.name === 'default-authentication-login');
+    const expectedLogin = allStages.body.results.find(
+      (s) => s.component === 'ak-stage-user-login-form' && s.name === 'default-authentication-login',
+    );
     expect(expectedLogin).toBeDefined();
     expect(lastStage).toBe(expectedLogin!.pk);
   }, 180_000);

--- a/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
+++ b/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
@@ -487,12 +487,15 @@ describe('RealAuthentikProvisionerService — scoped-token bootstrap', () => {
         { pk: 'rb0', order: 0, stage_obj: { component: 'ak-stage-prompt-form' } },
         { pk: 'rb1', order: 1, stage_obj: { component: 'ak-stage-user-write-form' } },
       ] });
-      // …then resolves the Login stage via the TYPED user_login endpoint (the
-      // polymorphic /stages/all/ endpoint ignores name__iexact and would return a
-      // password stage as results[0]).
-      if (call.method === 'GET' && call.path.startsWith('/api/v3/stages/user_login/')) return json({ results: [
-        { pk: 'pw-login-decoy', name: 'default-source-enrollment-login' },
-        { pk: 'login-stage', name: 'default-authentication-login' },
+      // …then resolves the Login stage from /stages/all/ by COMPONENT. That
+      // endpoint ignores name__iexact and lists every stage (a password stage
+      // sorts first here), and the scoped token can't read the typed
+      // /stages/user_login/ endpoint — so the code must filter by component and
+      // prefer the default-authentication-login name, not take results[0].
+      if (call.method === 'GET' && call.path.startsWith('/api/v3/stages/all/')) return json({ results: [
+        { pk: 'pw-stage', name: 'default-authentication-password', component: 'ak-stage-password-form' },
+        { pk: 'src-login', name: 'default-source-enrollment-login', component: 'ak-stage-user-login-form' },
+        { pk: 'login-stage', name: 'default-authentication-login', component: 'ak-stage-user-login-form' },
       ] });
       if (call.method === 'POST' && call.path === '/api/v3/flows/instances/') { created.push('flow'); return json({ pk: 'hola-recovery-pk' }, 201); }
       if (call.method === 'POST' && call.path === '/api/v3/flows/bindings/') { const b = call.body as { stage: string; order: number }; created.push(`bind:${b.stage}@${b.order}`); return json({ pk: 'b' }, 201); }
@@ -563,7 +566,10 @@ describe('RealAuthentikProvisionerService — scoped-token bootstrap', () => {
         { pk: 'bpw', order: 2, stage_obj: { component: 'ak-stage-password-form' } }, // the bug
       ] });
       if (call.method === 'DELETE' && call.path.startsWith('/api/v3/flows/bindings/')) { deleted.push(call.path); return new Response(null, { status: 204 }); }
-      if (call.method === 'GET' && call.path.startsWith('/api/v3/stages/user_login/')) return json({ results: [{ pk: 'login-stage', name: 'default-authentication-login' }] });
+      if (call.method === 'GET' && call.path.startsWith('/api/v3/stages/all/')) return json({ results: [
+        { pk: 'pw-stage', name: 'default-authentication-password', component: 'ak-stage-password-form' },
+        { pk: 'login-stage', name: 'default-authentication-login', component: 'ak-stage-user-login-form' },
+      ] });
       if (call.method === 'POST' && call.path === '/api/v3/flows/bindings/') { bound.push(call.body as { target: string; stage: string; order: number }); return json({ pk: 'nb' }, 201); }
       // Brand already bound to this flow → no re-patch needed.
       if (call.method === 'GET' && call.path.startsWith('/api/v3/core/brands/')) return json({ results: [{ brand_uuid: 'b1', flow_recovery: 'broken-flow' }] });

--- a/packages/server/src/services/core/provisioner.ts
+++ b/packages/server/src/services/core/provisioner.ts
@@ -787,19 +787,25 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
    * the default authentication flow ends with, which attaches the pending user
    * to a session.
    *
-   * Uses the TYPED `/api/v3/stages/user_login/` endpoint, NOT the polymorphic
-   * `/api/v3/stages/all/`: the latter ignores `name__iexact` and returns every
-   * stage type, so taking `results[0]` there hands back whatever sorts first
-   * (often a password stage). `/stages/user_login/` only ever returns user_login
-   * stages, so even the fallback is a valid login stage.
+   * Reads the polymorphic `/api/v3/stages/all/` endpoint and filters CLIENT-SIDE
+   * by the user_login `component`. Two pitfalls this avoids:
+   *  - `/stages/all/` IGNORES `?name__iexact=…` and returns every stage type, so
+   *    `results[0]` is whatever sorts first (often a password stage) — never
+   *    trust the server-side name filter here.
+   *  - The TYPED `/api/v3/stages/user_login/` endpoint would be cleaner, but the
+   *    least-privilege scoped provisioning token gets 403 on it; `/stages/all/`
+   *    is readable with the token (it's what the rest of provisioning uses).
+   * Each listed stage carries its admin `component`, so match `ak-stage-user-login-form`
+   * and prefer the one named `default-authentication-login`.
    */
   private async resolveLoginStagePk(): Promise<string | undefined> {
-    const stages = (await this.api<{ results: Array<{ pk: string; name?: string }> }>(
-      'GET', '/api/v3/stages/user_login/'
+    const all = (await this.api<{ results: Array<{ pk: string; name?: string; component?: string }> }>(
+      'GET', '/api/v3/stages/all/'
     )).results ?? [];
-    if (!stages.length) return undefined;
-    const preferred = stages.find((s) => (s.name ?? '').toLowerCase() === 'default-authentication-login');
-    return (preferred ?? stages[0]).pk;
+    const logins = all.filter((s) => s.component === RealAuthentikProvisionerService.LOGIN_STAGE_COMPONENT);
+    if (!logins.length) return undefined;
+    const preferred = logins.find((s) => (s.name ?? '').toLowerCase() === 'default-authentication-login');
+    return (preferred ?? logins[0]).pk;
   }
 
   /** Add a proxy provider to the embedded outpost; returns the outpost pk. */


### PR DESCRIPTION
## Symptom

Fresh bootstrap on 0.6.17 failed to provision the recovery link:

```
◇  Authentik could not provision the password-setup link.
   Sign in as akadmin instead: hola credentials --host paul@hola --show-password
```

## Root cause (regression from #219)

#219 switched `resolveLoginStagePk` to the typed `/api/v3/stages/user_login/` endpoint. But the **least-privilege scoped provisioning token gets `403`** on it (confirmed in the host logs):

```
Could not ensure a brand recovery flow … error: "Authentik GET /api/v3/stages/user_login/ failed: 403"
```

That throw propagated into `ensureRecoveryFlowAutoLogin` → `ensureBrandRecoveryFlow`'s catch returned `false` on every retry → `mintRecoveryLink` exhausted its attempts → no link.

## Fix

Read the polymorphic `/api/v3/stages/all/` endpoint (which the scoped token **can** read — it's what the rest of provisioning already uses) and filter **client-side by component** `ak-stage-user-login-form`, preferring the stage named `default-authentication-login`.

This keeps #219's correctness fix (never trust the ignored `name__iexact` / `results[0]`) without the permission regression.

Bonus catch: the *original* fallback filtered by component `ak-stage-user-login` (no `-form`) — which never matches what `/stages/all/` actually returns — so it always fell through to the mis-resolved password stage.

## Recovery on the host

After updating to this release, the server re-runs `ensureBootstrapAdmin` on boot (the named admin hasn't logged in yet), so it re-mints the link **and** the self-heal adds the missing `user_login` stage to the flow created during the failed bootstrap. Get the link with `hola credentials --host paul@hola`.

## Tests

- Contract tests updated to mock `/stages/all/` (password stage sorts first; login resolved by component + preferred name).
- Integration assertion mirrors prod (filter `/stages/all/` by component).
- server tests · typecheck · lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)