### PR TITLE
chore(release): 0.6.19

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "packages/cli": {
       "name": "@hola/cli",
-      "version": "0.6.18",
+      "version": "0.6.19",
       "bin": {
         "hola": "./bin/hola",
       },
@@ -36,11 +36,11 @@
     },
     "packages/compose": {
       "name": "@hola/compose",
-      "version": "0.6.18",
+      "version": "0.6.19",
     },
     "packages/sdk": {
       "name": "@hola/sdk",
-      "version": "0.6.18",
+      "version": "0.6.19",
       "dependencies": {
         "@hola/shared": "workspace:*",
       },
@@ -54,7 +54,7 @@
     },
     "packages/server": {
       "name": "@hola/server",
-      "version": "0.6.18",
+      "version": "0.6.19",
       "dependencies": {
         "@hola/shared": "workspace:*",
         "jose": "^5.9.6",
@@ -70,7 +70,7 @@
     },
     "packages/shared": {
       "name": "@hola/shared",
-      "version": "0.6.18",
+      "version": "0.6.19",
       "dependencies": {
         "yaml": "^2.9.0",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.6.18",
+  "version": "0.6.19",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.6.18';
+export const CLI_VERSION = '0.6.19';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.6.18",
+  "version": "0.6.19",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.6.18",
+  "version": "0.6.19",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.6.18",
+  "version": "0.6.19",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.6.18",
+  "version": "0.6.19",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Bumps published packages + CLI version to **0.6.19**.

Ships the install-wizard fixes for required secrets:
- #223 — Generate (🪄) button on secret fields + blocking-row highlight/hint
- #224 — required-but-empty secrets sorted to the top of the env list

Unblocks installing apps with a required-but-empty secret (e.g. Postiz's `JWT_SECRET`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)