### PR TITLE
feat(server): native-oidc can inject explicit IdP endpoints + static env

### DIFF
--- a/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
+++ b/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
@@ -155,6 +155,46 @@ describe('RealAuthentikProvisionerService (REST contract)', () => {
     expect(result.ref.applicationSlug).toBeTruthy();
   });
 
+  test('native-oidc injects explicit IdP endpoints + static env (Postiz-style apps)', async () => {
+    installFetch();
+    const svc = new RealAuthentikProvisionerService(CONFIG);
+
+    const result = await svc.provision({
+      deploymentId: 'dep-postiz0123456789',
+      appName: 'postiz',
+      mode: 'native-oidc' as const,
+      host: 'postiz.example.com',
+      oidc: {
+        redirectPath: '/settings',
+        scopes: ['openid', 'profile', 'email'],
+        env: {
+          issuer: 'POSTIZ_OAUTH_URL',
+          clientId: 'POSTIZ_OAUTH_CLIENT_ID',
+          clientSecret: 'POSTIZ_OAUTH_CLIENT_SECRET',
+          authUrl: 'POSTIZ_OAUTH_AUTH_URL',
+          tokenUrl: 'POSTIZ_OAUTH_TOKEN_URL',
+          userinfoUrl: 'POSTIZ_OAUTH_USERINFO_URL',
+        },
+        staticEnv: {
+          POSTIZ_GENERIC_OAUTH: 'true',
+          NEXT_PUBLIC_POSTIZ_OAUTH_DISPLAY_NAME: 'Authentik',
+        },
+      },
+    });
+
+    // Explicit Authentik endpoints (global, not per-application).
+    expect(result.env.POSTIZ_OAUTH_AUTH_URL).toBe('https://auth.example.com/application/o/authorize/');
+    expect(result.env.POSTIZ_OAUTH_TOKEN_URL).toBe('https://auth.example.com/application/o/token/');
+    expect(result.env.POSTIZ_OAUTH_USERINFO_URL).toBe('https://auth.example.com/application/o/userinfo/');
+    // Per-app issuer + generated creds.
+    expect(result.env.POSTIZ_OAUTH_URL).toBe(`https://auth.example.com/application/o/${result.ref.applicationSlug}/`);
+    expect(typeof result.env.POSTIZ_OAUTH_CLIENT_ID).toBe('string');
+    expect(typeof result.env.POSTIZ_OAUTH_CLIENT_SECRET).toBe('string');
+    // Static literals only present because OIDC was provisioned.
+    expect(result.env.POSTIZ_GENERIC_OAUTH).toBe('true');
+    expect(result.env.NEXT_PUBLIC_POSTIZ_OAUTH_DISPLAY_NAME).toBe('Authentik');
+  });
+
   test('rolls back the provider if application creation fails', async () => {
     installFetch(call => {
       if (call.method === 'POST' && call.path === '/api/v3/core/applications/') {

--- a/packages/server/src/services/core/provisioner.ts
+++ b/packages/server/src/services/core/provisioner.ts
@@ -37,8 +37,19 @@ export interface ProvisionInput {
     /** The app's expected env-var NAMES for each OIDC setting (optional — apps that
      *  configure OIDC via a setup command rather than env omit this). `redirectUri`
      *  is optional: apps that derive their own redirect URI from their base URL have
-     *  no env var for the literal callback. */
-    env?: { issuer: string; clientId: string; clientSecret: string; redirectUri?: string };
+     *  no env var for the literal callback. `authUrl`/`tokenUrl`/`userinfoUrl` are
+     *  for apps that need the IdP's explicit endpoints instead of discovery. */
+    env?: {
+      issuer: string;
+      clientId: string;
+      clientSecret: string;
+      redirectUri?: string;
+      authUrl?: string;
+      tokenUrl?: string;
+      userinfoUrl?: string;
+    };
+    /** Literal env injected only when OIDC is provisioned (enable flag, button label). */
+    staticEnv?: Record<string, string>;
   };
   ldap?: {
     env: { host: string; port: string; bindDn: string; bindPassword: string; baseDn: string };
@@ -270,7 +281,7 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
       this.logger.info('Reused existing OIDC client', { deploymentId: input.deploymentId, providerPk: existing.providerPk });
       const reuseSlug = existing.applicationSlug ?? slug;
       return {
-        env: this.oidcEnv(oidc.env, provider.client_id, provider.client_secret, redirectUri, reuseSlug),
+        env: this.oidcEnv(oidc, provider.client_id, provider.client_secret, redirectUri, reuseSlug),
         credentials: { clientId: provider.client_id, clientSecret: provider.client_secret, issuer: this.issuerUrl(reuseSlug), redirectUri },
         ref: existing,
       };
@@ -315,15 +326,14 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
     this.logger.info('Provisioned OIDC client', { deploymentId: input.deploymentId, providerPk: provider.pk, slug });
 
     return {
-      env: this.oidcEnv(oidc.env, clientId, clientSecret, redirectUri, slug),
+      env: this.oidcEnv(oidc, clientId, clientSecret, redirectUri, slug),
       credentials: { clientId, clientSecret, issuer: this.issuerUrl(slug), redirectUri },
       ref: { mode: 'native-oidc', providerPk: provider.pk, applicationSlug: slug, clientId },
     };
   }
 
   private issuerUrl(slug: string): string {
-    const base = this.config.authentikPublicUrl || this.config.authentikUrl || '';
-    return `${base}/application/o/${slug}/`;
+    return `${this.oauthBase()}/application/o/${slug}/`;
   }
 
   // ---- platform (dashboard) OIDC ----------------------------------------
@@ -916,20 +926,35 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
   }
 
   private oidcEnv(
-    names: { issuer: string; clientId: string; clientSecret: string; redirectUri?: string } | undefined,
+    oidc: ProvisionInput['oidc'],
     clientId: string,
     clientSecret: string,
     redirectUri: string,
     slug: string
   ): Record<string, string> {
-    if (!names) return {};
-    return {
-      [names.issuer]: this.issuerUrl(slug),
-      [names.clientId]: clientId,
-      [names.clientSecret]: clientSecret,
+    const out: Record<string, string> = {};
+    const names = oidc?.env;
+    if (names) {
+      out[names.issuer] = this.issuerUrl(slug);
+      out[names.clientId] = clientId;
+      out[names.clientSecret] = clientSecret;
       // Only inject the literal redirect URI when the app exposes an env var for it.
-      ...(names.redirectUri ? { [names.redirectUri]: redirectUri } : {}),
-    };
+      if (names.redirectUri) out[names.redirectUri] = redirectUri;
+      // Explicit IdP endpoints for apps that don't discover from the issuer.
+      // These are Authentik's global OIDC endpoints (not per-application).
+      const base = this.oauthBase();
+      if (names.authUrl) out[names.authUrl] = `${base}/application/o/authorize/`;
+      if (names.tokenUrl) out[names.tokenUrl] = `${base}/application/o/token/`;
+      if (names.userinfoUrl) out[names.userinfoUrl] = `${base}/application/o/userinfo/`;
+    }
+    // Literal env to set only when OIDC is provisioned (enable flag, button label).
+    if (oidc?.staticEnv) Object.assign(out, oidc.staticEnv);
+    return out;
+  }
+
+  /** Public Authentik base URL for building OIDC endpoint URLs. */
+  private oauthBase(): string {
+    return this.config.authentikPublicUrl || this.config.authentikUrl || '';
   }
 
   /**

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -334,7 +334,25 @@ export type AppAuthConfig = {
     // their base URL and have no env var for the literal callback URL (e.g.
     // Actual Budget uses ACTUAL_OPENID_SERVER_HOSTNAME). issuer/clientId/
     // clientSecret are always required when an env map is present.
-    env?: { issuer: string; clientId: string; clientSecret: string; redirectUri?: string };
+    //
+    // `authUrl`/`tokenUrl`/`userinfoUrl` are for apps that DON'T do OIDC
+    // discovery from the issuer and need the IdP's explicit endpoints (e.g.
+    // Postiz's POSTIZ_OAUTH_AUTH_URL/TOKEN_URL/USERINFO_URL). Hola fills them
+    // from the provider's well-known Authentik endpoints.
+    env?: {
+      issuer: string;
+      clientId: string;
+      clientSecret: string;
+      redirectUri?: string;
+      authUrl?: string;
+      tokenUrl?: string;
+      userinfoUrl?: string;
+    };
+    // Literal env to set ONLY when this app's OIDC is actually provisioned —
+    // e.g. an enable flag and the SSO button label (POSTIZ_GENERIC_OAUTH=true,
+    // NEXT_PUBLIC_POSTIZ_OAUTH_DISPLAY_NAME=Authentik). Kept out of the app's
+    // always-on defaultEnv so a non-SSO install doesn't show a dead SSO button.
+    staticEnv?: Record<string, string>;
     setup?: OidcSetupCommand;
   };
   // For `native-ldap`: the env-var NAMES this app expects its LDAP bind settings in.


### PR DESCRIPTION
Extends the `native-oidc` provisioner so apps that **don't do OIDC discovery** from the issuer — and need the IdP's explicit authorize/token/userinfo endpoints — can be wired to Authentik. Prompted by **Postiz** (`POSTIZ_OAUTH_AUTH_URL`/`TOKEN_URL`/`USERINFO_URL`), which currently ships with only Google + local auth.

## Changes
- `AppAuthConfig.oidc.env` gains optional `authUrl`/`tokenUrl`/`userinfoUrl`, filled from Authentik's **global** OIDC endpoints (`/application/o/{authorize,token,userinfo}/`).
- New `oidc.staticEnv`: literal env injected **only when OIDC is provisioned** (e.g. `POSTIZ_GENERIC_OAUTH=true` and the SSO button label) — kept out of the app's always-on `defaultEnv` so a non-SSO install doesn't render a dead SSO button.

Backwards-compatible: apps mapping only `issuer`/`clientId`/`clientSecret` (Gitea, Grafana) are unchanged. Generic primitive — no per-app logic in the server (ADR 0002 spirit).

## Test
New contract test provisions a Postiz-style app and asserts the three explicit endpoint URLs, the per-app issuer, generated creds, and the static enable flag/label. **292 server tests** pass; typecheck · lint · build green.

Paired with a catalog PR against `try-hola/apps` that flips Postiz's manifest `auth` to `native-oidc` using these fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)