### PR TITLE
feat(server): admin-by-group role claim for native-OIDC apps

### DIFF
--- a/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
+++ b/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
@@ -58,12 +58,19 @@ function installFetch(handler?: (call: RecordedCall) => Response | undefined) {
     // for the scoped token — see resolveScopeMappingPks / issue #144). Default
     // scope mappings carry stable `managed` identifiers.
     if (method === 'GET' && url.pathname === '/api/v3/propertymappings/all/') {
+      // A `?managed=` lookup (role-claim idempotency probe) filters by that id;
+      // nothing pre-exists in the happy path, so it returns empty -> create.
+      if (url.searchParams.has('managed')) return json({ results: [] });
       return json({ results: [
         { pk: 'scope-openid', managed: 'goauthentik.io/providers/oauth2/scope-openid', scope_name: 'openid' },
         { pk: 'scope-profile', managed: 'goauthentik.io/providers/oauth2/scope-profile', scope_name: 'profile' },
         { pk: 'scope-email', managed: 'goauthentik.io/providers/oauth2/scope-email', scope_name: 'email' },
         { pk: 'mapping-unrelated', managed: 'goauthentik.io/providers/ldap/something', scope_name: undefined },
       ] });
+    }
+    // Create an OAuth2 scope mapping (admin-by-group role claim).
+    if (method === 'POST' && url.pathname === '/api/v3/propertymappings/provider/scope/') {
+      return json({ pk: 'roleclaim-pk' }, 201);
     }
     if (method === 'POST' && url.pathname === '/api/v3/providers/oauth2/') {
       return json({ pk: 42, client_id: body.client_id, client_secret: body.client_secret }, 201);
@@ -196,6 +203,38 @@ describe('RealAuthentikProvisionerService (REST contract)', () => {
       { matching_mode: 'strict', url: 'https://immich.example.com/user-settings' },
       { matching_mode: 'strict', url: 'app.immich:///oauth-callback' },
     ]);
+  });
+
+  test('native-oidc provisions an admin-by-group role claim and attaches it to the provider', async () => {
+    installFetch();
+    const svc = new RealAuthentikProvisionerService(CONFIG);
+
+    await svc.provision({
+      deploymentId: 'dep-immich0123456789',
+      appName: 'immich',
+      mode: 'native-oidc' as const,
+      host: 'immich.example.com',
+      oidc: {
+        redirectPath: '/auth/login',
+        scopes: ['openid', 'profile', 'email'],
+        roleClaim: { claim: 'immich_role', adminGroup: 'hola-admins', adminValue: 'admin', memberValue: 'user' },
+      },
+    });
+
+    // A scope mapping was created riding on `profile` (a scope the client already
+    // requests), with a group-membership expression and a stable managed id.
+    const mapCall = calls.find(c => c.method === 'POST' && c.path === '/api/v3/propertymappings/provider/scope/')!;
+    expect(mapCall).toBeDefined();
+    const mb = mapCall.body as Record<string, string>;
+    expect(mb.scope_name).toBe('profile');
+    expect(mb.managed).toMatch(/^goauthentik\.io\/hola\/.*-roleclaim$/);
+    expect(mb.expression).toBe(
+      'return {"immich_role": "admin" if ak_is_group_member(request.user, name="hola-admins") else "user"}'
+    );
+
+    // Its pk was attached to the provider alongside the standard scope mappings.
+    const pbody = calls.find(c => c.method === 'POST' && c.path === '/api/v3/providers/oauth2/')!.body as Record<string, unknown>;
+    expect(pbody.property_mappings).toEqual(['scope-openid', 'scope-profile', 'scope-email', 'roleclaim-pk']);
   });
 
   test('native-oidc resolves scope mappings by managed id when scope_name is absent', async () => {

--- a/packages/server/src/__tests__/provisioner/manifest-auth.test.ts
+++ b/packages/server/src/__tests__/provisioner/manifest-auth.test.ts
@@ -147,6 +147,38 @@ describe('coerceManifestAuth', () => {
     ).toBeUndefined();
   });
 
+  test('native-oidc carries a roleClaim (admin-by-group), claim required + defaults left to provisioner', () => {
+    const result = coerceManifestAuth({
+      mode: 'native-oidc',
+      oidc: {
+        redirectPath: '/auth/login',
+        scopes: ['openid', 'profile', 'email'],
+        credentialsFile: { path: 'oidc.json' },
+        roleClaim: { claim: 'immich_role', adminGroup: 'hola-admins', adminValue: 'admin', memberValue: 'user' },
+      },
+    });
+    expect(result?.oidc?.roleClaim).toEqual({
+      claim: 'immich_role',
+      adminGroup: 'hola-admins',
+      adminValue: 'admin',
+      memberValue: 'user',
+    });
+  });
+
+  test('native-oidc roleClaim without a claim name is dropped (the rest still coerces)', () => {
+    const result = coerceManifestAuth({
+      mode: 'native-oidc',
+      oidc: {
+        redirectPath: '/cb',
+        scopes: ['openid'],
+        env: { issuer: 'ISS', clientId: 'CID', clientSecret: 'SEC' },
+        roleClaim: { adminGroup: 'hola-admins' },
+      },
+    });
+    expect(result?.oidc?.roleClaim).toBeUndefined();
+    expect(result?.oidc?.env).toBeDefined();
+  });
+
   test('native-oidc credentialsFile missing its path degrades to undefined', () => {
     expect(
       coerceManifestAuth({

--- a/packages/server/src/services/core/manifest-auth.ts
+++ b/packages/server/src/services/core/manifest-auth.ts
@@ -70,6 +70,26 @@ function coerceOidcCredentialsFile(v: unknown): { path: string } | undefined {
   return { path };
 }
 
+/** Coerce an admin-by-group role-claim directive. `claim` is required; the rest
+ *  (admin group, claim values, the scope it rides on) have provisioner defaults. */
+function coerceOidcRoleClaim(
+  v: unknown
+): { claim: string; adminGroup?: string; adminValue?: string; memberValue?: string; scope?: string } | undefined {
+  const rec = asRecord(v);
+  const claim = asString(rec?.claim);
+  if (!claim) return undefined;
+  const out: { claim: string; adminGroup?: string; adminValue?: string; memberValue?: string; scope?: string } = { claim };
+  const adminGroup = asString(rec?.adminGroup);
+  if (adminGroup) out.adminGroup = adminGroup;
+  const adminValue = asString(rec?.adminValue);
+  if (adminValue) out.adminValue = adminValue;
+  const memberValue = asString(rec?.memberValue);
+  if (memberValue) out.memberValue = memberValue;
+  const scope = asString(rec?.scope);
+  if (scope) out.scope = scope;
+  return out;
+}
+
 /** Coerce a post-deploy OIDC setup command. Requires a non-empty string[] command. */
 function coerceOidcSetup(value: unknown): OidcSetupCommand | undefined {
   const rec = asRecord(value);
@@ -115,6 +135,7 @@ export function coerceManifestAuth(value: unknown): AppAuthConfig | undefined {
     const staticEnv = coerceStringRecord(oidc?.staticEnv);
     const extraRedirectUris = asStringArray(oidc?.extraRedirectUris);
     const credentialsFile = coerceOidcCredentialsFile(oidc?.credentialsFile);
+    const roleClaim = coerceOidcRoleClaim(oidc?.roleClaim);
     // Require redirectPath + scopes, and at least one wiring mechanism (env, setup,
     // or a creds file a bundle sidecar renders). Unknown manifest fields are dropped
     // downstream (see catalog.ts), so every carried field must be coerced explicitly.
@@ -127,6 +148,7 @@ export function coerceManifestAuth(value: unknown): AppAuthConfig | undefined {
       ...(staticEnv ? { staticEnv } : {}),
       ...(extraRedirectUris ? { extraRedirectUris } : {}),
       ...(credentialsFile ? { credentialsFile } : {}),
+      ...(roleClaim ? { roleClaim } : {}),
     };
   }
 

--- a/packages/server/src/services/core/provisioner.ts
+++ b/packages/server/src/services/core/provisioner.ts
@@ -19,6 +19,7 @@ import { randomBytes, randomUUID } from 'crypto';
 import { getLogger } from '../../lib/logger';
 import { ProvisioningError } from '../../middleware/error-mapping';
 import type { AuthConfig } from '../../config/auth';
+import { DEFAULT_ADMIN_GROUP } from '../../config/oidc';
 import type { AuthMode, ProvisionedAuthRef, ForwardAuthMiddleware } from '@hola/shared';
 import { APP_HOST_TOKEN } from '@hola/shared/compose-validate';
 import type { ServiceHealth, HealthCheckable } from './types';
@@ -54,6 +55,10 @@ export interface ProvisionInput {
     /** Extra redirect URIs (beyond redirectPath) to register on the client. May
      *  contain the ${HOLA_APP_HOST} token or a non-http scheme (mobile callback). */
     extraRedirectUris?: string[];
+    /** Admin-by-group via a scalar role claim (e.g. Immich's `immich_role`). The
+     *  provisioner emits `claim`=`adminValue` for `adminGroup` members else
+     *  `memberValue`, riding on `scope` (default `profile`). */
+    roleClaim?: { claim: string; adminGroup?: string; adminValue?: string; memberValue?: string; scope?: string };
   };
   ldap?: {
     env: { host: string; port: string; bindDn: string; bindPassword: string; baseDn: string };
@@ -173,6 +178,11 @@ const PROVISIONER_PERMISSIONS = [
   'authentik_brands.view_brand',
   'authentik_brands.change_brand',
   'authentik_core.view_propertymapping',
+  // Create/update a custom OAuth2 scope mapping for admin-by-group role claims
+  // (e.g. Immich's immich_role). view_scopemapping is the typed-endpoint read perm.
+  'authentik_providers_oauth2.add_scopemapping',
+  'authentik_providers_oauth2.change_scopemapping',
+  'authentik_providers_oauth2.view_scopemapping',
   'authentik_outposts.view_outpost',
   'authentik_outposts.change_outpost',
   'authentik_flows.view_flow',
@@ -295,11 +305,17 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
     const existing = input.existingRef;
     if (existing && existing.mode === 'native-oidc' && existing.providerPk != null) {
       const provider = await this.api<AuthentikOAuth2Provider>('GET', `/api/v3/providers/oauth2/${existing.providerPk}/`);
+      const reuseSlug = existing.applicationSlug ?? slug;
+      // Ensure the role-claim mapping (idempotent) and attach it if not already —
+      // covers an app that added roleClaim to its manifest after first install.
+      const roleClaimPk = await this.ensureRoleClaimMapping(oidc.roleClaim, reuseSlug);
+      const mappings = provider.property_mappings ?? [];
+      const mergedMappings = roleClaimPk && !mappings.includes(roleClaimPk) ? [...mappings, roleClaimPk] : undefined;
       await this.api('PATCH', `/api/v3/providers/oauth2/${existing.providerPk}/`, {
         redirect_uris: redirectUris,
+        ...(mergedMappings ? { property_mappings: mergedMappings } : {}),
       });
       this.logger.info('Reused existing OIDC client', { deploymentId: input.deploymentId, providerPk: existing.providerPk });
-      const reuseSlug = existing.applicationSlug ?? slug;
       return {
         env: this.oidcEnv(oidc, provider.client_id, provider.client_secret, redirectUri, reuseSlug),
         credentials: { clientId: provider.client_id, clientSecret: provider.client_secret, issuer: this.issuerUrl(reuseSlug), redirectUri },
@@ -311,11 +327,14 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
     const clientId = randomUUID();
     const clientSecret = randomBytes(32).toString('hex');
 
-    const [authFlow, invalidationFlow, propertyMappings] = await Promise.all([
+    const [authFlow, invalidationFlow, propertyMappings, roleClaimPk] = await Promise.all([
       this.resolveFlowPk(AUTHZ_FLOW_SLUG, 'authorization'),
       this.resolveFlowPk(INVALIDATION_FLOW_SLUG, 'invalidation'),
       this.resolveScopeMappingPks(oidc.scopes),
+      this.ensureRoleClaimMapping(oidc.roleClaim, slug),
     ]);
+    // Attach the admin-by-group role claim alongside the standard scope mappings.
+    const allMappings = roleClaimPk ? [...propertyMappings, roleClaimPk] : propertyMappings;
 
     const provider = await this.api<AuthentikOAuth2Provider>('POST', '/api/v3/providers/oauth2/', {
       name: `hola-${input.appName}-${input.deploymentId.slice(0, 8)}`,
@@ -325,7 +344,7 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
       client_id: clientId,
       client_secret: clientSecret,
       redirect_uris: redirectUris,
-      property_mappings: propertyMappings,
+      property_mappings: allMappings,
       sub_mode: 'hashed_user_id',
     });
 
@@ -1035,6 +1054,64 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
     return pks;
   }
 
+  /**
+   * Ensure an Authentik scope mapping that emits an app's admin-by-group role
+   * claim (e.g. Immich's `immich_role` = "admin"/"user"), and return its pk to
+   * attach to the provider. The mapping rides on a scope the client already
+   * requests (default `profile`) — Authentik intersects requested∩configured
+   * scopes, so a bespoke scope name would be dropped unless the client also asked
+   * for it; reusing `profile` makes the claim merge in with no client change.
+   *
+   * Idempotent via a stable `managed` key (queried on the polymorphic endpoint the
+   * scoped token can read; written via the typed scope endpoint). Best-effort: a
+   * failure logs and returns undefined rather than aborting the deploy — the app
+   * then needs a manual admin promotion, surfaced in logs.
+   */
+  private async ensureRoleClaimMapping(
+    roleClaim: NonNullable<ProvisionInput['oidc']>['roleClaim'],
+    slug: string
+  ): Promise<string | undefined> {
+    if (!roleClaim) return undefined;
+    const claim = roleClaim.claim;
+    const adminGroup = roleClaim.adminGroup ?? DEFAULT_ADMIN_GROUP;
+    const adminValue = roleClaim.adminValue ?? 'admin';
+    const memberValue = roleClaim.memberValue ?? 'user';
+    const scopeName = roleClaim.scope ?? 'profile';
+    const managed = `goauthentik.io/hola/${slug}-roleclaim`;
+    // JSON.stringify yields double-quoted literals that are also valid Python strings.
+    const expression =
+      `return {${JSON.stringify(claim)}: ${JSON.stringify(adminValue)} ` +
+      `if ak_is_group_member(request.user, name=${JSON.stringify(adminGroup)}) ` +
+      `else ${JSON.stringify(memberValue)}}`;
+    const body = {
+      name: `hola ${claim} (${slug})`,
+      scope_name: scopeName,
+      description: 'Hola: role claim derived from group membership',
+      expression,
+      managed,
+    };
+    try {
+      const found = await this.api<{ results: Array<{ pk: string }> }>(
+        'GET',
+        `/api/v3/propertymappings/all/?managed=${encodeURIComponent(managed)}`
+      );
+      const existing = found.results?.[0];
+      if (existing) {
+        await this.api('PATCH', `/api/v3/propertymappings/provider/scope/${existing.pk}/`, body);
+        return existing.pk;
+      }
+      const created = await this.api<{ pk: string }>('POST', '/api/v3/propertymappings/provider/scope/', body);
+      return created.pk;
+    } catch (error) {
+      this.logger.warn('Could not ensure role-claim mapping; app may need a manual admin promotion', {
+        slug,
+        claim,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return undefined;
+    }
+  }
+
   // ---- scoped-token bootstrap -------------------------------------------
 
   /**
@@ -1159,6 +1236,7 @@ interface AuthentikOAuth2Provider {
   pk: number;
   client_id: string;
   client_secret: string;
+  property_mappings?: string[];
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -370,6 +370,20 @@ export type AppAuthConfig = {
     // (see Homepage's registry renderer + ADR 0002) reads this file and writes the
     // app config, so the server stays out of per-app config formats.
     credentialsFile?: { path: string };
+    // Admin-by-group for apps that derive their role from a SCALAR OIDC claim
+    // (e.g. Immich's `immich_role` = "admin"/"user"), rather than reading the raw
+    // `groups` list like Gitea. The provisioner creates an Authentik scope mapping
+    // that emits `claim` = `adminValue` for members of `adminGroup` (default the
+    // platform admin group), else `memberValue`, and rides it on the `scope` the
+    // client already requests (default `profile`). Lets the first SSO login land a
+    // member of the admin group as an app admin with no manual promotion.
+    roleClaim?: {
+      claim: string;
+      adminGroup?: string;
+      adminValue?: string;
+      memberValue?: string;
+      scope?: string;
+    };
   };
   // For `native-ldap`: the env-var NAMES this app expects its LDAP bind settings in.
   ldap?: {


### PR DESCRIPTION
## What

Lets native-OIDC apps that derive their role from a **scalar claim** (e.g. Immich's `immich_role` = `admin`/`user`) bootstrap an admin automatically from group membership — so a member of the platform admin group lands as an app admin on their **first SSO login**, with no manual promotion. This completes the click-the-tile, already-provisioned first-use experience for Immich (the bundle side, with `autoLaunch`, ships in try-hola/apps).

Follow-up to #247.

## Changes

- **shared / manifest-auth** — new `oidc.roleClaim { claim, adminGroup?, adminValue?, memberValue?, scope? }`. `claim` is required; the rest default in the provisioner (`adminGroup` → platform admin group, `admin`/`user`, scope `profile`).
- **provisioner** — `ensureRoleClaimMapping` idempotently (stable `managed` key) creates/updates an Authentik scope mapping returning `{claim: adminValue if ak_is_group_member(user, adminGroup) else memberValue}`, riding on a scope the client already requests (default `profile`) — Authentik intersects requested∩configured scopes, so a bespoke scope would be silently dropped. Attached to the provider alongside the standard scope mappings, on both fresh provision and re-provision. Best-effort: a failure logs and continues (app then needs a manual admin promotion).
- Adds `add/change/view_scopemapping` to the least-privilege provisioner token.

Note: Immich applies `roleClaim` only at user creation (not re-synced per login) — an upstream limitation, documented in the Immich package.

## Tests

Provisioner creates the mapping (profile scope, group-membership expression, managed id) and attaches its pk; manifest-auth coercion (+ claim-required negative). typecheck + targeted suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)