### PR TITLE
feat(icons): persist catalog icon onto deployments + render image icons (#238)

### DIFF
--- a/packages/server/src/__tests__/drafts/catalog-compose.test.ts
+++ b/packages/server/src/__tests__/drafts/catalog-compose.test.ts
@@ -24,7 +24,12 @@ const WITH_COMPOSE = 'services:\n  app:\n    image: nginx:1.27\n';
 // Stand-in for the remote catalog: one app ships a compose, one doesn't.
 function makeCatalog(): CatalogArg {
   return {
-    getApp: async (appId: string) => ({ id: appId, name: appId, icon: '📦' }),
+    getApp: async (appId: string) => ({
+      id: appId,
+      name: appId,
+      // A URL icon for one app, to assert the icon flows through unchanged.
+      icon: appId === 'with-compose' ? 'https://cdn.example.com/with-compose.png' : '📦',
+    }),
     getVersionDetail: async (appId: string) =>
       appId === 'with-compose'
         ? { defaultEnv: [], defaults: { ports: [], volumes: [] }, composeOverride: WITH_COMPOSE }
@@ -70,6 +75,16 @@ describe('Catalog → draft compose (#82)', () => {
 
     const artifacts = await drafts.getFinalizedArtifacts(draftId);
     expect(artifacts?.composeOverride).toContain('nginx:1.27');
+  });
+
+  test('persists the catalog icon on the draft and carries it through finalize (#238)', async () => {
+    const { draftId } = await drafts.createDraft({ appId: 'with-compose', version: '1.0.0' });
+    const draft = await drafts.getDraft(draftId);
+    expect(draft.icon).toBe('https://cdn.example.com/with-compose.png');
+
+    await drafts.finalizeDraft(draftId);
+    const artifacts = await drafts.getFinalizedArtifacts(draftId);
+    expect(artifacts?.manifest.icon).toBe('https://cdn.example.com/with-compose.png');
   });
 
   test('falls back to empty composeOverride when the bundle has none', async () => {

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -459,7 +459,10 @@ abstract class InMemoryDeploymentService implements DeploymentService {
         // not an opaque "deployment-<id>" placeholder. A caller-supplied name wins.
         name: request.name || app,
         app,
-        icon: '📦',
+        // Persist the catalog icon (emoji or image URL) carried through the
+        // finalized manifest, so the launcher and registry feed have a stable
+        // icon without a live catalog lookup. Falls back to a generic glyph.
+        icon: artifacts?.manifest.icon || '📦',
         status: 'installing',
         lifecycleState: 'releasing',
         draftId: request.draftId,

--- a/packages/server/src/services/core/draft.ts
+++ b/packages/server/src/services/core/draft.ts
@@ -49,6 +49,9 @@ export interface FinalizedManifest {
   draftId: string;
   appId: string;
   version?: string;
+  // App icon (emoji or image URL) carried from the catalog so the deployment
+  // record can persist it without re-reading the catalog at create time.
+  icon?: string;
   systemOverrides: Record<string, string>;
   appEnv: AppEnvVar[];
   ports: Array<{ host?: number; container: number; protocol: 'tcp' | 'udp' }>;
@@ -316,6 +319,7 @@ export class RealDraftService implements DraftService {
         draftId,
         appId: request.appId,
         version: request.version,
+        icon: app.icon,
         systemOverrides: {},
         appEnv: defaults.env,
         ports: defaults.defaults.ports,
@@ -601,7 +605,9 @@ export class RealDraftService implements DraftService {
         }
       }
 
-      const manifest = { ...canonicalSpec, checksum, finalizedAt };
+      // `icon` is presentation, not part of the deployable spec, so it's added
+      // outside canonicalSpec — keeping the checksum a pure function of the spec.
+      const manifest = { ...canonicalSpec, icon: draft.icon, checksum, finalizedAt };
       await this.storageService.writeFile(
         `${finalizedDir}/manifest.json`,
         JSON.stringify(manifest, null, 2)
@@ -698,6 +704,7 @@ export class MockDraftService implements DraftService {
       draftId,
       appId: request.appId,
       version: request.version,
+      icon: '📦',
       systemOverrides: {},
       appEnv: [ { key: 'APP_PORT', value: '8080', isSecret: false, description: 'Application port' } ],
       ports: [{ host: 8080, container: 80, protocol: 'tcp' }],
@@ -709,7 +716,7 @@ export class MockDraftService implements DraftService {
 
     return {
       draftId,
-      app: { id: request.appId, name: 'Mock App', icon: '📦' },
+      app: { id: request.appId, name: 'Mock App', icon: draft.icon ?? '📦' },
       systemEnv: [],
       appEnv: draft.appEnv,
       defaults: { ports: draft.ports, volumes: [{ hostPath: './data', containerPath: '/data', readOnly: false }] },
@@ -812,6 +819,7 @@ export class MockDraftService implements DraftService {
       draftId,
       appId: draft.appId,
       version: draft.version,
+      icon: draft.icon,
       systemOverrides: draft.systemOverrides,
       appEnv: draft.appEnv,
       ports: draft.ports,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -384,6 +384,9 @@ export type Draft = {
   draftId: string;
   appId: string;
   version?: string;
+  // App icon (emoji or image URL) seeded from the catalog and carried through
+  // finalize so the deployment can persist it without a live catalog lookup.
+  icon?: string;
   systemOverrides: Record<string, string>;
   appEnv: AppEnvVar[];
   ports: Array<{ host?: number; container: number; protocol: 'tcp' | 'udp' }>;

--- a/packages/web/src/__tests__/components/AppIcon.test.tsx
+++ b/packages/web/src/__tests__/components/AppIcon.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AppIcon } from '../../components/ui/AppIcon';
+
+describe('AppIcon', () => {
+  it('renders an emoji glyph when given an emoji', () => {
+    render(<AppIcon name="Gitea" emoji="🍵" />);
+    expect(screen.getByText('🍵')).toBeInTheDocument();
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+
+  it('falls back to a monogram when no icon is given', () => {
+    const { container } = render(<AppIcon name="Gitea" />);
+    expect(container.textContent).toBe('gi');
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+
+  it('renders an <img> for an http(s) URL icon', () => {
+    render(<AppIcon name="Gitea" emoji="https://cdn.example.com/gitea.png" />);
+    const img = screen.getByRole('img') as HTMLImageElement;
+    expect(img).toBeInTheDocument();
+    expect(img.src).toBe('https://cdn.example.com/gitea.png');
+    expect(img).toHaveAttribute('alt', 'Gitea icon');
+  });
+
+  it('renders an <img> for a data-URI icon', () => {
+    const dataUri = 'data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=';
+    render(<AppIcon name="App" emoji={dataUri} />);
+    expect((screen.getByRole('img') as HTMLImageElement).src).toBe(dataUri);
+  });
+
+  it('falls back to the monogram tile when the image fails to load', () => {
+    render(<AppIcon name="Gitea" emoji="https://cdn.example.com/broken.png" />);
+    fireEvent.error(screen.getByRole('img'));
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+    expect(screen.getByText('gi')).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/ui/AppIcon.tsx
+++ b/packages/web/src/components/ui/AppIcon.tsx
@@ -4,24 +4,49 @@ import { accentFor, monogram } from './accent';
 interface AppIconProps {
   /** App name — drives the deterministic accent colour and monogram fallback. */
   name: string;
-  /** Optional emoji/glyph from the catalog; preferred over the monogram. */
+  /** Optional icon from the catalog: an emoji/glyph OR an image URL (http(s)/data/absolute path). */
   emoji?: string;
   /** Square size in px. */
   size?: number;
   className?: string;
 }
 
+/** Whether the icon value is an image reference rather than an emoji/glyph. */
+const isImageIcon = (icon: string): boolean => /^(https?:\/\/|data:image\/|\/)/.test(icon.trim());
+
 /** The rounded, accent-tinted app tile used across the dashboard. */
 export const AppIcon: React.FC<AppIconProps> = ({ name, emoji, size = 54, className = '' }) => {
   const a = accentFor(name);
-  const glyph = (emoji && emoji.trim()) || monogram(name);
+  const value = emoji?.trim() ?? '';
+  // A broken image URL falls back to the emoji/monogram tile.
+  const [imgFailed, setImgFailed] = React.useState(false);
+  React.useEffect(() => { setImgFailed(false); }, [value]);
+
+  const radius = Math.round(size * 0.24);
+  const showImage = value !== '' && isImageIcon(value) && !imgFailed;
+
+  if (showImage) {
+    return (
+      <img
+        src={value}
+        alt={`${name} icon`}
+        width={size}
+        height={size}
+        onError={() => setImgFailed(true)}
+        className={`flex-none object-cover ${className}`}
+        style={{ width: size, height: size, borderRadius: radius, border: `1px solid ${a.border}` }}
+      />
+    );
+  }
+
+  const glyph = (!isImageIcon(value) && value) || monogram(name);
   return (
     <div
       className={`flex-none flex items-center justify-center font-bold leading-none ${className}`}
       style={{
         width: size,
         height: size,
-        borderRadius: Math.round(size * 0.24),
+        borderRadius: radius,
         background: a.bg,
         color: a.color,
         border: `1px solid ${a.border}`,


### PR DESCRIPTION
First step of #238 (Okta/Entra-style launcher) — the icon foundation. Small and low-risk; unblocks both page redesigns.

## Changes

**1. Persist the app icon (server).**
Today `createFromDraft` hardcodes `icon: '📦'` on the deployment, and the web UI compensates with a render-time join against the live catalog — so icons silently degrade to 📦 if the catalog is unreachable, and the cross-app registry feed publishes 📦 too.

Now the catalog icon (emoji **or** URL) is:
- seeded onto the draft (`Draft.icon`) in `createDraft`,
- carried through the finalized manifest (`FinalizedManifest.icon`) alongside `auth`/`consumes` — added *outside* `canonicalSpec` so it stays out of the deployable-spec checksum (it's presentation, not spec),
- written onto the deployment record at create time (`artifacts?.manifest.icon || '📦'`).

So the launcher and the registry feed (`reconcileAppRegistry`) get a stable icon without a live catalog lookup.

**2. Render image icons (web).**
`AppIcon` now renders `http(s)://` / `data:image/` / absolute-path values as an `<img>`, falling back to the emoji glyph and then the accent monogram (also on image load error). Emoji rendering is unchanged.

## Per the #238 decisions
- `catalog.json` stays the source of truth for icons; the value is persisted at write-time.
- The web render-time catalog join is **left in place** for now as the safety net for deployments created before this change. Dropping it (plus a reconcile backfill so legacy deployments self-heal) is a tracked follow-up — not in this PR to avoid regressing existing installs.

## Testing
- New server test: catalog icon flows draft → finalized manifest (`drafts/catalog-compose.test.ts`).
- New web test: `AppIcon` renders emoji, monogram fallback, http/data-URI images, and falls back on image error (`__tests__/components/AppIcon.test.tsx`).
- Full suite green: server 293 pass, web 138 pass; typecheck, lint, build all clean.

Part of #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)