### PR TITLE
fix(server): real no-op provisioner in production when auth backend is off (#110)

### DIFF
--- a/packages/server/src/__tests__/provisioner/none-provisioner.test.ts
+++ b/packages/server/src/__tests__/provisioner/none-provisioner.test.ts
@@ -1,0 +1,66 @@
+/**
+ * NoneProvisionerService — the real no-op provisioner used in production when
+ * HOLA_AUTH_MODE != authentik (issue #110). Unlike the Mock, it must inject
+ * NOTHING for modes that can run without SSO and REFUSE the ones that can't.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { NoneProvisionerService } from '../../services/core/provisioner';
+
+const base = {
+  deploymentId: 'dep-abcdef0123456789',
+  appName: 'gitea',
+  host: 'gitea.example.com',
+};
+
+describe('NoneProvisionerService', () => {
+  test('native-oidc is a no-op: injects no env and no fake credentials', async () => {
+    const svc = new NoneProvisionerService();
+    const result = await svc.provision({
+      ...base,
+      mode: 'native-oidc',
+      oidc: {
+        redirectPath: '/user/oauth2/authentik/callback',
+        scopes: ['openid', 'profile', 'email'],
+        env: { issuer: 'GITEA_OIDC_ISSUER', clientId: 'GITEA_OIDC_CLIENT_ID', clientSecret: 'GITEA_OIDC_CLIENT_SECRET' },
+      },
+    });
+    expect(result.env).toEqual({});
+    expect(result.credentials).toBeUndefined();
+    expect(result.middleware).toBeUndefined();
+    expect(result.ref).toEqual({ mode: 'native-oidc' });
+  });
+
+  test('none mode is a no-op', async () => {
+    const svc = new NoneProvisionerService();
+    const result = await svc.provision({ ...base, mode: 'none' });
+    expect(result.env).toEqual({});
+    expect(result.ref).toEqual({ mode: 'none' });
+  });
+
+  test('forward-auth is refused with an actionable error (no dead gate)', async () => {
+    const svc = new NoneProvisionerService();
+    const p = svc.provision({ ...base, appName: 'homepage', mode: 'forward-auth', forwardAuth: {} });
+    await expect(p).rejects.toThrow(/HOLA_AUTH_MODE=authentik/);
+  });
+
+  test('native-ldap is refused with an actionable error', async () => {
+    const svc = new NoneProvisionerService();
+    const p = svc.provision({
+      ...base,
+      mode: 'native-ldap',
+      ldap: { env: { host: 'H', port: 'P', bindDn: 'BD', bindPassword: 'BP', baseDn: 'BASE' } },
+    });
+    await expect(p).rejects.toThrow(/HOLA_AUTH_MODE=authentik/);
+  });
+
+  test('deprovision is a harmless no-op', async () => {
+    const svc = new NoneProvisionerService();
+    await expect(svc.deprovision({ deploymentId: base.deploymentId })).resolves.toBeUndefined();
+  });
+
+  test('healthCheck reports healthy', async () => {
+    const svc = new NoneProvisionerService();
+    expect((await svc.healthCheck()).healthy).toBe(true);
+  });
+});

--- a/packages/server/src/services/core/provisioner.ts
+++ b/packages/server/src/services/core/provisioner.ts
@@ -1205,3 +1205,63 @@ export class MockProvisionerService implements ProvisionerService {
     return { created: false };
   }
 }
+
+// ---------------------------------------------------------------------------
+// None backend — a real no-op used in PRODUCTION when HOLA_AUTH_MODE != authentik.
+// ---------------------------------------------------------------------------
+
+/**
+ * No-op provisioner for production deployments without an auth backend
+ * (`HOLA_AUTH_MODE != authentik`). Issue #110: the Mock provisioner is for
+ * test/dev and injects *fake* OIDC creds / a dead forward-auth middleware, which
+ * is wrong on a real host — it gave native-oidc apps junk `auth.mock` values and
+ * pointed forward-auth apps at a non-existent outpost.
+ *
+ * Instead this injects NOTHING for modes that can safely run without SSO, and
+ * REFUSES the ones that can't:
+ *  - `native-oidc` / `none`: no-op — the app keeps its own login.
+ *  - `forward-auth` / `native-ldap`: throw — a forward-auth route would be gated
+ *    by a dead outpost (unreachable) and an LDAP app would have no bind account,
+ *    so fail the deploy loudly with an actionable error rather than ship a broken
+ *    app. The operator must enable Authentik for these.
+ */
+export class NoneProvisionerService implements ProvisionerService {
+  private logger = getLogger().child({ service: 'NoneProvisionerService' });
+
+  async healthCheck(): Promise<ServiceHealth> {
+    return { healthy: true, lastCheck: new Date() };
+  }
+
+  async provision(input: ProvisionInput): Promise<ProvisionResult> {
+    if (input.mode === 'forward-auth' || input.mode === 'native-ldap') {
+      throw new ProvisioningError(
+        `App "${input.appName}" requires auth mode "${input.mode}", which needs an auth backend. Set HOLA_AUTH_MODE=authentik to install it.`
+      );
+    }
+    if (input.mode === 'native-oidc') {
+      this.logger.info('No auth backend; skipping native-oidc provisioning — app keeps its own login', {
+        deploymentId: input.deploymentId,
+        appName: input.appName,
+      });
+    }
+    return { env: {}, ref: { mode: input.mode } };
+  }
+
+  async deprovision(input: DeprovisionInput): Promise<void> {
+    // Nothing was ever provisioned.
+    this.logger.debug('No-op deprovision', { deploymentId: input.deploymentId, mode: input.ref?.mode });
+  }
+
+  async provisionPlatformOidc(): Promise<PlatformOidcResult> {
+    // Never reached in production: initializePlatformAuth() bails when mode != authentik.
+    throw new ProvisioningError('Dashboard OIDC requires HOLA_AUTH_MODE=authentik');
+  }
+
+  async ensureAdminGroup(): Promise<void> {
+    // No auth backend to hold a group.
+  }
+
+  async ensureBootstrapAdmin(): Promise<{ created: boolean; recoveryLink?: string }> {
+    return { created: false };
+  }
+}

--- a/packages/server/src/services/simple-factory.ts
+++ b/packages/server/src/services/simple-factory.ts
@@ -24,7 +24,7 @@ import { RealDraftService, MockDraftService, type DraftService } from './core/dr
 import { RealValidationService, MockValidationService, type ValidationService } from './core/validation';
 import { RealRoutingService, MockRoutingService, type RoutingService } from './core/routing';
 import { RealDeploymentService, MockDeploymentService, type DeploymentService } from './core/deployment';
-import { RealAuthentikProvisionerService, MockProvisionerService, type ProvisionerService } from './core/provisioner';
+import { RealAuthentikProvisionerService, MockProvisionerService, NoneProvisionerService, type ProvisionerService } from './core/provisioner';
 import { authConfig } from '../config/auth';
 
 /**
@@ -169,11 +169,13 @@ export function createServices(env: ServiceEnvironment): Services {
   // Shared draft service: the deployment service builds releases from its finalized artifacts.
   const drafts = new RealDraftService(storage, catalog, validation);
 
-  // Provision auth artifacts against the configured platform; no-op when disabled.
+  // Provision auth artifacts against the configured platform. When no backend is
+  // configured (mode != authentik) use the real no-op provisioner — NOT the Mock,
+  // which injects fake creds / a dead forward-auth gate into real apps (#110).
   const provisioner: ProvisionerService =
     authConfig.mode === 'authentik'
       ? new RealAuthentikProvisionerService(authConfig)
-      : new MockProvisionerService();
+      : new NoneProvisionerService();
 
   return {
     storage,


### PR DESCRIPTION
## Problem

`DeploymentService.provisionAuth` runs for **any** app whose manifest declares a non-`none` `auth.mode`, regardless of `HOLA_AUTH_MODE`. But the factory selected the provisioner by mode:

```ts
const provisioner = authConfig.mode === 'authentik'
  ? new RealAuthentikProvisionerService(authConfig)
  : new MockProvisionerService();  // <- test/dev mock, in production!
```

So on a **production** Hola without an auth backend, installing an app that declares auth used the **Mock** provisioner, which injects *fake* values into real apps:

- **native-oidc** (gitea, actual-budget): `mock-client-*` / `mock-secret-*` / `https://auth.mock/...`, and any `oidc.setup` command runs with that junk.
- **forward-auth** (homepage, uptime-kuma): a middleware pointing at `http://authentik-server:9000`, which doesn't exist → the app is unreachable.

## Change

Add `NoneProvisionerService` — a real no-op used in production when `mode != authentik`:

- **native-oidc / none**: inject nothing; the app keeps its own login.
- **forward-auth / native-ldap**: these *require* a backend (a forward-auth route would be gated by a dead outpost; an LDAP app would have no bind account), so they **throw an actionable error** (`Set HOLA_AUTH_MODE=authentik to install it`) and fail the deploy loudly instead of shipping a broken app.

Wire it into the production factory in place of Mock. `MockProvisionerService` stays for the test/dev factories.

## Testing

- New `none-provisioner.test.ts` (6 tests): native-oidc/none are no-ops with no env/creds/middleware; forward-auth and native-ldap are refused with the actionable error; deprovision/healthCheck are harmless.
- Full server suite (298 pass), typecheck, lint, and build all clean.

Note: `initializePlatformAuth` already returns early when `mode != authentik`, so the dashboard-OIDC methods are never invoked on this provisioner in production.

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)