### PR TITLE
fix(web): keep SSE streams alive + auto-refresh transitional status

### DIFF
--- a/packages/web/src/__tests__/sse/heartbeat-watchdog.test.ts
+++ b/packages/web/src/__tests__/sse/heartbeat-watchdog.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Regression test for the SSE heartbeat watchdog.
+ *
+ * The server emits keep-alives as a NAMED `heartbeat` SSE event. The client's
+ * onmessage only fires for default `message` events, so heartbeats were
+ * invisible to the watchdog and any idle stream (no log lines flowing) was torn
+ * down — making streaming logs and live status updates appear never to work.
+ * The client now listens for `heartbeat` and tolerates a generous window.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createSSEClient } from '../../utils/sse-client';
+import { ControllableEventSource, eventSourceController } from '../utils/mocks/controllable-eventsource';
+
+const STREAM_URL = 'http://localhost/api/deployments/x/logs/stream';
+
+describe('SSE heartbeat watchdog', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    eventSourceController.reset();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    eventSourceController.reset();
+  });
+
+  function makeClient(heartbeatTimeout: number) {
+    return createSSEClient({
+      reconnect: false,
+      heartbeatTimeout,
+      eventSourceFactory: (url) => new ControllableEventSource(url) as unknown as EventSource,
+    });
+  }
+
+  it('named heartbeat events keep an idle stream connected past the watchdog window', () => {
+    const client = makeClient(1000);
+    client.updateUrl(STREAM_URL);
+    client.connect();
+
+    const es = eventSourceController.getLastInstance()!;
+    es.simulateOpen();
+    expect(client.getState().connectionState).toBe('connected');
+
+    // No log lines, but heartbeats arrive every 800ms — under the 1000ms window.
+    for (let i = 0; i < 5; i++) {
+      vi.advanceTimersByTime(800);
+      es.simulateNamedEvent('heartbeat', '{}');
+    }
+    expect(client.getState().connectionState).toBe('connected');
+  });
+
+  it('still errors when the stream goes truly silent (no heartbeats)', () => {
+    const client = makeClient(1000);
+    client.updateUrl(STREAM_URL);
+    client.connect();
+
+    const es = eventSourceController.getLastInstance()!;
+    es.simulateOpen();
+    expect(client.getState().connectionState).toBe('connected');
+
+    vi.advanceTimersByTime(1100);
+    expect(client.getState().connectionState).toBe('error');
+  });
+});

--- a/packages/web/src/__tests__/utils/mocks/controllable-eventsource.ts
+++ b/packages/web/src/__tests__/utils/mocks/controllable-eventsource.ts
@@ -10,10 +10,14 @@ export interface ControllableEventSourceInstance {
   onmessage: ((event: MessageEvent) => void) | null;
   onerror: ((event: Event) => void) | null;
   close(): void;
-  
+  addEventListener(type: string, listener: (event: MessageEvent) => void): void;
+  removeEventListener(type: string, listener: (event: MessageEvent) => void): void;
+
   // Test control methods
   simulateOpen(): void;
   simulateMessage(data: string): void;
+  /** Dispatch a NAMED SSE event (e.g. 'heartbeat') to addEventListener listeners. */
+  simulateNamedEvent(type: string, data: string): void;
   simulateError(): void;
   simulateClose(): void;
 }
@@ -33,6 +37,7 @@ class ControllableEventSourceImpl implements ControllableEventSourceInstance {
   public onmessage: ((event: MessageEvent) => void) | null = null;
   public onerror: ((event: Event) => void) | null = null;
   public readyState = 0; // CONNECTING
+  private namedListeners = new Map<string, Set<(event: MessageEvent) => void>>();
 
   constructor(
     public url: string,
@@ -43,6 +48,21 @@ class ControllableEventSourceImpl implements ControllableEventSourceInstance {
 
   close(): void {
     this.readyState = 2; // CLOSED
+  }
+
+  addEventListener(type: string, listener: (event: MessageEvent) => void): void {
+    if (!this.namedListeners.has(type)) this.namedListeners.set(type, new Set());
+    this.namedListeners.get(type)!.add(listener);
+  }
+
+  removeEventListener(type: string, listener: (event: MessageEvent) => void): void {
+    this.namedListeners.get(type)?.delete(listener);
+  }
+
+  simulateNamedEvent(type: string, data: string): void {
+    if (this.readyState !== 1) return;
+    const event = new MessageEvent(type, { data });
+    this.namedListeners.get(type)?.forEach(listener => listener(event));
   }
 
   // Test control methods

--- a/packages/web/src/hooks/useDeploymentDetailApi.ts
+++ b/packages/web/src/hooks/useDeploymentDetailApi.ts
@@ -29,17 +29,20 @@ export function useDeploymentDetailApi(deploymentId: string | undefined) {
     return `deployment-detail-${deploymentId}`;
   }, [deploymentId]);
 
-  const fetchData = React.useCallback(async () => {
+  // `force` bypasses the 30s cache read — required for polling, since a status
+  // mid-transition (installing/updating) would otherwise be served stale for up
+  // to 30s and never appear to progress.
+  const fetchData = React.useCallback(async (force = false) => {
     if (!deploymentId || !cacheKey) {
       setState({ data: null, loading: false, error: null });
       return;
     }
 
-    const cached = globalCache.get(cacheKey);
     const now = Date.now();
-    
-    // Check cache first
-    if (cached && (now - cached.timestamp) < 30000) {
+    const cached = globalCache.get(cacheKey);
+
+    // Check cache first (unless forced)
+    if (!force && cached && (now - cached.timestamp) < 30000) {
       setState({
         data: cached.data as GetDeploymentResponse,
         loading: false,
@@ -47,9 +50,9 @@ export function useDeploymentDetailApi(deploymentId: string | undefined) {
       });
       return;
     }
-    
+
     setState(prev => ({ ...prev, loading: true, error: null }));
-    
+
     try {
       const result = await api.deployments.byId(deploymentId) as GetDeploymentResponse;
       globalCache.set(cacheKey, { data: result, timestamp: now });
@@ -66,6 +69,17 @@ export function useDeploymentDetailApi(deploymentId: string | undefined) {
   React.useEffect(() => {
     fetchData();
   }, [fetchData]);
+
+  // Auto-refresh while a deployment is mid-transition so the status badge moves
+  // from "Installing"/"Updating" to its terminal state without a manual reload
+  // (the deploy lifecycle runs asynchronously server-side).
+  const status = state.data?.status;
+  const isTransitional = status === 'installing' || status === 'updating';
+  React.useEffect(() => {
+    if (!isTransitional) return;
+    const interval = setInterval(() => { void fetchData(true); }, 4000);
+    return () => clearInterval(interval);
+  }, [isTransitional, fetchData]);
 
   // Update configuration
   const updateConfiguration = React.useCallback(async (request: PatchDeploymentRequest) => {

--- a/packages/web/src/hooks/useDeploymentsApi.ts
+++ b/packages/web/src/hooks/useDeploymentsApi.ts
@@ -20,13 +20,14 @@ export function useDeploymentsApi(params: GetDeploymentsRequest) {
     return `deployments-${JSON.stringify(params)}`;
   }, [params]);
 
-  // StrictMode-compatible fetchData pattern
-  const fetchData = React.useCallback(async () => {
+  // StrictMode-compatible fetchData pattern. `force` bypasses the cache read so
+  // polling reflects status changes instead of re-serving stale cached rows.
+  const fetchData = React.useCallback(async (force = false) => {
     const cached = globalCache.get(cacheKey);
     const now = Date.now();
-    
-    // Check cache (30 second TTL for deployments)
-    if (cached && (now - cached.timestamp) < 30000) {
+
+    // Check cache (30 second TTL for deployments) unless forced
+    if (!force && cached && (now - cached.timestamp) < 30000) {
       setState({
         data: cached.data as GetDeploymentsResponse,
         loading: false,
@@ -34,16 +35,16 @@ export function useDeploymentsApi(params: GetDeploymentsRequest) {
       });
       return;
     }
-    
+
     setState(prev => ({ ...prev, loading: true, error: null }));
-    
+
     try {
       // Use the current params directly from closure
       const result = await api.deployments.list(params) as GetDeploymentsResponse;
-      
+
       // Cache the result
       globalCache.set(cacheKey, { data: result, timestamp: now });
-      
+
       setState({
         data: result,
         loading: false,
@@ -63,6 +64,17 @@ export function useDeploymentsApi(params: GetDeploymentsRequest) {
   React.useEffect(() => {
     fetchData();
   }, [fetchData]);
+
+  // While any deployment is mid-transition (installing/updating), poll so the
+  // list reflects the terminal state without a manual reload.
+  const hasTransitional = state.data?.items?.some(
+    d => d.status === 'installing' || d.status === 'updating'
+  ) ?? false;
+  React.useEffect(() => {
+    if (!hasTransitional) return;
+    const interval = setInterval(() => { void fetchData(true); }, 4000);
+    return () => clearInterval(interval);
+  }, [hasTransitional, fetchData]);
 
   return {
     ...state,

--- a/packages/web/src/utils/sse-client.ts
+++ b/packages/web/src/utils/sse-client.ts
@@ -17,7 +17,12 @@ const DEFAULT_OPTIONS: Required<Omit<SSEOptions, 'eventSourceFactory'>> & { even
   maxReconnectDelay: 30000,
   reconnectAttempts: 10,
   heartbeatInterval: 30000,
-  heartbeatTimeout: 5000,
+  // Watchdog window for a silent-but-open stream. Must comfortably exceed the
+  // server's heartbeat cadence (15s) so a single delayed/dropped keep-alive
+  // doesn't tear down an idle log stream. At 5s, any stream not emitting a log
+  // line every 5s (an idle app, or a failed deploy with no containers) was
+  // killed on a loop — which is why streaming logs appeared never to work.
+  heartbeatTimeout: 45000,
   eventTypes: [],
   headers: {},
   eventSourceFactory: undefined,
@@ -159,6 +164,13 @@ export function createSSEClient(initialOptions: SSEOptions = {}): SSEClient {
       };
 
       eventSource.onmessage = handleMessage;
+      // The server sends keep-alives as a NAMED `heartbeat` SSE event, which the
+      // EventSource spec routes to addEventListener('heartbeat', …), NOT to
+      // onmessage. Without this listener the watchdog never saw heartbeats and
+      // an idle stream timed out. (Guarded for mock EventSources used in tests.)
+      if (typeof eventSource.addEventListener === 'function') {
+        eventSource.addEventListener('heartbeat', () => scheduleHeartbeat());
+      }
       eventSource.onerror = () => handleError('Connection error');
     } catch (err) {
       handleError(err instanceof Error ? err.message : 'Failed to connect');


### PR DESCRIPTION
Two **"live updates never work"** bugs, both surfaced during the Postiz install.

## 1. Streaming logs showed "Connection error" on any idle stream
The server sends keep-alives as a **named `heartbeat` SSE event**, which the EventSource spec routes to `addEventListener('heartbeat', …)` — **not** `onmessage`. The client only reset its **5 s** heartbeat watchdog on `onmessage`, so heartbeats were invisible to it. Any stream not emitting a log line every 5 s (an idle app, or a failed deploy with no containers) was torn down on a reconnect loop → "Connection error". It only ever *looked* implemented when logs happened to gush continuously.

**Fix:** the client now listens for `heartbeat` events (guarded for the mock EventSource) and uses a **45 s** watchdog window — comfortably above the server's 15 s cadence, so a delayed/dropped keep-alive can't kill an idle stream.

## 2. App status didn't update automatically
Postiz sat on **"Installing"** until a full page reload flipped it to "Running". `useDeploymentDetailApi`/`useDeploymentsApi` fetch once and **cache 30 s with no polling**, while the deploy lifecycle runs **async** server-side — so the terminal status never arrived without clearing the in-memory cache via reload.

**Fix:** both hooks now **poll every 4 s (cache-bypassing) while any deployment is `installing`/`updating`**, and stop once it reaches a terminal state.

## Tests
- New `heartbeat-watchdog` regression: a named heartbeat keeps an idle stream connected past the window; true silence still errors.
- Extended the mock EventSource with `addEventListener` + named-event dispatch.
- typecheck · lint · **133 web tests** · build — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)