### PR TITLE
fix(shared): stop generateChangelog mutating version history; correct SDK preflight type

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -4,7 +4,7 @@ import {
   CreateDraftRequest, CreateDraftResponse, GetDraftResponse, 
   PatchDraftRequest, PatchDraftResponse,
   UploadDraftFileResponse, DeleteDraftFileResponse,
-  ValidateDraftResponse, FinalizeDraftResponse,
+  ValidateDraftResponse, EnhancedPreflightResponse, FinalizeDraftResponse,
   // Phase 7 Deployment types
   CreateDeploymentFromDraftRequest, CreateDeploymentFromDraftResponse,
   GetDeploymentsRequest, GetDeploymentsResponse, GetDeploymentResponse,
@@ -100,7 +100,7 @@ export class HolaSdk {
     removeFile: (draftId: string, uploadId: string) => 
       this.delete<DeleteDraftFileResponse>(API.drafts.uploadById(draftId, uploadId)),
     validate: (draftId: string) => this.post<ValidateDraftResponse>(API.drafts.validate(draftId)),
-    preflight: (draftId: string) => this.post<ValidateDraftResponse>(API.drafts.preflight(draftId)),
+    preflight: (draftId: string) => this.post<EnhancedPreflightResponse>(API.drafts.preflight(draftId)),
     finalize: (draftId: string) => this.post<FinalizeDraftResponse>(API.drafts.finalize(draftId)),
   };
 

--- a/packages/server/src/__tests__/shared/migration-tracker.test.ts
+++ b/packages/server/src/__tests__/shared/migration-tracker.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Regression: generateChangelog() must not mutate the shared API_VERSION_HISTORY.
+ * It once iterated `API_VERSION_HISTORY.reverse()` (in place), permanently
+ * reversing the shared array so getLatestVersion() returned the oldest version
+ * and the call was non-idempotent.
+ */
+import { describe, it, expect } from 'bun:test';
+import { generateChangelog, getLatestVersion } from '@hola/shared';
+
+describe('generateChangelog', () => {
+  it('does not reverse API_VERSION_HISTORY (getLatestVersion stays stable, idempotent)', () => {
+    const latestBefore = getLatestVersion().version;
+
+    const first = generateChangelog();
+    expect(getLatestVersion().version).toBe(latestBefore);
+
+    // Idempotent: a second call produces identical output and still doesn't
+    // corrupt the ordering.
+    const second = generateChangelog();
+    expect(second).toBe(first);
+    expect(getLatestVersion().version).toBe(latestBefore);
+  });
+});

--- a/packages/shared/src/docs/migration-tracker.ts
+++ b/packages/shared/src/docs/migration-tracker.ts
@@ -442,7 +442,11 @@ This document tracks all changes to the Hola API across different versions.
 
 `;
 
-  for (const version of API_VERSION_HISTORY.reverse()) {
+  // Iterate newest-first on a COPY — Array.reverse() mutates in place, and
+  // API_VERSION_HISTORY is shared module state that getLatestVersion/getVersion/
+  // generateMigrationGuide rely on being in chronological order (this once left
+  // it permanently reversed and made generateChangelog non-idempotent).
+  for (const version of [...API_VERSION_HISTORY].reverse()) {
     changelog += `## [${version.version}] - ${version.releaseDate}
 
 ${version.description}


### PR DESCRIPTION
Two confirmed findings from the whole-codebase review.

## `generateChangelog()` mutated shared state (`docs/migration-tracker.ts`)
It iterated `API_VERSION_HISTORY.reverse()`, which reverses the array **in place**. `API_VERSION_HISTORY` is shared module state that `getLatestVersion()` / `getVersion()` / `generateMigrationGuide()` rely on being chronological — so after one `generateChangelog()` call, `getLatestVersion()` returned the *oldest* version and the index/slice logic broke; the function was also non-idempotent. Now iterates a copy (`[...API_VERSION_HISTORY].reverse()`), matching the sibling `generateChangelogHTML`.

## SDK `drafts.preflight` mistyped (`sdk/index.ts`)
It was typed `ValidateDraftResponse`, but `/api/drafts/:id/preflight` returns `EnhancedPreflightResponse` (`{ ok, checks, reservationToken? }`, confirmed in the draft service + server route). Callers reading `.checks` got an untyped/misrepresented shape. Corrected to `EnhancedPreflightResponse`.

## Tests
Added a `generateChangelog` idempotency + ordering regression test (`getLatestVersion()` stays stable across calls). Full typecheck/lint/build/test gate green (server 311).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Dk3o6ZKgSgrLkQuW9s86L