### PR TITLE
fix(server): resolve OIDC scope mappings via polymorphic endpoint (avoid 403)

### DIFF
--- a/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
+++ b/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
@@ -54,8 +54,16 @@ function installFetch(handler?: (call: RecordedCall) => Response | undefined) {
     if (method === 'GET' && url.pathname.startsWith('/api/v3/flows/instances/')) {
       return json({ pk: `flow-${url.pathname.split('/').slice(-2, -1)[0]}` });
     }
-    if (method === 'GET' && url.pathname.startsWith('/api/v3/propertymappings/provider/scope/')) {
-      return json({ results: [{ pk: `scope-${url.searchParams.get('scope_name')}` }] });
+    // Polymorphic property-mappings list (the typed provider/scope endpoint 403s
+    // for the scoped token — see resolveScopeMappingPks / issue #144). Default
+    // scope mappings carry stable `managed` identifiers.
+    if (method === 'GET' && url.pathname === '/api/v3/propertymappings/all/') {
+      return json({ results: [
+        { pk: 'scope-openid', managed: 'goauthentik.io/providers/oauth2/scope-openid', scope_name: 'openid' },
+        { pk: 'scope-profile', managed: 'goauthentik.io/providers/oauth2/scope-profile', scope_name: 'profile' },
+        { pk: 'scope-email', managed: 'goauthentik.io/providers/oauth2/scope-email', scope_name: 'email' },
+        { pk: 'mapping-unrelated', managed: 'goauthentik.io/providers/ldap/something', scope_name: undefined },
+      ] });
     }
     if (method === 'POST' && url.pathname === '/api/v3/providers/oauth2/') {
       return json({ pk: 42, client_id: body.client_id, client_secret: body.client_secret }, 201);
@@ -138,6 +146,12 @@ describe('RealAuthentikProvisionerService (REST contract)', () => {
     expect(pbody.authorization_flow).toBeTruthy();
     expect(pbody.invalidation_flow).toBeTruthy();
 
+    // Scope mappings were resolved from the polymorphic endpoint and attached, so
+    // the OIDC client releases openid/profile/email claims (issue #144). The
+    // provisioner must NOT hit the typed endpoint the scoped token is denied.
+    expect(pbody.property_mappings).toEqual(['scope-openid', 'scope-profile', 'scope-email']);
+    expect(calls.some(c => c.path.startsWith('/api/v3/propertymappings/provider/scope/'))).toBe(false);
+
     // An application was linked to the provider pk.
     const appCall = calls.find(c => c.method === 'POST' && c.path === '/api/v3/core/applications/')!;
     expect(appCall).toBeDefined();
@@ -153,6 +167,40 @@ describe('RealAuthentikProvisionerService (REST contract)', () => {
     expect(result.ref.mode).toBe('native-oidc');
     expect(result.ref.providerPk).toBe(42);
     expect(result.ref.applicationSlug).toBeTruthy();
+  });
+
+  test('native-oidc resolves scope mappings by managed id when scope_name is absent', async () => {
+    // The polymorphic endpoint doesn't always surface scope_name; the `managed`
+    // identifier is the stable fallback (issue #144).
+    installFetch((call) => {
+      if (call.method === 'GET' && call.path === '/api/v3/propertymappings/all/') return json({ results: [
+        { pk: 'pk-openid', managed: 'goauthentik.io/providers/oauth2/scope-openid' },
+        { pk: 'pk-profile', managed: 'goauthentik.io/providers/oauth2/scope-profile' },
+        { pk: 'pk-email', managed: 'goauthentik.io/providers/oauth2/scope-email' },
+      ] });
+      return undefined;
+    });
+    const svc = new RealAuthentikProvisionerService(CONFIG);
+
+    await svc.provision(OIDC_INPUT);
+
+    const pbody = calls.find(c => c.method === 'POST' && c.path === '/api/v3/providers/oauth2/')!.body as Record<string, unknown>;
+    expect(pbody.property_mappings).toEqual(['pk-openid', 'pk-profile', 'pk-email']);
+  });
+
+  test('native-oidc still provisions (with no scope mappings) if listing them fails', async () => {
+    // Best-effort: a 403/500 on the list must not abort the whole provision.
+    installFetch((call) => {
+      if (call.method === 'GET' && call.path === '/api/v3/propertymappings/all/') return new Response('denied', { status: 403 });
+      return undefined;
+    });
+    const svc = new RealAuthentikProvisionerService(CONFIG);
+
+    const result = await svc.provision(OIDC_INPUT);
+
+    const pbody = calls.find(c => c.method === 'POST' && c.path === '/api/v3/providers/oauth2/')!.body as Record<string, unknown>;
+    expect(pbody.property_mappings).toEqual([]);
+    expect(result.ref.providerPk).toBe(42);
   });
 
   test('native-oidc injects explicit IdP endpoints + static env (Postiz-style apps)', async () => {
@@ -356,7 +404,9 @@ describe('RealAuthentikProvisionerService — scoped-token bootstrap', () => {
       if (method === 'POST' && url.pathname === '/api/v3/core/tokens/') { tokenCreated = true; return json({ pk: 1 }, 201); }
       // OIDC provisioning calls (should use the scoped token):
       if (method === 'GET' && url.pathname.startsWith('/api/v3/flows/instances/')) return json({ pk: 'flow' });
-      if (method === 'GET' && url.pathname.startsWith('/api/v3/propertymappings/provider/scope/')) return json({ results: [{ pk: 'm' }] });
+      if (method === 'GET' && url.pathname === '/api/v3/propertymappings/all/') return json({ results: [
+        { pk: 'm', managed: 'goauthentik.io/providers/oauth2/scope-openid', scope_name: 'openid' },
+      ] });
       if (method === 'POST' && url.pathname === '/api/v3/providers/oauth2/') return json({ pk: 1, client_id: body.client_id, client_secret: body.client_secret }, 201);
       if (method === 'POST' && url.pathname === '/api/v3/core/applications/') return json({ pk: 2 }, 201);
       return new Response('unexpected', { status: 500 });

--- a/packages/server/src/services/core/provisioner.ts
+++ b/packages/server/src/services/core/provisioner.ts
@@ -144,10 +144,6 @@ const PROVISIONER_PERMISSIONS = [
   'authentik_providers_oauth2.view_oauth2provider',
   'authentik_providers_oauth2.change_oauth2provider',
   'authentik_providers_oauth2.delete_oauth2provider',
-  // Read OAuth2 scope mappings to attach openid/profile/email to provisioned
-  // clients (the generic core.view_propertymapping is insufficient for the
-  // provider/scope subclass endpoint — Authentik returns 403 without this).
-  'authentik_providers_oauth2.view_scopemapping',
   'authentik_providers_proxy.add_proxyprovider',
   'authentik_providers_proxy.view_proxyprovider',
   'authentik_providers_proxy.change_proxyprovider',
@@ -977,22 +973,40 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
     }
   }
 
-  /** Best-effort: collect scope-mapping pks for the requested scope names. */
+  /**
+   * Resolve scope-mapping pks for the requested scope names so the provisioned
+   * OIDC provider releases the standard `openid`/`profile`/`email` claims.
+   *
+   * Reads the polymorphic `/api/v3/propertymappings/all/` endpoint and filters
+   * CLIENT-SIDE — the TYPED `/api/v3/propertymappings/provider/scope/` endpoint
+   * needs the `authentik_providers_oauth2.view_scopemapping` model permission the
+   * least-privilege scoped token is denied (403), so providers ended up with no
+   * scope mappings and degraded SSO (issue #144). The polymorphic endpoint only
+   * needs the generic `authentik_core.view_propertymapping` the token already
+   * holds — the same pattern resolveLoginStagePk() uses for the login stage.
+   *
+   * Matches each scope by its stable `managed` identifier (Authentik's default
+   * scope mappings are `goauthentik.io/providers/oauth2/scope-<scope>`) or, when
+   * the serializer exposes it, by `scope_name`. Best-effort: a list failure logs
+   * and returns nothing rather than aborting the whole provision.
+   */
   private async resolveScopeMappingPks(scopes: string[]): Promise<string[]> {
+    type ScopeMapping = { pk: string; managed?: string | null; scope_name?: string };
+    let mappings: ScopeMapping[];
+    try {
+      mappings = (await this.api<{ results: ScopeMapping[] }>('GET', '/api/v3/propertymappings/all/')).results ?? [];
+    } catch (error) {
+      this.logger.warn('Could not list OIDC scope mappings; provider will have none', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return [];
+    }
     const pks: string[] = [];
     for (const scope of scopes) {
-      try {
-        const res = await this.api<{ results: Array<{ pk: string }> }>(
-          'GET',
-          `/api/v3/propertymappings/provider/scope/?scope_name=${encodeURIComponent(scope)}`
-        );
-        if (res.results?.[0]?.pk) pks.push(res.results[0].pk);
-      } catch (error) {
-        this.logger.warn('Could not resolve OIDC scope mapping; continuing', {
-          scope,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
+      const managed = `goauthentik.io/providers/oauth2/scope-${scope}`;
+      const match = mappings.find((m) => m.scope_name === scope || m.managed === managed);
+      if (match) pks.push(match.pk);
+      else this.logger.warn('No OIDC scope mapping found for scope; continuing', { scope });
     }
     return pks;
   }


### PR DESCRIPTION
## Problem

When provisioning a `native-oidc` app, the server's least-privilege scoped Authentik token gets **403** reading provider scope property-mappings, so the OIDC provider is created **without** scope mappings. Logins authenticate but receive no standard `openid`/`profile`/`email` claims — SSO is provisioned but degraded (#144).

```
warn  Could not resolve OIDC scope mapping; continuing  scope=openid  error=... /api/v3/propertymappings/provider/scope/?scope_name=openid failed: 403
```

The typed `/api/v3/propertymappings/provider/scope/` endpoint requires the `authentik_providers_oauth2.view_scopemapping` model permission, which the scoped token is denied — the same class of problem the codebase already hit with the login stage (typed `/stages/user_login/` → 403, fixed by reading polymorphic `/stages/all/`).

## Change

- `resolveScopeMappingPks` now reads the **polymorphic** `/api/v3/propertymappings/all/` endpoint (one call for all scopes) and filters **client-side**, matching each scope by its stable `managed` identifier (`goauthentik.io/providers/oauth2/scope-<scope>`) or `scope_name` when present. This endpoint only needs the generic `authentik_core.view_propertymapping` the token already holds.
- Drops the now-unused `authentik_providers_oauth2.view_scopemapping` grant (true least privilege).
- Stays best-effort: a list failure logs and provisions with no mappings rather than aborting.

## Testing

- `bun --cwd packages/server test authentik-contract` → 22 pass. New assertions: scope mapping pks are attached to the provider POST, the typed endpoint is never called, `managed`-only matching works, and a 403 on the list doesn't abort the provision.
- Full server suite (294 pass), typecheck, and lint all clean.

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)