### PR TITLE
fix(server): stop SSE/monitoring/timeout/metric resource leaks

### DIFF
--- a/packages/server/src/__tests__/lib/metrics-path.test.ts
+++ b/packages/server/src/__tests__/lib/metrics-path.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Metric path templating tests — bounds HTTP-metric label cardinality by
+ * collapsing per-resource identifiers to placeholders.
+ */
+import { describe, it, expect } from 'bun:test';
+import { templateMetricPath } from '../../lib/metrics';
+
+describe('templateMetricPath', () => {
+  it('collapses deployment ids, UUIDs, job ids, hex ids, and numbers', () => {
+    expect(templateMetricPath('/api/deployments/gitea-3f9a2c7b')).toBe('/api/deployments/:id');
+    expect(templateMetricPath('/api/drafts/2fb89ae5-ee38-4659-9b55-e4d422a74528/uploads')).toBe('/api/drafts/:id/uploads');
+    expect(templateMetricPath('/api/jobs/job_1782253680249_9wewojfyyi6/logs')).toBe('/api/jobs/:id/logs');
+    expect(templateMetricPath('/api/items/42')).toBe('/api/items/:n');
+    expect(templateMetricPath('/api/x/deadbeefcafe123')).toBe('/api/x/:id');
+  });
+
+  it('leaves static route segments untouched', () => {
+    expect(templateMetricPath('/api/deployments')).toBe('/api/deployments');
+    expect(templateMetricPath('/api/system/status')).toBe('/api/system/status');
+    expect(templateMetricPath('/api/auth/callback')).toBe('/api/auth/callback');
+    expect(templateMetricPath('/api/health')).toBe('/api/health');
+  });
+});

--- a/packages/server/src/__tests__/utils/sse-cleanup.test.ts
+++ b/packages/server/src/__tests__/utils/sse-cleanup.test.ts
@@ -1,0 +1,46 @@
+/**
+ * SSE stream teardown tests.
+ *
+ * The WHATWG Streams runtime tears down via cancel() (client disconnect), not via
+ * start()'s return value — so cancel() must run the heartbeat-timer + onSubscribe
+ * cleanup, otherwise every dropped connection leaks them.
+ */
+import { describe, it, expect } from 'bun:test';
+import { createSSEStream, type SSEStreamController } from '../../utils/sse';
+
+describe('createSSEStream teardown', () => {
+  it('runs the onSubscribe cleanup when the reader cancels (client disconnect)', async () => {
+    let cleaned = false;
+    const stream = createSSEStream({
+      heartbeatIntervalMs: 10,
+      onSubscribe: (controller) => {
+        controller.sendRaw({ event: 'hello', data: { ok: true } });
+        return () => { cleaned = true; };
+      },
+    });
+
+    const reader = stream.getReader();
+    const first = await reader.read();
+    expect(first.done).toBe(false);
+
+    await reader.cancel();
+    expect(cleaned).toBe(true); // previously stayed false — cancel() was a no-op
+  });
+
+  it('runs the onSubscribe cleanup on an explicit controller.close()', async () => {
+    let cleaned = false;
+    let ctrl: SSEStreamController | undefined;
+    const stream = createSSEStream({
+      heartbeatIntervalMs: 0,
+      onSubscribe: (controller) => {
+        ctrl = controller;
+        return () => { cleaned = true; };
+      },
+    });
+
+    const reader = stream.getReader();
+    ctrl?.close();
+    expect(cleaned).toBe(true);
+    await reader.cancel().catch(() => {});
+  });
+});

--- a/packages/server/src/lib/metrics.ts
+++ b/packages/server/src/lib/metrics.ts
@@ -232,22 +232,49 @@ export function getMetrics(): Metrics {
   return globalMetrics;
 }
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const DEPLOY_ID_RE = /^[a-z0-9][a-z0-9-]*-[0-9a-f]{8}$/i; // slug + 8 hex (makeDeploymentId)
+const JOB_ID_RE = /^job_\d+_[a-z0-9]+$/i;
+const HEX_ID_RE = /^[0-9a-f]{12,}$/i;
+
+/**
+ * Collapse per-resource identifiers (deployment/draft/job ids, UUIDs, numbers)
+ * in a request path to placeholders, so the path used as a metric label has
+ * BOUNDED cardinality. Without this, every distinct id mints a permanent new
+ * label series in the (never-evicted) counter/timer maps — an unbounded memory
+ * leak that an attacker hitting random paths could amplify.
+ */
+export function templateMetricPath(path: string): string {
+  return path
+    .split('/')
+    .map((seg) => {
+      if (!seg) return seg;
+      if (/^\d+$/.test(seg)) return ':n';
+      if (UUID_RE.test(seg) || DEPLOY_ID_RE.test(seg) || JOB_ID_RE.test(seg) || HEX_ID_RE.test(seg)) {
+        return ':id';
+      }
+      return seg;
+    })
+    .join('/');
+}
+
 /**
  * Standard metrics for HTTP requests
  */
 export function recordHttpRequest(method: string, path: string, status: number, duration: number): void {
   const metrics = getMetrics();
-  
+  const templatedPath = templateMetricPath(path);
+
   metrics.counter('http_requests').increment({
     method,
-    path,
+    path: templatedPath,
     status: status.toString(),
     status_class: `${Math.floor(status / 100)}xx`
   });
-  
+
   metrics.timer('http_request_duration').record(duration, {
     method,
-    path,
+    path: templatedPath,
     status: status.toString()
   });
 }

--- a/packages/server/src/middleware/error-mapping.ts
+++ b/packages/server/src/middleware/error-mapping.ts
@@ -288,16 +288,20 @@ export function createTimeoutMiddleware(timeoutMs: number = 30000) {
     request: Request,
     handler: (req: Request) => Promise<Response>
   ): Promise<Response> => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
     const timeoutPromise = new Promise<never>((_, reject) => {
-      setTimeout(() => {
+      timer = setTimeout(() => {
         reject(new TimeoutError(`Request timeout after ${timeoutMs}ms`));
       }, timeoutMs);
     });
 
-    return Promise.race([
-      handler(request),
-      timeoutPromise,
-    ]);
+    try {
+      return await Promise.race([handler(request), timeoutPromise]);
+    } finally {
+      // Clear the timer once the race settles so a fast request doesn't leave a
+      // 30s timer (and its rejected promise) armed per request.
+      if (timer) clearTimeout(timer);
+    }
   };
 }
 

--- a/packages/server/src/services/core/system-monitoring.ts
+++ b/packages/server/src/services/core/system-monitoring.ts
@@ -91,7 +91,6 @@ export interface SystemMonitoringService {
 export class RealSystemMonitoringService implements SystemMonitoringService, HealthCheckable {
   private logger = getLogger().child({ service: 'SystemMonitoringService' });
   private holaDataPath: string;
-  private monitoringInterval?: NodeJS.Timeout;
 
   constructor(holaDataPath?: string) {
     this.holaDataPath = holaDataPath || getHolaDataDir();
@@ -103,24 +102,29 @@ export class RealSystemMonitoringService implements SystemMonitoringService, Hea
     try {
       this.logger.debug('Getting disk usage', { path: targetPath });
       
-      // Use df command for accurate disk usage on Unix systems
-      const { stdout } = await execAsync(`df -B1 "${targetPath}"`);
+      // Use df for accurate disk usage on Unix systems. `-P` (POSIX) guarantees
+      // exactly one physical line per filesystem, so a long device name can't wrap
+      // the data onto a second line and break parsing (which silently fell back to
+      // a fabricated estimate). `-B1` reports raw bytes.
+      const { stdout } = await execAsync(`df -P -B1 "${targetPath}"`);
       const lines = stdout.trim().split('\n');
-      
+
       if (lines.length < 2) {
         throw new Error('Invalid df output');
       }
-      
-      // Parse df output (format: Filesystem 1B-blocks Used Available Use% Mounted)
-      const parts = lines[1].split(/\s+/);
+
+      // Data is the last line: Filesystem 1B-blocks Used Available Capacity Mounted.
+      const parts = lines[lines.length - 1].trim().split(/\s+/);
       if (parts.length < 4) {
         throw new Error('Unable to parse df output');
       }
-      
+
       const totalBytes = parseInt(parts[1], 10);
       const usedBytes = parseInt(parts[2], 10);
       const freeBytes = parseInt(parts[3], 10);
-      const percentUsed = Math.round((usedBytes / totalBytes) * 100);
+      // Guard against a zero/NaN total (e.g. a pseudo-filesystem) so percentUsed
+      // never becomes NaN/Infinity — mirrors getMemoryUsage.
+      const percentUsed = totalBytes > 0 ? Math.round((usedBytes / totalBytes) * 100) : 0;
       
       this.logger.debug('Disk usage retrieved', {
         path: targetPath,
@@ -402,8 +406,11 @@ export class RealSystemMonitoringService implements SystemMonitoringService, Hea
       this.logger.error('Failed to get initial system status', error instanceof Error ? error : undefined);
     });
     
-    // Periodic updates
-    this.monitoringInterval = setInterval(async () => {
+    // Periodic updates. Keep the handle LOCAL to this subscription: the service is
+    // a process-wide singleton, so storing the timer on a shared instance field
+    // meant a second subscriber overwrote the first's handle — leaking the first
+    // timer forever and making stop() clear the wrong one.
+    let timer: ReturnType<typeof setInterval> | undefined = setInterval(async () => {
       try {
         const status = await this.getSystemStatus();
         callback(status);
@@ -411,12 +418,12 @@ export class RealSystemMonitoringService implements SystemMonitoringService, Hea
         this.logger.error('Failed to get system status during monitoring', error instanceof Error ? error : undefined);
       }
     }, interval);
-    
+
     return {
       stop: () => {
-        if (this.monitoringInterval) {
-          clearInterval(this.monitoringInterval);
-          this.monitoringInterval = undefined;
+        if (timer) {
+          clearInterval(timer);
+          timer = undefined;
           this.logger.info('System monitoring stopped');
         }
       },

--- a/packages/server/src/utils/sse.ts
+++ b/packages/server/src/utils/sse.ts
@@ -42,47 +42,18 @@ function formatSSEEvent(event: SSERawEvent): string {
 export function createSSEStream(options: SSEStreamOptions): ReadableStream<Uint8Array> {
   const { onSubscribe, heartbeatIntervalMs = 15000, logger, keepAliveEvent } = options;
 
+  // Teardown shared between start() and cancel(). The Streams runtime does NOT
+  // treat start()'s return value as a teardown hook — only cancel() runs when the
+  // client disconnects — so cancel() must invoke this to stop the heartbeat timer
+  // and run the onSubscribe cleanup. Otherwise every dropped connection leaks a
+  // timer and its subscription (e.g. a `docker compose logs -f` child process).
+  let teardown: (() => void) | undefined;
+
   return new ReadableStream<Uint8Array>({
     start(controller) {
       let isClosed = false;
       let cleanup: (() => void) | undefined;
       let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
-
-      const safeEmit = (event: SSERawEvent) => {
-        if (isClosed) return;
-        try {
-          controller.enqueue(encoder.encode(formatSSEEvent(event)));
-        } catch (error) {
-          isClosed = true;
-          logger?.debug?.('SSE enqueue failed; closing stream', {
-            error: error instanceof Error ? error.message : String(error),
-          });
-          try {
-            controller.close();
-          } catch {
-            // ignore double close
-          }
-          cleanup?.();
-        }
-      };
-
-      const api: SSEStreamController = {
-        send(event) {
-          safeEmit({ event: 'message', data: event });
-        },
-        sendRaw(event) {
-          safeEmit(event);
-        },
-        heartbeat(data = {}) {
-          safeEmit({ event: 'heartbeat', data });
-        },
-        close() {
-          if (isClosed) return;
-          isClosed = true;
-          cleanup?.();
-          controller.close();
-        },
-      };
 
       const clear = () => {
         if (heartbeatTimer) {
@@ -99,6 +70,50 @@ export function createSSEStream(options: SSEStreamOptions): ReadableStream<Uint8
           }
           cleanup = undefined;
         }
+      };
+
+      const safeEmit = (event: SSERawEvent) => {
+        if (isClosed) return;
+        try {
+          controller.enqueue(encoder.encode(formatSSEEvent(event)));
+        } catch (error) {
+          isClosed = true;
+          logger?.debug?.('SSE enqueue failed; closing stream', {
+            error: error instanceof Error ? error.message : String(error),
+          });
+          try {
+            controller.close();
+          } catch {
+            // ignore double close
+          }
+          clear();
+        }
+      };
+
+      const api: SSEStreamController = {
+        send(event) {
+          safeEmit({ event: 'message', data: event });
+        },
+        sendRaw(event) {
+          safeEmit(event);
+        },
+        heartbeat(data = {}) {
+          safeEmit({ event: 'heartbeat', data });
+        },
+        close() {
+          if (isClosed) return;
+          isClosed = true;
+          clear();
+          controller.close();
+        },
+      };
+
+      // Expose teardown so cancel() (client disconnect) stops the heartbeat timer
+      // and runs the onSubscribe cleanup.
+      teardown = () => {
+        if (isClosed) return;
+        isClosed = true;
+        clear();
       };
 
       try {
@@ -120,16 +135,12 @@ export function createSSEStream(options: SSEStreamOptions): ReadableStream<Uint8
         logger?.error?.('SSE subscription failed', error instanceof Error ? error : undefined);
         api.sendRaw({ event: 'error', data: { message: 'internal_error' } });
         api.close();
-        return clear;
       }
-
-      return () => {
-        isClosed = true;
-        clear();
-      };
     },
     cancel() {
-      // No-op: cleanup handled by start return function
+      // The client disconnected (or the reader was cancelled): stop the heartbeat
+      // timer and run the onSubscribe cleanup so nothing leaks per dropped stream.
+      teardown?.();
     },
   });
 }


### PR DESCRIPTION
Five confirmed resource-leak / robustness findings from the whole-codebase review.

## SSE streams leaked on disconnect (`utils/sse.ts`)
`cancel()` was a no-op and the cleanup function returned from `start()` is **ignored** by the WHATWG Streams runtime — teardown only runs on `cancel()`. So every dropped log/status stream leaked its heartbeat `setInterval` and its `onSubscribe` cleanup (e.g. a `docker compose logs -f` child process, a log-bus subscription, `monitoring.stop()`). Teardown is now hoisted and invoked from `cancel()`. Also fixed `close()` / enqueue-error paths, which cleared the subscription but not the heartbeat timer.

## Monitoring timer leak on a shared singleton (`system-monitoring.ts`)
`startMonitoring` stored its interval on `this.monitoringInterval`, but the service is a process-wide singleton — a second `/api/system/status/stream` subscriber overwrote the first's handle, leaking the first timer forever and making `stop()` clear the wrong one. The handle is now local to each subscription.

## `df` parsing + `getDiskUsage` NaN (`system-monitoring.ts`)
A long device name makes `df` wrap the data onto a second line, so `lines[1]` was just the device and parsing threw → a **fabricated** 50%/100GB estimate that then fed the preflight disk-space gate. Now uses `df -P` (POSIX: one physical line per filesystem) and reads the last line. Also guards `percentUsed` against a zero total (no more `NaN`), mirroring `getMemoryUsage`.

## Unbounded metric label cardinality (`lib/metrics.ts`)
The raw request pathname (with per-resource UUIDs / deployment / job ids) was used directly as a metric label in never-evicted counter/timer maps — every distinct id minted a permanent series (memory growth / DoS). A new `templateMetricPath` collapses ids/UUIDs/numbers to `:id`/`:n` before labeling.

## Timeout middleware timer leak (`middleware/error-mapping.ts`)
The `setTimeout` in the `Promise.race` was never cleared when the handler won, leaving a 30s timer (and a rejected promise) armed per request. Now cleared in `finally`. (Currently unused, fixed for correctness when wired.)

## Tests
New SSE-teardown tests (cleanup runs on `cancel()` and `close()`) and metric-path templating tests. Full typecheck/lint/build/test gate green (server 314).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Dk3o6ZKgSgrLkQuW9s86L