### PR TITLE
fix(web): float required-but-empty secrets to the top of the env list

### DIFF
--- a/packages/web/src/pages/InstallWizard.tsx
+++ b/packages/web/src/pages/InstallWizard.tsx
@@ -101,9 +101,18 @@ export const InstallWizard: React.FC = () => {
       try {
         const result = await createDraftHook.createDraft({ appId });
 
-        // Update state with draft data
+        // Update state with draft data. Float required-but-empty secrets to the
+        // top so the operator sees what they must fill first (env order doesn't
+        // affect deployment). Stable otherwise, and sorted once at load so rows
+        // don't jump around as values are typed in.
         setSystemEnvVars(result.systemEnv);
-        setEnvVars(result.appEnv);
+        const needsValue = (e: AppEnvVar) => Boolean(e.key && e.isSecret && !e.value);
+        setEnvVars(
+          [...result.appEnv]
+            .map((env, i) => ({ env, i }))
+            .sort((a, b) => Number(needsValue(b.env)) - Number(needsValue(a.env)) || a.i - b.i)
+            .map(({ env }) => env)
+        );
         setPorts(result.defaults.ports);
         setVolumes(result.defaults.volumes);
 


### PR DESCRIPTION
Follow-up to #223. Catalog env vars arrive in **manifest order** (not alphabetical), so a required secret like Postiz's `JWT_SECRET` can sit below unrelated rows and be missed.

Sort required-but-empty secrets to the top **once at load** — stable for everything else, and one-shot so rows don't jump around as values are typed in. Env-var order doesn't affect deployment.

Together with #223 (generate button + blocking-row highlight), a blocking secret is now at the top of the list, outlined, and one click from satisfied.

typecheck · lint · 131 web tests — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)