### PR TITLE
feat(cli,compose): make Authentik SSO the default; drop the bootstrap opt-out

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,9 @@ install as **Docker Compose** stacks, orchestrated by a server and routed by
   Authentik's embedded outpost), and `native-ldap` (per-app bind accounts). The
   interface is platform-agnostic (an Authelia+LLDAP backend is tracked in #88). The
   server self-bootstraps a least-privilege scoped token from an admin bootstrap
-  token. Authentik is opt-in via `HOLA_AUTH_MODE=authentik` (a compose profile).
+  token. Authentik is the **default** — `hola init` always sets
+  `HOLA_AUTH_MODE=authentik` (a compose profile); `none` remains an internal
+  dev/test mode, not an install-time choice.
 
 ## Conventions
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -57,7 +57,8 @@ set `HOLA_TOKEN`. Development and test run with auth disabled. See ADR 0001.
 The web dashboard reads `GET /api/auth/config` (unauthenticated) at load to pick a
 login flow:
 
-- **SSO (recommended).** With `HOLA_AUTH_MODE=authentik`, the server self-provisions
+- **SSO (default).** With `HOLA_AUTH_MODE=authentik` (what `hola init` always sets),
+  the server self-provisions
   a public OIDC client for the dashboard at startup (registered at
   `https://<HOLA_DOMAIN>/auth/callback`) and the login screen shows **Sign in with
   SSO** — an Authorization Code + PKCE flow against Authentik. The browser sends the
@@ -95,11 +96,12 @@ deployment's list, detail, and history views. See the
 
 ### Single sign-on (SSO)
 
-Set `HOLA_AUTH_MODE=authentik` in `.env` to deploy **Authentik** alongside the
-stack and have Hola auto-provision each catalog app's auth on install (OIDC
-today). `install.sh` generates the bootstrap secrets and activates the
-`authentik` compose profile. It is opt-in (Authentik needs ~2 GB RAM + Postgres);
-the default `none` deploys apps without auth wiring. See the SSO notes in the
+SSO is the default. `HOLA_AUTH_MODE=authentik` deploys **Authentik** alongside the
+stack and has Hola auto-provision each catalog app's auth on install (OIDC today);
+`hola init` always sets it and `install.sh` generates the bootstrap secrets and
+activates the `authentik` compose profile. Authentik needs ~2 GB RAM + Postgres.
+Setting `HOLA_AUTH_MODE=none` by hand opts out (apps deploy without auth wiring) —
+an advanced/dev escape hatch, not offered by the installer. See the SSO notes in the
 compose [README](../packages/compose/README.md#authentication--sso).
 
 ### Routing generation

--- a/packages/cli/src/__tests__/install-schema.test.ts
+++ b/packages/cli/src/__tests__/install-schema.test.ts
@@ -16,10 +16,11 @@ describe('install schema', () => {
     expect(defaultFor(authDomain, { HOLA_BASE_DOMAIN: 'hola.example.com' })).toBe('auth.hola.example.com');
   });
 
-  it('defaults SSO to authentik (secure by default) with it listed first', () => {
+  it('forces SSO to authentik — not a prompt, written as a fixed value', () => {
     const authMode = INSTALL_SCHEMA.find((f) => f.key === 'HOLA_AUTH_MODE')!;
-    expect(defaultFor(authMode, {})).toBe('authentik');
-    expect(authMode.options?.[0]?.value).toBe('authentik');
+    expect(authMode.fixed).toBe('authentik');
+    // No longer an interactive choice: no options, so 'none' can't be selected.
+    expect(authMode.options).toBeUndefined();
   });
 
   it('reuses the first email (Let\'s Encrypt) as the default for the admin email', () => {
@@ -54,22 +55,22 @@ describe('install schema', () => {
     expect(cf.requiredWhen!({ ACME_DNS_PROVIDER: 'cloudflare' })).toBe(true);
     expect(cf.requiredWhen!({ ACME_DNS_PROVIDER: 'route53' })).toBe(false);
     expect(aws.requiredWhen!({ ACME_DNS_PROVIDER: 'route53' })).toBe(true);
-    expect(authDomain.requiredWhen!({ HOLA_AUTH_MODE: 'authentik' })).toBe(true);
-    expect(authDomain.requiredWhen!({ HOLA_AUTH_MODE: 'none' })).toBe(false);
+    // Authentik is always on, so its login domain is always required (no gate).
+    expect(authDomain.requiredWhen).toBeUndefined();
   });
 
-  it('prompts the named admin only under authentik; username/name only once an email is given', () => {
+  it('always prompts the admin email; username/name only once an email is given', () => {
     const email = INSTALL_SCHEMA.find((f) => f.key === 'HOLA_ADMIN_EMAIL')!;
     const username = INSTALL_SCHEMA.find((f) => f.key === 'HOLA_ADMIN_USERNAME')!;
     const name = INSTALL_SCHEMA.find((f) => f.key === 'HOLA_ADMIN_NAME')!;
 
-    expect(email.requiredWhen!({ HOLA_AUTH_MODE: 'authentik' })).toBe(true);
-    expect(email.requiredWhen!({ HOLA_AUTH_MODE: 'none' })).toBe(false);
+    // Authentik is mandatory, so the named-admin email is always offered (optional value).
+    expect(email.requiredWhen).toBeUndefined();
 
     // Username/name are skipped when no admin email was supplied.
-    expect(username.requiredWhen!({ HOLA_AUTH_MODE: 'authentik' })).toBe(false);
-    expect(username.requiredWhen!({ HOLA_AUTH_MODE: 'authentik', HOLA_ADMIN_EMAIL: 'me@x.io' })).toBe(true);
-    expect(name.requiredWhen!({ HOLA_AUTH_MODE: 'authentik', HOLA_ADMIN_EMAIL: 'me@x.io' })).toBe(true);
+    expect(username.requiredWhen!({})).toBe(false);
+    expect(username.requiredWhen!({ HOLA_ADMIN_EMAIL: 'me@x.io' })).toBe(true);
+    expect(name.requiredWhen!({ HOLA_ADMIN_EMAIL: 'me@x.io' })).toBe(true);
 
     // Username defaults to the email local part.
     expect(defaultFor(username, { HOLA_ADMIN_EMAIL: 'paul@x.io' })).toBe('paul');

--- a/packages/cli/src/install/schema.ts
+++ b/packages/cli/src/install/schema.ts
@@ -38,11 +38,13 @@ export interface InstallField {
   validate?: (v: string, c: ConfigMap) => string | undefined;
   /** When present and false for the current answers, the field is skipped. */
   requiredWhen?: (c: ConfigMap) => boolean;
+  /** Written to .env verbatim without prompting. Used for values that are no
+   *  longer a user choice (e.g. HOLA_AUTH_MODE is always `authentik`). */
+  fixed?: string;
 }
 
 const isRoute53 = (c: ConfigMap) => c.ACME_DNS_PROVIDER === 'route53';
 const isCloudflare = (c: ConfigMap) => c.ACME_DNS_PROVIDER === 'cloudflare';
-const isAuthentik = (c: ConfigMap) => c.HOLA_AUTH_MODE === 'authentik';
 
 /** IANA timezone of the machine running the wizard (e.g. America/New_York), or '' if undetectable. Honors $TZ. */
 export function systemTimeZone(): string {
@@ -153,23 +155,20 @@ export const INSTALL_SCHEMA: InstallField[] = [
     default: () => systemTimeZone(),
   },
   {
+    // SSO is always on: Hola provisions per-app auth against the bundled
+    // Authentik stack. Not a prompt — written as a constant. (`none` remains a
+    // valid internal mode for dev/tests, just not an install-time choice.)
     key: 'HOLA_AUTH_MODE',
-    type: 'select',
+    type: 'text',
     prompt: 'SSO platform for catalog apps',
-    help: 'Note: authentik brings up the bundled Authentik stack (~2 GB RAM)',
-    // Secure by default: provision per-app SSO unless the operator opts out.
-    default: 'authentik',
-    options: [
-      { value: 'authentik', label: 'authentik — auto-provision per-app SSO' },
-      { value: 'none', label: 'none — apps use their own auth' },
-    ],
+    fixed: 'authentik',
   },
   {
     key: 'HOLA_AUTHENTIK_DOMAIN',
     type: 'text',
     prompt: 'Authentik login domain',
+    help: 'The bundled Authentik SSO stack needs ~2 GB RAM + Postgres',
     default: (c) => (c.HOLA_BASE_DOMAIN ? `auth.${c.HOLA_BASE_DOMAIN}` : ''),
-    requiredWhen: isAuthentik,
     validate: isDomain,
   },
   // Note: we deliberately do NOT prompt for the built-in `akadmin` superuser's
@@ -185,7 +184,6 @@ export const INSTALL_SCHEMA: InstallField[] = [
     help: 'akadmin stays as a separate internal break-glass account; blank to use only that.',
     // Default to the first email given, so you sign in as yourself out of the box.
     default: (c) => c.LETSENCRYPT_EMAIL || '',
-    requiredWhen: isAuthentik,
     validate: isEmailOrEmpty,
   },
   {
@@ -194,13 +192,13 @@ export const INSTALL_SCHEMA: InstallField[] = [
     prompt: 'Your username',
     default: (c) => (c.HOLA_ADMIN_EMAIL ? c.HOLA_ADMIN_EMAIL.split('@')[0] : ''),
     // Only asked once a named admin email is given.
-    requiredWhen: (c) => isAuthentik(c) && !!c.HOLA_ADMIN_EMAIL?.trim(),
+    requiredWhen: (c) => !!c.HOLA_ADMIN_EMAIL?.trim(),
   },
   {
     key: 'HOLA_ADMIN_NAME',
     type: 'text',
     prompt: 'Your display name (optional)',
-    requiredWhen: (c) => isAuthentik(c) && !!c.HOLA_ADMIN_EMAIL?.trim(),
+    requiredWhen: (c) => !!c.HOLA_ADMIN_EMAIL?.trim(),
   },
   {
     key: 'HOLA_USE_AUTH',

--- a/packages/cli/src/install/wizard.ts
+++ b/packages/cli/src/install/wizard.ts
@@ -35,6 +35,12 @@ export async function runWizard(opts: WizardOptions): Promise<WizardResult> {
   for (const field of INSTALL_SCHEMA) {
     if (field.requiredWhen && !field.requiredWhen(config)) continue;
 
+    // Fixed fields are written verbatim, never prompted (e.g. HOLA_AUTH_MODE).
+    if (field.fixed !== undefined) {
+      config[field.key] = field.fixed;
+      continue;
+    }
+
     // A `fromEnv` field offers a value already set in the environment (AWS_*); the
     // prompt prefills with it (masked secrets render as dots) so the user just
     // presses Enter. A blank answer still means "use the detected value" and is

--- a/packages/compose/.env.example
+++ b/packages/compose/.env.example
@@ -78,11 +78,12 @@ HOLA_OIDC_AUDIENCE=
 HOLA_OIDC_ADMIN_GROUP=
 
 # --- Authentication & SSO for catalog apps (Authentik) ---
-# `none` (default): no SSO platform; catalog apps deploy without auth wiring.
-# `authentik`: bring up the bundled Authentik stack (server + worker + Postgres,
-#   ~2 GB RAM) under the `authentik` compose profile and let Hola auto-provision
-#   per-app auth (OIDC today) on install. See README "Authentication & SSO".
-HOLA_AUTH_MODE=none
+# SSO is standard. `authentik` brings up the bundled Authentik stack (server +
+# worker + Postgres, ~2 GB RAM) under the `authentik` compose profile and lets
+# Hola auto-provision per-app auth (OIDC today) on install. See README
+# "Authentication & SSO". (`none` disables it — an advanced/dev escape hatch
+# only; `hola init` always configures `authentik`.)
+HOLA_AUTH_MODE=authentik
 
 # Browser-facing domain for the Authentik login UI (needs DNS + TLS, like HOLA_DOMAIN).
 HOLA_AUTHENTIK_DOMAIN=auth.local.hola

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -217,15 +217,16 @@ Apps are pulled from GHCR (`ghcr.io/try-hola/*`) as OCI bundles; the bundle's `c
 becomes the deployment. Pulling requires the package to be **public** (or a registry token).
 
 ## Authentication & SSO
-Catalog apps can integrate with single sign-on. When enabled, Hola deploys **Authentik** (an
-all-in-one SSO platform) as part of the stack and **auto-provisions** each app's auth on install —
-e.g. for an app with native OIDC, Hola creates the OAuth2 client in Authentik and injects the
+Catalog apps integrate with single sign-on. Hola deploys **Authentik** (an all-in-one SSO
+platform) as part of the stack and **auto-provisions** each app's auth on install — e.g. for an
+app with native OIDC, Hola creates the OAuth2 client in Authentik and injects the
 issuer/client id/secret into the app, so SSO works on first boot with no manual setup.
 
-This is **opt-in** (Authentik needs ~2 GB RAM + Postgres). Enable it in `.env`:
+This is the **default** (`hola init` always configures it; Authentik needs ~2 GB RAM + Postgres).
+The relevant `.env` keys:
 
 ```bash
-HOLA_AUTH_MODE=authentik          # default is `none` (no SSO platform)
+HOLA_AUTH_MODE=authentik          # standard; `none` opts out (advanced/dev only)
 HOLA_AUTHENTIK_DOMAIN=auth.example.com   # browser-facing login UI (needs DNS + TLS)
 ```
 

--- a/packages/compose/docker-compose.yml
+++ b/packages/compose/docker-compose.yml
@@ -108,11 +108,12 @@ services:
       # Remote app catalog (JSON). The turnkey default lives in .env.example; blank
       # disables the catalog. See README "App catalog".
       - HOLA_CATALOG_URL=${HOLA_CATALOG_URL:-}
-      # Auth/SSO: when HOLA_AUTH_MODE=authentik the server provisions per-app auth
-      # (OIDC clients, etc.) against the Authentik stack below. `none` disables it.
-      # See README "Authentication & SSO". URL is the internal compose DNS name;
+      # Auth/SSO: with HOLA_AUTH_MODE=authentik (the standard) the server
+      # provisions per-app auth (OIDC clients, etc.) against the Authentik stack
+      # below. `none` disables it (advanced/dev escape hatch). See README
+      # "Authentication & SSO". URL is the internal compose DNS name;
       # PUBLIC_URL/API_TOKEN are written into .env by scripts/install.sh.
-      - HOLA_AUTH_MODE=${HOLA_AUTH_MODE:-none}
+      - HOLA_AUTH_MODE=${HOLA_AUTH_MODE:-authentik}
       - HOLA_AUTHENTIK_URL=${HOLA_AUTHENTIK_URL:-http://authentik-server:9000}
       - HOLA_AUTHENTIK_PUBLIC_URL=${HOLA_AUTHENTIK_PUBLIC_URL:-}
       # The server self-bootstraps a least-privilege scoped token from the admin

--- a/packages/compose/scripts/install.sh
+++ b/packages/compose/scripts/install.sh
@@ -45,6 +45,9 @@ ensure_secret() { # generate only if currently blank/missing
 }
 
 AUTH_MODE="$(env_get HOLA_AUTH_MODE | tr -d '"'"'"' ' | xargs || true)"
+# SSO is the default — an unset/blank mode means authentik (matches the compose
+# `${HOLA_AUTH_MODE:-authentik}` default). Only an explicit `none` opts out.
+AUTH_MODE="${AUTH_MODE:-authentik}"
 if [[ "$AUTH_MODE" == "authentik" ]]; then
   echo "[install] HOLA_AUTH_MODE=authentik: provisioning Authentik secrets"
   if ! command -v openssl >/dev/null 2>&1; then


### PR DESCRIPTION
SSO has always been the goal — make it standard instead of an install-time choice.

## Changes
- **CLI bootstrap** — `hola init` no longer asks *"SSO platform for catalog apps"*. `HOLA_AUTH_MODE` is written as a fixed `authentik` (new schema `fixed` field, applied by the wizard without prompting). The Authentik login domain and admin email/username are now **always** collected (dropped the `isAuthentik` gating).
- **compose** — `HOLA_AUTH_MODE` defaults to `authentik` (was `none`); `install.sh` treats an unset/blank mode as authentik, so it always generates the Authentik secrets and activates the `authentik` compose profile. `.env.example` ships `authentik`.
- **docs** — OPERATIONS, compose README, CLAUDE.md: SSO is the default, not opt-in.

`none` survives as an **internal dev/test mode** (the Mock provisioner, the server config default) — it's just no longer offered by the installer.

## Test
typecheck · lint · build green; **cli 112**, **server 292**, **web 133** tests pass (updated the two schema tests that asserted the old select + `requiredWhen` gates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)