### PR TITLE
feat: persist app display name; drop the render-time catalog join (#238)

### DIFF
--- a/packages/server/src/__tests__/deployments/persistence.test.ts
+++ b/packages/server/src/__tests__/deployments/persistence.test.ts
@@ -187,12 +187,14 @@ describe('Deployment persistence (real service)', () => {
     expect(rollback.previousReleaseId).toBe(promoted.releaseId);
   });
 
-  test('a deployment created without a name defaults to the app slug', async () => {
+  test('a deployment created without a name defaults to the catalog product name', async () => {
     const { drafts, deployments } = makeSystem();
     const created = await deployments.createFromDraft({ draftId: await finalizedDraft(drafts), options: { autoStart: false } });
     const detail = await deployments.getDeployment(created.deploymentId);
-    // Not an opaque "deployment-<id>" placeholder — the UI shows the app.
-    expect(detail.name).toBe('gitea');
+    // The catalog product name is persisted at install (carried via the finalized
+    // manifest), so the UI shows a readable name without a live catalog join —
+    // never an opaque "deployment-<id>" placeholder. Falls back to the app slug.
+    expect(detail.name).toBe('Test App');
   });
 
   test('a failed promotion leaves the previous release active', async () => {

--- a/packages/server/src/__tests__/drafts/catalog-compose.test.ts
+++ b/packages/server/src/__tests__/drafts/catalog-compose.test.ts
@@ -26,7 +26,8 @@ function makeCatalog(): CatalogArg {
   return {
     getApp: async (appId: string) => ({
       id: appId,
-      name: appId,
+      // A product name distinct from the id, to assert it flows through.
+      name: appId === 'with-compose' ? 'With Compose' : appId,
       // A URL icon for one app, to assert the icon flows through unchanged.
       icon: appId === 'with-compose' ? 'https://cdn.example.com/with-compose.png' : '📦',
     }),
@@ -77,14 +78,16 @@ describe('Catalog → draft compose (#82)', () => {
     expect(artifacts?.composeOverride).toContain('nginx:1.27');
   });
 
-  test('persists the catalog icon on the draft and carries it through finalize (#238)', async () => {
+  test('persists the catalog icon + display name on the draft and carries them through finalize (#238)', async () => {
     const { draftId } = await drafts.createDraft({ appId: 'with-compose', version: '1.0.0' });
     const draft = await drafts.getDraft(draftId);
     expect(draft.icon).toBe('https://cdn.example.com/with-compose.png');
+    expect(draft.displayName).toBe('With Compose');
 
     await drafts.finalizeDraft(draftId);
     const artifacts = await drafts.getFinalizedArtifacts(draftId);
     expect(artifacts?.manifest.icon).toBe('https://cdn.example.com/with-compose.png');
+    expect(artifacts?.manifest.displayName).toBe('With Compose');
   });
 
   test('falls back to empty composeOverride when the bundle has none', async () => {

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -455,9 +455,11 @@ abstract class InMemoryDeploymentService implements DeploymentService {
 
       const deployment: EnhancedDeploymentDetail = {
         id: deploymentId,
-        // Default to the app slug (e.g. "uptime-kuma") so the UI shows the app,
-        // not an opaque "deployment-<id>" placeholder. A caller-supplied name wins.
-        name: request.name || app,
+        // Default to the catalog product name (e.g. "Uptime Kuma"), falling back
+        // to the app slug — so the UI shows a readable app name without a live
+        // catalog lookup, never an opaque "deployment-<id>". A caller-supplied
+        // name wins.
+        name: request.name || artifacts?.manifest.displayName || app,
         app,
         // Persist the catalog icon (emoji or image URL) carried through the
         // finalized manifest, so the launcher and registry feed have a stable

--- a/packages/server/src/services/core/draft.ts
+++ b/packages/server/src/services/core/draft.ts
@@ -49,9 +49,11 @@ export interface FinalizedManifest {
   draftId: string;
   appId: string;
   version?: string;
-  // App icon (emoji or image URL) carried from the catalog so the deployment
-  // record can persist it without re-reading the catalog at create time.
+  // App icon (emoji or image URL) and product display name carried from the
+  // catalog so the deployment record can persist both without re-reading the
+  // catalog at create time.
   icon?: string;
+  displayName?: string;
   systemOverrides: Record<string, string>;
   appEnv: AppEnvVar[];
   ports: Array<{ host?: number; container: number; protocol: 'tcp' | 'udp' }>;
@@ -320,6 +322,7 @@ export class RealDraftService implements DraftService {
         appId: request.appId,
         version: request.version,
         icon: app.icon,
+        displayName: app.name,
         systemOverrides: {},
         appEnv: defaults.env,
         ports: defaults.defaults.ports,
@@ -605,9 +608,10 @@ export class RealDraftService implements DraftService {
         }
       }
 
-      // `icon` is presentation, not part of the deployable spec, so it's added
-      // outside canonicalSpec — keeping the checksum a pure function of the spec.
-      const manifest = { ...canonicalSpec, icon: draft.icon, checksum, finalizedAt };
+      // `icon`/`displayName` are presentation, not part of the deployable spec,
+      // so they're added outside canonicalSpec — keeping the checksum a pure
+      // function of the spec.
+      const manifest = { ...canonicalSpec, icon: draft.icon, displayName: draft.displayName, checksum, finalizedAt };
       await this.storageService.writeFile(
         `${finalizedDir}/manifest.json`,
         JSON.stringify(manifest, null, 2)
@@ -705,6 +709,7 @@ export class MockDraftService implements DraftService {
       appId: request.appId,
       version: request.version,
       icon: '📦',
+      displayName: 'Mock App',
       systemOverrides: {},
       appEnv: [ { key: 'APP_PORT', value: '8080', isSecret: false, description: 'Application port' } ],
       ports: [{ host: 8080, container: 80, protocol: 'tcp' }],
@@ -716,7 +721,7 @@ export class MockDraftService implements DraftService {
 
     return {
       draftId,
-      app: { id: request.appId, name: 'Mock App', icon: draft.icon ?? '📦' },
+      app: { id: request.appId, name: draft.displayName ?? 'Mock App', icon: draft.icon ?? '📦' },
       systemEnv: [],
       appEnv: draft.appEnv,
       defaults: { ports: draft.ports, volumes: [{ hostPath: './data', containerPath: '/data', readOnly: false }] },
@@ -820,6 +825,7 @@ export class MockDraftService implements DraftService {
       appId: draft.appId,
       version: draft.version,
       icon: draft.icon,
+      displayName: draft.displayName,
       systemOverrides: draft.systemOverrides,
       appEnv: draft.appEnv,
       ports: draft.ports,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -384,9 +384,11 @@ export type Draft = {
   draftId: string;
   appId: string;
   version?: string;
-  // App icon (emoji or image URL) seeded from the catalog and carried through
-  // finalize so the deployment can persist it without a live catalog lookup.
+  // App icon (emoji or image URL) and product display name seeded from the
+  // catalog and carried through finalize, so the deployment can persist both
+  // without a live catalog lookup at render time.
   icon?: string;
+  displayName?: string;
   systemOverrides: Record<string, string>;
   appEnv: AppEnvVar[];
   ports: Array<{ host?: number; container: number; protocol: 'tcp' | 'udp' }>;

--- a/packages/web/src/__tests__/pages/Apps.test.tsx
+++ b/packages/web/src/__tests__/pages/Apps.test.tsx
@@ -17,14 +17,11 @@ afterEach(() => {
   global.fetch = originalFetch;
 });
 
-function mockApi(deployments: unknown[], catalog: unknown[]) {
+// The launcher renders from the deployments list alone — name + icon are persisted
+// on each deployment at install, so there's no live catalog join here.
+function mockApi(deployments: unknown[]) {
   global.fetch = vi.fn(async (input: RequestInfo | URL) => {
     const url = String(input);
-    if (url.includes(API.catalog.apps)) {
-      return new Response(JSON.stringify({ items: catalog, page: 1, limit: 100, total: catalog.length }), {
-        status: 200, headers: { 'Content-Type': 'application/json' },
-      });
-    }
     if (url.includes(API.deployments.base)) {
       return new Response(JSON.stringify({ items: deployments, page: 1, limit: 100, total: deployments.length }), {
         status: 200, headers: { 'Content-Type': 'application/json' },
@@ -37,10 +34,9 @@ function mockApi(deployments: unknown[], catalog: unknown[]) {
 const renderApps = () => render(<MemoryRouter><Apps /></MemoryRouter>);
 
 describe('Apps landing', () => {
-  it('shows the catalog product name (not the deployment name) and links to the public URL', async () => {
+  it('renders the persisted app name + icon and launches the public URL', async () => {
     mockApi(
-      [{ id: 'gitea-abc12345', name: 'deployment-gitea-abc12345', app: 'gitea', icon: '📦', status: 'running', ports: [], lastUpdated: 'now', url: 'https://gitea.local.hola' }],
-      [{ id: 'gitea', name: 'Gitea', description: '', icon: '🍵', category: 'apps', rating: 0, downloads: 0, tags: [], featured: false }],
+      [{ id: 'gitea-abc12345', name: 'Gitea', app: 'gitea', icon: '🍵', status: 'running', ports: [], lastUpdated: 'now', url: 'https://gitea.local.hola' }],
     );
 
     renderApps();
@@ -49,58 +45,43 @@ describe('Apps landing', () => {
     expect(link).toHaveAttribute('href', 'https://gitea.local.hola');
     expect(link).toHaveAttribute('target', '_blank');
     expect(screen.getByText('Gitea')).toBeInTheDocument();
-    // The deployment's internal name must NOT be shown.
-    expect(screen.queryByText('deployment-gitea-abc12345')).not.toBeInTheDocument();
-    expect(screen.getByText('🍵')).toBeInTheDocument(); // catalog icon wins over fallback
+    expect(screen.getByText('🍵')).toBeInTheDocument(); // persisted icon
     // Running tiles read as launchable ("Open"), not a status pill.
     expect(screen.getByText('Open')).toBeInTheDocument();
     // …and keep a manage shortcut to their deployment detail for troubleshooting.
     expect(screen.getByTitle('Manage & logs')).toHaveAttribute('href', '/deployments/gitea-abc12345');
   });
 
-  it('renders every installed app, not just running ones', async () => {
+  it('renders every installed app; running launches externally, others route to detail', async () => {
     mockApi(
       [
-        { id: 'a-1', name: 'deployment-a-1', app: 'a', icon: '📦', status: 'running', ports: [], lastUpdated: 'now', url: 'https://a.local.hola' },
-        { id: 'b-1', name: 'deployment-b-1', app: 'b', icon: '📦', status: 'stopped', ports: [], lastUpdated: 'now' },
-      ],
-      [
-        { id: 'a', name: 'Alpha', description: '', icon: '📦', category: 'apps', rating: 0, downloads: 0, tags: [], featured: false },
-        { id: 'b', name: 'Bravo', description: '', icon: '📦', category: 'apps', rating: 0, downloads: 0, tags: [], featured: false },
+        { id: 'a-1', name: 'Alpha', app: 'a', icon: '📦', status: 'running', ports: [], lastUpdated: 'now', url: 'https://a.local.hola' },
+        { id: 'b-1', name: 'Bravo', app: 'b', icon: '📦', status: 'stopped', ports: [], lastUpdated: 'now' },
       ],
     );
 
     renderApps();
 
-    // Running app opens externally; stopped app links to its detail page. Tiles
-    // show the catalog product name.
     expect(await screen.findByTitle('Open Alpha')).toHaveAttribute('href', 'https://a.local.hola');
     expect(screen.getByTitle('Bravo — view deployment')).toHaveAttribute('href', '/deployments/b-1');
   });
 
-  it('falls back to the app id when the catalog has no match', async () => {
+  it('falls back to the app id when the deployment has no display name', async () => {
     mockApi(
-      [{ id: 'x-1', name: 'deployment-x-1', app: 'uptime-kuma', icon: '📦', status: 'installing', ports: [], lastUpdated: 'now' }],
-      [],
+      [{ id: 'x-1', name: '', app: 'uptime-kuma', icon: '📦', status: 'installing', ports: [], lastUpdated: 'now' }],
     );
 
     renderApps();
 
-    // No catalog entry → fall back to the app id, never the deployment name.
     const link = await screen.findByTitle('uptime-kuma — view deployment');
     expect(link).toHaveAttribute('href', '/deployments/x-1');
-    expect(screen.queryByText('deployment-x-1')).not.toBeInTheDocument();
   });
 
   it('filters the grid by the search box', async () => {
     mockApi(
       [
-        { id: 'a-1', name: 'deployment-a-1', app: 'a', icon: '📦', status: 'running', ports: [], lastUpdated: 'now', url: 'https://a.local.hola' },
-        { id: 'b-1', name: 'deployment-b-1', app: 'b', icon: '📦', status: 'running', ports: [], lastUpdated: 'now', url: 'https://b.local.hola' },
-      ],
-      [
-        { id: 'a', name: 'Alpha', description: '', icon: '📦', category: 'apps', rating: 0, downloads: 0, tags: [], featured: false },
-        { id: 'b', name: 'Bravo', description: '', icon: '📦', category: 'apps', rating: 0, downloads: 0, tags: [], featured: false },
+        { id: 'a-1', name: 'Alpha', app: 'a', icon: '📦', status: 'running', ports: [], lastUpdated: 'now', url: 'https://a.local.hola' },
+        { id: 'b-1', name: 'Bravo', app: 'b', icon: '📦', status: 'running', ports: [], lastUpdated: 'now', url: 'https://b.local.hola' },
       ],
     );
 
@@ -114,7 +95,7 @@ describe('Apps landing', () => {
   });
 
   it('shows an empty state when nothing is installed', async () => {
-    mockApi([], []);
+    mockApi([]);
     renderApps();
     await waitFor(() => {
       expect(screen.getByText(/No apps installed yet/i)).toBeInTheDocument();

--- a/packages/web/src/pages/Apps.tsx
+++ b/packages/web/src/pages/Apps.tsx
@@ -3,7 +3,6 @@ import { Link } from 'react-router-dom';
 import { ExternalLink, Package, Plus, Search, SlidersHorizontal } from 'lucide-react';
 
 import { useDeploymentsApi } from '../hooks/useDeploymentsApi';
-import { useCatalogAppsApi } from '../hooks/useCatalogApi';
 import { AppIcon } from '../components/ui/AppIcon';
 import { StatusBadge } from '../components/ui/StatusBadge';
 import type { GetDeploymentsRequest } from '@hola/shared';
@@ -17,30 +16,16 @@ import type { GetDeploymentsRequest } from '@hola/shared';
  * deployment detail so a tile is never a dead end, and every running tile keeps a
  * subtle "manage" shortcut to its detail for troubleshooting.
  *
- * Data is what the server already owns — deployments plus the catalog (for the
- * product name and, as a fallback, the icon) — joined client-side.
+ * The name and icon are persisted on the deployment at install (seeded from the
+ * catalog), so this renders from the deployments list alone — no live catalog
+ * join, and it keeps working if the catalog is unreachable.
  */
 
 const DEPLOYMENTS_PARAMS: GetDeploymentsRequest = { page: 1, limit: 100 };
-const CATALOG_PARAMS = { page: 1, limit: 100 };
 
 export const Apps: React.FC = () => {
   const { data: deploymentsData, loading, error } = useDeploymentsApi(DEPLOYMENTS_PARAMS);
-  const { data: catalogData } = useCatalogAppsApi(CATALOG_PARAMS);
   const [query, setQuery] = React.useState('');
-
-  // Join app id -> catalog icon + display name so tiles show the real app glyph
-  // and product name (e.g. "Uptime Kuma"), not the deployment's internal name.
-  const iconByApp = React.useMemo(() => {
-    const map = new Map<string, string>();
-    for (const app of catalogData?.items ?? []) map.set(app.id, app.icon);
-    return map;
-  }, [catalogData]);
-  const nameByApp = React.useMemo(() => {
-    const map = new Map<string, string>();
-    for (const app of catalogData?.items ?? []) map.set(app.id, app.name);
-    return map;
-  }, [catalogData]);
 
   const apps = React.useMemo(() => deploymentsData?.items ?? [], [deploymentsData]);
   const runningCount = React.useMemo(
@@ -48,15 +33,12 @@ export const Apps: React.FC = () => {
     [apps],
   );
 
-  // Client-side filter over the product name, deployment name, and app id.
+  // Client-side filter over the app name and id.
   const visibleApps = React.useMemo(() => {
     const q = query.trim().toLowerCase();
     if (!q) return apps;
-    return apps.filter((a) => {
-      const name = (nameByApp.get(a.app) || a.app || a.name).toLowerCase();
-      return name.includes(q) || a.app.toLowerCase().includes(q) || a.name.toLowerCase().includes(q);
-    });
-  }, [apps, query, nameByApp]);
+    return apps.filter((a) => a.name.toLowerCase().includes(q) || a.app.toLowerCase().includes(q));
+  }, [apps, query]);
 
   return (
     <div className="animate-fadein">
@@ -104,10 +86,10 @@ export const Apps: React.FC = () => {
       {!loading && !error && visibleApps.length > 0 && (
         <div className="grid gap-4 grid-cols-[repeat(auto-fill,minmax(180px,1fr))]">
           {visibleApps.map((app) => {
-            const icon = iconByApp.get(app.app) || app.icon || '';
-            // Prefer the catalog product name; fall back to the app id (always
-            // readable) before the deployment's internal name.
-            const displayName = nameByApp.get(app.app) || app.app || app.name;
+            // Name + icon are persisted on the deployment at install (seeded from
+            // the catalog), falling back to the app id for older records.
+            const icon = app.icon || '';
+            const displayName = app.name || app.app;
             const openable = app.status === 'running' && !!app.url;
 
             return (

--- a/packages/web/src/pages/Deployments.tsx
+++ b/packages/web/src/pages/Deployments.tsx
@@ -18,7 +18,6 @@ import type {
 } from '@hola/shared';
 import { api } from '../utils/api';
 import { useDeploymentsApi } from '../hooks/useDeploymentsApi';
-import { useCatalogAppsApi } from '../hooks/useCatalogApi';
 import { AppIcon } from '../components/ui/AppIcon';
 import { StatusBadge } from '../components/ui/StatusBadge';
 
@@ -33,10 +32,6 @@ const STATUS_FILTERS: { value: DeploymentStatus | 'all'; label: string }[] = [
 
 const GRID_COLS =
   'grid grid-cols-[2.4fr_1.1fr_0.9fr_1.9fr_0.9fr_130px] gap-[14px] px-[18px]';
-
-// Module-level constant so its identity is stable across renders (matches Apps.tsx).
-// A fresh object literal here would change every render and re-fetch the catalog.
-const CATALOG_PARAMS = { page: 1, limit: 100 };
 
 export const Deployments: React.FC = () => {
   const navigate = useNavigate();
@@ -65,15 +60,6 @@ export const Deployments: React.FC = () => {
 
   const deployments = deploymentsResponse?.items || [];
   const totalDeployments = deploymentsResponse?.total || 0;
-
-  // Join app id -> catalog product name + glyph so the "App" column shows the
-  // real app (e.g. "Uptime Kuma" 📈), not a "deployment-<id>" placeholder.
-  const { data: catalogData } = useCatalogAppsApi(CATALOG_PARAMS);
-  const appMeta = React.useMemo(() => {
-    const map = new Map<string, { name: string; icon: string }>();
-    for (const app of catalogData?.items ?? []) map.set(app.id, { name: app.name, icon: app.icon });
-    return map;
-  }, [catalogData]);
 
   const handleAction = useCallback(async (deploymentId: string, action: 'start' | 'stop' | 'restart') => {
     try {
@@ -221,9 +207,10 @@ export const Deployments: React.FC = () => {
 
           {/* Body rows */}
           {deployments.map((deployment) => {
-            const meta = appMeta.get(deployment.app);
-            const displayName = meta?.name || deployment.app || deployment.name;
-            const displayIcon = meta?.icon || deployment.icon;
+            // Name + icon are persisted on the deployment (seeded from the catalog
+            // at install), falling back to the app id for older records.
+            const displayName = deployment.name || deployment.app;
+            const displayIcon = deployment.icon;
             return (
             <div
               key={deployment.id}


### PR DESCRIPTION
Third step of #238. **Stacked on #240** (which is stacked on #239) — base is `feat/apps-launcher`, so the diff is just this change.

Implements the Q2 follow-up from the [#238 decisions](https://github.com/try-hola/hola/issues/238#issuecomment-4770287642): render from the persisted deployment record and drop the render-time catalog join. **No legacy backfill** (per your call) — pre-persistence deployments fall back to the app slug + generic glyph.

## Why
Both the launcher (`Apps`) and the deployments table joined the **live catalog** every render to resolve each app's product name and icon. The icon is already persisted on the deployment (#239); this does the same for the product **name** and removes the join entirely, so both pages keep working even if the catalog is unreachable.

## Server
- Seed the catalog product name onto the draft as `displayName` in `createDraft`.
- Carry it through the `FinalizedManifest` (outside `canonicalSpec`, like `icon`, so it stays out of the deployable-spec checksum).
- Use it as the deployment's default name at create: `request.name || manifest.displayName || app slug`. So a no-name install now shows "Uptime Kuma" instead of "uptime-kuma", and a user-supplied name still wins.

## Web
- `Apps` and `Deployments` render name + icon straight from the deployments list — removed `useCatalogAppsApi` and the per-render join maps from both.

## Testing
- Server: draft test asserts `displayName` flows draft → finalized manifest; persistence test asserts the product-name default.
- Web: `Apps.test.tsx` renders from the deployment record (no catalog mock); full web suite green (139).
- Server 293 pass; typecheck, lint, build all clean.

Part of #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)