### PR TITLE
fix(cli): make --no-stream take effect and escape $ in rendered .env values

### DIFF
--- a/packages/cli/src/__tests__/install-schema.test.ts
+++ b/packages/cli/src/__tests__/install-schema.test.ts
@@ -152,9 +152,12 @@ describe('renderEnv', () => {
     expect(out).toContain('NEW_KEY=v');
   });
 
-  it('does not interpret $ in values', () => {
-    const out = renderEnv({ TOK: 'a$&b' }, 'TOK=old\n');
-    expect(out).toContain('TOK=a$&b');
+  it('escapes $ so compose .env interpolation keeps values literal, and round-trips via parseEnv', () => {
+    const out = renderEnv({ TOK: 'a$b$&c' }, 'TOK=old\n');
+    // Stored as `$$` so `docker compose` interpolation yields the literal value…
+    expect(out).toContain('TOK=a$$b$$&c');
+    // …and reading it back unescapes to the original (e.g. for `hola credentials`).
+    expect(parseEnv(out).TOK).toBe('a$b$&c');
   });
 
   it('schemaTemplate emits a documented stub for off-repo runs', () => {

--- a/packages/cli/src/__tests__/opts.test.ts
+++ b/packages/cli/src/__tests__/opts.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { camelKeys } from '../lib/opts';
+import { camelKeys, streamOpts } from '../lib/opts';
 
 describe('camelKeys', () => {
   it('camelCases kebab-case flag keys (the sade/mri multi-word fix)', () => {
@@ -21,5 +21,21 @@ describe('camelKeys', () => {
   it('leaves single-word keys (and mri --no-x → {x:false}) untouched', () => {
     const out = camelKeys({ host: 'me@vm', json: false, stream: false, _: ['a'] });
     expect(out).toEqual({ host: 'me@vm', json: false, stream: false, _: ['a'] });
+  });
+});
+
+describe('streamOpts (--no-stream normalization)', () => {
+  it('sets noStream=true when sade parsed --no-stream into {stream:false}', () => {
+    // Reproduces sade/mri: `--no-stream` becomes `{ stream: false }`, never `noStream`.
+    expect(streamOpts({ stream: false }).noStream).toBe(true);
+  });
+
+  it('leaves noStream=false when the flag is absent', () => {
+    expect(streamOpts({}).noStream).toBe(false);
+    expect(streamOpts({ stream: true }).noStream).toBe(false);
+  });
+
+  it('still honors an explicit noStream:true', () => {
+    expect(streamOpts({ noStream: true }).noStream).toBe(true);
   });
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,7 +2,7 @@
 import sade from 'sade';
 
 import { CLI_VERSION } from './version';
-import { camelKeys } from './lib/opts';
+import { camelKeys, streamOpts } from './lib/opts';
 
 // Lazy command loaders to avoid unnecessary dependencies until invoked
 const load = async <T,>(p: Promise<T>): Promise<T> => p;
@@ -106,7 +106,7 @@ prog
   .option('--json', 'Print the result as JSON', false)
   .action(async (appId, opts) => {
     const { runInstall } = await load(import('./commands/install/install'));
-    await runInstall(appId, camelKeys(opts));
+    await runInstall(appId, streamOpts(opts));
   });
 
 // deployments — list installed deployments
@@ -139,7 +139,7 @@ prog
   .option('--json', 'Print the result as JSON', false)
   .action(async (deploymentId, opts) => {
     const { runDeploymentAction } = await load(import('./commands/deployments/actions'));
-    await runDeploymentAction('stop', deploymentId, camelKeys(opts));
+    await runDeploymentAction('stop', deploymentId, streamOpts(opts));
   });
 
 prog
@@ -149,7 +149,7 @@ prog
   .option('--json', 'Print the result as JSON', false)
   .action(async (deploymentId, opts) => {
     const { runDeploymentAction } = await load(import('./commands/deployments/actions'));
-    await runDeploymentAction('restart', deploymentId, camelKeys(opts));
+    await runDeploymentAction('restart', deploymentId, streamOpts(opts));
   });
 
 // uninstall — remove a deployment (containers, data, auth) — destructive
@@ -173,7 +173,7 @@ prog
   .option('--json', 'Print the result as JSON', false)
   .action(async (deploymentId, opts) => {
     const { runRollback } = await load(import('./commands/deployments/actions'));
-    await runRollback(deploymentId, camelKeys(opts));
+    await runRollback(deploymentId, streamOpts(opts));
   });
 
 // Fallback banner when no args

--- a/packages/cli/src/install/render-env.ts
+++ b/packages/cli/src/install/render-env.ts
@@ -5,6 +5,20 @@
 
 import { INSTALL_SCHEMA, defaultFor, type ConfigMap, type InstallField } from './schema';
 
+/**
+ * Docker Compose interpolates `$` in `.env` values (`$FOO` / `${FOO}`), so a
+ * literal `$` must be written as `$$`. These helpers keep the in-memory config
+ * always *unescaped* and the file always *escaped*, so a secret containing `$`
+ * (Cloudflare token, AWS key, …) survives the round-trip instead of being
+ * silently corrupted by compose, and re-runs don't double-escape.
+ */
+export function escapeEnvValue(value: string): string {
+  return value.replace(/\$/g, () => '$$');
+}
+function unescapeEnvValue(value: string): string {
+  return value.replace(/\$\$/g, () => '$');
+}
+
 /** Parse a `.env` text into a flat map (ignores comments/blank lines). */
 export function parseEnv(text: string): ConfigMap {
   const out: ConfigMap = {};
@@ -12,7 +26,7 @@ export function parseEnv(text: string): ConfigMap {
     const line = raw.trim();
     if (!line || line.startsWith('#') || !line.includes('=')) continue;
     const eq = line.indexOf('=');
-    out[line.slice(0, eq).trim()] = line.slice(eq + 1).trim();
+    out[line.slice(0, eq).trim()] = unescapeEnvValue(line.slice(eq + 1).trim());
   }
   return out;
 }
@@ -26,7 +40,7 @@ export function renderEnv(config: ConfigMap, baseText: string): string {
   const appended: string[] = [];
   for (const [key, value] of Object.entries(config)) {
     const re = new RegExp(`^${escapeRe(key)}=.*$`, 'm');
-    const line = `${key}=${value}`;
+    const line = `${key}=${escapeEnvValue(value)}`;
     if (re.test(text)) {
       // Function replacement avoids `$&`/`$1` interpretation in the value.
       text = text.replace(re, () => line);

--- a/packages/cli/src/lib/opts.ts
+++ b/packages/cli/src/lib/opts.ts
@@ -9,3 +9,14 @@ export const camelKeys = <T extends Record<string, unknown>>(opts: T): T => {
   }
   return out as T;
 };
+
+/**
+ * camelKeys + normalize the `--no-stream` flag. sade/mri routes `--no-stream` to
+ * `{ stream: false }` and never sets `noStream`, so command handlers that read
+ * `opts.noStream` would never see the flag take effect. Surface it explicitly so
+ * `--no-stream` actually disables job watching.
+ */
+export const streamOpts = <T extends Record<string, unknown>>(opts: T): T & { noStream: boolean } => {
+  const o = camelKeys(opts);
+  return { ...o, noStream: o.noStream === true || o.stream === false };
+};


### PR DESCRIPTION
Two confirmed CLI findings from the whole-codebase review.

## `--no-stream` was a dead flag (`index.ts`, `lib/opts.ts`)
On `install` / `stop` / `restart` / `rollback`, sade/mri routes `--no-stream` to `{ stream: false }` and **never** sets `noStream` — but the handlers read `opts.noStream`, so the flag was always ignored and the job was watched regardless (reproduced: `--no-stream` → `{stream:false}`, no `noStream` key). Added `streamOpts()` (camelKeys + derive `noStream` from `stream === false`, still honoring an explicit `noStream:true` for the unit-test call style) and wired the four streaming commands through it.

## `render-env` corrupted secrets containing `$` (`install/render-env.ts`)
Values were written raw, but Docker Compose interpolates `$` in `.env` (`$FOO` / `${FOO}`), so a secret with a literal `$` (Cloudflare DNS token, AWS secret key, …) was silently truncated/mangled — producing opaque TLS-cert-issuance / API-auth failures. `renderEnv` now escapes `$`→`$$` and `parseEnv` reverses it, so values round-trip (and `hola credentials` still shows the real value) and re-runs don't double-escape.

## Tests
`streamOpts` normalization tests (reproducing sade's `{stream:false}`) and a `$`-escaping round-trip test.

> Note: one pre-existing, unrelated test (`defaults the timezone…`) fails only in a UTC sandbox where `Intl` resolves `UTC` instead of an IANA `Region/City` zone — it fails on `main` too and passes on CI hosts. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Dk3o6ZKgSgrLkQuW9s86L