### PR TITLE
fix(server): pre-pull images before compose up + buffer job logs

### DIFF
--- a/packages/server/src/__tests__/deployments/lifecycle.test.ts
+++ b/packages/server/src/__tests__/deployments/lifecycle.test.ts
@@ -114,11 +114,11 @@ describe('Deployment lifecycle (real orchestration wiring)', () => {
     expect((await deployments.getDeployment(created.deploymentId)).status).toBe('stopped');
   });
 
-  test('a Compose failure marks the job and the deployment failed', async () => {
-    const failingDocker = {
-      ...new MockDockerService(),
-      composeUp: async () => ({ success: false, output: 'mock: image pull failed' }),
-    } as unknown as DockerService;
+  test('a Compose up failure marks the job and the deployment failed', async () => {
+    // Override on a real instance so the other methods (incl. composePull) keep
+    // working — only `up` fails, exercising the post-pull failure path.
+    const failingDocker = new MockDockerService();
+    failingDocker.composeUp = async () => ({ success: false, output: 'mock: compose up failed' });
 
     const { jobs, drafts, deployments } = makeSystem(failingDocker);
     const created = await deployments.createFromDraft({ draftId: await finalizedDraft(drafts), name: 'gitea' });
@@ -127,6 +127,26 @@ describe('Deployment lifecycle (real orchestration wiring)', () => {
     expect(job.status).toBe('failed');
 
     expect((await deployments.getDeployment(created.deploymentId)).status).toBe('error');
+  });
+
+  test('an image-pull failure fails the deploy before Compose up runs', async () => {
+    const pullFailingDocker = new MockDockerService();
+    let upCalled = false;
+    pullFailingDocker.composePull = async () => ({ success: false, output: 'denied: requested access to the resource is denied' });
+    pullFailingDocker.composeUp = async () => { upCalled = true; return { success: true, output: '' }; };
+
+    const { jobs, drafts, deployments, logging } = makeSystem(pullFailingDocker);
+    const created = await deployments.createFromDraft({ draftId: await finalizedDraft(drafts), name: 'gitea' });
+
+    const lines: string[] = [];
+    const sub = logging.onLog({ kind: 'deployment', id: created.deploymentId }, (log) => lines.push(log.message));
+    const job = await waitForJob(jobs, created.jobId!);
+    sub.unsubscribe();
+
+    expect(job.status).toBe('failed');
+    expect(upCalled).toBe(false);
+    expect((await deployments.getDeployment(created.deploymentId)).status).toBe('error');
+    expect(lines.some(m => m.includes('Image pull failed') && m.includes('denied'))).toBe(true);
   });
 
   test('lifecycle logs are streamed to the deployment log target', async () => {

--- a/packages/server/src/__tests__/jobs/structured-logs.test.ts
+++ b/packages/server/src/__tests__/jobs/structured-logs.test.ts
@@ -46,7 +46,7 @@ describe('Jobs and Structured Logs', () => {
   });
 
   describe('Job logs SSE', () => {
-    it('GET /api/jobs/:id/logs returns a JSON snapshot (live logs are on /logs/stream)', async () => {
+    it('GET /api/jobs/:id/logs returns an empty snapshot for a job with no logs', async () => {
       const services = getServices();
   // Use a valid JobType ('install' used for generic log stream testing)
   const job = await services.jobs.createJob({ type: 'install', deploymentId: 'homeassistant-main' });
@@ -58,6 +58,22 @@ describe('Jobs and Structured Logs', () => {
       expect(res.headers.get('content-type')).toContain('application/json');
       const body = await res.json();
       expect(body).toEqual({ items: [] });
+    }, TEST_TIMEOUT);
+
+    it('GET /api/jobs/:id/logs replays buffered lines so a finished job still shows why it ended', async () => {
+      const services = getServices();
+      const job = await services.jobs.createJob({ type: 'install', deploymentId: 'postiz-main' });
+      const jobId = job.id;
+
+      await services.logging.logJob(jobId, 'info', 'Pulling images (first install can take several minutes)…');
+      await services.logging.logJob(jobId, 'error', 'Image pull failed: denied');
+
+      const res = await fetch(`${BASE_URL}${API.jobs.logs(jobId)}`);
+      expect(res.ok).toBe(true);
+      const body = await res.json() as { items: Array<{ level: string; message: string }> };
+      expect(body.items).toHaveLength(2);
+      expect(body.items[0]).toMatchObject({ level: 'info' });
+      expect(body.items[1]).toMatchObject({ level: 'error', message: 'Image pull failed: denied' });
     }, TEST_TIMEOUT);
 
     it('GET /api/deployments/:id/logs returns a real container-log snapshot as JSON', async () => {

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -387,13 +387,19 @@ async function route(url: URL, req: Request): Promise<Response> {
           timestamp: j.finishedAt ?? j.startedAt,
         }));
 
-      const erroredDeployments = deployments.filter(d => d.status === 'error').length;
-      const failedRecentJobs = recentJobs.filter(j => j.status === 'failed').length;
+      // One incident, one alert: a failed install surfaces as BOTH an errored
+      // deployment and a failed job — fold the job into its deployment so it
+      // isn't double-counted. Standalone failed jobs (no errored deployment,
+      // e.g. system jobs) still count on their own.
+      const erroredDeploymentIds = new Set(deployments.filter(d => d.status === 'error').map(d => d.id));
+      const unattributedFailedJobs = recentJobs.filter(
+        j => j.status === 'failed' && !(j.deploymentId && erroredDeploymentIds.has(j.deploymentId))
+      ).length;
 
       const payload: GetSummaryResponse = {
         deploymentsCount: deployments.length,
         activeJobsCount,
-        alertsCount: erroredDeployments + failedRecentJobs,
+        alertsCount: erroredDeploymentIds.size + unattributedFailedJobs,
         recentJobs,
         system: systemStatus,
       };
@@ -1062,12 +1068,21 @@ async function route(url: URL, req: Request): Promise<Response> {
     }
   }
 
-  // Snapshot of prior job logs. Live job logs stream from `/logs/stream` below;
-  // there is no historical log buffer yet, so this returns an empty snapshot
-  // rather than fabricated sample lines.
+  // Snapshot of prior job logs from the logging service's in-memory ring buffer,
+  // so a finished/failed job still shows why it ended (the live `/logs/stream`
+  // below has nothing to replay once the job is over).
   const jobLogsMatch = pathname.match(/^\/api\/jobs\/([^/]+)\/logs$/);
   if (jobLogsMatch && req.method === 'GET') {
-    return json({ items: [] });
+    const jobId = jobLogsMatch[1];
+    const items = getServices().logging
+      .recentLogs({ kind: 'job', id: jobId })
+      .map(entry => ({
+        timestamp: entry.timestamp,
+        service: entry.service,
+        level: entry.level,
+        message: entry.message,
+      }));
+    return json({ items });
   }
 
   // Job Logs SSE Stream - new endpoint for real-time job logs and updates
@@ -1080,6 +1095,19 @@ async function route(url: URL, req: Request): Promise<Response> {
         logger,
         onSubscribe(controller) {
           controller.heartbeat();
+          // Replay buffered history first so a tab opened mid/post-run sees the
+          // prior lines (incl. the failure) before live lines start flowing.
+          for (const entry of services.logging.recentLogs({ kind: 'job', id: jobId })) {
+            controller.send({
+              type: 'log',
+              data: {
+                timestamp: entry.timestamp,
+                service: entry.service,
+                level: entry.level,
+                message: entry.message,
+              },
+            });
+          }
           const sub = services.logging.onLog({ kind: 'job', id: jobId }, entry => {
             controller.send({
               type: 'log',

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -1175,9 +1175,18 @@ export class RealDeploymentService extends InMemoryDeploymentService {
         nextStatus = 'running';
         nextLifecycle = 'active';
       } else {
-        // deploy / start / rollback -> compose up
+        // deploy / start / rollback -> pull images, then compose up
         const provisioned = await this.provisionAuth(deployment);
-        const res = await this.dockerService.composeUp(await this.materializeCompose(deployment, provisioned?.env ?? {}), projectName);
+        const composeDir = await this.materializeCompose(deployment, provisioned?.env ?? {});
+
+        // Pull first (generous timeout) so `up` isn't gated on download time —
+        // large stacks like Postiz used to be SIGKILLed mid-pull by up's 2-min cap.
+        await logBoth('info', 'Pulling images (first install can take several minutes)…');
+        const pull = await this.dockerService.composePull(composeDir, projectName);
+        if (!pull.success) throw new Error(`Image pull failed: ${pull.output}`);
+        await ctx.setProgress(60);
+
+        const res = await this.dockerService.composeUp(composeDir, projectName);
         output = res.output;
         if (!res.success) throw new Error(res.output);
         if (provisioned) await this.completeAuthWiring(deployment, provisioned, projectName, logBoth);

--- a/packages/server/src/services/core/docker.ts
+++ b/packages/server/src/services/core/docker.ts
@@ -54,6 +54,10 @@ export interface DockerService {
   checkDockerAvailability(): Promise<boolean>;
   
   // Compose operations
+  /** Pull all images for a project ahead of `up`, with a generous timeout.
+   *  Image pulls for large multi-service apps (e.g. Postiz) routinely exceed the
+   *  short `up` timeout; pulling first means `up` only has to start local images. */
+  composePull(projectPath: string, projectName: string): Promise<{ success: boolean; output: string }>;
   composeUp(projectPath: string, projectName: string): Promise<{ success: boolean; output: string }>;
   composeDown(projectPath: string, projectName: string): Promise<{ success: boolean; output: string }>;
   composePs(projectPath: string, projectName: string): Promise<ComposeProject>;
@@ -154,18 +158,51 @@ export class RealDockerService implements DockerService, HealthCheckable {
     return info.available;
   }
 
-  async composeUp(projectPath: string, projectName: string): Promise<{ success: boolean; output: string }> {
+  async composePull(projectPath: string, projectName: string): Promise<{ success: boolean; output: string }> {
     try {
-      this.logger.info('Starting compose project', { projectPath, projectName });
-      
+      this.logger.info('Pulling compose images', { projectPath, projectName });
+
       const composeFile = join(projectPath, 'docker-compose.yml');
       if (!existsSync(composeFile)) {
         throw new Error(`docker-compose.yml not found at ${composeFile}`);
       }
-      
+
+      // `--quiet`: suppress per-layer progress (it produced ~100KB of noise and
+      // buried real errors); only warnings/errors are printed. 30-minute ceiling
+      // accommodates large first-time pulls on a slow homelab connection.
+      const { stdout, stderr } = await execFileAsync(
+        'docker',
+        ['compose', '-f', composeFile, '-p', projectName, 'pull', '--quiet'],
+        { cwd: projectPath, timeout: 1_800_000, maxBuffer: 16 * 1024 * 1024 }
+      );
+      const output = [stdout, stderr].filter(Boolean).join('\n');
+      this.logger.info('Compose images pulled', { projectName, output: output.substring(0, 1000) });
+      return { success: true, output };
+    } catch (error) {
+      // execFile rejects on non-zero exit (e.g. denied/manifest-unknown) or on
+      // timeout; surface stdout+stderr+message so the caller logs the real cause.
+      const e = error as { stdout?: string; stderr?: string; message?: string };
+      const output = [e.stdout, e.stderr, e.message].filter(Boolean).join('\n') || String(error);
+      this.logger.error('Failed to pull compose images', error instanceof Error ? error : undefined, { projectName });
+      return { success: false, output };
+    }
+  }
+
+  async composeUp(projectPath: string, projectName: string): Promise<{ success: boolean; output: string }> {
+    try {
+      this.logger.info('Starting compose project', { projectPath, projectName });
+
+      const composeFile = join(projectPath, 'docker-compose.yml');
+      if (!existsSync(composeFile)) {
+        throw new Error(`docker-compose.yml not found at ${composeFile}`);
+      }
+
+      // Images are pre-pulled by composePull, so `up` only starts local images.
+      // The 5-minute timeout covers container creation for large stacks (it is
+      // no longer gated on download time).
       const { stdout, stderr } = await execAsync(
         `docker compose -f "${composeFile}" -p "${projectName}" up -d`,
-        { cwd: projectPath, timeout: 120000 } // 2 minute timeout
+        { cwd: projectPath, timeout: 300000 } // 5 minute timeout
       );
       
       const output = [stdout, stderr].filter(Boolean).join('\n');
@@ -624,6 +661,11 @@ export class MockDockerService implements DockerService {
 
   async checkDockerAvailability(): Promise<boolean> {
     return true;
+  }
+
+  async composePull(projectPath: string, projectName: string): Promise<{ success: boolean; output: string }> {
+    this.logger.debug('Mock compose pull', { projectPath, projectName });
+    return { success: true, output: `[mock] Project ${projectName} images pulled` };
   }
 
   async composeUp(projectPath: string, projectName: string): Promise<{ success: boolean; output: string }> {

--- a/packages/server/src/services/core/logging.ts
+++ b/packages/server/src/services/core/logging.ts
@@ -21,9 +21,41 @@ export type StructuredLog = SharedLogEntry & { target: LoggingTarget };
 export interface LoggingService extends HealthCheckable {
   log(target: LoggingTarget, level: SharedLogEntry['level'], message: string, metadata?: Record<string, unknown>): Promise<void>;
   onLog(target: LoggingTarget, listener: Listener<StructuredLog>): { unsubscribe(): void };
+  /** Recent buffered log lines for a target, oldest-first. Lets the Logs tab
+   *  show why a finished/failed job ended instead of "No logs available"
+   *  (the live SSE stream alone has nothing to replay once the job is over). */
+  recentLogs(target: LoggingTarget, limit?: number): StructuredLog[];
   // Convenience
   logJob(jobId: string, level: SharedLogEntry['level'], message: string, metadata?: Record<string, unknown>): Promise<void>;
   logDeployment(deploymentId: string, level: SharedLogEntry['level'], message: string, metadata?: Record<string, unknown>): Promise<void>;
+}
+
+/** Per-target in-memory ring buffer of recent log lines. Bounded two ways so a
+ *  long-lived server can't leak: at most MAX_LINES per target, and at most
+ *  MAX_TARGETS distinct targets (oldest target evicted first). */
+class LogRingBuffer {
+  private static readonly MAX_LINES = 1000;
+  private static readonly MAX_TARGETS = 256;
+  private buffers = new Map<string, StructuredLog[]>();
+
+  push(key: string, entry: StructuredLog): void {
+    let buf = this.buffers.get(key);
+    if (!buf) {
+      buf = [];
+      this.buffers.set(key, buf);
+      if (this.buffers.size > LogRingBuffer.MAX_TARGETS) {
+        const oldest = this.buffers.keys().next().value;
+        if (oldest !== undefined) this.buffers.delete(oldest);
+      }
+    }
+    buf.push(entry);
+    if (buf.length > LogRingBuffer.MAX_LINES) buf.splice(0, buf.length - LogRingBuffer.MAX_LINES);
+  }
+
+  recent(key: string, limit?: number): StructuredLog[] {
+    const buf = this.buffers.get(key) ?? [];
+    return limit && limit < buf.length ? buf.slice(buf.length - limit) : [...buf];
+  }
 }
 
 class SimplePubSub<TopicKey, Payload> {
@@ -61,6 +93,7 @@ export class RealLoggingService implements LoggingService {
   private logger = getLogger().child({ service: 'RealLoggingService' });
   private storage: StorageService;
   private bus = new SimplePubSub<string, StructuredLog>();
+  private buffer = new LogRingBuffer();
   private initialized = false;
 
   constructor(storage?: StorageService) {
@@ -106,7 +139,8 @@ export class RealLoggingService implements LoggingService {
       target,
     };
 
-    // Broadcast first for live subscribers
+    // Retain for the snapshot/replay buffer, then broadcast to live subscribers.
+    this.buffer.push(this.targetKey(target), entry);
     this.bus.emit(this.targetKey(target), entry);
 
     // Persist via file logger (best-effort)
@@ -124,6 +158,10 @@ export class RealLoggingService implements LoggingService {
     return this.bus.subscribe(this.targetKey(target), listener);
   }
 
+  recentLogs(target: LoggingTarget, limit?: number): StructuredLog[] {
+    return this.buffer.recent(this.targetKey(target), limit);
+  }
+
   async logJob(jobId: string, level: SharedLogEntry['level'], message: string, metadata?: Record<string, unknown>): Promise<void> {
     return this.log({ kind: 'job', id: jobId }, level, message, metadata);
   }
@@ -139,6 +177,7 @@ export class RealLoggingService implements LoggingService {
 export class MockLoggingService implements LoggingService {
   private logger = getLogger().child({ service: 'MockLoggingService' });
   private bus = new SimplePubSub<string, StructuredLog>();
+  private buffer = new LogRingBuffer();
 
   private targetKey(target: LoggingTarget): string {
     return target.kind + ':' + target.id;
@@ -156,12 +195,17 @@ export class MockLoggingService implements LoggingService {
       message,
       target,
     };
+    this.buffer.push(this.targetKey(target), entry);
     this.bus.emit(this.targetKey(target), entry);
     this.logger.debug('Mock log', { target, level, message });
   }
 
   onLog(target: LoggingTarget, listener: Listener<StructuredLog>): { unsubscribe(): void } {
     return this.bus.subscribe(this.targetKey(target), listener);
+  }
+
+  recentLogs(target: LoggingTarget, limit?: number): StructuredLog[] {
+    return this.buffer.recent(this.targetKey(target), limit);
   }
 
   async logJob(jobId: string, level: SharedLogEntry['level'], message: string, metadata?: Record<string, unknown>): Promise<void> {


### PR DESCRIPTION
Three deploy-observability fixes, all surfaced by a **Postiz install that failed silently at 10% with "No logs available."**

## A — Pre-pull images before `up` (the root cause)
`composeUp` had a hard **2-minute timeout** that also covered the image pull. Postiz pulls **five images** (postiz-app, temporal, 2× postgres, redis); the pull ran past 120 s, so `docker compose up -d` was **SIGKILLed mid-pull** — the deploy failed with 98 KB of pull progress and no error string.

`runLifecycleJob` now runs **`docker compose pull --quiet`** first (30-min ceiling, clean output) and then `up -d` (timeout raised 2 min → 5 min, no longer gated on download time). A genuine pull failure (`denied`/`manifest unknown`) now surfaces its real cause.

## B — Buffer job logs
`GET /api/jobs/:id/logs` returned `{items:[]}` by design, so once a job's live SSE stream ended the Logs tab showed **"No logs available"** — you couldn't see why it failed. `LoggingService` now keeps a **bounded per-target ring buffer** (1000 lines × 256 targets); the snapshot endpoint serves it and the SSE stream **replays it on connect**.

## C — De-dupe the dashboard alert count
One failed install counted **twice** (errored deployment + failed job → "2 needs attention"). A failed job tied to an already-errored deployment now folds into that single incident.

## Tests
- New: job-log snapshot replays buffered lines; image-pull failure fails the deploy **before** `up` runs (asserts `up` not called + "Image pull failed … denied" logged).
- Fixed the existing Compose-failure test (it spread a class instance, dropping prototype methods) to override on a real instance.
- typecheck · lint · **291 server tests** · web build — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)