### PR TITLE
fix(server): data & catalog correctness (logs, settings, bundle cache, manifest)

### DIFF
--- a/packages/server/src/__tests__/lib/file-logger-flush.test.ts
+++ b/packages/server/src/__tests__/lib/file-logger-flush.test.ts
@@ -1,0 +1,45 @@
+/**
+ * File-logger flush tests — concurrent flushes (the 5s timer + synchronous
+ * error-level logging) must be serialized and append, so no buffered entry is
+ * lost to an interleaved read-modify-write.
+ */
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { RealFileLogger } from '../../lib/file-logger';
+import { MockStorageService } from '../../services/core/storage';
+
+describe('RealFileLogger.flush', () => {
+  let storage: MockStorageService;
+
+  beforeEach(async () => {
+    storage = new MockStorageService();
+    await storage.initialize();
+  });
+
+  it('serializes concurrent flushes and appends without losing entries', async () => {
+    // Capture every append so we can assert each entry lands exactly once.
+    const appended: string[] = [];
+    const origAppend = storage.appendFile.bind(storage);
+    storage.appendFile = async (p, c) => {
+      appended.push(c.toString());
+      return origAppend(p, c);
+    };
+
+    const logger = new RealFileLogger(storage, { flushInterval: 10 * 60 * 1000 });
+    await logger.initialize();
+
+    // info() only buffers (no auto-flush); seed several entries.
+    await logger.info('entry-alpha');
+    await logger.info('entry-bravo');
+    await logger.info('entry-charlie');
+
+    // Fire several flushes concurrently — the old read-modify-write could drop
+    // already-drained entries; serialization + append must preserve all of them.
+    await Promise.all([logger.flush(), logger.flush(), logger.flush()]);
+
+    const all = appended.join('');
+    for (const msg of ['entry-alpha', 'entry-bravo', 'entry-charlie']) {
+      const occurrences = all.split(`"message":"${msg}"`).length - 1;
+      expect(occurrences).toBe(1);
+    }
+  });
+});

--- a/packages/server/src/__tests__/services/settings-upsert.test.ts
+++ b/packages/server/src/__tests__/services/settings-upsert.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Settings repository upsert test — updating settings must preserve the row's
+ * created_at (and not churn it), proving it UPDATEs in place rather than the old
+ * INSERT OR REPLACE (which deletes + reinserts, resetting created_at).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { RealStorageService } from '../../services/core/storage';
+import { RealDatabaseService } from '../../services/core/database';
+import { DatabaseSettingsRepository } from '../../services/core/repositories';
+
+describe('DatabaseSettingsRepository upsert', () => {
+  let dataRoot: string;
+  let database: RealDatabaseService;
+
+  beforeEach(async () => {
+    dataRoot = mkdtempSync(join(tmpdir(), 'hola-settings-'));
+    database = new RealDatabaseService(new RealStorageService({ holaDir: dataRoot }));
+    await database.initialize();
+  });
+
+  afterEach(() => {
+    rmSync(dataRoot, { recursive: true, force: true });
+  });
+
+  it('preserves created_at across an update (UPDATE in place, not delete+reinsert)', async () => {
+    const repo = new DatabaseSettingsRepository(database);
+
+    // First save creates the row.
+    const settings = await repo.getSystemSettings();
+    // Pin created_at to a known past value so a REPLACE (which resets it to now)
+    // is detectable.
+    const PAST = '2000-01-01T00:00:00.000Z';
+    await database.run("UPDATE settings SET created_at = ? WHERE type = 'system'", [PAST]);
+
+    // Re-save: the conflict path runs.
+    await repo.updateSystemSettings(settings);
+
+    const row = await database.get<{ created_at: string }>(
+      "SELECT created_at FROM settings WHERE type = 'system'",
+    );
+    expect(row?.created_at).toBe(PAST);
+  });
+});

--- a/packages/server/src/lib/file-logger.ts
+++ b/packages/server/src/lib/file-logger.ts
@@ -56,6 +56,9 @@ export class RealFileLogger implements FileLogger {
   private buffer: LogEntry[] = [];
   private flushTimer?: NodeJS.Timeout;
   private initialized = false;
+  // Serializes flush() calls (the 5s timer and synchronous error-level logging
+  // both trigger it) so they can't interleave and drop already-drained entries.
+  private flushChain: Promise<void> = Promise.resolve();
 
   private readonly levelPriorities: Record<LogLevel, number> = {
     debug: 0,
@@ -163,6 +166,16 @@ export class RealFileLogger implements FileLogger {
   }
 
   async flush(): Promise<void> {
+    // Chain onto the previous flush so only one runs at a time; keep the chain
+    // alive even if a flush rejects (catch on the stored chain) so one failure
+    // doesn't wedge every future flush. The caller still observes this flush's
+    // result via `run`.
+    const run = this.flushChain.then(() => this.doFlush());
+    this.flushChain = run.catch(() => {});
+    return run;
+  }
+
+  private async doFlush(): Promise<void> {
     if (this.buffer.length === 0) {
       return;
     }
@@ -172,23 +185,19 @@ export class RealFileLogger implements FileLogger {
 
     try {
       const content = this.formatEntries(entries);
-      
+
       // Check if rotation is needed
       await this.checkRotation();
 
-      // Append to current log file
+      // Append to the current log file rather than read-modify-write the whole
+      // file: O(append) instead of O(file size) per flush, and no read-then-write
+      // window for a concurrent flush to clobber (flushes are also serialized).
       const logFilePath = this.storage.resolveHolaPath('logs', this.currentLogFile);
-      
-      let existingContent = '';
-      if (await this.storage.fileExists(logFilePath)) {
-        existingContent = await this.storage.readFileAsString(logFilePath);
-      }
+      await this.storage.appendFile(logFilePath, content);
 
-      await this.storage.writeFile(logFilePath, existingContent + content);
-
-      this.logger.debug('Log entries flushed', { 
-        count: entries.length, 
-        file: this.currentLogFile 
+      this.logger.debug('Log entries flushed', {
+        count: entries.length,
+        file: this.currentLogFile
       });
     } catch (error) {
       this.logger.error('Failed to flush log entries', error as Error);

--- a/packages/server/src/services/core/bundles.ts
+++ b/packages/server/src/services/core/bundles.ts
@@ -45,49 +45,58 @@ export class RealBundleService implements BundleService, HealthCheckable {
 
   async ensurePulled(opts: { appId: string; version: string; ociRef: string }): Promise<BundleInfo> {
     this.enforceAllowlist(opts.ociRef);
-    const dest = join(this.baseCache, sanitize(opts.appId), sanitize(opts.version));
-    mkdirSync(dest, { recursive: true });
-
-    // Touch cache entry for LRU tracking
-    this.cacheManager.touch(opts.appId, opts.version);
-
-    // If already has compose.yaml and manifest.json, assume cached
-    if (existsSync(join(dest, 'compose.yaml')) && existsSync(join(dest, 'manifest.json'))) {
-      this.logger.debug('Bundle already cached', { appId: opts.appId, version: opts.version });
-      return { localPath: dest, ...this.safeStat(dest) };
-    }
-
-    // Clean dest to avoid mixed content
-    try { rmSync(dest, { recursive: true, force: true }); } catch { /* ignore existing */ }
-    mkdirSync(dest, { recursive: true });
-
-    // Run cache cleanup before pulling new content
-    await this.cleanup();
-
-    // oras pull to a temp dir then move is ideal; for simplicity, pull into dest
-    const pullCmd = `oras pull --include-subject ${shellEscape(opts.ociRef)} -o ${shellEscape(dest)}`;
-    this.logger.info('Pulling OCI bundle via ORAS', { ref: opts.ociRef, dest });
+    // Protect this bundle from eviction while we pull and return it: cleanup()
+    // runs inside ensurePulled, so a concurrent pull could otherwise rmSync a
+    // bundle dir that's mid-pull/in-use. (The cache's "never evict in-use" guard
+    // was previously dead because nothing ever marked a bundle in-use.)
+    this.cacheManager.markInUse(opts.appId, opts.version);
     try {
-      const { stdout, stderr } = await execAsync(pullCmd);
-      this.logger.debug('ORAS pull output', { stdout: stdout?.slice(0, 500), stderr: stderr?.slice(0, 500) });
-    } catch (error) {
-      this.logger.error('ORAS pull failed', error as Error, { ref: opts.ociRef });
-      throw new Error('ORAS_PULL_FAILED', { cause: error });
-    }
+      const dest = join(this.baseCache, sanitize(opts.appId), sanitize(opts.version));
+      mkdirSync(dest, { recursive: true });
 
-    // Optional signature verify-if-present
-    if (catalogConfig.signaturePolicy !== 'none') {
-      const verifyResult = await this.verifySignature(dest);
-      if (catalogConfig.signaturePolicy === 'required' && !verifyResult.verified) {
-        this.logger.error('Bundle signature verification failed', undefined, { ref: opts.ociRef, error: verifyResult.error });
-        rmSync(dest, { recursive: true, force: true });
-        throw new Error('SIGNATURE_VERIFICATION_FAILED');
-      } else if (!verifyResult.verified) {
-        this.logger.warn('Bundle signature verification failed but policy is optional', { ref: opts.ociRef, error: verifyResult.error });
+      // Touch cache entry for LRU tracking
+      this.cacheManager.touch(opts.appId, opts.version);
+
+      // If already has compose.yaml and manifest.json, assume cached
+      if (existsSync(join(dest, 'compose.yaml')) && existsSync(join(dest, 'manifest.json'))) {
+        this.logger.debug('Bundle already cached', { appId: opts.appId, version: opts.version });
+        return { localPath: dest, ...this.safeStat(dest) };
       }
-    }
 
-    return { localPath: dest, ...this.safeStat(dest) };
+      // Clean dest to avoid mixed content
+      try { rmSync(dest, { recursive: true, force: true }); } catch { /* ignore existing */ }
+      mkdirSync(dest, { recursive: true });
+
+      // Run cache cleanup before pulling new content
+      await this.cleanup();
+
+      // oras pull to a temp dir then move is ideal; for simplicity, pull into dest
+      const pullCmd = `oras pull --include-subject ${shellEscape(opts.ociRef)} -o ${shellEscape(dest)}`;
+      this.logger.info('Pulling OCI bundle via ORAS', { ref: opts.ociRef, dest });
+      try {
+        const { stdout, stderr } = await execAsync(pullCmd);
+        this.logger.debug('ORAS pull output', { stdout: stdout?.slice(0, 500), stderr: stderr?.slice(0, 500) });
+      } catch (error) {
+        this.logger.error('ORAS pull failed', error as Error, { ref: opts.ociRef });
+        throw new Error('ORAS_PULL_FAILED', { cause: error });
+      }
+
+      // Optional signature verify-if-present
+      if (catalogConfig.signaturePolicy !== 'none') {
+        const verifyResult = await this.verifySignature(dest);
+        if (catalogConfig.signaturePolicy === 'required' && !verifyResult.verified) {
+          this.logger.error('Bundle signature verification failed', undefined, { ref: opts.ociRef, error: verifyResult.error });
+          rmSync(dest, { recursive: true, force: true });
+          throw new Error('SIGNATURE_VERIFICATION_FAILED');
+        } else if (!verifyResult.verified) {
+          this.logger.warn('Bundle signature verification failed but policy is optional', { ref: opts.ociRef, error: verifyResult.error });
+        }
+      }
+
+      return { localPath: dest, ...this.safeStat(dest) };
+    } finally {
+      this.cacheManager.markNotInUse(opts.appId, opts.version);
+    }
   }
 
   async validateLayout(bundlePath: string): Promise<{ ok: boolean; errors: string[]; warnings: string[] }> {

--- a/packages/server/src/services/core/catalog.ts
+++ b/packages/server/src/services/core/catalog.ts
@@ -186,8 +186,11 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
 
       const manifest: Manifest = JSON.parse(raw) as unknown as Manifest;
 
-      // minimal validation
-      if (!manifest || !Array.isArray(manifest.defaultEnv) || typeof manifest.defaults !== 'object') {
+      // minimal validation. `defaults` is optional (an app may declare only
+      // defaultEnv with no extra ports/volumes), so only reject it when present
+      // but malformed — `typeof undefined !== 'object'` must not fail a valid
+      // manifest. Downstream reads already use `manifest.defaults?.…`.
+      if (!manifest || !Array.isArray(manifest.defaultEnv) || (manifest.defaults !== undefined && typeof manifest.defaults !== 'object')) {
         throw new Error('MANIFEST_MISSING_FIELDS');
       }
 

--- a/packages/server/src/services/core/repositories.ts
+++ b/packages/server/src/services/core/repositories.ts
@@ -157,9 +157,13 @@ export class DatabaseSettingsRepository implements SettingsRepository {
       const data = JSON.stringify(settings);
       const now = new Date().toISOString();
 
+      // UPSERT (not INSERT OR REPLACE): REPLACE deletes the conflicting row and
+      // re-inserts, resetting created_at and churning the autoincrement id on
+      // every save. ON CONFLICT updates in place, preserving id + created_at.
       await this.db.run(`
-        INSERT OR REPLACE INTO settings (type, data, updated_at)
+        INSERT INTO settings (type, data, updated_at)
         VALUES (?, ?, ?)
+        ON CONFLICT(type) DO UPDATE SET data = excluded.data, updated_at = excluded.updated_at
       `, ['system', data, now]);
 
       this.logger.info('System settings updated in database');
@@ -199,9 +203,11 @@ export class DatabaseSettingsRepository implements SettingsRepository {
       const data = JSON.stringify(settings);
       const now = new Date().toISOString();
 
+      // UPSERT in place to preserve id + created_at (see updateSystemSettings).
       await this.db.run(`
-        INSERT OR REPLACE INTO settings (type, data, updated_at)
+        INSERT INTO settings (type, data, updated_at)
         VALUES (?, ?, ?)
+        ON CONFLICT(type) DO UPDATE SET data = excluded.data, updated_at = excluded.updated_at
       `, ['backup', data, now]);
 
       this.logger.info('Backup settings updated in database');

--- a/packages/server/src/services/core/storage.ts
+++ b/packages/server/src/services/core/storage.ts
@@ -37,6 +37,9 @@ export interface StorageService extends HealthCheckable {
   // File operations
   // `mode` (e.g. 0o600) restricts permissions for files holding secrets.
   writeFile(path: string, content: string | Buffer, mode?: number): Promise<void>;
+  /** Append to a file (creating it + parent dirs if needed). Use for append-only
+   *  files like logs, where rewriting the whole file would be O(size) and racy. */
+  appendFile(path: string, content: string | Buffer): Promise<void>;
   readFile(path: string): Promise<Buffer>;
   readFileAsString(path: string, encoding?: BufferEncoding): Promise<string>;
   deleteFile(path: string): Promise<void>;
@@ -203,6 +206,21 @@ export class RealStorageService implements StorageService {
     }
   }
 
+  async appendFile(path: string, content: string | Buffer): Promise<void> {
+    path = this.resolveStoragePath(path);
+
+    try {
+      if (this.config.createDirs) {
+        await this.ensureDir(dirname(path));
+      }
+      await fs.appendFile(path, content);
+      this.logger.debug('File appended', { path });
+    } catch (error) {
+      this.logger.error('Failed to append file', error as Error, { path });
+      throw new Error(`Failed to append file ${path}: ${error}`, { cause: error });
+    }
+  }
+
   private async writeFileAtomic(path: string, content: string | Buffer, mode?: number): Promise<void> {
     const tempPath = `${path}.tmp.${randomUUID()}`;
 
@@ -350,6 +368,12 @@ export class MockStorageService implements StorageService {
     const buffer = Buffer.isBuffer(content) ? content : Buffer.from(content);
     this.files.set(path, buffer);
     this.logger.debug('Mock file written', { path, size: buffer.length, mode });
+  }
+
+  async appendFile(path: string, content: string | Buffer): Promise<void> {
+    const buffer = Buffer.isBuffer(content) ? content : Buffer.from(content);
+    const existing = this.files.get(path);
+    this.files.set(path, existing ? Buffer.concat([existing, buffer]) : buffer);
   }
 
   async readFile(path: string): Promise<Buffer> {


### PR DESCRIPTION
Four confirmed correctness findings from the whole-codebase review.

## File-logger flush race + O(filesize) memory (`lib/file-logger.ts`)
`flush()` did an unlocked read-whole-file → write-whole-file, triggered concurrently by the 5s interval and synchronous error-level logging. Two interleaved flushes both read the same content and the later write clobbered the earlier — silently losing already-drained entries — and each flush reloaded the entire (up to 50MB) file. Now flushes are **serialized** (chained, error-isolated) and **append** via a new `StorageService.appendFile` primitive (Real + Mock).

## Settings churned `created_at`/`id` (`repositories.ts`)
`updateSystemSettings`/`updateBackupSettings` used `INSERT OR REPLACE`, which deletes the conflicting row and re-inserts — resetting `created_at` to now and reallocating the id on every save. Replaced with `INSERT … ON CONFLICT(type) DO UPDATE` (the `idx_settings_type` unique index is the conflict target), which updates in place.

## Dead bundle-cache in-use protection (`bundles.ts`)
The cache's headline guarantee ("never evict in-use bundles") was dead: `markInUse` was never called from production, so `isInUse()` was always false and `cleanup()` (which runs inside `ensurePulled`) could `rmSync` a bundle another deploy was mid-pull on. `ensurePulled` now marks the bundle in-use for the duration of the pull (released in `finally`).

## Catalog rejected valid manifests (`catalog.ts`)
`getVersionDetail` threw `MANIFEST_MISSING_FIELDS` when `typeof manifest.defaults !== 'object'` — true for an omitted (optional) `defaults` block, failing the install for an app that only declares `defaultEnv`. Now only rejects when `defaults` is present but malformed; downstream already reads `manifest.defaults?.…`.

## Tests
New file-logger flush (concurrent flushes preserve every entry once), settings-upsert (`created_at` preserved across updates), and storage-containment/append coverage. Full typecheck/lint/build/test gate green (server 312).

> Note: the related ingress-service heuristic finding (`services[app] || names[0]`) is intentionally **not** in this PR — a correct fix needs a manifest-declared web/ingress service (a cross-repo schema change), so it's left for a focused follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Dk3o6ZKgSgrLkQuW9s86L