### PR TITLE
fix(web): live-update cache key, polling backoff stall, optimistic rollback race

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ packages/*/coverage
 
 # Bun compile scratch artifacts
 *.bun-build
+
+# Core dumps (e.g. from a crashed test worker)
+core
+core.*

--- a/packages/web/src/__tests__/hooks/optimistic-updates.test.tsx
+++ b/packages/web/src/__tests__/hooks/optimistic-updates.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useOptimisticUpdates } from '../../hooks/useOptimisticUpdates';
+import { globalCache } from '../../utils/cache';
+
+describe('useOptimisticUpdates rollback timeout', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    globalCache.clear();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    globalCache.clear();
+  });
+
+  it('re-applies the update on a slow-but-successful action even after the rollback timer fired', async () => {
+    globalCache.set('k', { n: 1 });
+    const { result } = renderHook(() => useOptimisticUpdates<{ n: number }>());
+
+    let resolveAction!: (v: string) => void;
+    const serverAction = () => new Promise<string>((r) => { resolveAction = r; });
+
+    let actionPromise!: Promise<string>;
+    act(() => {
+      actionPromise = result.current.applyOptimisticUpdate(
+        'k',
+        () => ({ n: 2 }),
+        serverAction,
+        { rollbackTimeout: 100 },
+      );
+    });
+
+    // Optimistic value applied immediately.
+    expect(globalCache.get('k')).toEqual({ n: 2 });
+
+    // The rollback timer fires while the (slow) action is still in flight.
+    await act(async () => { await vi.advanceTimersByTimeAsync(150); });
+    expect(globalCache.get('k')).toEqual({ n: 1 }); // rolled back
+
+    // The action then resolves successfully — the cache must reflect the update,
+    // not the stale rolled-back value (the divergence this fix prevents).
+    await act(async () => { resolveAction('ok'); await actionPromise; });
+    expect(globalCache.get('k')).toEqual({ n: 2 });
+  });
+});

--- a/packages/web/src/hooks/useLiveUpdates.ts
+++ b/packages/web/src/hooks/useLiveUpdates.ts
@@ -37,22 +37,9 @@ export function useLiveJobUpdates(jobId?: string, options?: {
         progress: event.data.progress,
         finishedAt: event.data.finishedAt,
       });
-      
-      // Update cache for job detail if available
-      const cacheKey = `job-${jobId}`;
-      const cached = globalCache.get(cacheKey);
-      if (cached && cached.data && typeof cached.data === 'object') {
-        globalCache.set(cacheKey, {
-          ...cached,
-          data: {
-            ...(cached.data as Job),
-            status: event.data.status,
-            progress: event.data.progress,
-            finishedAt: event.data.finishedAt,
-          },
-          timestamp: Date.now(),
-        });
-      }
+      // Note: no cache write here — the only job cache key is the parameterized
+      // list key (`jobs-<params>` in useJobsApi), which a single job update can't
+      // target; the live UI is driven by the jobData state above.
     }
   }, [jobId]);
 
@@ -128,23 +115,10 @@ export function useLiveSystemStatus() {
         ...event.data,
       } as SystemStatus));
       setLastUpdate(new Date().toISOString());
-      
-      // Update summary cache if available
-      const summaryCache = globalCache.get('dashboard-summary');
-      if (summaryCache && summaryCache.data && typeof summaryCache.data === 'object') {
-        const summaryData = summaryCache.data as GetSummaryResponse;
-        globalCache.set('dashboard-summary', {
-          ...summaryCache,
-          data: {
-            ...summaryData,
-            system: {
-              ...summaryData.system,
-              ...event.data,
-            },
-          },
-          timestamp: Date.now(),
-        });
-      }
+      // Note: no cache write here — useWorkingApi reads `dashboard-summary` as a
+      // bare value (not the {data,timestamp} wrapper this used to write) and never
+      // populates that key, so the write was a dead no-op; the live UI is driven by
+      // the systemStatus state above.
     }
   }, []);
 
@@ -219,8 +193,11 @@ export function useLiveDeploymentStatus(deploymentId?: string) {
         lastUpdated: event.data.lastUpdated,
       });
       
-      // Update deployment cache if available
-      const cacheKey = `deployment-${deploymentId}`;
+      // Refresh the cached deployment detail so the live status reaches it (the
+      // reader, useDeploymentDetailApi, keys on `deployment-detail-<id>` — this
+      // previously wrote `deployment-<id>`, which no reader reads, so the SSE
+      // update never reached the cache).
+      const cacheKey = `deployment-detail-${deploymentId}`;
       const cached = globalCache.get(cacheKey);
       if (cached && cached.data && typeof cached.data === 'object') {
         const deploymentData = cached.data as DeploymentDetail;

--- a/packages/web/src/hooks/useOptimisticUpdates.ts
+++ b/packages/web/src/hooks/useOptimisticUpdates.ts
@@ -96,6 +96,12 @@ export function useOptimisticUpdates<T>() {
           clearTimeout(rollbackTimer);
         }
 
+        // The rollback timer may have already fired and reverted the cache while a
+        // slow-but-successful action was still in flight. The action succeeded, so
+        // re-assert the updated value rather than leave the cache showing the
+        // rolled-back (pre-update) state, which would diverge from the server.
+        globalCache.set(cacheKey, optimisticData);
+
         // Remove from pending updates on success
         setPendingUpdates(prev => {
           const next = new Map(prev);

--- a/packages/web/src/hooks/usePoll.ts
+++ b/packages/web/src/hooks/usePoll.ts
@@ -70,6 +70,11 @@ export function usePoll<T>(
   const mountedRef = useRef(true);
   const timeoutRef = useRef<number | null>(null);
   const isPollingRef = useRef(false);
+  // Live consecutive-error count. scheduleNext's setTimeout closure must read this
+  // (not the captured state.errorCount), since its recursive call reuses the same
+  // closure — closing over state would freeze the count, so backoff never grew and
+  // the maxErrors stop-check never tripped.
+  const errorCountRef = useRef(0);
 
   // Cleanup on unmount
   useEffect(() => {
@@ -92,6 +97,7 @@ export function usePoll<T>(
 
       if (!mountedRef.current) return false;
 
+      errorCountRef.current = 0;
       setState(prev => ({
         ...prev,
         data,
@@ -105,7 +111,8 @@ export function usePoll<T>(
       if (!mountedRef.current) return false;
 
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      
+
+      errorCountRef.current += 1;
       setState(prev => ({
         ...prev,
         loading: false,
@@ -128,8 +135,12 @@ export function usePoll<T>(
 
       const success = await fetchData();
 
-      // If we hit max errors, stop polling
-      if (!success && state.errorCount + 1 >= maxErrors) {
+      // Read the LIVE error count (fetchData just updated the ref) — not a stale
+      // captured state.errorCount.
+      const errorCount = errorCountRef.current;
+
+      // If we hit max consecutive errors, stop polling.
+      if (!success && errorCount >= maxErrors) {
         isPollingRef.current = false;
         setState(prev => ({ ...prev, isPolling: false }));
         return;
@@ -139,7 +150,7 @@ export function usePoll<T>(
       let nextInterval = interval;
       if (!success && errorBackoff.enabled) {
         nextInterval = calculateBackoffDelay(
-          state.errorCount + 1,
+          errorCount,
           errorBackoff.baseDelay,
           errorBackoff.maxDelay
         );
@@ -147,13 +158,14 @@ export function usePoll<T>(
 
       scheduleNext(nextInterval);
     }, nextDelay);
-  }, [interval, fetchData, state.errorCount, maxErrors, errorBackoff]);
+  }, [interval, fetchData, maxErrors, errorBackoff]);
 
   // Start polling
   const start = useCallback(() => {
     if (isPollingRef.current) return;
 
     isPollingRef.current = true;
+    errorCountRef.current = 0;
     setState(prev => ({ ...prev, isPolling: true, errorCount: 0 }));
 
     // Do initial fetch then schedule polling
@@ -181,6 +193,7 @@ export function usePoll<T>(
   // Reset all state
   const reset = useCallback(() => {
     stop();
+    errorCountRef.current = 0;
     setState({
       data: null,
       loading: false,


### PR DESCRIPTION
Three confirmed web data-layer findings from the whole-codebase review.

## Live-update SSE cache writes were dead (`hooks/useLiveUpdates.ts`)
SSE handlers wrote updates to `job-<id>`, `deployment-<id>`, and `dashboard-summary` — none of which any reader reads (`useDeploymentDetailApi` keys on `deployment-detail-<id>`, `useJobsApi` on `jobs-<params>`, and `useWorkingApi` reads `dashboard-summary` as a bare value it never populates). All three writes were guarded no-ops.
- **Deployment**: aligned to `deployment-detail-<id>` (same `{data,timestamp}` shape `useDeploymentDetailApi` stores), so the live status now actually reaches the cache.
- **Job / summary**: removed — there's no alignable reader (a single job update can't target the parameterized list key), and the live UI already flows through component state.

## `usePoll` never backed off or stopped (`hooks/usePoll.ts`)
`scheduleNext`'s `setTimeout` closed over `state.errorCount`, and its recursive call reused that frozen closure — so exponential backoff never grew and the `>= maxErrors` stop-check never tripped, hammering a failing endpoint at the base interval forever. The consecutive-error count is now read from a live ref.

## Optimistic rollback could diverge from the server (`hooks/useOptimisticUpdates.ts`)
If `rollbackTimeout` fired while a slow-but-successful action was still in flight, the cache was rolled back and never re-applied — leaving it showing the pre-update value while the server had the new one. On success the updated value is now re-asserted.

## Tests
An optimistic-rollback-race test (slow success after the timer fires → cache reflects the update). (A `usePoll` fake-timer test was omitted — async recursive `setTimeout` under fake timers hangs the worker; the fix is verified by inspection.) Full typecheck/lint/build/test gate green (web 140).

Also adds a `core`/`core.*` `.gitignore` entry (a crashed test worker can drop a multi-GB core dump in the tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Dk3o6ZKgSgrLkQuW9s86L