### PR TITLE
fix(cli): rename install --version to --app-version (avoid sade global collision)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -38,7 +38,7 @@ Commands are registered in `src/index.ts` with lazy loaders and implemented unde
 
 ### Catalog & install
 - `hola catalog [query]` — browse/search the app catalog. Options: `--category`, `--limit`, `--json`.
-- `hola install <appId>` — install a catalog app (draft from catalog → validate → finalize → deploy → watch). Options: `--version`, `--name`, `--set KEY=VALUE` (repeatable), `--strict`, `--no-stream`, `--json`.
+- `hola install <appId>` — install a catalog app (draft from catalog → validate → finalize → deploy → watch). Pin a version with `--app-version` or inline as `hola install <appId>@<version>` (defaults to the newest release). Options: `--app-version`, `--name`, `--set KEY=VALUE` (repeatable), `--strict`, `--no-stream`, `--json`.
 
 ### Deployments
 - `hola deployments` — list deployments. Options: `--status`, `--json`.

--- a/packages/cli/src/__tests__/install.test.ts
+++ b/packages/cli/src/__tests__/install.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
-import { runInstall } from '../commands/install/install';
+import { runInstall, resolveAppAndVersion } from '../commands/install/install';
 import type { HolaSdk } from '@hola/sdk';
 
 function makeSdk(overrides: { drafts?: Record<string, unknown> } = {}) {
@@ -68,5 +68,42 @@ describe('install', () => {
     expect(res).toBeUndefined();
     expect(sdk.drafts.create).not.toHaveBeenCalled();
     expect(process.exitCode).toBe(1);
+  });
+
+  it('pins the version from --app-version', async () => {
+    const sdk = makeSdk();
+    await runInstall('gitea', { appVersion: '1.2.1', noStream: true }, { sdk: sdk as unknown as HolaSdk });
+    expect(sdk.drafts.create).toHaveBeenCalledWith({ appId: 'gitea', version: '1.2.1' });
+  });
+
+  it('pins the version from an inline <appId>@<version>', async () => {
+    const sdk = makeSdk();
+    await runInstall('uptime-kuma@1.2.1', { noStream: true }, { sdk: sdk as unknown as HolaSdk });
+    expect(sdk.drafts.create).toHaveBeenCalledWith({ appId: 'uptime-kuma', version: '1.2.1' });
+  });
+
+  it('lets --app-version win over an inline suffix and defaults the name to the bare id', async () => {
+    const sdk = makeSdk();
+    const res = await runInstall('uptime-kuma@9.9.9', { appVersion: '1.2.1', noStream: true, json: true }, { sdk: sdk as unknown as HolaSdk });
+    expect(sdk.drafts.create).toHaveBeenCalledWith({ appId: 'uptime-kuma', version: '1.2.1' });
+    expect(res?.deploymentId).toBe('dep1');
+  });
+});
+
+describe('resolveAppAndVersion', () => {
+  it('defaults to latest when no version is given', () => {
+    expect(resolveAppAndVersion('gitea')).toEqual({ appId: 'gitea', version: 'latest' });
+  });
+
+  it('reads an inline @version', () => {
+    expect(resolveAppAndVersion('gitea@1.2.1')).toEqual({ appId: 'gitea', version: '1.2.1' });
+  });
+
+  it('prefers the explicit flag over the inline suffix', () => {
+    expect(resolveAppAndVersion('gitea@1.0.0', '2.0.0')).toEqual({ appId: 'gitea', version: '2.0.0' });
+  });
+
+  it('splits on the last @ so the version is taken from the suffix', () => {
+    expect(resolveAppAndVersion('ns/app@3.1.4')).toEqual({ appId: 'ns/app', version: '3.1.4' });
   });
 });

--- a/packages/cli/src/commands/install/install.ts
+++ b/packages/cli/src/commands/install/install.ts
@@ -4,12 +4,29 @@ import type { CreateDraftResponse, GetDraftResponse, AppEnvVar } from '@hola/sha
 import { finalizeAndDeploy, reportDeployError, type DeployResult } from '../../lib/deploy-flow';
 
 export interface InstallOptions {
-  version?: string;
+  /** From `--app-version`. Not `--version` — that's sade's global flag and never reaches us. */
+  appVersion?: string;
   name?: string;
   set?: string | string[];
   noStream?: boolean;
   json?: boolean;
   strict?: boolean;
+}
+
+/**
+ * Split an inline `<appId>@<version>` into its parts. An explicit `--app-version`
+ * (passed via `flagVersion`) wins over the inline suffix. Splits on the last `@`
+ * so app ids that themselves contain `@` are preserved. Returns `latest` when no
+ * version is given anywhere — the server resolves that to the newest release.
+ */
+export function resolveAppAndVersion(
+  appId: string,
+  flagVersion?: string
+): { appId: string; version: string } {
+  const at = appId.lastIndexOf('@');
+  const inlineVersion = at > 0 ? appId.slice(at + 1) : undefined;
+  const bareAppId = at > 0 ? appId.slice(0, at) : appId;
+  return { appId: bareAppId, version: flagVersion || inlineVersion || 'latest' };
 }
 
 /** Parse repeated `--set KEY=VALUE` into a map. */
@@ -31,12 +48,12 @@ function parseSet(set?: string | string[]): Record<string, string> {
  * web install wizard drives.
  */
 export async function runInstall(
-  appId: string,
+  rawAppId: string,
   opts: InstallOptions,
   injected?: { sdk?: HolaSdk }
 ): Promise<DeployResult | undefined> {
   const sdk = injected?.sdk ?? new HolaSdk();
-  const version = opts.version ?? 'latest';
+  const { appId, version } = resolveAppAndVersion(rawAppId, opts.appVersion);
   const name = opts.name ?? appId;
   const out = (msg: string) => { if (!opts.json) console.log(msg); };
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -91,10 +91,14 @@ prog
   });
 
 // install — install a catalog app by id (draft from catalog → finalize → deploy)
+// Note: the app version is `--app-version`, not `--version` — the latter is sade's
+// global flag (prints the CLI version), so it can never reach this handler. You can
+// also pin a version inline as `hola install <appId>@<version>`.
 prog
   .command('install <appId>')
   .describe('Install a catalog app: draft from catalog → validate → finalize → deploy → watch')
-  .option('--version', 'App version', 'latest')
+  .example('install uptime-kuma@1.2.1')
+  .option('--app-version', 'App version to install (or use <appId>@<version>)', 'latest')
   .option('--name', 'Deployment name (default: the app id)')
   .option('--set', 'Override an env var, KEY=VALUE (repeatable)')
   .option('--strict', 'Fail on validation warnings', false)


### PR DESCRIPTION
## Problem

`hola install <app> --version 1.2.1` printed the CLI version (`hola, x.y.z`) and exited instead of installing — the install command's `--version` option collided with sade's built-in global `-v, --version`. So a specific app version could **never** be selected via the CLI (#133).

The second half of #133 (the default `latest` being unresolvable → `VERSION_NOT_FOUND`) is **already handled server-side**: `RealCatalogService.getVersionDetail` resolves `latest` to the newest concrete release via `pickLatestVersion`. So this PR is CLI-only.

## Change

- Rename the install option `--version` → `--app-version` so it no longer shadows the global flag.
- Also support pinning inline as `hola install <appId>@<version>` (splits on the last `@`, so namespaced ids survive). The explicit `--app-version` flag wins over the inline suffix.
- Default stays `latest`.
- Update the CLI README and add tests for both the flag and the inline syntax (plus unit tests for `resolveAppAndVersion`).

## Testing

- `bun --cwd packages/cli test install.test` → 11 passed.
- `bun run lint` clean; CLI typecheck clean. (Note: an unrelated pre-existing `@hola/server` typecheck failure re: a missing `jose` dependency, and a pre-existing `install-schema` timezone test that fails on UTC hosts — both present on `main`, unrelated to this change.)

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)