### PR TITLE
feat(server): native-OIDC for multi-callback + config-file apps

### DIFF
--- a/packages/server/src/__tests__/deployments/auth-provisioning.test.ts
+++ b/packages/server/src/__tests__/deployments/auth-provisioning.test.ts
@@ -220,6 +220,44 @@ describe('Auth provisioning lifecycle', () => {
     expect(meta.metadata.auth.ref.providerPk).toBe(42);
   });
 
+  test('native-oidc credentialsFile: writes the provisioned OIDC creds JSON into the data root before start (for a bundle sidecar to render)', async () => {
+    const prev = process.env.HOLA_APPS_BIND_ROOT;
+    process.env.HOLA_APPS_BIND_ROOT = join(dataRoot, 'apps');
+    try {
+      const auth: AppAuthConfig = {
+        mode: 'native-oidc',
+        oidc: {
+          redirectPath: '/auth/login',
+          scopes: ['openid', 'profile', 'email'],
+          extraRedirectUris: ['https://${HOLA_APP_HOST}/user-settings', 'app.immich:///oauth-callback'],
+          credentialsFile: { path: 'oidc.json' },
+        },
+      };
+      const sys = makeSystem({ auth });
+      const created = await sys.deployments.createFromDraft({ draftId: await finalizedDraft(sys.drafts), name: 'gitea' });
+      expect((await waitForJob(sys.jobs, created.jobId!)).status).toBe('completed');
+
+      // A GENERIC creds file (not the app's config format) was written under
+      // <HOLA_APPS_BIND_ROOT>/<deploymentId>/ (the host path ${HOLA_APP_DATA} maps to).
+      const file = join(process.env.HOLA_APPS_BIND_ROOT, created.deploymentId, 'oidc.json');
+      const doc = JSON.parse(await readFile(file, 'utf-8')) as { issuer: string; clientId: string; clientSecret: string; redirectUri: string };
+      expect(doc.clientId).toBe('cid-123');
+      expect(doc.clientSecret).toBe('csecret-456');
+      expect(doc.issuer).toBe('https://auth.example.com/application/o/gitea-x/');
+      expect(doc.redirectUri).toBe('https://gitea.local.hola/auth/login');
+
+      // The provisioner received the extra redirect URIs to register on the client.
+      const spy = sys.provisioner as SpyProvisioner;
+      expect(spy.provisions[0].oidc?.extraRedirectUris).toEqual([
+        'https://${HOLA_APP_HOST}/user-settings',
+        'app.immich:///oauth-callback',
+      ]);
+    } finally {
+      if (prev === undefined) delete process.env.HOLA_APPS_BIND_ROOT;
+      else process.env.HOLA_APPS_BIND_ROOT = prev;
+    }
+  });
+
   test('resolves install tokens (${HOLA_APP_HOST} / ${HOLA_BASE_DOMAIN}) in app env', async () => {
     const sys = makeSystem({ auth: undefined });
     const compose = [

--- a/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
+++ b/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
@@ -169,6 +169,35 @@ describe('RealAuthentikProvisionerService (REST contract)', () => {
     expect(result.ref.applicationSlug).toBeTruthy();
   });
 
+  test('native-oidc registers extra redirect URIs (host token + non-http scheme) for web+mobile apps', async () => {
+    installFetch();
+    const svc = new RealAuthentikProvisionerService(CONFIG);
+
+    // Immich-shaped: web login derives from redirectPath; user-settings carries
+    // the ${HOLA_APP_HOST} token; the mobile callback is a custom scheme.
+    await svc.provision({
+      deploymentId: 'dep-immich0123456789',
+      appName: 'immich',
+      mode: 'native-oidc' as const,
+      host: 'immich.example.com',
+      oidc: {
+        redirectPath: '/auth/login',
+        scopes: ['openid', 'profile', 'email'],
+        extraRedirectUris: [
+          'https://${HOLA_APP_HOST}/user-settings',
+          'app.immich:///oauth-callback',
+        ],
+      },
+    });
+
+    const pbody = calls.find(c => c.method === 'POST' && c.path === '/api/v3/providers/oauth2/')!.body as Record<string, unknown>;
+    expect(pbody.redirect_uris).toEqual([
+      { matching_mode: 'strict', url: 'https://immich.example.com/auth/login' },
+      { matching_mode: 'strict', url: 'https://immich.example.com/user-settings' },
+      { matching_mode: 'strict', url: 'app.immich:///oauth-callback' },
+    ]);
+  });
+
   test('native-oidc resolves scope mappings by managed id when scope_name is absent', async () => {
     // The polymorphic endpoint doesn't always surface scope_name; the `managed`
     // identifier is the stable fallback (issue #144).

--- a/packages/server/src/__tests__/provisioner/manifest-auth.test.ts
+++ b/packages/server/src/__tests__/provisioner/manifest-auth.test.ts
@@ -104,6 +104,58 @@ describe('coerceManifestAuth', () => {
     ).toBeUndefined();
   });
 
+  test('native-oidc carries staticEnv (the SSO enable flag/button label)', () => {
+    const result = coerceManifestAuth({
+      mode: 'native-oidc',
+      oidc: {
+        redirectPath: '/cb',
+        scopes: ['openid'],
+        env: { issuer: 'ISS', clientId: 'CID', clientSecret: 'SEC' },
+        staticEnv: { POSTIZ_GENERIC_OAUTH: 'true', NEXT_PUBLIC_POSTIZ_OAUTH_DISPLAY_NAME: 'Authentik' },
+      },
+    });
+    expect(result?.oidc?.staticEnv).toEqual({
+      POSTIZ_GENERIC_OAUTH: 'true',
+      NEXT_PUBLIC_POSTIZ_OAUTH_DISPLAY_NAME: 'Authentik',
+    });
+  });
+
+  test('native-oidc carries extraRedirectUris and a credentialsFile, and credentialsFile alone is a valid wiring mechanism', () => {
+    const result = coerceManifestAuth({
+      mode: 'native-oidc',
+      oidc: {
+        redirectPath: '/auth/login',
+        scopes: ['openid', 'profile', 'email'],
+        extraRedirectUris: ['https://${HOLA_APP_HOST}/user-settings', 'app.immich:///oauth-callback'],
+        credentialsFile: { path: 'oidc.json' },
+      },
+    });
+    expect(result).toEqual({
+      mode: 'native-oidc',
+      oidc: {
+        redirectPath: '/auth/login',
+        scopes: ['openid', 'profile', 'email'],
+        extraRedirectUris: ['https://${HOLA_APP_HOST}/user-settings', 'app.immich:///oauth-callback'],
+        credentialsFile: { path: 'oidc.json' },
+      },
+    });
+  });
+
+  test('native-oidc with neither env, setup, nor credentialsFile degrades to undefined', () => {
+    expect(
+      coerceManifestAuth({ mode: 'native-oidc', oidc: { redirectPath: '/cb', scopes: ['openid'] } })
+    ).toBeUndefined();
+  });
+
+  test('native-oidc credentialsFile missing its path degrades to undefined', () => {
+    expect(
+      coerceManifestAuth({
+        mode: 'native-oidc',
+        oidc: { redirectPath: '/cb', scopes: ['openid'], credentialsFile: {} },
+      })
+    ).toBeUndefined();
+  });
+
   test('coerces native-ldap and forward-auth blocks', () => {
     expect(
       coerceManifestAuth({

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -1129,6 +1129,46 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     }
   }
 
+  /**
+   * Write the provisioned OIDC credentials as a GENERIC JSON file into an app's
+   * data root BEFORE the stack starts (manifest `auth.oidc.credentialsFile`), for
+   * apps that ingest OIDC only from a file read at boot (e.g. Immich — UI locked,
+   * no OIDC env vars). The file holds `{ issuer, clientId, clientSecret,
+   * redirectUri }`; a sidecar/init container in the app BUNDLE renders it into the
+   * app's own config format (see Homepage's registry renderer + ADR 0002), so the
+   * server never deals with per-app config formats. The path is relative to
+   * `${HOLA_APP_DATA}` (the same per-install root compose mounts). No-op without a
+   * credentialsFile directive or credentials. Written 0600 (holds the secret).
+   */
+  private async writeOidcCredentialsFile(
+    deployment: EnhancedDeploymentDetail,
+    provisioned: { credentials?: ProvisionCredentials; auth: NonNullable<FinalizedManifest['auth']> },
+    logBoth: (level: 'info' | 'warn' | 'error' | 'debug', message: string) => Promise<void>
+  ): Promise<void> {
+    const cf = provisioned.auth.oidc?.credentialsFile;
+    const creds = provisioned.credentials;
+    if (!cf || !creds) return;
+
+    const content = JSON.stringify(
+      { issuer: creds.issuer, clientId: creds.clientId, clientSecret: creds.clientSecret, redirectUri: creds.redirectUri },
+      null,
+      2
+    );
+
+    // Resolve under the app's data root; reject path traversal out of it.
+    const rel = cf.path.replace(/^\/+/, '');
+    if (rel.split('/').includes('..')) {
+      throw new Error(`Invalid auth.oidc.credentialsFile path '${cf.path}' (must stay within the app data root)`);
+    }
+    const root = this.appRootFor(deployment.id);
+    const target = `${root}/${rel}`;
+    const slash = target.lastIndexOf('/');
+    if (slash > root.length) await this.storageService.ensureDir(target.slice(0, slash));
+    else await this.storageService.ensureDir(root);
+    await this.storageService.writeFile(target, content, 0o600);
+    await logBoth('info', `Auth: wrote OIDC credentials file ${rel} for the bundle to render`);
+  }
+
   private jobTypeToAction(type: Job['type']): string {
     switch (type) {
       case 'stop': return 'stop';
@@ -1173,7 +1213,9 @@ export class RealDeploymentService extends InMemoryDeploymentService {
         nextLifecycle = 'stopped';
       } else if (action === 'restart') {
         const provisioned = await this.provisionAuth(deployment);
-        const res = await this.dockerService.composeRestart(await this.materializeCompose(deployment, provisioned?.env ?? {}), projectName);
+        const composeDir = await this.materializeCompose(deployment, provisioned?.env ?? {});
+        if (provisioned) await this.writeOidcCredentialsFile(deployment, provisioned, logBoth);
+        const res = await this.dockerService.composeRestart(composeDir, projectName);
         output = res.output;
         if (!res.success) throw new Error(res.output);
         if (provisioned) await this.completeAuthWiring(deployment, provisioned, projectName, logBoth);
@@ -1183,6 +1225,9 @@ export class RealDeploymentService extends InMemoryDeploymentService {
         // deploy / start / rollback -> pull images, then compose up
         const provisioned = await this.provisionAuth(deployment);
         const composeDir = await this.materializeCompose(deployment, provisioned?.env ?? {});
+        // Drop the provisioned OIDC creds file into the data root before `up` so a
+        // bundle sidecar can render the app's SSO config for first boot (e.g. Immich).
+        if (provisioned) await this.writeOidcCredentialsFile(deployment, provisioned, logBoth);
 
         // Pull first (generous timeout) so `up` isn't gated on download time —
         // large stacks like Postiz used to be SIGKILLed mid-pull by up's 2-min cap.

--- a/packages/server/src/services/core/manifest-auth.ts
+++ b/packages/server/src/services/core/manifest-auth.ts
@@ -48,6 +48,28 @@ function coerceOidcEnv(
   return { ...required, ...(redirectUri ? { redirectUri } : {}) };
 }
 
+/** Coerce a flat string→string record (e.g. oidc.staticEnv); undefined unless it
+ *  is a record with at least one non-empty string value. */
+function coerceStringRecord(v: unknown): Record<string, string> | undefined {
+  const rec = asRecord(v);
+  if (!rec) return undefined;
+  const out: Record<string, string> = {};
+  for (const [k, val] of Object.entries(rec)) {
+    if (typeof val !== 'string' || val.length === 0) return undefined;
+    out[k] = val;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/** Coerce an OIDC credentials-file directive: the data-root-relative `path` where
+ *  the server drops the provisioned creds JSON for a bundle sidecar to render. */
+function coerceOidcCredentialsFile(v: unknown): { path: string } | undefined {
+  const rec = asRecord(v);
+  const path = asString(rec?.path);
+  if (!path) return undefined;
+  return { path };
+}
+
 /** Coerce a post-deploy OIDC setup command. Requires a non-empty string[] command. */
 function coerceOidcSetup(value: unknown): OidcSetupCommand | undefined {
   const rec = asRecord(value);
@@ -90,9 +112,22 @@ export function coerceManifestAuth(value: unknown): AppAuthConfig | undefined {
     const scopes = asStringArray(oidc?.scopes);
     const env = coerceOidcEnv(oidc?.env);
     const setup = coerceOidcSetup(oidc?.setup);
-    // Require redirectPath + scopes, and at least one wiring mechanism (env or setup).
-    if (!redirectPath || !scopes || (!env && !setup)) return undefined;
-    result.oidc = { redirectPath, scopes, ...(env ? { env } : {}), ...(setup ? { setup } : {}) };
+    const staticEnv = coerceStringRecord(oidc?.staticEnv);
+    const extraRedirectUris = asStringArray(oidc?.extraRedirectUris);
+    const credentialsFile = coerceOidcCredentialsFile(oidc?.credentialsFile);
+    // Require redirectPath + scopes, and at least one wiring mechanism (env, setup,
+    // or a creds file a bundle sidecar renders). Unknown manifest fields are dropped
+    // downstream (see catalog.ts), so every carried field must be coerced explicitly.
+    if (!redirectPath || !scopes || (!env && !setup && !credentialsFile)) return undefined;
+    result.oidc = {
+      redirectPath,
+      scopes,
+      ...(env ? { env } : {}),
+      ...(setup ? { setup } : {}),
+      ...(staticEnv ? { staticEnv } : {}),
+      ...(extraRedirectUris ? { extraRedirectUris } : {}),
+      ...(credentialsFile ? { credentialsFile } : {}),
+    };
   }
 
   if (m === 'native-ldap') {

--- a/packages/server/src/services/core/provisioner.ts
+++ b/packages/server/src/services/core/provisioner.ts
@@ -20,6 +20,7 @@ import { getLogger } from '../../lib/logger';
 import { ProvisioningError } from '../../middleware/error-mapping';
 import type { AuthConfig } from '../../config/auth';
 import type { AuthMode, ProvisionedAuthRef, ForwardAuthMiddleware } from '@hola/shared';
+import { APP_HOST_TOKEN } from '@hola/shared/compose-validate';
 import type { ServiceHealth, HealthCheckable } from './types';
 
 export interface ProvisionInput {
@@ -50,6 +51,9 @@ export interface ProvisionInput {
     };
     /** Literal env injected only when OIDC is provisioned (enable flag, button label). */
     staticEnv?: Record<string, string>;
+    /** Extra redirect URIs (beyond redirectPath) to register on the client. May
+     *  contain the ${HOLA_APP_HOST} token or a non-http scheme (mobile callback). */
+    extraRedirectUris?: string[];
   };
   ldap?: {
     env: { host: string; port: string; bindDn: string; bindPassword: string; baseDn: string };
@@ -193,6 +197,25 @@ function slugify(s: string): string {
     .slice(0, 50);
 }
 
+/**
+ * Build the Authentik `redirect_uris` list: the primary URI (from redirectPath)
+ * plus any manifest-declared extras, with the `${HOLA_APP_HOST}` token expanded
+ * to the app's public host. Extras may be full https URLs or a non-http scheme
+ * (e.g. a mobile callback `app.immich:///oauth-callback`). De-duplicated; all
+ * registered with strict matching. A manifest with no extras yields exactly the
+ * single strict URI Hola has always emitted.
+ */
+function buildRedirectUris(
+  host: string,
+  primary: string,
+  extras?: string[]
+): Array<{ matching_mode: 'strict'; url: string }> {
+  const urls = [primary, ...(extras ?? []).map(u => u.replaceAll(APP_HOST_TOKEN, host))];
+  const seen = new Set<string>();
+  const deduped = urls.filter(u => (seen.has(u) ? false : (seen.add(u), true)));
+  return deduped.map(url => ({ matching_mode: 'strict', url }));
+}
+
 export class RealAuthentikProvisionerService implements ProvisionerService {
   private logger = getLogger().child({ service: 'RealAuthentikProvisionerService' });
 
@@ -265,14 +288,15 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
     if (!oidc) throw new ProvisioningError('native-oidc requires an oidc config block');
 
     const redirectUri = `https://${input.host}${oidc.redirectPath}`;
+    const redirectUris = buildRedirectUris(input.host, redirectUri, oidc.extraRedirectUris);
     const slug = slugify(`hola-${input.appName}-${input.deploymentId.slice(0, 8)}`);
 
-    // Idempotent re-provision: reuse the existing client, refresh its redirect URI.
+    // Idempotent re-provision: reuse the existing client, refresh its redirect URIs.
     const existing = input.existingRef;
     if (existing && existing.mode === 'native-oidc' && existing.providerPk != null) {
       const provider = await this.api<AuthentikOAuth2Provider>('GET', `/api/v3/providers/oauth2/${existing.providerPk}/`);
       await this.api('PATCH', `/api/v3/providers/oauth2/${existing.providerPk}/`, {
-        redirect_uris: [{ matching_mode: 'strict', url: redirectUri }],
+        redirect_uris: redirectUris,
       });
       this.logger.info('Reused existing OIDC client', { deploymentId: input.deploymentId, providerPk: existing.providerPk });
       const reuseSlug = existing.applicationSlug ?? slug;
@@ -300,7 +324,7 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
       client_type: 'confidential',
       client_id: clientId,
       client_secret: clientSecret,
-      redirect_uris: [{ matching_mode: 'strict', url: redirectUri }],
+      redirect_uris: redirectUris,
       property_mappings: propertyMappings,
       sub_mode: 'hashed_user_id',
     });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -354,6 +354,22 @@ export type AppAuthConfig = {
     // always-on defaultEnv so a non-SSO install doesn't show a dead SSO button.
     staticEnv?: Record<string, string>;
     setup?: OidcSetupCommand;
+    // Extra redirect URIs to register on the OIDC client, beyond the one derived
+    // from `redirectPath`. Each entry may contain the `${HOLA_APP_HOST}` token
+    // (expanded to the app's public host) OR a non-http scheme. For apps whose
+    // OIDC client needs several callbacks across web + mobile — e.g. Immich uses
+    // `/auth/login`, `/user-settings`, and the mobile `app.immich:///oauth-callback`.
+    extraRedirectUris?: string[];
+    // For apps that ingest OIDC ONLY from a config FILE written before first boot
+    // (e.g. Immich: the admin UI is locked when a config file is present, there
+    // are no OIDC env vars, and `${ENV}` is not expanded inside the file). When set,
+    // the server writes the provisioned OIDC values as a GENERIC JSON creds file —
+    // `{ issuer, clientId, clientSecret, redirectUri }` — to `path` (relative to the
+    // app's `${HOLA_APP_DATA}` root) before the stack starts. Rendering those creds
+    // into the app's own config format is the BUNDLE's job: a sidecar/init container
+    // (see Homepage's registry renderer + ADR 0002) reads this file and writes the
+    // app config, so the server stays out of per-app config formats.
+    credentialsFile?: { path: string };
   };
   // For `native-ldap`: the env-var NAMES this app expects its LDAP bind settings in.
   ldap?: {


### PR DESCRIPTION
## What

Extends native-oidc provisioning so apps with **multiple OAuth redirect URIs** and apps that ingest OIDC **only from a config file** (e.g. Immich) can be wired up automatically — while keeping per-app config-format rendering in the **bundle** (ADR 0002), not the server.

Unblocks the Immich catalog package (try-hola/apps): SSO that works on **web and mobile** via Immich's native OIDC, no forward-auth gate.

## Changes

- **provisioner** — register **multiple** redirect URIs on the OAuth client, not just the one from `redirectPath`. New `oidc.extraRedirectUris` may carry the `${HOLA_APP_HOST}` token or a non-http scheme (the mobile `app.immich:///oauth-callback`); deduped, all strict-matched. Apps with no extras emit the exact single strict URI as before.
- **deployment** — when an app declares `oidc.credentialsFile`, write the provisioned `{ issuer, clientId, clientSecret, redirectUri }` as a **generic** JSON file into the app data root (0600, traversal-guarded) before the stack starts — same data-root-write pattern as the app-registry feed. A bundle sidecar renders it into the app's own config format. Runs on deploy + restart; no-op without a backend (no credentials) so non-SSO installs keep their own login.
- **manifest-auth** — coerce `extraRedirectUris`, `credentialsFile`, and `staticEnv`. **`staticEnv` was previously dropped** at the coercion chokepoint (`catalog.ts`), so its SSO enable flags/labels never reached deploy — this also **fixes Postiz and Mealie SSO**.

## Tests

Provisioner multi-redirect-URI registration; manifest-auth coercion of staticEnv/extraRedirectUris/credentialsFile (+ negatives); deployment-level test asserting the generic creds file is written with provisioned values. Full server suite (315) + typecheck + lint + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)