### PR TITLE
feat(web): Okta/Entra-style app launcher; frame Deployments as troubleshooting (#238)

### DIFF
--- a/packages/web/src/__tests__/pages/Apps.test.tsx
+++ b/packages/web/src/__tests__/pages/Apps.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import { API } from '@hola/shared';
@@ -52,7 +52,10 @@ describe('Apps landing', () => {
     // The deployment's internal name must NOT be shown.
     expect(screen.queryByText('deployment-gitea-abc12345')).not.toBeInTheDocument();
     expect(screen.getByText('🍵')).toBeInTheDocument(); // catalog icon wins over fallback
-    expect(screen.getByText('Running')).toBeInTheDocument(); // status pill label
+    // Running tiles read as launchable ("Open"), not a status pill.
+    expect(screen.getByText('Open')).toBeInTheDocument();
+    // …and keep a manage shortcut to their deployment detail for troubleshooting.
+    expect(screen.getByTitle('Manage & logs')).toHaveAttribute('href', '/deployments/gitea-abc12345');
   });
 
   it('renders every installed app, not just running ones', async () => {
@@ -72,7 +75,7 @@ describe('Apps landing', () => {
     // Running app opens externally; stopped app links to its detail page. Tiles
     // show the catalog product name.
     expect(await screen.findByTitle('Open Alpha')).toHaveAttribute('href', 'https://a.local.hola');
-    expect(screen.getByTitle('Bravo')).toHaveAttribute('href', '/deployments/b-1');
+    expect(screen.getByTitle('Bravo — view deployment')).toHaveAttribute('href', '/deployments/b-1');
   });
 
   it('falls back to the app id when the catalog has no match', async () => {
@@ -84,9 +87,30 @@ describe('Apps landing', () => {
     renderApps();
 
     // No catalog entry → fall back to the app id, never the deployment name.
-    const link = await screen.findByTitle('uptime-kuma');
+    const link = await screen.findByTitle('uptime-kuma — view deployment');
     expect(link).toHaveAttribute('href', '/deployments/x-1');
     expect(screen.queryByText('deployment-x-1')).not.toBeInTheDocument();
+  });
+
+  it('filters the grid by the search box', async () => {
+    mockApi(
+      [
+        { id: 'a-1', name: 'deployment-a-1', app: 'a', icon: '📦', status: 'running', ports: [], lastUpdated: 'now', url: 'https://a.local.hola' },
+        { id: 'b-1', name: 'deployment-b-1', app: 'b', icon: '📦', status: 'running', ports: [], lastUpdated: 'now', url: 'https://b.local.hola' },
+      ],
+      [
+        { id: 'a', name: 'Alpha', description: '', icon: '📦', category: 'apps', rating: 0, downloads: 0, tags: [], featured: false },
+        { id: 'b', name: 'Bravo', description: '', icon: '📦', category: 'apps', rating: 0, downloads: 0, tags: [], featured: false },
+      ],
+    );
+
+    renderApps();
+
+    expect(await screen.findByText('Alpha')).toBeInTheDocument();
+    fireEvent.change(screen.getByPlaceholderText('Search apps…'), { target: { value: 'brav' } });
+
+    expect(screen.getByText('Bravo')).toBeInTheDocument();
+    expect(screen.queryByText('Alpha')).not.toBeInTheDocument();
   });
 
   it('shows an empty state when nothing is installed', async () => {

--- a/packages/web/src/pages/Apps.tsx
+++ b/packages/web/src/pages/Apps.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { ExternalLink, Package, Plus } from 'lucide-react';
+import { ExternalLink, Package, Plus, Search, SlidersHorizontal } from 'lucide-react';
 
 import { useDeploymentsApi } from '../hooks/useDeploymentsApi';
 import { useCatalogAppsApi } from '../hooks/useCatalogApi';
@@ -9,12 +9,16 @@ import { StatusBadge } from '../components/ui/StatusBadge';
 import type { GetDeploymentsRequest } from '@hola/shared';
 
 /**
- * Apps — the default landing: a launcher for installed apps.
+ * Apps — the default landing: an Okta/Entra-style launcher for installed apps.
  *
- * Everything here is data the server already owns (deployments + the catalog for
- * icons), joined client-side — no separate dashboard app to keep in sync. Every
- * installed app is shown: running apps with a URL open in a new tab; the rest
- * link to their deployment detail so a tile is never a dead end.
+ * The job here is *launch*, not manage. Running apps are full-colour tiles that
+ * open the app in a new tab; everything technical (logs, lifecycle, config) lives
+ * on the Deployments page. Non-running apps are dimmed and route to their
+ * deployment detail so a tile is never a dead end, and every running tile keeps a
+ * subtle "manage" shortcut to its detail for troubleshooting.
+ *
+ * Data is what the server already owns — deployments plus the catalog (for the
+ * product name and, as a fallback, the icon) — joined client-side.
  */
 
 const DEPLOYMENTS_PARAMS: GetDeploymentsRequest = { page: 1, limit: 100 };
@@ -23,6 +27,7 @@ const CATALOG_PARAMS = { page: 1, limit: 100 };
 export const Apps: React.FC = () => {
   const { data: deploymentsData, loading, error } = useDeploymentsApi(DEPLOYMENTS_PARAMS);
   const { data: catalogData } = useCatalogAppsApi(CATALOG_PARAMS);
+  const [query, setQuery] = React.useState('');
 
   // Join app id -> catalog icon + display name so tiles show the real app glyph
   // and product name (e.g. "Uptime Kuma"), not the deployment's internal name.
@@ -43,9 +48,19 @@ export const Apps: React.FC = () => {
     [apps],
   );
 
+  // Client-side filter over the product name, deployment name, and app id.
+  const visibleApps = React.useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return apps;
+    return apps.filter((a) => {
+      const name = (nameByApp.get(a.app) || a.app || a.name).toLowerCase();
+      return name.includes(q) || a.app.toLowerCase().includes(q) || a.name.toLowerCase().includes(q);
+    });
+  }, [apps, query, nameByApp]);
+
   return (
     <div className="animate-fadein">
-      <div className="flex items-end gap-3.5 mb-[22px]">
+      <div className="flex items-end gap-3.5 mb-[22px] flex-wrap">
         <div>
           <h1 className="m-0 text-2xl font-semibold tracking-[-0.02em]">Your apps</h1>
           <p className="mt-1.5 text-text-muted text-sm">
@@ -55,6 +70,20 @@ export const Apps: React.FC = () => {
           </p>
         </div>
         <div className="flex-1" />
+        {apps.length > 0 && (
+          <div className="relative flex items-center">
+            <span className="absolute left-[11px] flex text-text-faint">
+              <Search className="w-4 h-4" />
+            </span>
+            <input
+              type="text"
+              placeholder="Search apps…"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              className="h-10 w-56 bg-surface-1 border border-border rounded-[10px] text-text-strong pl-[34px] pr-3 text-[13.5px] outline-none focus:border-primary"
+            />
+          </div>
+        )}
         <Link
           to="/catalog"
           className="flex items-center gap-2 h-10 px-4 bg-primary text-white rounded-[10px] text-sm font-semibold shadow-primary-glow hover:brightness-110 transition"
@@ -72,50 +101,81 @@ export const Apps: React.FC = () => {
         </div>
       )}
 
-      {!loading && !error && apps.length > 0 && (
-        <div className="grid gap-4 grid-cols-[repeat(auto-fill,minmax(212px,1fr))]">
-          {apps.map((app) => {
+      {!loading && !error && visibleApps.length > 0 && (
+        <div className="grid gap-4 grid-cols-[repeat(auto-fill,minmax(180px,1fr))]">
+          {visibleApps.map((app) => {
             const icon = iconByApp.get(app.app) || app.icon || '';
             // Prefer the catalog product name; fall back to the app id (always
             // readable) before the deployment's internal name.
             const displayName = nameByApp.get(app.app) || app.app || app.name;
             const openable = app.status === 'running' && !!app.url;
 
-            const tile = (
-              <div className="group relative h-full bg-surface-1 border border-border rounded-[14px] p-[22px] transition hover:-translate-y-[3px] hover:border-primary hover:shadow-elevation-4">
-                <div className="flex items-start justify-between">
-                  <AppIcon name={displayName} emoji={icon} size={54} />
-                  {openable && (
-                    <ExternalLink className="w-4 h-4 text-text-faint group-hover:text-primary transition-colors" />
+            return (
+              <div
+                key={app.id}
+                className={`group relative flex flex-col items-center text-center bg-surface-1 border border-border rounded-[14px] px-4 pt-[26px] pb-5 transition hover:-translate-y-[3px] hover:border-primary hover:shadow-elevation-4 ${
+                  openable ? '' : 'opacity-70 hover:opacity-100'
+                }`}
+              >
+                {/* Stretched primary action: launch when running, else go to detail.
+                    A sibling (not nested) of the manage link below, so the HTML
+                    stays valid while the whole tile is clickable. */}
+                {openable ? (
+                  <a
+                    href={app.url!}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label={`Open ${displayName}`}
+                    title={`Open ${displayName}`}
+                    className="absolute inset-0 z-[1] rounded-[14px]"
+                  />
+                ) : (
+                  <Link
+                    to={`/deployments/${app.id}`}
+                    aria-label={`${displayName} — view deployment`}
+                    title={`${displayName} — view deployment`}
+                    className="absolute inset-0 z-[1] rounded-[14px]"
+                  />
+                )}
+
+                {/* Manage shortcut (running tiles only — non-running tiles already
+                    route to the detail). Sits above the stretched link. */}
+                {openable && (
+                  <Link
+                    to={`/deployments/${app.id}`}
+                    onClick={(e) => e.stopPropagation()}
+                    title="Manage & logs"
+                    aria-label={`Manage ${displayName}`}
+                    className="absolute top-2.5 right-2.5 z-[2] w-7 h-7 flex items-center justify-center rounded-[8px] text-text-faint opacity-0 group-hover:opacity-100 hover:text-primary hover:bg-primary-weak transition"
+                  >
+                    <SlidersHorizontal className="w-[15px] h-[15px]" />
+                  </Link>
+                )}
+                {openable && (
+                  <ExternalLink className="absolute top-2.5 left-2.5 w-4 h-4 text-text-faint opacity-0 group-hover:opacity-100 group-hover:text-primary transition" />
+                )}
+
+                <AppIcon name={displayName} emoji={icon} size={60} />
+                <div className="mt-3.5 font-semibold text-[14.5px] leading-tight truncate max-w-full">
+                  {displayName}
+                </div>
+                <div className="mt-2 min-h-[24px] flex items-center">
+                  {openable ? (
+                    <span className="text-[12.5px] text-text-faint">Open</span>
+                  ) : (
+                    <StatusBadge status={app.status} />
                   )}
                 </div>
-                <div className="mt-4 font-semibold text-base truncate">{displayName}</div>
-                <div className="mt-2">
-                  <StatusBadge status={app.status} />
-                </div>
-                {app.url && (
-                  <div className="mt-2 font-mono text-[11.5px] text-text-faint truncate">{app.url}</div>
-                )}
               </div>
             );
-
-            return openable ? (
-              <a
-                key={app.id}
-                href={app.url!}
-                target="_blank"
-                rel="noopener noreferrer"
-                title={`Open ${displayName}`}
-                className="block"
-              >
-                {tile}
-              </a>
-            ) : (
-              <Link key={app.id} to={`/deployments/${app.id}`} title={displayName} className="block">
-                {tile}
-              </Link>
-            );
           })}
+        </div>
+      )}
+
+      {/* No results for the current search (but apps do exist). */}
+      {!loading && !error && apps.length > 0 && visibleApps.length === 0 && (
+        <div className="px-5 py-16 text-center text-text-muted text-sm bg-surface-1 border border-dashed border-border rounded-[14px]">
+          No apps match “{query}”.
         </div>
       )}
 

--- a/packages/web/src/pages/Deployments.tsx
+++ b/packages/web/src/pages/Deployments.tsx
@@ -117,7 +117,8 @@ export const Deployments: React.FC = () => {
         <div>
           <h1 className="m-0 text-2xl font-semibold tracking-[-0.02em]">Deployments</h1>
           <p className="mt-1.5 text-text-muted text-sm">
-            {totalDeployments} deployments across your server.
+            Status, logs, and lifecycle controls for all {totalDeployments} installed apps. To just
+            open an app, head to <Link to="/apps" className="text-primary hover:underline">Your apps</Link>.
           </p>
         </div>
         <div className="flex-1" />


### PR DESCRIPTION
Second step of #238. **Stacked on #239** (icon foundation) — review/merge that first; this PR targets `feat/persist-app-icon` so the diff is just the UI work.

## Apps → launcher
- Logo-forward grid with a **search** box.
- **Running** apps are full-colour tiles whose primary action opens the app in a new tab, plus a subtle **"manage & logs"** shortcut (top-right, on hover) to the deployment detail — so the launcher and the troubleshooting view are connected.
- **Non-running** apps are dimmed, show a status pill, and route to their deployment detail (a tile is never a dead end).
- Removed the raw URL / management chrome from tiles.
- Tile clickability uses a **stretched link** that's a *sibling* of the manage link (not nested), keeping the HTML valid while the whole tile is clickable.

## Deployments → under the hood
- Header reframed as "Status, logs, and lifecycle controls…", with a pointer back to **Your apps** for plain launching. The existing table + actions + detail tabs already serve as the troubleshooting surface.

## Per the #238 decisions
- All installed apps are shown; launchability is conveyed by tile state (Q3).
- The catalog join stays as the icon/name source (Q2 — render-time join kept as the safety net for now).
- Builds on the image-icon `AppIcon` support from #239, so URL logos render in the launcher.

## Testing
- `Apps.test.tsx` updated for the launch-first tiles (running shows "Open" + a manage shortcut; non-running routes to detail) and a new **search** test.
- Full web suite green (139 pass); typecheck, lint, and build all clean.

## Screenshots
_Not included — the SPA needs a running server + auth to render. Behavior is covered by the page tests above._

Part of #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)