### PR TITLE
feat: add `hola update` + update-available detection (#149)

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -184,16 +184,43 @@ docker run --rm -v hola-data:/data -v "$PWD":/backup alpine \
 
 ## Upgrade
 
-Re-run `hola bootstrap` with a newer CLI: it downloads the new compose bundle
-(which pins the new `ghcr.io/try-hola` image tags) and re-runs the idempotent
-installer. On the host directly:
+The supported upgrade path is `hola update` — it brings an existing install up to
+the invoking CLI's version **without** re-running the setup wizard and **without**
+touching your `.env` or the ACME cert store:
 
 ```bash
-cd packages/compose
-./scripts/up.sh --pull always   # pull the version-pinned images, recreate changed services
+hola update --host user@vm          # upgrade to this CLI's version
+hola update --host user@vm --check  # just report CLI / installed / latest versions
 ```
 
-State in the `hola-data` volume is preserved across upgrades.
+It preflights the host, downloads the version-pinned compose bundle (pinning the
+new `ghcr.io/try-hola` image tags), extracts it over the install dir, and re-runs
+the idempotent installer — which pulls the new images, backfills any newly-required
+`.env` keys, and recreates only the changed services. Use the same `--ref`,
+`--tarball-url`, `--dir`, and `--dry-run` overrides as `hola bootstrap`.
+
+Keep the **same install dir** (`--dir`) across upgrades. The Let's Encrypt cert
+store is a dir-relative bind mount (`traefik/acme/acme.json`), so relocating the
+dir starts with an empty store and re-issues every cert.
+
+**Pre-0.6.23 hosts (no SSO).** Authentik became the default in 0.6.23. A host with
+an unset `HOLA_AUTH_MODE` is reconciled automatically (the installer enables
+Authentik and generates its secrets). A host pinned to an explicit
+`HOLA_AUTH_MODE=none` is left as-is and `update` asks you to choose — pass
+`--enable-sso` to turn SSO on (derives `auth.<base>` and pulls in ~2 GB of
+Authentik services) or `--keep-auth-mode` to keep it off.
+
+To upgrade on the host directly instead of over SSH:
+
+```bash
+cd /opt/hola               # the install dir
+curl -fsSL <bundle-url> | tar xz -C .   # extract the new bundle over the dir
+HOLA_BOOTSTRAP=1 ./scripts/install.sh   # idempotent: pulls images, recreates changed services
+```
+
+State in the `hola-data` volume is preserved across upgrades. The web dashboard and
+the CLI both surface an "update available" notice (a cached check against the
+newest published release) pointing you to `hola update`.
 
 ## Troubleshooting
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -218,9 +218,11 @@ curl -fsSL <bundle-url> | tar xz -C .   # extract the new bundle over the dir
 HOLA_BOOTSTRAP=1 ./scripts/install.sh   # idempotent: pulls images, recreates changed services
 ```
 
-State in the `hola-data` volume is preserved across upgrades. The web dashboard and
-the CLI both surface an "update available" notice (a cached check against the
-newest published release) pointing you to `hola update`.
+State in the `hola-data` volume is preserved across upgrades. The web dashboard
+shows an "update available" banner, and the CLI appends a one-line notice to any
+command that talks to the server (both read one cached server-side check against
+the newest published release). Run `hola update --check` for the discrete report,
+or set `HOLA_NO_UPDATE_NOTICE=1` to silence the per-command notice.
 
 ## Troubleshooting
 

--- a/packages/cli/src/__tests__/update-notice.test.ts
+++ b/packages/cli/src/__tests__/update-notice.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+import { updateNoticeLine, maybeNotifyUpdate } from '../lib/update-notice';
+import { CLI_VERSION } from '../version';
+import type { HolaSdk } from '@hola/sdk';
+
+function fakeSdk(updateCheck: () => Promise<unknown>): HolaSdk {
+  return { system: { updateCheck } } as unknown as HolaSdk;
+}
+
+describe('updateNoticeLine', () => {
+  it('announces a newer release when one is available', () => {
+    const line = updateNoticeLine({ current: '0.6.20', latest: '0.6.25', updateAvailable: true, releaseUrl: null });
+    expect(line).toContain('0.6.25');
+    expect(line).toContain('hola update');
+  });
+
+  it('flags CLI↔server skew when the CLI is ahead and no newer release exists', () => {
+    const line = updateNoticeLine({ current: '0.0.1', latest: '0.0.1', updateAvailable: false, releaseUrl: null });
+    expect(line).toContain('newer than the server');
+    expect(line).toContain('hola update');
+  });
+
+  it('says nothing when the CLI matches the server and no update is available', () => {
+    const line = updateNoticeLine({ current: CLI_VERSION, latest: CLI_VERSION, updateAvailable: false, releaseUrl: null });
+    expect(line).toBeNull();
+  });
+});
+
+describe('maybeNotifyUpdate', () => {
+  afterEach(() => { delete process.env.HOLA_NO_UPDATE_NOTICE; vi.restoreAllMocks(); });
+
+  it('does not call the server under --json', async () => {
+    const updateCheck = vi.fn(async () => ({ current: '0.6.20', latest: '0.6.25', updateAvailable: true, releaseUrl: null }));
+    await maybeNotifyUpdate(fakeSdk(updateCheck), { json: true });
+    expect(updateCheck).not.toHaveBeenCalled();
+  });
+
+  it('respects HOLA_NO_UPDATE_NOTICE', async () => {
+    process.env.HOLA_NO_UPDATE_NOTICE = '1';
+    const updateCheck = vi.fn(async () => ({ current: '0.6.20', latest: '0.6.25', updateAvailable: true, releaseUrl: null }));
+    await maybeNotifyUpdate(fakeSdk(updateCheck), {});
+    expect(updateCheck).not.toHaveBeenCalled();
+  });
+
+  it('prints a notice to stderr when an update is available', async () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const updateCheck = vi.fn(async () => ({ current: '0.6.20', latest: '0.6.25', updateAvailable: true, releaseUrl: null }));
+    await maybeNotifyUpdate(fakeSdk(updateCheck), {});
+    expect(err).toHaveBeenCalledTimes(1);
+    expect(String(err.mock.calls[0][0])).toContain('0.6.25');
+  });
+
+  it('swallows server errors without throwing', async () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const updateCheck = vi.fn(async () => { throw new Error('network down'); });
+    await expect(maybeNotifyUpdate(fakeSdk(updateCheck), {})).resolves.toBeUndefined();
+    expect(err).not.toHaveBeenCalled();
+  });
+
+  it('is silent when there is nothing to report', async () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const updateCheck = vi.fn(async () => ({ current: CLI_VERSION, latest: CLI_VERSION, updateAvailable: false, releaseUrl: null }));
+    await maybeNotifyUpdate(fakeSdk(updateCheck), {});
+    expect(err).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/__tests__/update.test.ts
+++ b/packages/cli/src/__tests__/update.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { runUpdate, type UpdateResult, type UpdateCheckReport } from '../commands/update/update';
+import { scriptedPrompter } from '../install/prompter';
+import type { Runner } from '../lib/runner';
+
+const OK_PREFLIGHT = 'docker=ok\ncurl=ok\ntar=ok\ncompose=ok\ndockerperm=ok\n';
+
+const ENV_AUTHENTIK =
+  'HOLA_DOMAIN=apps.example.com\nHOLA_BASE_DOMAIN=hola.example.com\nHOLA_AUTH_MODE=authentik\nHOLA_AUTHENTIK_DOMAIN=auth.hola.example.com\n';
+const ENV_NONE = 'HOLA_DOMAIN=apps.example.com\nHOLA_BASE_DOMAIN=hola.example.com\nHOLA_AUTH_MODE=none\n';
+
+const EXAMPLE_BASE = 'HOLA_DOMAIN=\nHOLA_BASE_DOMAIN=\nHOLA_AUTH_MODE=authentik\n';
+
+function makeRunner(opts?: {
+  preflight?: string;
+  env?: string;
+  version?: string;
+  /** The .env.example shipped by the OLD (installed) bundle, read before extract. */
+  oldExample?: string;
+  /** The .env.example shipped by the NEW bundle, read after extract. */
+  newExample?: string;
+}): Runner & { calls: { cmd: string; input?: string }[] } {
+  const preflight = opts?.preflight ?? OK_PREFLIGHT;
+  const env = opts?.env ?? ENV_AUTHENTIK;
+  const version = opts?.version ?? '0.6.20';
+  const oldExample = opts?.oldExample ?? EXAMPLE_BASE;
+  const newExample = opts?.newExample ?? EXAMPLE_BASE;
+  const calls: { cmd: string; input?: string }[] = [];
+  return {
+    calls,
+    ssh: vi.fn(async (_host: string, cmd: string, o?: { input?: string }) => {
+      calls.push({ cmd, input: o?.input });
+      if (cmd.includes('command -v')) return { code: 0, stdout: preflight, stderr: '' };
+      // The combined state read (version + old .env.example + .env) is matched first.
+      if (cmd.includes('__HOLA_ENV__')) {
+        return { code: 0, stdout: `__HOLA_VERSION__=${version}\n__HOLA_EXAMPLE__\n${oldExample}\n__HOLA_ENV__\n${env}`, stderr: '' };
+      }
+      if (cmd.includes('.env.example')) return { code: 0, stdout: newExample, stderr: '' };
+      if (cmd.includes('cat') && cmd.includes('/VERSION')) return { code: 0, stdout: version, stderr: '' };
+      if (cmd.includes('compose ps')) return { code: 0, stdout: '', stderr: '' };
+      return { code: 0, stdout: '', stderr: '' };
+    }),
+    local: vi.fn(async () => ({ code: 0, stdout: '', stderr: '' })),
+  } as Runner & { calls: { cmd: string; input?: string }[] };
+}
+
+describe('hola update', () => {
+  beforeEach(() => { process.exitCode = 0; });
+  afterEach(() => { process.exitCode = 0; });
+
+  it('runs the upgrade steps in order without writing the .env', async () => {
+    const runner = makeRunner();
+    const res = (await runUpdate(
+      { host: 'me@vm', ref: 'cli-v0.6.23', json: true },
+      { prompter: scriptedPrompter({}), runner },
+    )) as UpdateResult;
+
+    expect(res.steps).toEqual([
+      'Preflight host',
+      'Read current install',
+      'Download Hola 0.6.23 stack into /opt/hola',
+      'Check config drift (.env.example vs .env)',
+      'Run install.sh',
+    ]);
+    // No `.env` is ever rewritten — it's preserved in place.
+    expect(runner.calls.some((c) => c.cmd.includes('cat > /opt/hola/.env'))).toBe(false);
+    expect(res.fromVersion).toBe('0.6.20');
+    expect(res.toVersion).toBe('0.6.23');
+    expect(res.ssoAction).toBe('already-on');
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('downloads the version-pinned bundle and extracts over the dir (no .env, no acme)', async () => {
+    const runner = makeRunner();
+    await runUpdate(
+      { host: 'me@vm', ref: 'cli-v0.6.23', dir: '/opt/hola', json: true },
+      { prompter: scriptedPrompter({}), runner },
+    );
+    const fetch = runner.calls.find((c) => c.cmd.includes('tar xz -C /opt/hola'))!;
+    expect(fetch.cmd).toMatch(/curl -fsSL \S*releases\/download\/cli-v0\.6\.23\/hola-compose-0\.6\.23\.tar\.gz/);
+    // Update never creates the dir (it must already exist) — no mkdir/sudo dance.
+    expect(fetch.cmd).not.toContain('mkdir');
+  });
+
+  it('honors --tarball-url', async () => {
+    const runner = makeRunner();
+    await runUpdate(
+      { host: 'me@vm', tarballUrl: 'https://example.com/custom.tar.gz', json: true },
+      { prompter: scriptedPrompter({}), runner },
+    );
+    expect(runner.calls.some((c) => c.cmd.includes('curl -fsSL https://example.com/custom.tar.gz'))).toBe(true);
+  });
+
+  it('aborts when no install (.env) is found on the host', async () => {
+    const runner = makeRunner({ env: '' });
+    const res = await runUpdate(
+      { host: 'me@vm', json: true },
+      { prompter: scriptedPrompter({}), runner },
+    );
+    expect(res).toBeUndefined();
+    expect(process.exitCode).toBe(1);
+    expect(runner.calls.some((c) => c.cmd.includes('install.sh'))).toBe(false);
+  });
+
+  it('aborts before install when preflight finds Docker missing', async () => {
+    const runner = makeRunner({ preflight: 'docker=missing\ncurl=ok\ntar=ok\ncompose=missing\ndockerperm=fail\n' });
+    const res = await runUpdate({ host: 'me@vm', json: true }, { prompter: scriptedPrompter({}), runner });
+    expect(res).toBeUndefined();
+    expect(process.exitCode).toBe(1);
+    expect(runner.calls.some((c) => c.cmd.includes('install.sh'))).toBe(false);
+  });
+
+  it('requires --host', async () => {
+    const res = await runUpdate({ json: true }, { prompter: scriptedPrompter({}), runner: makeRunner() });
+    expect(res).toBeUndefined();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('--dry-run connects to nothing and exits 0', async () => {
+    const runner = makeRunner();
+    const res = (await runUpdate(
+      { host: 'me@vm', dryRun: true, json: true },
+      { prompter: scriptedPrompter({}), runner },
+    )) as UpdateResult;
+    expect(runner.calls).toHaveLength(0);
+    expect(res.steps.length).toBeGreaterThan(0);
+    expect(process.exitCode).toBe(0);
+  });
+
+  // --- Auth-mode reconciliation (issue #149) --------------------------------
+
+  it('explicit HOLA_AUTH_MODE=none + --enable-sso flips the mode and derives the domain', async () => {
+    const runner = makeRunner({ env: ENV_NONE });
+    const res = (await runUpdate(
+      { host: 'me@vm', enableSso: true, json: true },
+      { prompter: scriptedPrompter({}), runner },
+    )) as UpdateResult;
+    expect(res.ssoAction).toBe('enabled');
+    const setEnv = runner.calls.find((c) => c.cmd.includes('_set HOLA_AUTH_MODE'))!;
+    expect(setEnv.cmd).toContain('_set HOLA_AUTH_MODE authentik');
+    // Domain derived from HOLA_BASE_DOMAIN since the .env had none.
+    expect(setEnv.cmd).toContain('_set HOLA_AUTHENTIK_DOMAIN auth.hola.example.com');
+  });
+
+  it('explicit HOLA_AUTH_MODE=none + --keep-auth-mode keeps it off and writes no env change', async () => {
+    const runner = makeRunner({ env: ENV_NONE });
+    const res = (await runUpdate(
+      { host: 'me@vm', keepAuthMode: true, json: true },
+      { prompter: scriptedPrompter({}), runner },
+    )) as UpdateResult;
+    expect(res.ssoAction).toBe('kept-none');
+    expect(runner.calls.some((c) => c.cmd.includes('_set HOLA_AUTH_MODE'))).toBe(false);
+  });
+
+  it('explicit none under --json with no decision flag aborts', async () => {
+    const runner = makeRunner({ env: ENV_NONE });
+    const res = await runUpdate({ host: 'me@vm', json: true }, { prompter: scriptedPrompter({}), runner });
+    expect(res).toBeUndefined();
+    expect(process.exitCode).toBe(1);
+    expect(runner.calls.some((c) => c.cmd.includes('install.sh'))).toBe(false);
+  });
+
+  it('--enable-sso and --keep-auth-mode together is rejected', async () => {
+    const runner = makeRunner({ env: ENV_NONE });
+    const res = await runUpdate(
+      { host: 'me@vm', enableSso: true, keepAuthMode: true, json: true },
+      { prompter: scriptedPrompter({}), runner },
+    );
+    expect(res).toBeUndefined();
+    expect(process.exitCode).toBe(1);
+  });
+
+  // --- Config drift ---------------------------------------------------------
+
+  it('warns only about genuinely new required keys (not auto-managed or defaulted ones)', async () => {
+    const runner = makeRunner({
+      // This release adds a new blank required key plus an auto-managed Authentik secret.
+      newExample: `${EXAMPLE_BASE}HOLA_NEW_THING=\nAUTHENTIK_NEW_SECRET=\nHOLA_WITH_DEFAULT=somevalue\n`,
+    });
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      await runUpdate({ host: 'me@vm' }, { prompter: scriptedPrompter({}), runner });
+      const printed = log.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(printed).toContain('HOLA_NEW_THING');
+      // Auto-managed (install.sh generates it) and defaulted keys are NOT flagged.
+      expect(printed).not.toContain('AUTHENTIK_NEW_SECRET');
+      expect(printed).not.toContain('HOLA_WITH_DEFAULT');
+    } finally {
+      log.mockRestore();
+    }
+  });
+
+  it('does not warn on a same-version re-run (old and new .env.example match)', async () => {
+    const runner = makeRunner();
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      await runUpdate({ host: 'me@vm' }, { prompter: scriptedPrompter({}), runner });
+      const printed = log.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(printed).not.toContain('New required config');
+    } finally {
+      log.mockRestore();
+    }
+  });
+
+  // --- `--check` ------------------------------------------------------------
+
+  it('--check reports installed / latest / updateAvailable without mutating', async () => {
+    const runner = makeRunner({ version: '0.6.20' });
+    const res = (await runUpdate(
+      { host: 'me@vm', check: true, json: true },
+      { prompter: scriptedPrompter({}), runner, fetchLatest: async () => ({ version: '0.6.25', url: 'https://example.com/r' }) },
+    )) as UpdateCheckReport;
+    expect(res.installed).toBe('0.6.20');
+    expect(res.latest).toBe('0.6.25');
+    expect(res.updateAvailable).toBe(true);
+    expect(res.releaseUrl).toBe('https://example.com/r');
+    // No install/extract happened.
+    expect(runner.calls.some((c) => c.cmd.includes('install.sh') || c.cmd.includes('tar xz'))).toBe(false);
+  });
+});

--- a/packages/cli/src/commands/catalog/catalog.ts
+++ b/packages/cli/src/commands/catalog/catalog.ts
@@ -1,6 +1,8 @@
 import { HolaSdk } from '@hola/sdk';
 import type { GetCatalogAppsResponse } from '@hola/shared';
 
+import { maybeNotifyUpdate } from '../../lib/update-notice';
+
 export interface CatalogOptions {
   category?: string;
   limit?: number | string;
@@ -30,6 +32,7 @@ export async function runCatalog(
 
     if (!res.items.length) {
       console.log('No apps found. (Is HOLA_CATALOG_URL set on the server?)');
+      await maybeNotifyUpdate(sdk, opts);
       return;
     }
 
@@ -38,6 +41,7 @@ export async function runCatalog(
       console.log(`${(app.icon || '📦')} ${app.id.padEnd(idWidth)}  ${app.description}`);
     }
     console.log(`\n${res.total} app(s). Install with: hola install <id>`);
+    await maybeNotifyUpdate(sdk, opts);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.error(`Catalog list failed: ${msg}`);

--- a/packages/cli/src/commands/deployments/actions.ts
+++ b/packages/cli/src/commands/deployments/actions.ts
@@ -2,6 +2,7 @@ import { HolaSdk } from '@hola/sdk';
 import type { GetDeploymentResponse, PostDeploymentActionResponse, RollbackResponse } from '@hola/shared';
 
 import { watchJob, reportDeployError } from '../../lib/deploy-flow';
+import { maybeNotifyUpdate } from '../../lib/update-notice';
 import { clackPrompter, PromptCancelled, type Prompter } from '../../install/prompter';
 
 export interface ActionOptions {
@@ -36,6 +37,7 @@ export async function runDeploymentAction(
       out(status ? `Done (${status}).` : 'Done.');
     }
     if (status === 'failed') process.exitCode = 1;
+    await maybeNotifyUpdate(sdk, opts);
     return { jobId: res.jobId, status };
   } catch (err) {
     return reportDeployError(err);
@@ -77,6 +79,7 @@ export async function runRollback(
       out(status ? `Done (${status}).` : 'Done.');
     }
     if (status === 'failed') process.exitCode = 1;
+    await maybeNotifyUpdate(sdk, opts);
     return res;
   } catch (err) {
     return reportDeployError(err);
@@ -133,6 +136,7 @@ export async function runUninstall(
     } else {
       out(`Uninstalled ${name}.`);
     }
+    await maybeNotifyUpdate(sdk, opts);
     return { uninstalled: deploymentId };
   } catch (err) {
     if (err instanceof PromptCancelled) {

--- a/packages/cli/src/commands/deployments/deployments.ts
+++ b/packages/cli/src/commands/deployments/deployments.ts
@@ -3,6 +3,7 @@ import { API } from '@hola/shared';
 import type { GetDeploymentsResponse } from '@hola/shared';
 
 import { streamSSE } from '../../lib/sse';
+import { maybeNotifyUpdate } from '../../lib/update-notice';
 
 export interface DeploymentsListOptions {
   status?: string;
@@ -27,6 +28,7 @@ export async function runDeploymentsList(
     }
     if (!res.items.length) {
       console.log('No deployments.');
+      await maybeNotifyUpdate(sdk, opts);
       return;
     }
     const idWidth = Math.max(2, ...res.items.map(d => d.id.length));
@@ -36,6 +38,7 @@ export async function runDeploymentsList(
       console.log(`${d.id.padEnd(idWidth)}  ${d.name.padEnd(nameWidth)}  ${d.status.padEnd(10)}${url}`);
     }
     console.log(`\n${res.total} deployment(s).`);
+    await maybeNotifyUpdate(sdk, opts);
   } catch (err) {
     reportListError(err);
   }
@@ -70,11 +73,13 @@ export async function runDeploymentLogs(
     const entries = res.entries ?? [];
     if (!entries.length) {
       console.log('No logs.');
+      await maybeNotifyUpdate(sdk, opts);
       return;
     }
     for (const e of entries) {
       console.log(`${e.timestamp ? `${e.timestamp} ` : ''}${e.message ?? ''}`);
     }
+    await maybeNotifyUpdate(sdk, opts);
   } catch (err) {
     reportListError(err);
   }

--- a/packages/cli/src/commands/install/install.ts
+++ b/packages/cli/src/commands/install/install.ts
@@ -2,6 +2,7 @@ import { HolaSdk } from '@hola/sdk';
 import type { CreateDraftResponse, GetDraftResponse, AppEnvVar } from '@hola/shared';
 
 import { finalizeAndDeploy, reportDeployError, type DeployResult } from '../../lib/deploy-flow';
+import { maybeNotifyUpdate } from '../../lib/update-notice';
 
 export interface InstallOptions {
   /** From `--app-version`. Not `--version` — that's sade's global flag and never reaches us. */
@@ -80,6 +81,7 @@ export async function runInstall(
     if (opts.json) console.log(JSON.stringify(result, null, 2));
     else out(`Done. ${appId} → job status: ${result.status}`);
     if (result.status === 'failed' || result.status === 'error') process.exitCode = 1;
+    await maybeNotifyUpdate(sdk, opts);
     return result;
   } catch (err) {
     return reportDeployError(err);

--- a/packages/cli/src/commands/update/update.ts
+++ b/packages/cli/src/commands/update/update.ts
@@ -1,0 +1,471 @@
+import { isNewerVersion } from '@hola/shared';
+
+import { clackPrompter, PromptCancelled, type Prompter } from '../../install/prompter';
+import { parseEnv } from '../../install/render-env';
+import { systemRunner, type Runner } from '../../lib/runner';
+import { createSpinner, formatComposeLine, parseComposePs, renderContainerTable, colors } from '../../lib/ui';
+import { CLI_VERSION } from '../../version';
+
+export interface UpdateOptions {
+  host?: string;
+  repo?: string;
+  ref?: string;
+  /** Override the compose-bundle download URL (defaults to the release asset for this CLI version). */
+  tarballUrl?: string;
+  dir?: string;
+  /** For an explicit HOLA_AUTH_MODE=none host: turn SSO on as part of the upgrade. */
+  enableSso?: boolean;
+  /** For an explicit HOLA_AUTH_MODE=none host: keep it off (suppress the prompt/warning). */
+  keepAuthMode?: boolean;
+  /** Report versions (CLI / installed / latest release) without changing anything. */
+  check?: boolean;
+  dryRun?: boolean;
+  json?: boolean;
+}
+
+export interface UpdateResult {
+  host: string;
+  dir: string;
+  ref: string;
+  /** The version the host was on before the upgrade (null if it couldn't be read). */
+  fromVersion: string | null;
+  /** The version the host was upgraded to. */
+  toVersion: string;
+  /** What was decided about SSO reconciliation (for an explicit `none` host). */
+  ssoAction?: 'enabled' | 'kept-none' | 'already-on' | 'backfilled';
+  steps: string[];
+}
+
+export interface UpdateCheckReport {
+  host: string;
+  cli: string;
+  /** The version installed on the host (from its VERSION file), or null. */
+  installed: string | null;
+  /** Newest published release, or null if the lookup failed. */
+  latest: string | null;
+  updateAvailable: boolean;
+  /** CLI is newer than the running server — an upgrade would close the skew. */
+  skew: boolean;
+  releaseUrl: string | null;
+}
+
+class UpdateAbort extends Error {}
+
+const DEFAULT_REPO = 'https://github.com/try-hola/hola.git';
+const DEFAULT_DIR = '/opt/hola';
+
+const VERSION_MARKER = '__HOLA_VERSION__=';
+const EXAMPLE_MARKER = '__HOLA_EXAMPLE__';
+const ENV_MARKER = '__HOLA_ENV__';
+
+/** Keys install.sh / compose generate or derive on their own — never "missing" config. */
+const AUTO_MANAGED = /^(AUTHENTIK_|COMPOSE_)/;
+function isAutoManaged(key: string): boolean {
+  return AUTO_MANAGED.test(key) || key === 'HOLA_AUTHENTIK_PUBLIC_URL' || key === 'HOLA_AUTHENTIK_URL';
+}
+
+/** Strip a leading `cli-v` from a release tag to get the bare version (cli-v0.3.0 → 0.3.0). */
+function versionFromRef(ref: string): string {
+  return ref.startsWith('cli-v') ? ref.slice('cli-v'.length) : ref;
+}
+
+/** Derive the GitHub release-download base from a clone URL (…/hola.git → …/hola). */
+function releaseBase(repo: string): string {
+  return repo.replace(/\.git$/, '');
+}
+
+/** Derive the GitHub API releases URL from a clone URL (…/owner/repo.git → api.github.com/repos/owner/repo/releases). */
+function releasesApiUrl(repo: string): string | null {
+  const m = repo.replace(/\.git$/, '').match(/github\.com[/:]([^/]+)\/([^/]+)$/);
+  if (!m) return null;
+  return `https://api.github.com/repos/${m[1]}/${m[2]}/releases?per_page=30`;
+}
+
+interface GitHubRelease {
+  tag_name: string;
+  html_url: string;
+  draft: boolean;
+  prerelease: boolean;
+}
+
+/**
+ * Newest stable `cli-v*` release (version + notes URL), or null on any failure.
+ * Fail-safe so an offline/rate-limited check never blocks or misreports.
+ */
+async function fetchLatestRelease(
+  repo: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<{ version: string; url: string } | null> {
+  const api = releasesApiUrl(repo);
+  if (!api) return null;
+  try {
+    const res = await fetchImpl(api, {
+      headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'hola-cli' },
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) return null;
+    const releases = (await res.json()) as GitHubRelease[];
+    if (!Array.isArray(releases)) return null;
+    let best: { version: string; url: string } | null = null;
+    for (const r of releases) {
+      if (r.draft || r.prerelease) continue;
+      if (typeof r.tag_name !== 'string' || !r.tag_name.startsWith('cli-v')) continue;
+      const version = r.tag_name.slice('cli-v'.length);
+      if (!best || isNewerVersion(version, best.version)) best = { version, url: r.html_url };
+    }
+    return best;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Config-preserving in-place upgrade of an existing install to the invoking CLI's
+ * version. Over SSH it preflights the host, reads the current `.env`/VERSION,
+ * reconciles the auth mode to the Authentik-default baseline (prompting/flag-gated
+ * for an explicit `none`), downloads the version-pinned bundle and extracts it over
+ * the install dir WITHOUT touching `.env` or the ACME store, re-runs the idempotent
+ * installer (which backfills newly-required keys and recreates changed services),
+ * and reports old → new. Returns the result, or undefined on failure.
+ */
+export async function runUpdate(
+  opts: UpdateOptions,
+  injected?: {
+    prompter?: Prompter;
+    runner?: Runner;
+    /** Injectable release lookup for tests / `--check`. */
+    fetchLatest?: (repo: string) => Promise<{ version: string; url: string } | null>;
+  },
+): Promise<UpdateResult | UpdateCheckReport | undefined> {
+  const prompter = injected?.prompter ?? clackPrompter();
+  const runner = injected?.runner ?? systemRunner();
+  const fetchLatest = injected?.fetchLatest ?? ((repo: string) => fetchLatestRelease(repo));
+  const out = (msg: string) => { if (!opts.json) console.log(msg); };
+
+  const host = opts.host;
+  const repo = opts.repo ?? DEFAULT_REPO;
+  const ref = opts.ref ?? `cli-v${CLI_VERSION}`;
+  const version = versionFromRef(ref);
+  const dir = opts.dir ?? DEFAULT_DIR;
+  const composeDir = dir;
+  const tarballUrl = opts.tarballUrl ?? `${releaseBase(repo)}/releases/download/${ref}/hola-compose-${version}.tar.gz`;
+  const steps: string[] = [];
+
+  try {
+    if (!host) throw new UpdateAbort('--host user@vm is required.');
+    if (opts.enableSso && opts.keepAuthMode) {
+      throw new UpdateAbort('--enable-sso and --keep-auth-mode are mutually exclusive.');
+    }
+
+    // Helper: run a remote step (or describe it under --dry-run).
+    const ssh = async (title: string, cmd: string, o?: { input?: string; stream?: boolean }) => {
+      steps.push(title);
+      if (opts.dryRun) {
+        out(`# ${title}`);
+        out(`  ssh ${host} ${cmd}`);
+        return { code: 0, stdout: '', stderr: '' };
+      }
+      out(colors.dim(`==> ${title}`));
+      return runner.ssh(host, cmd, {
+        input: o?.input,
+        stream: o?.stream ? (l) => out(`  ${l}`) : undefined,
+      });
+    };
+
+    // --- `--check`: read the installed version + latest release, report, exit. ---
+    if (opts.check) {
+      const read = await runner.ssh(host, `cat ${composeDir}/VERSION 2>/dev/null | tr -d ' \\t\\r\\n'`);
+      if (read.code !== 0) throw new UpdateAbort(`Could not connect to ${host} (ssh exit ${read.code}).`);
+      const installed = read.stdout.trim() || null;
+      const latest = await fetchLatest(repo);
+      const report: UpdateCheckReport = {
+        host,
+        cli: CLI_VERSION,
+        installed,
+        latest: latest?.version ?? null,
+        updateAvailable: !!(latest && installed && isNewerVersion(latest.version, installed)),
+        skew: !!(installed && isNewerVersion(CLI_VERSION, installed)),
+        releaseUrl: latest?.url ?? null,
+      };
+      if (opts.json) {
+        console.log(JSON.stringify(report, null, 2));
+      } else {
+        out(`CLI version:       ${colors.bold(report.cli)}`);
+        out(`Installed (host):  ${colors.bold(report.installed ?? 'unknown')}`);
+        out(`Latest release:    ${colors.bold(report.latest ?? 'unavailable')}`);
+        if (report.updateAvailable) {
+          out(`\n${colors.yellow('A newer Hola version')} (${colors.bold(report.latest!)}) is available.`);
+          out(`Run ${colors.cyan(`hola update --host ${host}`)} to upgrade.`);
+        } else if (report.skew) {
+          out(`\n${colors.yellow('Version skew:')} the server (${report.installed}) is older than your CLI (${report.cli}).`);
+          out(`Run ${colors.cyan(`hola update --host ${host}`)} to bring it up to the CLI's version.`);
+        } else {
+          out(`\n${colors.green('✔')} Up to date.`);
+        }
+      }
+      return report;
+    }
+
+    // 1) Preflight (single remote probe → key=value lines). The host pulls
+    //    prebuilt images, so it needs docker + compose + curl/tar — but not git.
+    const probe =
+      'for c in docker curl tar; do command -v "$c" >/dev/null 2>&1 && echo "$c=ok" || echo "$c=missing"; done; ' +
+      'docker compose version >/dev/null 2>&1 && echo compose=ok || echo compose=missing; ' +
+      'docker ps >/dev/null 2>&1 && echo dockerperm=ok || echo dockerperm=fail';
+    if (opts.dryRun) {
+      await ssh('Preflight host', probe);
+    } else {
+      const r = await ssh('Preflight host', probe);
+      if (r.code !== 0) throw new UpdateAbort(`Could not connect to ${host} (ssh exit ${r.code}).`);
+      const p = parsePreflight(r.stdout);
+      assertPreflight(p);
+      out('  host OK (docker, compose, curl/tar, permissions)');
+    }
+
+    // 2) Read the current install: its .env (for the deployment config + auth mode)
+    //    and VERSION (the old version, for the old → new report). One round trip.
+    let config: Record<string, string> = {};
+    let fromVersion: string | null = null;
+    let oldExampleKeys: string[] = [];
+    if (opts.dryRun) {
+      await ssh('Read current install', readStateCmd(composeDir));
+    } else {
+      const read = await ssh('Read current install', readStateCmd(composeDir));
+      if (read.code !== 0) throw new UpdateAbort(`Could not connect to ${host} (ssh exit ${read.code}).`);
+      const parsed = parseState(read.stdout);
+      if (!parsed.hasEnv) {
+        throw new UpdateAbort(
+          `No Hola install found at ${composeDir}/.env on ${host}.\n` +
+            `Install first with: hola bootstrap --host ${host}` + (opts.dir ? ` --dir ${opts.dir}` : ''),
+        );
+      }
+      config = parsed.config;
+      fromVersion = parsed.version;
+      oldExampleKeys = parsed.exampleKeys;
+      out(`  found install ${fromVersion ? colors.bold(`v${fromVersion}`) : colors.dim('(version unknown)')} at ${composeDir}`);
+    }
+
+    // 3) Reconcile auth mode to the Authentik-default baseline (issue #149). An
+    //    unset/blank mode is backfilled automatically by install.sh (no-op here);
+    //    an EXPLICIT `none` is surfaced and gated on a choice (flag or prompt).
+    let ssoAction: UpdateResult['ssoAction'];
+    const rawMode = (config.HOLA_AUTH_MODE ?? '').trim();
+    if (rawMode === 'authentik') {
+      ssoAction = 'already-on';
+    } else if (rawMode === '' ) {
+      // install.sh defaults blank → authentik and generates the secrets idempotently.
+      if (!opts.dryRun) {
+        ssoAction = 'backfilled';
+        out(`  ${colors.dim('SSO not set — install.sh will enable Authentik (the default) and generate secrets.')}`);
+      }
+    } else if (rawMode === 'none') {
+      const decision = await decideSso(opts, prompter);
+      if (decision === 'enable') {
+        const authDomain =
+          config.HOLA_AUTHENTIK_DOMAIN?.trim() ||
+          (config.HOLA_BASE_DOMAIN?.trim() ? `auth.${config.HOLA_BASE_DOMAIN.trim()}` : '');
+        if (!authDomain) {
+          throw new UpdateAbort(
+            'Cannot enable SSO: no HOLA_AUTHENTIK_DOMAIN and no HOLA_BASE_DOMAIN to derive it from.',
+          );
+        }
+        // Flip the mode + domain in the host .env BEFORE install.sh runs, so it
+        // generates the Authentik secrets and activates the profile this pass.
+        const setEnv = await ssh(
+          'Enable SSO (set auth mode + Authentik domain)',
+          envSetCmd(composeDir, [['HOLA_AUTH_MODE', 'authentik'], ['HOLA_AUTHENTIK_DOMAIN', authDomain]]),
+        );
+        if (!opts.dryRun && setEnv.code !== 0) throw new UpdateAbort(`Updating ${composeDir}/.env failed (exit ${setEnv.code}).`);
+        ssoAction = 'enabled';
+        out(`  ${colors.yellow('Enabling Authentik SSO')} (login at https://${authDomain}; pulls in ~2 GB of services).`);
+      } else {
+        ssoAction = 'kept-none';
+        out(`  ${colors.dim('Keeping HOLA_AUTH_MODE=none. SSO is now the standard — re-run with --enable-sso to turn it on.')}`);
+      }
+    }
+
+    // 4) Download + extract the version-pinned bundle over the install dir. The
+    //    tarball carries scripts/compose/.env.example/VERSION but NOT .env or
+    //    traefik/acme — extracting over the dir preserves the operator's config
+    //    and the ACME cert store. The dir already exists (we just read its .env).
+    const fetchStack = `set -e; curl -fsSL ${tarballUrl} | tar xz -C ${dir}`;
+    const fetchRes = await ssh(`Download Hola ${version} stack into ${composeDir}`, fetchStack, { stream: true });
+    if (!opts.dryRun && fetchRes.code !== 0) {
+      throw new UpdateAbort(
+        `Downloading the compose bundle failed (exit ${fetchRes.code}). ` +
+          `Check that release ${ref} exists and the host can reach ${tarballUrl}.`,
+      );
+    }
+
+    // 5) Config drift: surface keys this RELEASE newly introduced (new bundle's
+    //    .env.example minus the old one) that have no safe default and aren't on
+    //    the host — i.e. a genuinely new *required* setting install.sh can't fill.
+    //    Auto-managed keys (AUTHENTIK_*/COMPOSE_*, generated by install.sh) and
+    //    keys that ship a default value in the example are intentionally excluded.
+    if (!opts.dryRun) {
+      const ex = await ssh('Check config drift (.env.example vs .env)', `cat ${composeDir}/.env.example 2>/dev/null`);
+      const concerning = newRequiredKeys(ex.stdout, oldExampleKeys, config);
+      if (concerning.length) {
+        out(`  ${colors.yellow('New required config')} in this release with no default and not in your .env: ${concerning.join(', ')}`);
+        out(`  ${colors.dim('Set these after the upgrade if the affected service misbehaves.')}`);
+      }
+    }
+
+    // 6) Re-run the idempotent installer: it backfills newly-required keys, pulls
+    //    the new pinned images, and recreates only the changed services. State in
+    //    the hola-data volume is preserved. HOLA_BOOTSTRAP=1 silences its hints.
+    steps.push('Run install.sh');
+    const installCmd = `cd ${composeDir} && HOLA_BOOTSTRAP=1 ./scripts/install.sh`;
+    if (opts.dryRun) {
+      out('# Run install.sh');
+      out(`  ssh ${host} ${installCmd}`);
+    } else {
+      const spin = opts.json ? null : createSpinner('Upgrading — pulling images, recreating services…');
+      const installRes = await runner.ssh(host, installCmd, {
+        stream: spin ? (l) => { const f = formatComposeLine(l); if (f) spin.update(f); } : undefined,
+      });
+      if (installRes.code !== 0) {
+        spin?.fail('Upgrade failed.');
+        throw new UpdateAbort(`install.sh failed (exit ${installRes.code}).`);
+      }
+      spin?.succeed(colors.green('Stack is up.'));
+
+      if (!opts.json) {
+        const ps = await runner.ssh(host, `cd ${composeDir} && docker compose ps --format json 2>/dev/null`);
+        const table = renderContainerTable(parseComposePs(ps.stdout));
+        if (table) out(`\n${table}\n`);
+      }
+    }
+
+    const result: UpdateResult = { host, dir, ref, fromVersion, toVersion: version, ssoAction, steps };
+    if (opts.json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else if (opts.dryRun) {
+      out('\nDry run — no connection was made. Re-run without --dry-run to execute.');
+    } else {
+      const span = fromVersion && fromVersion !== version ? `${colors.bold(`v${fromVersion}`)} → ${colors.bold(`v${version}`)}` : colors.bold(`v${version}`);
+      out(`\n${colors.green('✔ Done.')} ${colors.bold(host)} is now on ${span}.`);
+      if (ssoAction === 'enabled') out(`  SSO provisioning runs on first boot; retrieve sign-in with ${colors.cyan(`hola credentials --host ${host}`)}.`);
+    }
+    return result;
+  } catch (err) {
+    if (err instanceof UpdateAbort || err instanceof PromptCancelled) {
+      console.error(err.message);
+      process.exitCode = 1;
+      return undefined;
+    }
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`update failed: ${msg}`);
+    if (/ENOENT|spawn ssh/i.test(msg)) console.error('Hint: the `ssh` client must be installed and on PATH.');
+    process.exitCode = 1;
+    return undefined;
+  }
+}
+
+/** Decide SSO handling for an explicit `none` host: flags win; else prompt; else (scripted) require a flag. */
+async function decideSso(opts: UpdateOptions, prompter: Prompter): Promise<'enable' | 'keep'> {
+  if (opts.enableSso) return 'enable';
+  if (opts.keepAuthMode) return 'keep';
+  // Non-interactive (scripted) runs must choose explicitly — never silently flip a
+  // ~2 GB stack on, nor silently leave a host off the new standard.
+  if (opts.json) {
+    throw new UpdateAbort(
+      'This host has HOLA_AUTH_MODE=none. SSO (Authentik) is now the standard.\n' +
+        'Re-run with --enable-sso to turn it on, or --keep-auth-mode to keep it off.',
+    );
+  }
+  const ans = await prompter.prompt({
+    key: '_enable_sso',
+    type: 'confirm',
+    message: 'SSO (Authentik) is now standard but this host has it off. Enable it now? (~2 GB of services)',
+    default: 'false',
+  });
+  return ans === 'true' ? 'enable' : 'keep';
+}
+
+/** Remote command that prints the install's VERSION, old .env.example, and .env behind markers, in one read. */
+function readStateCmd(dir: string): string {
+  return (
+    `printf '%s' '${VERSION_MARKER}'; cat ${dir}/VERSION 2>/dev/null | tr -d ' \\t\\r\\n'; ` +
+    `printf '\\n%s\\n' '${EXAMPLE_MARKER}'; cat ${dir}/.env.example 2>/dev/null; ` +
+    `printf '\\n%s\\n' '${ENV_MARKER}'; cat ${dir}/.env 2>/dev/null`
+  );
+}
+
+/** Parse readStateCmd output into the version, the pre-upgrade .env.example keys, and the parsed .env. */
+function parseState(
+  stdout: string,
+): { version: string | null; config: Record<string, string>; exampleKeys: string[]; hasEnv: boolean } {
+  const exIdx = stdout.indexOf(`\n${EXAMPLE_MARKER}\n`);
+  const envIdx = stdout.indexOf(`\n${ENV_MARKER}\n`);
+  let version: string | null = null;
+  let exampleText = '';
+  let envText = stdout;
+  if (exIdx >= 0 && envIdx > exIdx) {
+    const vLine = stdout.slice(0, exIdx).split('\n').find((l) => l.startsWith(VERSION_MARKER));
+    version = (vLine ? vLine.slice(VERSION_MARKER.length).trim() : '') || null;
+    exampleText = stdout.slice(exIdx + EXAMPLE_MARKER.length + 2, envIdx);
+    envText = stdout.slice(envIdx + ENV_MARKER.length + 2);
+  } else if (envIdx >= 0) {
+    // Older host with no .env.example to compare against — still recover the env.
+    envText = stdout.slice(envIdx + ENV_MARKER.length + 2);
+  }
+  const config = parseEnv(envText);
+  return { version, config, exampleKeys: Object.keys(parseEnv(exampleText)), hasEnv: Object.keys(config).length > 0 };
+}
+
+/** Idempotent remote env_set (mirrors install.sh): replace/append each KEY=VALUE in .env. */
+function envSetCmd(dir: string, pairs: [string, string][]): string {
+  const fn =
+    `cd ${dir} && set -e; ` +
+    `_set() { tmp=$(mktemp); grep -vE "^$1=" .env > "$tmp" 2>/dev/null || true; printf '%s=%s\\n' "$1" "$2" >> "$tmp"; mv "$tmp" .env; }; `;
+  const calls = pairs.map(([k, v]) => `_set ${k} ${v}`).join('; ');
+  return fn + calls;
+}
+
+/**
+ * Keys this release newly introduced (in the new .env.example but not the old one)
+ * that have NO default value in the example, aren't auto-generated by install.sh,
+ * and aren't already on the host — i.e. a genuinely new required setting the
+ * operator must supply. Empty on a same-version re-run.
+ */
+function newRequiredKeys(newExample: string, oldExampleKeys: string[], config: Record<string, string>): string[] {
+  const old = new Set(oldExampleKeys);
+  const newMap = parseEnv(newExample);
+  return Object.keys(newMap).filter(
+    (k) => !old.has(k) && newMap[k] === '' && !(k in config) && !isAutoManaged(k),
+  );
+}
+
+function parsePreflight(stdout: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const line of stdout.split('\n')) {
+    const t = line.trim();
+    const eq = t.indexOf('=');
+    if (eq > 0) out[t.slice(0, eq)] = t.slice(eq + 1);
+  }
+  return out;
+}
+
+function assertPreflight(p: Record<string, string>): void {
+  if (p.docker !== 'ok' || p.compose !== 'ok') {
+    throw new UpdateAbort(
+      'Docker + the Compose v2 plugin are required on the host. Install with:\n' +
+        '  curl -fsSL https://get.docker.com | sh\n' +
+        'then re-run update.',
+    );
+  }
+  if (p.dockerperm !== 'ok') {
+    throw new UpdateAbort(
+      "This SSH user can't run docker. Add them to the docker group:\n" +
+        '  sudo usermod -aG docker $USER   (then reconnect)\n' +
+        'then re-run update.',
+    );
+  }
+  if (p.curl !== 'ok' || p.tar !== 'ok') {
+    throw new UpdateAbort(
+      'curl and tar are required on the host to download the compose bundle ' +
+        '(e.g. `sudo apt-get install -y curl tar`), then re-run update.',
+    );
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -48,6 +48,25 @@ prog
     await runBootstrap(camelKeys(opts));
   });
 
+// update — upgrade an existing install to this CLI's version (config-preserving, no wizard)
+prog
+  .command('update')
+  .describe('Upgrade an existing host to this CLI’s version over SSH — no wizard, preserves .env')
+  .option('--host', 'Target host, e.g. user@vm (required)')
+  .option('--repo', 'Hola repo to download release assets from', 'https://github.com/try-hola/hola.git')
+  .option('--ref', `Release tag to install (default cli-v${CLI_VERSION})`)
+  .option('--tarball-url', 'Override the compose-bundle download URL (advanced)')
+  .option('--dir', 'Install directory on the host', '/opt/hola')
+  .option('--enable-sso', 'For a HOLA_AUTH_MODE=none host: enable Authentik SSO (the new standard)', false)
+  .option('--keep-auth-mode', 'For a HOLA_AUTH_MODE=none host: keep SSO off (no prompt)', false)
+  .option('--check', 'Report CLI / installed / latest versions without changing anything', false)
+  .option('--dry-run', 'Print the plan without connecting', false)
+  .option('--json', 'Print the result as JSON', false)
+  .action(async (opts) => {
+    const { runUpdate } = await load(import('./commands/update/update'));
+    await runUpdate(camelKeys(opts));
+  });
+
 // teardown — remove a Hola deployment from a host over SSH (inverse of bootstrap)
 prog
   .command('teardown')

--- a/packages/cli/src/lib/update-notice.ts
+++ b/packages/cli/src/lib/update-notice.ts
@@ -1,0 +1,49 @@
+// A best-effort "an upgrade is available" notice appended to the end of any
+// command that already talks to the server. It reuses the command's SDK (so it
+// hits the same host with the same cached server-side check the web dashboard
+// uses), prints at most one line to STDERR, and NEVER affects the command's
+// output, exit code, or success — every failure is swallowed.
+
+import type { HolaSdk } from '@hola/sdk';
+import { isNewerVersion, type GetUpdateCheckResponse } from '@hola/shared';
+
+import { CLI_VERSION } from '../version';
+import { colors } from './ui';
+
+/**
+ * Build the one-line notice for an update-check result, or null when nothing is
+ * worth saying. Prefers the "newer release exists" message; otherwise flags the
+ * case where this CLI is ahead of the running server (a `hola update` would close
+ * the skew). Pure + exported so it can be unit-tested without a network.
+ */
+export function updateNoticeLine(res: GetUpdateCheckResponse): string | null {
+  if (res.updateAvailable && res.latest) {
+    return colors.yellow(
+      `A newer Hola version (${res.latest}) is available — the server is on ${res.current}. ` +
+        'Run `hola update --host …` to upgrade.',
+    );
+  }
+  if (res.current && isNewerVersion(CLI_VERSION, res.current)) {
+    return colors.yellow(
+      `Your CLI (${CLI_VERSION}) is newer than the server (${res.current}). ` +
+        'Run `hola update --host …` to upgrade the server.',
+    );
+  }
+  return null;
+}
+
+/**
+ * Fetch the server's (cached) update-check and print a one-line notice. No-op
+ * under `--json` (keeps machine output clean) or when HOLA_NO_UPDATE_NOTICE is
+ * set, and silent on any error so it can be called unconditionally on success.
+ */
+export async function maybeNotifyUpdate(sdk: HolaSdk, opts: { json?: boolean }): Promise<void> {
+  if (opts.json || process.env.HOLA_NO_UPDATE_NOTICE) return;
+  try {
+    const res = (await sdk.system.updateCheck()) as GetUpdateCheckResponse;
+    const line = updateNoticeLine(res);
+    if (line) console.error(`\n${line}`);
+  } catch {
+    // Best-effort: a version check must never change a command's outcome.
+  }
+}

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -166,12 +166,27 @@ still pass explicit `-f` flags either way.
 
 ## Upgrade
 
-The supported upgrade path is `hola bootstrap` with a newer CLI — it downloads the new bundle
-(which pins the new image tags) and re-runs the idempotent installer. On the host directly:
+The supported upgrade path is `hola update` with a newer CLI — config-preserving and
+no wizard:
 
 ```bash
-cd packages/compose
-./scripts/up.sh --pull always   # pull the version-pinned images and recreate changed services
+hola update --host user@your-vm          # upgrade to the CLI's version (add --dry-run to preview)
+hola update --host user@your-vm --check  # report CLI / installed / latest versions only
+```
+
+It downloads the new version-pinned bundle, extracts it over the install dir **without
+touching `.env` or `traefik/acme`**, and re-runs the idempotent installer (pull new images,
+backfill newly-required `.env` keys, recreate changed services). Keep the same `--dir` so the
+dir-relative ACME cert store carries forward. A pre-0.6.23 `HOLA_AUTH_MODE=none` host is
+surfaced — pass `--enable-sso` or `--keep-auth-mode` to choose; an unset mode is reconciled to
+the Authentik default automatically.
+
+On the host directly:
+
+```bash
+cd /opt/hola                              # the install dir
+curl -fsSL <bundle-url> | tar xz -C .     # extract the new bundle over the dir
+HOLA_BOOTSTRAP=1 ./scripts/install.sh     # idempotent: pulls images, recreates changed services
 ```
 
 (From a source checkout, `git pull` then `HOLA_BUILD=1 ./scripts/up.sh --build` to rebuild locally.)

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -13,7 +13,9 @@ import {
   RollbackRequest, RollbackResponse, GetDeploymentHistoryResponse,
   // Catalog types
   GetCatalogAppsRequest, GetCatalogAppsResponse, GetCatalogAppResponse,
-  GetCatalogAppVersionsResponse, GetCatalogAppVersionDetailResponse
+  GetCatalogAppVersionsResponse, GetCatalogAppVersionDetailResponse,
+  // System types
+  GetUpdateCheckResponse
 } from '@hola/shared';
 
 export type SdkInitOptions = {
@@ -126,6 +128,7 @@ export class HolaSdk {
   system = {
     status: () => this.get(API.system.status),
     health: () => this.get(API.system.health),
+    updateCheck: () => this.get<GetUpdateCheckResponse>(API.system.updateCheck),
   };
 }
 

--- a/packages/server/src/__tests__/system/update-check.test.ts
+++ b/packages/server/src/__tests__/system/update-check.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Update-check service + shared version comparison.
+ *
+ * The service does a cached, fail-safe GitHub release lookup. We drive it with an
+ * injected `fetch` and clock so there's no real network or wall-clock dependency.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { compareVersions, isNewerVersion } from '@hola/shared';
+import { RealUpdateCheckService } from '../../services/core/update-check';
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return { ok, status, json: async () => body } as unknown as Response;
+}
+
+const RELEASES = [
+  { tag_name: 'cli-v0.6.25', html_url: 'https://gh/0.6.25', draft: false, prerelease: false },
+  { tag_name: 'cli-v0.7.0-rc.1', html_url: 'https://gh/0.7.0rc', draft: false, prerelease: true },
+  { tag_name: 'cli-v0.6.20', html_url: 'https://gh/0.6.20', draft: false, prerelease: false },
+  { tag_name: 'cli-v0.9.0', html_url: 'https://gh/0.9.0', draft: true, prerelease: false },
+  { tag_name: 'v-not-a-cli-tag', html_url: 'https://gh/x', draft: false, prerelease: false },
+];
+
+describe('compareVersions / isNewerVersion', () => {
+  it('orders numeric cores correctly', () => {
+    expect(compareVersions('0.6.23', '0.6.20')).toBeGreaterThan(0);
+    expect(compareVersions('0.6.2', '0.6.20')).toBeLessThan(0);
+    expect(compareVersions('1.0.0', '0.99.99')).toBeGreaterThan(0);
+    expect(compareVersions('0.6.23', '0.6.23')).toBe(0);
+  });
+
+  it('treats a release as newer than its prerelease', () => {
+    expect(isNewerVersion('1.2.0', '1.2.0-rc.1')).toBe(true);
+    expect(isNewerVersion('1.2.0-rc.1', '1.2.0')).toBe(false);
+  });
+
+  it('tolerates leading v / cli-v and differing segment counts', () => {
+    expect(compareVersions('cli-v0.6.23', 'v0.6.23')).toBe(0);
+    expect(compareVersions('1.2', '1.2.0')).toBe(0);
+  });
+});
+
+describe('RealUpdateCheckService', () => {
+  it('reports an available update for the newest stable cli-v release', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(RELEASES));
+    const svc = new RealUpdateCheckService('0.6.20', { fetchImpl: fetchImpl as unknown as typeof fetch });
+    const res = await svc.check();
+    expect(res).toEqual({
+      current: '0.6.20',
+      latest: '0.6.25', // skips the prerelease 0.7.0-rc.1 and the draft 0.9.0
+      updateAvailable: true,
+      releaseUrl: 'https://gh/0.6.25',
+    });
+  });
+
+  it('reports up-to-date when current >= newest release', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(RELEASES));
+    const svc = new RealUpdateCheckService('0.6.25', { fetchImpl: fetchImpl as unknown as typeof fetch });
+    const res = await svc.check();
+    expect(res.updateAvailable).toBe(false);
+    expect(res.latest).toBe('0.6.25');
+  });
+
+  it('caches the result within the TTL (one outbound call)', async () => {
+    let t = 1000;
+    const fetchImpl = vi.fn(async () => jsonResponse(RELEASES));
+    const svc = new RealUpdateCheckService('0.6.20', {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      ttlMs: 60_000,
+      now: () => t,
+    });
+    await svc.check();
+    t += 30_000; // still within TTL
+    await svc.check();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    t += 40_000; // past TTL → refetch
+    await svc.check();
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('is fail-safe on a network error', async () => {
+    const fetchImpl = vi.fn(async () => { throw new Error('offline'); });
+    const svc = new RealUpdateCheckService('0.6.20', { fetchImpl: fetchImpl as unknown as typeof fetch });
+    const res = await svc.check();
+    expect(res).toEqual({ current: '0.6.20', latest: null, updateAvailable: false, releaseUrl: null });
+  });
+
+  it('is fail-safe on a non-OK response', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({}, false, 403));
+    const svc = new RealUpdateCheckService('0.6.20', { fetchImpl: fetchImpl as unknown as typeof fetch });
+    const res = await svc.check();
+    expect(res.updateAvailable).toBe(false);
+    expect(res.latest).toBeNull();
+  });
+});

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -38,6 +38,7 @@ import {
   type PatchBackupSettingsRequest,
   type PatchBackupSettingsResponse,
   type GetSystemStatusResponse,
+  type GetUpdateCheckResponse,
   type Job,
   type JobStatus,
   type RollbackRequest,
@@ -1302,6 +1303,17 @@ async function route(url: URL, req: Request): Promise<Response> {
     try {
       const services = getServices();
       const payload: GetSystemStatusResponse = await services.systemMonitoring.getSystemStatus();
+      return json(payload);
+    } catch (error) {
+      return errorResponse(req, error);
+    }
+  }
+
+  // Update-availability check (cached GitHub release lookup; shared by web + CLI)
+  if (pathname === API.system.updateCheck && req.method === 'GET') {
+    try {
+      const services = getServices();
+      const payload: GetUpdateCheckResponse = await services.updateCheck.check();
       return json(payload);
     } catch (error) {
       return errorResponse(req, error);

--- a/packages/server/src/services/core/system-monitoring.ts
+++ b/packages/server/src/services/core/system-monitoring.ts
@@ -35,6 +35,11 @@ const HOLA_VERSION: string = (() => {
   }
 })();
 
+/** The running Hola version (see HOLA_VERSION above). Shared with the update-check service. */
+export function getHolaVersion(): string {
+  return HOLA_VERSION;
+}
+
 export interface DiskUsage {
   freeBytes: number;
   totalBytes: number;

--- a/packages/server/src/services/core/update-check.ts
+++ b/packages/server/src/services/core/update-check.ts
@@ -1,0 +1,122 @@
+/**
+ * Update-availability check.
+ *
+ * The newest published Hola version is the latest `cli-v*` release of
+ * `try-hola/hola`. To keep many clients (web dashboard + every CLI talking to the
+ * host) from each hitting GitHub — and to make a single outbound call from the
+ * host — the server performs the check and caches the result with a TTL. The web
+ * banner and `hola update --check` both read this one cached answer.
+ *
+ * The check is fail-safe: any network/parse/rate-limit error resolves to
+ * `{ latest: null, updateAvailable: false }` so the dashboard never shows a false
+ * "update available" and never errors on an offline host.
+ */
+
+import { isNewerVersion, type UpdateCheckResult } from '@hola/shared';
+import { getLogger } from '../../lib/logger';
+import { getHolaVersion } from './system-monitoring';
+
+export interface UpdateCheckService {
+  /** Current version, newest release, and whether an upgrade is available. */
+  check(): Promise<UpdateCheckResult>;
+}
+
+/** GitHub releases for the repo Hola ships from. */
+const RELEASES_API = 'https://api.github.com/repos/try-hola/hola/releases?per_page=30';
+/** Cache TTL — releases are infrequent and we never want to hammer the API. */
+const DEFAULT_TTL_MS = 60 * 60 * 1000; // 1 hour
+/** Bound the outbound call so a slow/hung GitHub never blocks the endpoint. */
+const FETCH_TIMEOUT_MS = 5000;
+
+interface GitHubRelease {
+  tag_name: string;
+  html_url: string;
+  draft: boolean;
+  prerelease: boolean;
+}
+
+/**
+ * Real implementation: cached GitHub lookup. `fetchImpl` and `now` are injectable
+ * so tests can drive the cache and the network without real I/O.
+ */
+export class RealUpdateCheckService implements UpdateCheckService {
+  private logger = getLogger().child({ service: 'UpdateCheckService' });
+  private cache: { value: UpdateCheckResult; expires: number } | null = null;
+
+  constructor(
+    private readonly current: string = getHolaVersion(),
+    private readonly opts: {
+      ttlMs?: number;
+      fetchImpl?: typeof fetch;
+      now?: () => number;
+    } = {},
+  ) {}
+
+  async check(): Promise<UpdateCheckResult> {
+    const now = (this.opts.now ?? Date.now)();
+    if (this.cache && this.cache.expires > now) {
+      return this.cache.value;
+    }
+
+    const result = await this.fetchLatest();
+    const ttl = this.opts.ttlMs ?? DEFAULT_TTL_MS;
+    this.cache = { value: result, expires: now + ttl };
+    return result;
+  }
+
+  private async fetchLatest(): Promise<UpdateCheckResult> {
+    const fail = (reason: string, err?: unknown): UpdateCheckResult => {
+      this.logger.debug('Update check unavailable', { reason, error: err instanceof Error ? err.message : err });
+      return { current: this.current, latest: null, updateAvailable: false, releaseUrl: null };
+    };
+
+    try {
+      const doFetch = this.opts.fetchImpl ?? fetch;
+      const res = await doFetch(RELEASES_API, {
+        headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'hola-server' },
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      });
+      if (!res.ok) return fail(`HTTP ${res.status}`);
+
+      const releases = (await res.json()) as GitHubRelease[];
+      if (!Array.isArray(releases)) return fail('unexpected payload');
+
+      // Only stable `cli-v*` releases count (skip drafts and prereleases). Pick the
+      // newest by version, not by list order, so the answer is order-independent.
+      let best: { version: string; url: string } | null = null;
+      for (const r of releases) {
+        if (r.draft || r.prerelease) continue;
+        if (typeof r.tag_name !== 'string' || !r.tag_name.startsWith('cli-v')) continue;
+        const version = r.tag_name.slice('cli-v'.length);
+        if (!best || isNewerVersion(version, best.version)) {
+          best = { version, url: r.html_url };
+        }
+      }
+      if (!best) return fail('no stable cli-v release found');
+
+      return {
+        current: this.current,
+        latest: best.version,
+        updateAvailable: isNewerVersion(best.version, this.current),
+        releaseUrl: best.url,
+      };
+    } catch (err) {
+      return fail('fetch failed', err);
+    }
+  }
+}
+
+/** Mock for test/dev: no network. Defaults to "up to date"; override via constructor. */
+export class MockUpdateCheckService implements UpdateCheckService {
+  constructor(private readonly result?: Partial<UpdateCheckResult>) {}
+
+  async check(): Promise<UpdateCheckResult> {
+    return {
+      current: '1.0.0',
+      latest: '1.0.0',
+      updateAvailable: false,
+      releaseUrl: null,
+      ...this.result,
+    };
+  }
+}

--- a/packages/server/src/services/simple-factory.ts
+++ b/packages/server/src/services/simple-factory.ts
@@ -16,6 +16,7 @@ import { resolveAdminApiKey, createAdminApiKeyProvider } from './auth/api-key-co
 import { createOidcAuthProvider } from './auth/oidc-provider';
 import { RealDockerService, MockDockerService, type DockerService } from './core/docker';
 import { RealSystemMonitoringService, MockSystemMonitoringService, type SystemMonitoringService } from './core/system-monitoring';
+import { RealUpdateCheckService, MockUpdateCheckService, type UpdateCheckService } from './core/update-check';
 import { RealLoggingService, MockLoggingService, type LoggingService } from './core/logging';
 import { RealJobService, MockJobService, type JobService } from './core/jobs';
 import { RealCatalogService, MockCatalogService, type CatalogService } from './core/catalog';
@@ -38,6 +39,7 @@ export interface Services {
   auth: AuthService;
   docker: DockerService;
   systemMonitoring: SystemMonitoringService;
+  updateCheck: UpdateCheckService;
   logging: LoggingService;
   jobs: JobService;
   catalog: CatalogService;
@@ -77,6 +79,7 @@ export function createServices(env: ServiceEnvironment): Services {
       auth: new MockAuthService(),
       docker: new MockDockerService(),
       systemMonitoring: new MockSystemMonitoringService(),
+      updateCheck: new MockUpdateCheckService(),
       logging: new MockLoggingService(),
       jobs,
       catalog: new MockCatalogService(),
@@ -125,6 +128,7 @@ export function createServices(env: ServiceEnvironment): Services {
       auth: authService,
       docker,
       systemMonitoring,
+      updateCheck: new MockUpdateCheckService(),
       logging,
       jobs,
       catalog,
@@ -185,6 +189,7 @@ export function createServices(env: ServiceEnvironment): Services {
     auth: authService,
     docker,
     systemMonitoring,
+    updateCheck: new RealUpdateCheckService(),
     logging,
     jobs,
     catalog,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -68,11 +68,49 @@ export const API = {
   system: {
     status: '/api/system/status',
     health: '/api/system/health',
+    updateCheck: '/api/system/update-check',
     healthz: '/healthz',
     readyz: '/readyz',
     metrics: '/metrics',
   },
 } as const;
+
+// ------------------------------------------------------
+// Version comparison (shared by the server update-check and the CLI)
+// ------------------------------------------------------
+
+/**
+ * Compare two semver-ish version strings (e.g. `0.6.23`, `0.6.23-rc.1`). Returns
+ * a negative number if `a < b`, positive if `a > b`, and 0 if equal. Tolerant of
+ * a leading `v`/`cli-v` and of differing segment counts; a release ranks above a
+ * prerelease of the same numeric version (`1.2.0` > `1.2.0-rc.1`). Non-numeric
+ * release segments fall back to a string compare so it never throws.
+ */
+export function compareVersions(a: string, b: string): number {
+  const parse = (v: string) => {
+    const cleaned = v.trim().replace(/^cli-v/, '').replace(/^v/, '');
+    const [core, pre = ''] = cleaned.split('-', 2);
+    const nums = core.split('.').map((n) => parseInt(n, 10) || 0);
+    return { nums, pre };
+  };
+  const pa = parse(a);
+  const pb = parse(b);
+  const len = Math.max(pa.nums.length, pb.nums.length);
+  for (let i = 0; i < len; i++) {
+    const diff = (pa.nums[i] ?? 0) - (pb.nums[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  // Same numeric core: a release (no prerelease tag) outranks a prerelease.
+  if (!pa.pre && pb.pre) return 1;
+  if (pa.pre && !pb.pre) return -1;
+  if (pa.pre === pb.pre) return 0;
+  return pa.pre < pb.pre ? -1 : 1;
+}
+
+/** True when `candidate` is a strictly newer version than `current`. */
+export function isNewerVersion(candidate: string, current: string): boolean {
+  return compareVersions(candidate, current) > 0;
+}
 
 // ------------------------------------------------------
 // Common helpers
@@ -652,6 +690,26 @@ export type PatchBackupSettingsResponse = GetBackupSettingsResponse;
 // System status
 // ------------------------------------------------------
 export type GetSystemStatusResponse = SystemStatus;
+
+/**
+ * Result of the update-available check shared by the web dashboard and the CLI.
+ * The server computes this from its own pinned version vs. the newest published
+ * `cli-v*` release, caching the outbound GitHub call so many clients share one
+ * lookup. `latest`/`releaseUrl` are null when the check could not be performed
+ * (offline, rate-limited) — in that case `updateAvailable` is false (fail-safe).
+ */
+export type UpdateCheckResult = {
+  /** The version this server is running (its pinned image tag). */
+  current: string;
+  /** The newest published release version, or null if the check failed. */
+  latest: string | null;
+  /** True only when `latest` is a strictly newer version than `current`. */
+  updateAvailable: boolean;
+  /** Link to the latest release's notes, or null if unknown. */
+  releaseUrl: string | null;
+};
+
+export type GetUpdateCheckResponse = UpdateCheckResult;
 
 export type SystemHealthResponse = {
   healthStatus: Record<string, {

--- a/packages/web/src/__tests__/components/UpdateAvailableBanner.test.tsx
+++ b/packages/web/src/__tests__/components/UpdateAvailableBanner.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { UpdateAvailableBanner } from '../../components/UpdateAvailableBanner';
+import type { UpdateCheckResult } from '@hola/shared';
+
+const updateCheck = vi.fn();
+vi.mock('../../utils/api-hybrid', () => ({
+  api: { system: { updateCheck: () => updateCheck() } },
+}));
+
+function mockResult(result: UpdateCheckResult) {
+  updateCheck.mockResolvedValue(result);
+}
+
+describe('UpdateAvailableBanner', () => {
+  beforeEach(() => {
+    updateCheck.mockReset();
+  });
+
+  it('renders nothing when no update is available', async () => {
+    mockResult({ current: '1.0.0', latest: '1.0.0', updateAvailable: false, releaseUrl: null });
+    const { container } = render(<UpdateAvailableBanner />);
+    // Allow the mount-effect fetch to resolve.
+    await Promise.resolve();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when the update-check request fails', async () => {
+    updateCheck.mockRejectedValue(new Error('offline'));
+    const { container } = render(<UpdateAvailableBanner />);
+    await Promise.resolve();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows versions and a release link when an update is available', async () => {
+    mockResult({
+      current: '1.0.0',
+      latest: '1.2.0',
+      updateAvailable: true,
+      releaseUrl: 'https://example.com/releases/1.2.0',
+    });
+    render(<UpdateAvailableBanner />);
+
+    expect(await screen.findByText(/Hola 1\.2\.0/)).toBeInTheDocument();
+    expect(screen.getByText('1.0.0')).toBeInTheDocument();
+    const link = screen.getByRole('link', { name: /View release/ });
+    expect(link).toHaveAttribute('href', 'https://example.com/releases/1.2.0');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('hides after the dismiss button is clicked', async () => {
+    mockResult({ current: '1.0.0', latest: '1.2.0', updateAvailable: true, releaseUrl: null });
+    render(<UpdateAvailableBanner />);
+
+    const dismiss = await screen.findByLabelText('Dismiss update notification');
+    fireEvent.click(dismiss);
+    expect(screen.queryByText(/Hola 1\.2\.0/)).not.toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/UpdateAvailableBanner.tsx
+++ b/packages/web/src/components/UpdateAvailableBanner.tsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+import { ArrowUpCircle, ExternalLink, X } from 'lucide-react';
+import { useUpdateCheck } from '../hooks/useUpdateCheck';
+
+/**
+ * Dismissible banner shown when the server reports an available Hola update.
+ * Points operators at the CLI (`hola update`) — there is no in-app update action.
+ * Dismissal is session-only (local state, not persisted).
+ */
+export const UpdateAvailableBanner: React.FC = () => {
+  const { data } = useUpdateCheck();
+  const [dismissed, setDismissed] = useState(false);
+
+  if (!data?.updateAvailable || dismissed) return null;
+
+  return (
+    <div className="flex-none flex items-center gap-3 px-[22px] py-[10px] border-b border-warning/30 bg-warning/10 text-[13px]">
+      <ArrowUpCircle className="w-[18px] h-[18px] flex-none text-warning" />
+      <div className="min-w-0 flex-1 text-text-strong">
+        <span className="font-semibold">Hola {data.latest}</span> is available — you&rsquo;re on{' '}
+        <span className="font-mono text-text-muted">{data.current}</span>. Update with{' '}
+        <code className="font-mono text-[12px] px-[5px] py-px bg-surface-2 border border-border rounded-[5px]">
+          hola update --host …
+        </code>
+      </div>
+
+      {data.releaseUrl && (
+        <a
+          href={data.releaseUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hidden sm:inline-flex items-center gap-[6px] flex-none text-warning hover:underline font-medium"
+        >
+          View release
+          <ExternalLink className="w-[14px] h-[14px]" />
+        </a>
+      )}
+
+      <button
+        onClick={() => setDismissed(true)}
+        aria-label="Dismiss update notification"
+        className="w-7 h-7 flex-none flex items-center justify-center rounded-[7px] text-text-muted cursor-pointer hover:text-text-strong hover:bg-surface-2 transition-colors"
+      >
+        <X className="w-4 h-4" />
+      </button>
+    </div>
+  );
+};

--- a/packages/web/src/components/layout/AppShell.tsx
+++ b/packages/web/src/components/layout/AppShell.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode, useState } from 'react';
 import { Sidebar } from './Sidebar';
 import { Topbar } from './Topbar';
+import { UpdateAvailableBanner } from '../UpdateAvailableBanner';
 
 interface AppShellProps {
   children: ReactNode;
@@ -17,6 +18,7 @@ export const AppShell: React.FC<AppShellProps> = ({ children }) => {
       />
       <div className="flex flex-1 flex-col min-w-0">
         <Topbar />
+        <UpdateAvailableBanner />
         <main className="flex-1 overflow-y-auto relative">
           <div className="px-8 py-7 max-w-[1280px] mx-auto">{children}</div>
         </main>

--- a/packages/web/src/hooks/useUpdateCheck.ts
+++ b/packages/web/src/hooks/useUpdateCheck.ts
@@ -1,0 +1,42 @@
+import React from 'react';
+import { api } from '../utils/api-hybrid'; // Use hybrid API
+import type { UpdateCheckResult } from '@hola/shared';
+
+// Fetches the server's update-check result once on mount. Failures are tolerated
+// silently — the banner simply won't show when there's no data.
+export function useUpdateCheck() {
+  const [state, setState] = React.useState<{
+    data: UpdateCheckResult | null;
+    loading: boolean;
+    error: string | null;
+  }>({
+    data: null,
+    loading: false,
+    error: null,
+  });
+
+  const fetchData = React.useCallback(async () => {
+    setState(prev => ({ ...prev, loading: true, error: null }));
+
+    try {
+      const result = await api.system.updateCheck() as UpdateCheckResult;
+      setState({
+        data: result,
+        loading: false,
+        error: null,
+      });
+    } catch (error) {
+      setState({
+        data: null,
+        loading: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  }, []); // Empty dependency array for StrictMode compatibility
+
+  React.useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  return state;
+}

--- a/packages/web/src/utils/api.ts
+++ b/packages/web/src/utils/api.ts
@@ -291,6 +291,7 @@ export const api = {
   // System status
   system: {
     status: () => apiClient.get(API.system.status),
+    updateCheck: () => apiClient.get(API.system.updateCheck),
   },
 
   // Catalog with smart caching

--- a/packages/web/src/utils/sdk-adapter.ts
+++ b/packages/web/src/utils/sdk-adapter.ts
@@ -27,7 +27,7 @@ import type {
   GetSettingsResponse, PatchSettingsRequest, PatchSettingsResponse,
   GetBackupSettingsResponse, PatchBackupSettingsRequest, PatchBackupSettingsResponse,
   // System types
-  GetSystemStatusResponse
+  GetSystemStatusResponse, GetUpdateCheckResponse
 } from '@hola/shared';
 import { globalCache, CacheTTL } from './cache';
 import { safeFetchEnhanced, createEnhancedError, type EnhancedError } from './error-enhanced';
@@ -285,8 +285,10 @@ export class SdkAdapter {
 
   // System status
   system = {
-    status: (): Promise<GetSystemStatusResponse> => 
+    status: (): Promise<GetSystemStatusResponse> =>
       this.getWithCache('/api/system/status', () => this.sdk.get<GetSystemStatusResponse>('/api/system/status')),
+    updateCheck: (): Promise<GetUpdateCheckResponse> =>
+      this.getWithCache('/api/system/update-check', () => this.sdk.get<GetUpdateCheckResponse>('/api/system/update-check')),
   };
 
   // Catalog with smart caching


### PR DESCRIPTION
Closes #149.

Adds a first-class, config-preserving upgrade path so an existing install can be brought up to the invoking CLI's version without re-running the wizard, plus update-available detection on both the web dashboard and the CLI.

## `hola update --host user@vm`
- Preflights the host, reads the current `.env`/`VERSION`, downloads the version-pinned compose bundle and extracts it over the install dir **without touching `.env` or the dir-relative ACME cert store**, then re-runs the idempotent `install.sh` (pull new images, backfill keys, recreate changed services). State in the `hola-data` volume is preserved.
- Reports **old → new** version.
- Mirrors `bootstrap`'s `--ref`, `--tarball-url`, `--dir`, `--dry-run`, `--json`.

### Auth-mode reconciliation (Authentik became the default in 0.6.23)
- **Unset/blank `HOLA_AUTH_MODE`** → `install.sh` already backfills it to `authentik` and generates the secrets; `update` just notes it.
- **Explicit `HOLA_AUTH_MODE=none`** → surfaced and gated on a choice: `--enable-sso` (derives `auth.<base>`, flips the mode before install) or `--keep-auth-mode`. Interactive runs prompt (default keep); scripted (`--json`) runs require one of the flags rather than silently flipping a ~2 GB stack on/off.
- **General drift rule** → diffs the **old vs new** bundle `.env.example` and warns only about keys this release *newly* introduced that have no default and aren't auto-generated (`AUTHENTIK_*`/`COMPOSE_*`), so the warning isn't drowned in keys `install.sh` handles.

### `hola update --check`
Reports CLI / installed / latest-release versions and flags CLI↔server skew, directing to `hola update`.

## Update-available detection (web + CLI share one source)
- **Server**: `GET /api/system/update-check` backed by a **TTL-cached, fail-safe** GitHub release lookup (newest stable `cli-v*`), wired Real/Mock through `simple-factory`. Shared `UpdateCheckResult` type + `compareVersions`/`isNewerVersion` helpers in `@hola/shared`.
- **Web**: dismissible "update available" banner in the app shell — no in-app update action, it points operators at `hola update`.

## Docs
`docs/OPERATIONS.md` and `packages/compose/README.md` now document `hola update` as the supported upgrade path (including the same-dir / ACME-store caveat and the pre-0.6.23 SSO reconciliation).

## Open questions deferred (flagged in the issue)
- **Rollback** of a failed pull/unhealthy stack — `update` reports old→new but doesn't auto-rollback yet.
- **Host-local mode** (run from the install dir without SSH) — documented as a manual sequence; not a subcommand.
- **Moving the ACME store to a named volume** — left as the separate change the issue flags; `update` keeps the same dir by default, which preserves it.

## Testing
- `bun run typecheck` · `bun run lint` · `bun run build` — green across all packages.
- New tests: CLI `update.test.ts` (14), server `update-check.test.ts` (8, incl. version-compare), web `UpdateAvailableBanner.test.tsx` (4). Server (309) + web (143) suites pass.
- Pre-existing unrelated failure: `install-schema.test.ts`'s timezone default expects an IANA `Region/City`, but this sandbox's TZ resolves to `UTC` (not touched by this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)