### PR TITLE
fix(server): correct deploy-lifecycle job cancellation, recovery, restart, teardown

### DIFF
--- a/packages/server/src/__tests__/jobs/job-cancellation.test.ts
+++ b/packages/server/src/__tests__/jobs/job-cancellation.test.ts
@@ -1,0 +1,107 @@
+/**
+ * RealJobService cancellation + crash-recovery tests.
+ *
+ * Covers the lifecycle correctness fixes: cancelJob never overwrites a job that
+ * already reached a terminal state; a running job cancelled at a cooperative
+ * checkpoint ends 'cancelled' (not clobbered back to 'completed'); and jobs left
+ * 'running' by a crash are recovered (failed) the next time the service starts.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { RealStorageService } from '../../services/core/storage';
+import { RealDatabaseService } from '../../services/core/database';
+import { RealLoggingService } from '../../services/core/logging';
+import { RealJobService, JobCancelledError } from '../../services/core/jobs';
+
+function deferred<T = void>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => { resolve = r; });
+  return { promise, resolve };
+}
+
+async function waitFor(predicate: () => Promise<boolean> | boolean, timeoutMs = 5000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (await predicate()) return;
+    await new Promise((r) => setTimeout(r, 20));
+  }
+  throw new Error('timeout waiting for condition');
+}
+
+describe('RealJobService cancellation + recovery', () => {
+  let dataRoot: string;
+  let storage: RealStorageService;
+  let database: RealDatabaseService;
+  let logging: RealLoggingService;
+
+  beforeEach(async () => {
+    dataRoot = mkdtempSync(join(tmpdir(), 'hola-jobs-'));
+    storage = new RealStorageService({ holaDir: dataRoot });
+    database = new RealDatabaseService(storage);
+    await database.initialize();
+    logging = new RealLoggingService(storage);
+  });
+
+  afterEach(() => {
+    rmSync(dataRoot, { recursive: true, force: true });
+  });
+
+  it('cancelJob does not overwrite a job that already completed', async () => {
+    const jobs = new RealJobService(database, logging);
+    jobs.setExecutor(async () => true); // completes immediately
+    const job = await jobs.createJob({ type: 'install', deploymentId: 'dep-1' });
+    await waitFor(async () => (await jobs.getJob(job.id))?.status === 'completed');
+
+    await jobs.cancelJob(job.id);
+
+    // Still completed — the terminal state was not corrupted to 'cancelled'.
+    expect((await jobs.getJob(job.id))?.status).toBe('completed');
+  });
+
+  it('a running job cancelled at a checkpoint ends cancelled, not completed', async () => {
+    const jobs = new RealJobService(database, logging);
+    const started = deferred();
+    const release = deferred();
+    jobs.setExecutor(async (ctx) => {
+      started.resolve();
+      await release.promise;
+      // Cooperative checkpoint after the (simulated) long-running work.
+      if (ctx.isCancelled()) throw new JobCancelledError();
+      return true;
+    });
+
+    const job = await jobs.createJob({ type: 'install', deploymentId: 'dep-2' });
+    await started.promise; // executor is running; DB row is 'running'
+
+    await jobs.cancelJob(job.id); // running → sets the flag only, writes no status
+    release.resolve(); // executor resumes, observes cancellation, throws
+
+    // 'cancelled' is a DB-level status surfaced through toShared (the shared
+    // JobStatus union doesn't name it), so read it as a string.
+    const statusOf = async () => (await jobs.getJob(job.id))?.status as string | undefined;
+    await waitFor(async () => (await statusOf()) === 'cancelled');
+    expect(await statusOf()).toBe('cancelled');
+  });
+
+  it('recovers orphaned running jobs on restart (marks them failed)', async () => {
+    // jobsA starts a job whose executor hangs, leaving a 'running' row behind as
+    // if the process had crashed mid-job.
+    const jobsA = new RealJobService(database, logging);
+    const started = deferred();
+    jobsA.setExecutor(async () => {
+      started.resolve();
+      await new Promise(() => {}); // never resolves
+      return true;
+    });
+    const job = await jobsA.createJob({ type: 'install', deploymentId: 'dep-3' });
+    await started.promise;
+    expect((await jobsA.getJob(job.id))?.status).toBe('running');
+
+    // A fresh service over the same DB treats the orphan as interrupted on start.
+    const jobsB = new RealJobService(database, logging);
+    await jobsB.listJobs(); // triggers ensureStarted recovery
+    expect((await jobsB.getJob(job.id))?.status).toBe('failed');
+  });
+});

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -42,6 +42,7 @@ import { NotFoundError, ConflictError } from '../../middleware/error-mapping';
 import type { HealthCheckable, ServiceHealth } from './types';
 import type { StorageService } from './storage';
 import type { JobService, JobContext } from './jobs';
+import { JobCancelledError } from './jobs';
 import type { DockerService } from './docker';
 import type { DraftService, FinalizedArtifacts, FinalizedManifest } from './draft';
 import type { RoutingService } from './routing';
@@ -1215,7 +1216,12 @@ export class RealDeploymentService extends InMemoryDeploymentService {
         const provisioned = await this.provisionAuth(deployment);
         const composeDir = await this.materializeCompose(deployment, provisioned?.env ?? {});
         if (provisioned) await this.writeOidcCredentialsFile(deployment, provisioned, logBoth);
-        const res = await this.dockerService.composeRestart(composeDir, projectName);
+        // Use `up -d` (recreate) rather than `docker compose restart`: restart
+        // restarts the existing containers in place and would NOT re-read the
+        // freshly materialized compose, so changed env/labels (e.g. updated OIDC
+        // wiring) would silently never reach the app. `up -d` recreates only the
+        // services whose config changed, using the already-present images.
+        const res = await this.dockerService.composeUp(composeDir, projectName);
         output = res.output;
         if (!res.success) throw new Error(res.output);
         if (provisioned) await this.completeAuthWiring(deployment, provisioned, projectName, logBoth);
@@ -1235,6 +1241,10 @@ export class RealDeploymentService extends InMemoryDeploymentService {
         const pull = await this.dockerService.composePull(composeDir, projectName);
         if (!pull.success) throw new Error(`Image pull failed: ${pull.output}`);
         await ctx.setProgress(60);
+
+        // Cooperative cancellation: bail out before recreating containers (the
+        // irreversible step) if the job was cancelled during the long pull.
+        if (ctx.isCancelled()) throw new JobCancelledError();
 
         const res = await this.dockerService.composeUp(composeDir, projectName);
         output = res.output;
@@ -1385,11 +1395,18 @@ export class RealDeploymentService extends InMemoryDeploymentService {
   protected override async onDeprovision(deployment: EnhancedDeploymentDetail): Promise<void> {
     const auth = deployment.metadata.auth;
     if (!auth) return;
-    await this.provisioner.deprovision({ deploymentId: deployment.id, ref: auth.ref });
-    // Tear down the extra forward-auth provider from a `fallback: forward-auth` too.
-    if (auth.fallbackRef) {
-      await this.provisioner.deprovision({ deploymentId: deployment.id, ref: auth.fallbackRef });
-    }
+    // Tear down both refs independently: a failure deprovisioning the primary
+    // must not leave the `fallback: forward-auth` provider (and its outpost
+    // binding) orphaned in the auth backend. Surface the first error after both
+    // attempts so the caller still sees the failure.
+    const results = await Promise.allSettled([
+      this.provisioner.deprovision({ deploymentId: deployment.id, ref: auth.ref }),
+      auth.fallbackRef
+        ? this.provisioner.deprovision({ deploymentId: deployment.id, ref: auth.fallbackRef })
+        : Promise.resolve(),
+    ]);
+    const failed = results.find((r): r is PromiseRejectedResult => r.status === 'rejected');
+    if (failed) throw failed.reason;
   }
 
   protected override async loadFinalizedArtifacts(draftId: string): Promise<FinalizedArtifacts | null> {

--- a/packages/server/src/services/core/jobs.ts
+++ b/packages/server/src/services/core/jobs.ts
@@ -23,6 +23,18 @@ import type { Job as SharedJob, JobStatus as SharedJobStatus, JobType as SharedJ
 
 export type JobUpdate = { id: string; status: SharedJobStatus; progress?: number; finishedAt?: string };
 
+/**
+ * Thrown by an executor (or a cooperative checkpoint) to signal that a job was
+ * cancelled mid-flight, as opposed to failing. The job service records it as
+ * `cancelled` rather than `failed`.
+ */
+export class JobCancelledError extends Error {
+  constructor() {
+    super('Job cancelled');
+    this.name = 'JobCancelledError';
+  }
+}
+
 export interface CreateJobParams {
   type: SharedJobType;
   payload?: Record<string, unknown>;
@@ -139,6 +151,7 @@ export class RealJobService implements JobService {
         const handled = await this.executor(ctx);
         if (handled) {
           await this.repo.updateStatus(id, 'completed');
+          this.cancelled.delete(id);
           const finishedAt = new Date().toISOString();
           this.bus.emit(id, { id, status: 'completed', progress: 100, finishedAt });
           await this.logging.logJob(id, 'info', 'Job completed');
@@ -193,10 +206,17 @@ export class RealJobService implements JobService {
       this.bus.emit(id, { id, status: 'completed', progress: 100, finishedAt });
       await this.logging.logJob(id, 'info', 'Job completed');
     } catch (error) {
-      await this.repo.update(id, { status: 'failed', error: error instanceof Error ? error.message : String(error) });
       const finishedAt = new Date().toISOString();
-      this.bus.emit(id, { id, status: 'failed', finishedAt });
-      await this.logging.logJob(id, 'error', 'Job failed', { error: error instanceof Error ? error.message : String(error) });
+      if (error instanceof JobCancelledError) {
+        await this.repo.updateStatus(id, 'cancelled');
+        this.cancelled.delete(id);
+        this.bus.emit(id, { id, status: 'failed', finishedAt });
+        await this.logging.logJob(id, 'warn', 'Job cancelled');
+      } else {
+        await this.repo.update(id, { status: 'failed', error: error instanceof Error ? error.message : String(error) });
+        this.bus.emit(id, { id, status: 'failed', finishedAt });
+        await this.logging.logJob(id, 'error', 'Job failed', { error: error instanceof Error ? error.message : String(error) });
+      }
     } finally {
       this.running--;
       this.tick();
@@ -212,12 +232,21 @@ export class RealJobService implements JobService {
   private async ensureStarted() {
     if (this.started) return;
     await this.db.initialize();
-    // Re-enqueue any pending jobs
     try {
+      // Re-enqueue jobs that were still queued when the process stopped.
       const pending = await this.repo.findByStatus('pending');
       pending.forEach(j => this.enqueue(j.id));
+      // Any job left 'running' was orphaned by a crash/restart — no executor is
+      // driving it anymore — so fail it rather than leave the deployment wedged
+      // showing an in-progress job that never resolves.
+      const orphaned = await this.repo.findByStatus('running');
+      for (const j of orphaned) {
+        await this.repo.update(j.id, { status: 'failed', error: 'Interrupted by server restart' });
+        this.bus.emit(j.id, { id: j.id, status: 'failed', finishedAt: new Date().toISOString() });
+        await this.logging.logJob(j.id, 'error', 'Job failed: interrupted by server restart');
+      }
     } catch (e) {
-      this.logger.warn('Failed to load pending jobs', { error: e instanceof Error ? e.message : String(e) });
+      this.logger.warn('Failed to recover jobs on startup', { error: e instanceof Error ? e.message : String(e) });
     }
     this.started = true;
   }
@@ -236,11 +265,27 @@ export class RealJobService implements JobService {
   }
 
   async cancelJob(id: string): Promise<void> {
-  // Mark for cooperative cancellation and remove from queue if present
-  this.cancelled.add(id);
-  this.queue = this.queue.filter(j => j !== id);
-  await this.repo.updateStatus(id, 'cancelled');
-  this.bus.emit(id, { id, status: 'failed', finishedAt: new Date().toISOString() });
+    const entity = await this.repo.findById(id);
+    // Never overwrite a job that already reached a terminal state — doing so would
+    // corrupt its recorded outcome (e.g. rewriting a 'completed' job to 'cancelled').
+    if (!entity || entity.status === 'completed' || entity.status === 'failed' || entity.status === 'cancelled') {
+      return;
+    }
+    // Flag for cooperative cancellation and drop it from the queue if still waiting.
+    this.cancelled.add(id);
+    this.queue = this.queue.filter(j => j !== id);
+    if (entity.status === 'running') {
+      // A running job is finalized by runJob once a cooperative checkpoint observes
+      // the flag (it throws JobCancelledError) — writing a terminal status here would
+      // be clobbered by the executor's own completion write. Best-effort: a single
+      // long-running Compose call can't be interrupted, so cancellation only takes
+      // effect at the next checkpoint.
+      return;
+    }
+    // Not yet running: finalize now so a dequeued job doesn't sit pending forever.
+    await this.repo.updateStatus(id, 'cancelled');
+    this.cancelled.delete(id);
+    this.bus.emit(id, { id, status: 'failed', finishedAt: new Date().toISOString() });
   }
 
   async getJob(id: string): Promise<SharedJob | null> {


### PR DESCRIPTION
Four confirmed deploy-lifecycle findings from the whole-codebase review.

## `restart` ignored config changes (`deployment.ts`)
The `restart` action re-provisioned auth and re-materialized `docker-compose.yml` (with new env/labels), then called `docker compose restart`, which restarts containers **in place** and never re-reads the compose file — so updated OIDC/auth wiring silently never reached the app. Now uses `up -d` (recreate, like the deploy/start path), which applies the new config using the already-present images.

## `cancelJob` was unsound (`jobs.ts`)
- Overwrote the status of **any** job, including terminal ones — rewriting a `completed`/`failed` row to `cancelled` and corrupting history. Now guards terminal states (no-op).
- A running job's status was set to `cancelled` and then clobbered back to `completed` by the executor, and the executor never observed cancellation. Now: `cancelJob` flags a running job (no DB write), `runLifecycleJob` throws `JobCancelledError` at a cooperative checkpoint (after the long image pull, before the irreversible `up`), and `runJob` records `cancelled` instead of `failed`. Best-effort — a single in-flight Compose call still can't be interrupted, but cancellation now takes effect at the next checkpoint and never corrupts state.

## Crash recovery missed running jobs (`jobs.ts`)
`ensureStarted` only re-enqueued `pending` jobs; a job left `running` when the process died stayed `running` forever, wedging the deployment in an in-progress state. Now orphaned `running` jobs are failed on startup ("Interrupted by server restart").

## `onDeprovision` could orphan the fallback (`deployment.ts`)
If deprovisioning the primary `auth.ref` threw, the `fallback: forward-auth` provider was never torn down. Now both refs are deprovisioned independently (`Promise.allSettled`) and the first error is surfaced after both attempts.

## Tests
New `RealJobService` cancellation + recovery tests (terminal-state guard, cooperative cancel ends `cancelled` not `completed`, orphaned-running recovery). Full typecheck/lint/build/test gate green (server 313 + 3 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Dk3o6ZKgSgrLkQuW9s86L