### PR TITLE
fix(server): harden upload path handling, query-token, settings errors, audit logs

### DIFF
--- a/packages/server/src/__tests__/drafts/file-operations.test.ts
+++ b/packages/server/src/__tests__/drafts/file-operations.test.ts
@@ -67,6 +67,28 @@ describe('Draft File Operations', () => {
     expect(uploadResult.kind).toBe('composeOverride');
   });
 
+  test('should reject an upload whose name contains path separators or ".."', async () => {
+    const createResponse = await makeRequest<CreateDraftResponse>({
+      method: 'POST',
+      url: `${baseURL}/api/drafts`,
+      body: { appId: 'nextcloud', version: '1.0.0' } as CreateDraftRequest,
+    });
+    const draft = createResponse.data!;
+
+    const uploadResponse = await makeRequest<UploadDraftFileResponse>({
+      method: 'POST',
+      url: `${baseURL}/api/drafts/${draft.draftId}/uploads`,
+      body: {
+        name: '../../../../etc/passwd', // traversal in the file name
+        content: Buffer.from('x').toString('base64'),
+        kind: 'additionalFile',
+      },
+    });
+
+    expect(uploadResponse.success).toBe(false);
+    expect(uploadResponse.error?.code).toBe('INVALID_NAME');
+  });
+
   test('should delete a file from draft', async () => {
     // Create a draft first
     const createRequest: CreateDraftRequest = {

--- a/packages/server/src/__tests__/services/storage-containment.test.ts
+++ b/packages/server/src/__tests__/services/storage-containment.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Storage path-containment tests — relative paths must stay inside the hola data
+ * root, so an untrusted path component (e.g. an uploaded file name) can't write
+ * outside it via '..'. Absolute paths are deliberate (apps bind root) and pass.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { RealStorageService } from '../../services/core/storage';
+
+describe('RealStorageService path containment', () => {
+  let dataRoot: string;
+  let storage: RealStorageService;
+
+  beforeEach(async () => {
+    dataRoot = mkdtempSync(join(tmpdir(), 'hola-storage-'));
+    storage = new RealStorageService({ holaDir: dataRoot });
+    await storage.initialize();
+  });
+
+  afterEach(() => {
+    rmSync(dataRoot, { recursive: true, force: true });
+  });
+
+  it('writes a normal relative path under the data root', async () => {
+    await storage.writeFile('drafts/d1/files/abc-config.yml', Buffer.from('ok'));
+    expect(existsSync(join(dataRoot, 'drafts/d1/files/abc-config.yml'))).toBe(true);
+  });
+
+  it('rejects a relative path that climbs out of the data root', async () => {
+    await expect(
+      storage.writeFile('drafts/d1/files/abc-../../../../../../tmp/evil', Buffer.from('x')),
+    ).rejects.toThrow(/escapes the storage root/);
+  });
+});

--- a/packages/server/src/middleware/auth.ts
+++ b/packages/server/src/middleware/auth.ts
@@ -7,7 +7,7 @@
 import { getLogger } from '../lib/logger';
 import type { Principal, AuthService, Capability } from '../services/auth/auth-service';
 import { getServices } from '../services/simple-factory';
-import { featureFlags } from '../config/features';
+import { featureFlags, environmentConfig } from '../config/features';
 
 export interface AuthContext {
   isAuthenticated: boolean;
@@ -48,11 +48,17 @@ function extractToken(req: Request): string | null {
     return sessionCookie;
   }
 
-  // Try query parameter (less secure, for development)
-  const url = new URL(req.url);
-  const queryToken = url.searchParams.get('token') || url.searchParams.get('api_key');
-  if (queryToken) {
-    return queryToken;
+  // Try query parameter — only outside production. The browser authenticates SSE
+  // (EventSource can't set headers) via the same-origin HttpOnly session cookie
+  // above, so a query-string credential is purely a dev/testing convenience; in
+  // production it would leak the admin key into proxy/access logs and browser
+  // history, so it's disabled there.
+  if (environmentConfig.enableDevApi) {
+    const url = new URL(req.url);
+    const queryToken = url.searchParams.get('token') || url.searchParams.get('api_key');
+    if (queryToken) {
+      return queryToken;
+    }
   }
 
   return null;

--- a/packages/server/src/middleware/request.ts
+++ b/packages/server/src/middleware/request.ts
@@ -59,10 +59,12 @@ export function createRequestMiddleware() {
     const url = new URL(req.url);
     const userContext = extractUserContext(req);
     
-    // Extract auth context (if available from auth middleware)
+    // Auth runs INSIDE next() (authMiddleware is nested below this middleware), so
+    // the principal isn't known yet at request start — it's backfilled after
+    // next() returns, below. This read is null on the first pass.
     const authContext = getAuthContext(req);
     const principal = authContext?.principal;
-    
+
     // Create request-scoped logger
     const logContext: LogContext = {
       requestId,
@@ -126,26 +128,38 @@ export function createRequestMiddleware() {
       );
     }
     
+    // authMiddleware ran inside next(), so the principal is known now — backfill
+    // it onto the stored context (for anything that reads it post-hoc) and the
+    // completion log, restoring per-principal audit visibility.
+    const resolvedAuth = getAuthContext(req);
+    if (resolvedAuth) {
+      context.auth = resolvedAuth;
+      context.principal = resolvedAuth.principal;
+    }
+
     // Add request ID to response headers
     const headers = new Headers(response.headers);
     headers.set('x-request-id', requestId);
-    
+
     const finalResponse = new Response(response.body, {
       status: response.status,
       statusText: response.statusText,
       headers,
     });
-    
+
     // Record metrics and log completion
     const duration = Date.now() - startTime;
     const status = finalResponse.status;
-    
+
     recordHttpRequest(req.method, url.pathname, status, duration);
-    
+
     logger.info('Request completed', {
       status,
       duration,
       error: error?.message,
+      authenticated: resolvedAuth?.isAuthenticated ?? false,
+      principalId: resolvedAuth?.principal?.id,
+      principalType: resolvedAuth?.principal?.type,
     });
     
     return finalResponse;

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -661,10 +661,22 @@ async function route(url: URL, req: Request): Promise<Response> {
         };
       }
 
+      // The file name becomes part of the on-disk blob path, so it must be a bare
+      // file name — reject path separators / '..' the same way `path` is guarded
+      // above (else a crafted name could traverse outside the draft directory).
+      if (
+        fileData.name.includes('/') ||
+        fileData.name.includes('\\') ||
+        fileData.name === '.' ||
+        fileData.name === '..'
+      ) {
+        return json({ error: { code: 'INVALID_NAME', message: 'File name must not contain path separators or ".."' } }, { status: 400 });
+      }
+
       const services = getServices();
       const payload = await services.drafts.uploadFile(draftId, fileData);
-      
-      logger.info('File uploaded successfully', { 
+
+      logger.info('File uploaded successfully', {
         requestId: context?.requestId, 
         draftId,
         uploadId: payload.uploadId,
@@ -1242,11 +1254,10 @@ async function route(url: URL, req: Request): Promise<Response> {
       return json(payload);
     } catch (error) {
       logger.error('Failed to update system settings', error as Error);
-      // Return validation error or service error
-      return json(
-        { error: { code: 'UPDATE_FAILED', message: error instanceof Error ? error.message : 'Failed to update settings' } }, 
-        { status: 500 }
-      );
+      // Route through the shared mapper so a typed ValidationError keeps its
+      // user-facing message + 400, but an unexpected error returns a generic 500
+      // instead of leaking internal details (paths, driver errors).
+      return errorResponse(req, error);
     }
   }
 
@@ -1289,11 +1300,8 @@ async function route(url: URL, req: Request): Promise<Response> {
       return json(payload);
     } catch (error) {
       logger.error('Failed to update backup settings', error as Error);
-      // Return validation error or service error
-      return json(
-        { error: { code: 'UPDATE_FAILED', message: error instanceof Error ? error.message : 'Failed to update backup settings' } }, 
-        { status: 500 }
-      );
+      // Sanitize via the shared mapper (see system-settings handler above).
+      return errorResponse(req, error);
     }
   }
 

--- a/packages/server/src/services/core/storage.ts
+++ b/packages/server/src/services/core/storage.ts
@@ -6,7 +6,7 @@
  */
 
 import { promises as fs } from 'fs';
-import { join, dirname, isAbsolute } from 'path';
+import { join, dirname, isAbsolute, resolve, relative, sep } from 'path';
 import { tmpdir } from 'os';
 import { randomUUID } from 'crypto';
 import { getLogger } from '../../lib/logger';
@@ -281,7 +281,18 @@ export class RealStorageService implements StorageService {
 
   // Utility operations
   private resolveStoragePath(path: string): string {
-    return isAbsolute(path) ? path : this.resolveHolaPath(path);
+    // Absolute paths are deliberate (e.g. the apps bind root, which lives outside
+    // the hola data dir) and pass through. Relative paths resolve under the data
+    // root and MUST stay inside it: reject any that climb out via '..' so an
+    // untrusted component (e.g. an uploaded file name) can't write outside it.
+    if (isAbsolute(path)) return path;
+    const base = resolve(this.config.holaDir);
+    const resolved = resolve(base, path);
+    const rel = relative(base, resolved);
+    if (rel === '..' || rel.startsWith(`..${sep}`) || isAbsolute(rel)) {
+      throw new Error(`Path '${path}' escapes the storage root`);
+    }
+    return resolved;
   }
 
   resolveHolaPath(...segments: string[]): string {


### PR DESCRIPTION
Five confirmed server-hardening findings from the whole-codebase review.

## Draft-upload path traversal (`server.ts`, `storage.ts`)
The uploaded file `name` becomes part of the on-disk blob path (`drafts/<id>/files/<uploadId>-<name>`) but was never sanitized — only the sibling `path` field was traversal-checked. A crafted `name` with enough `..` could write outside the draft dir (authenticated arbitrary file write). Two layers:
- **Route guard**: reject a `name` containing path separators or `..` (400 `INVALID_NAME`).
- **Defense-in-depth**: `resolveStoragePath` now rejects any *relative* path that resolves outside the data root (`escapes the storage root`), protecting every read/write caller. Absolute paths (the apps bind root, deliberately outside the data dir) still pass.

## Query-param auth disabled in production (`middleware/auth.ts`)
`?token=` / `?api_key=` was accepted in all environments, leaking the admin key into proxy/access logs and browser history. The browser authenticates SSE (EventSource can't set headers) via the same-origin HttpOnly session cookie and **never** puts a token in a URL — confirmed the SPA builds no token-bearing URLs — so the query param is purely a dev/test convenience. Now gated on `environmentConfig.enableDevApi` (off in production).

## Settings PATCH error leak (`server.ts`)
The system- and backup-settings PATCH handlers returned `error.message` raw at 500, leaking internal details. Now routed through the shared `mapErrorToResponse`: a typed `ValidationError` keeps its user-facing message + 400, an unexpected error becomes a generic 500.

## Request audit logging (`middleware/request.ts`)
The request-scoped logger read the auth context *before* `authMiddleware` ran (it's nested inside `next()`), so the principal was always absent from request logs. The principal is now backfilled after `next()` onto the stored context and the "Request completed" log/metrics.

## Tests
Upload name-guard route test + storage-containment unit tests (normal path writes; `..`-escaping path rejected). Full typecheck/lint/build/test gate green (server 313).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Dk3o6ZKgSgrLkQuW9s86L