### PR TITLE
fix(server): native-oidc role-claim scope + scope-mapping self-heal on reuse

### DIFF
--- a/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
+++ b/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
@@ -237,6 +237,49 @@ describe('RealAuthentikProvisionerService (REST contract)', () => {
     expect(pbody.property_mappings).toEqual(['scope-openid', 'scope-profile', 'scope-email', 'roleclaim-pk']);
   });
 
+  test('native-oidc role claim rides on a scope the client actually requests (not a hardcoded profile)', async () => {
+    installFetch();
+    const svc = new RealAuthentikProvisionerService(CONFIG);
+
+    await svc.provision({
+      deploymentId: 'dep-app00000123456789',
+      appName: 'app',
+      mode: 'native-oidc' as const,
+      host: 'app.example.com',
+      oidc: {
+        redirectPath: '/auth/login',
+        scopes: ['openid', 'email'], // NO 'profile'
+        roleClaim: { claim: 'app_role', adminGroup: 'hola-admins', adminValue: 'admin', memberValue: 'user' },
+      },
+    });
+
+    // The claim must ride on a REQUESTED scope ('email'), else Authentik drops it.
+    const mapCall = calls.find(c => c.method === 'POST' && c.path === '/api/v3/propertymappings/provider/scope/')!;
+    expect((mapCall.body as Record<string, string>).scope_name).toBe('email');
+  });
+
+  test('native-oidc reuse re-resolves and reattaches scope mappings (heals a degraded provider)', async () => {
+    installFetch((call) => {
+      // Existing provider created during a transient scope-listing failure → no mappings.
+      if (call.method === 'GET' && call.path === '/api/v3/providers/oauth2/42/') {
+        return json({ pk: 42, client_id: 'cid', client_secret: 'sec', property_mappings: [] });
+      }
+      return undefined;
+    });
+    const svc = new RealAuthentikProvisionerService(CONFIG);
+
+    await svc.provision({ ...OIDC_INPUT, existingRef: { mode: 'native-oidc', providerPk: 42, applicationSlug: 'gitea-dep-abcd' } });
+
+    // The reuse PATCH (re)attaches the standard scope mappings even though the
+    // provider had none — previously these were never healed on reuse.
+    const patch = calls.find(c => c.method === 'PATCH' && c.path === '/api/v3/providers/oauth2/42/')!;
+    expect(patch).toBeDefined();
+    const pm = (patch.body as { property_mappings: string[] }).property_mappings;
+    expect(pm).toContain('scope-openid');
+    expect(pm).toContain('scope-profile');
+    expect(pm).toContain('scope-email');
+  });
+
   test('native-oidc resolves scope mappings by managed id when scope_name is absent', async () => {
     // The polymorphic endpoint doesn't always surface scope_name; the `managed`
     // identifier is the stable fallback (issue #144).

--- a/packages/server/src/services/core/provisioner.ts
+++ b/packages/server/src/services/core/provisioner.ts
@@ -306,14 +306,21 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
     if (existing && existing.mode === 'native-oidc' && existing.providerPk != null) {
       const provider = await this.api<AuthentikOAuth2Provider>('GET', `/api/v3/providers/oauth2/${existing.providerPk}/`);
       const reuseSlug = existing.applicationSlug ?? slug;
-      // Ensure the role-claim mapping (idempotent) and attach it if not already —
-      // covers an app that added roleClaim to its manifest after first install.
-      const roleClaimPk = await this.ensureRoleClaimMapping(oidc.roleClaim, reuseSlug);
-      const mappings = provider.property_mappings ?? [];
-      const mergedMappings = roleClaimPk && !mappings.includes(roleClaimPk) ? [...mappings, roleClaimPk] : undefined;
+      // Self-heal on every redeploy: re-resolve the standard scope mappings and the
+      // role-claim mapping and (re)attach them. An app first provisioned during a
+      // transient scope-listing failure (empty property_mappings) would otherwise
+      // stay permanently degraded — the dashboard path already self-heals this way.
+      // Union with what's already attached so a transient re-failure can't wipe a
+      // provider's mappings, and mappings we don't manage aren't dropped.
+      const [scopePks, roleClaimPk] = await Promise.all([
+        this.resolveScopeMappingPks(oidc.scopes),
+        this.ensureRoleClaimMapping(oidc.roleClaim, reuseSlug, oidc.scopes),
+      ]);
+      const desired = new Set<string>([...(provider.property_mappings ?? []), ...scopePks]);
+      if (roleClaimPk) desired.add(roleClaimPk);
       await this.api('PATCH', `/api/v3/providers/oauth2/${existing.providerPk}/`, {
         redirect_uris: redirectUris,
-        ...(mergedMappings ? { property_mappings: mergedMappings } : {}),
+        property_mappings: [...desired],
       });
       this.logger.info('Reused existing OIDC client', { deploymentId: input.deploymentId, providerPk: existing.providerPk });
       return {
@@ -331,7 +338,7 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
       this.resolveFlowPk(AUTHZ_FLOW_SLUG, 'authorization'),
       this.resolveFlowPk(INVALIDATION_FLOW_SLUG, 'invalidation'),
       this.resolveScopeMappingPks(oidc.scopes),
-      this.ensureRoleClaimMapping(oidc.roleClaim, slug),
+      this.ensureRoleClaimMapping(oidc.roleClaim, slug, oidc.scopes),
     ]);
     // Attach the admin-by-group role claim alongside the standard scope mappings.
     const allMappings = roleClaimPk ? [...propertyMappings, roleClaimPk] : propertyMappings;
@@ -1057,26 +1064,42 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
   /**
    * Ensure an Authentik scope mapping that emits an app's admin-by-group role
    * claim (e.g. Immich's `immich_role` = "admin"/"user"), and return its pk to
-   * attach to the provider. The mapping rides on a scope the client already
-   * requests (default `profile`) — Authentik intersects requested∩configured
-   * scopes, so a bespoke scope name would be dropped unless the client also asked
-   * for it; reusing `profile` makes the claim merge in with no client change.
+   * attach to the provider. The mapping must ride on a scope the client actually
+   * requests — Authentik intersects requested∩configured scopes, so a claim on an
+   * unrequested scope is silently dropped. So the default scope is chosen from the
+   * app's own requested scopes (preferring `profile`/`email`) rather than a fixed
+   * `profile` the app may not request.
    *
    * Idempotent via a stable `managed` key (queried on the polymorphic endpoint the
    * scoped token can read; written via the typed scope endpoint). Best-effort: a
    * failure logs and returns undefined rather than aborting the deploy — the app
    * then needs a manual admin promotion, surfaced in logs.
    */
+  /**
+   * Pick a scope the client actually requests to carry the admin-by-group role
+   * claim. Authentik only emits a scope's mappings when the client asks for that
+   * scope, so the claim must ride on a requested scope. Prefer profile/email;
+   * otherwise any requested non-openid scope; else openid (or profile if the list
+   * is somehow empty).
+   */
+  private defaultRoleClaimScope(requestedScopes: string[]): string {
+    for (const preferred of ['profile', 'email']) {
+      if (requestedScopes.includes(preferred)) return preferred;
+    }
+    return requestedScopes.find((s) => s !== 'openid') ?? requestedScopes[0] ?? 'profile';
+  }
+
   private async ensureRoleClaimMapping(
     roleClaim: NonNullable<ProvisionInput['oidc']>['roleClaim'],
-    slug: string
+    slug: string,
+    requestedScopes: string[]
   ): Promise<string | undefined> {
     if (!roleClaim) return undefined;
     const claim = roleClaim.claim;
     const adminGroup = roleClaim.adminGroup ?? DEFAULT_ADMIN_GROUP;
     const adminValue = roleClaim.adminValue ?? 'admin';
     const memberValue = roleClaim.memberValue ?? 'user';
-    const scopeName = roleClaim.scope ?? 'profile';
+    const scopeName = roleClaim.scope ?? this.defaultRoleClaimScope(requestedScopes);
     const managed = `goauthentik.io/hola/${slug}-roleclaim`;
     // JSON.stringify yields double-quoted literals that are also valid Python strings.
     const expression =


### PR DESCRIPTION
Two confirmed provisioner findings from the whole-codebase review.

## Admin-by-group role claim rode an unrequested scope (`provisioner.ts`)
`ensureRoleClaimMapping` defaulted the claim's scope to a hardcoded `profile`. Authentik only emits a scope's property mappings when the client **requests** that scope, so for an app whose `oidc.scopes` omit `profile` (e.g. `['openid','email']`), the role claim was silently dropped and admin-by-group never worked — the app needed a manual admin promotion. The default scope is now chosen from the app's own requested scopes (preferring `profile`/`email`, else a requested non-`openid` scope), so the claim rides on a scope the client actually asks for. An explicit `roleClaim.scope` still wins.

## Native-oidc reuse never healed scope mappings (`provisioner.ts`)
If the first provision happened during a transient `resolveScopeMappingPks` failure, the provider was created with **empty** `property_mappings` (no openid/profile/email claims) and the reuse path only PATCHed `redirect_uris` — so it stayed permanently degraded across every redeploy. (The dashboard client already self-heals this way.) Reuse now re-resolves the scope + role-claim mappings and reattaches them, **unioned** with whatever's already attached so a transient re-failure can't wipe a healthy provider's mappings.

## Tests
A role-claim-scope test (app requesting `['openid','email']` → claim on `email`, not `profile`) and a reuse-self-heal test (degraded provider with `[]` mappings gets them reattached on reuse). Full typecheck/lint/build/test gate green (server 312).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Dk3o6ZKgSgrLkQuW9s86L