### PR TITLE
fix(web): auth-config retry, OIDC callback drop, NaN ports, SSO button flash

### DIFF
--- a/packages/web/src/__tests__/hooks/useAuth-retry.test.tsx
+++ b/packages/web/src/__tests__/hooks/useAuth-retry.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+
+import { AuthProvider, useAuth } from '../../hooks/useAuth';
+
+function Probe() {
+  const { status, mode } = useAuth();
+  return <div data-testid="probe">{`status:${status} mode:${String(mode)}`}</div>;
+}
+
+describe('AuthProvider boot config retry', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it('retries the /api/auth/config fetch on a transient failure instead of forcing apikey', async () => {
+    let configCalls = 0;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.includes('/api/auth/config')) {
+        configCalls += 1;
+        if (configCalls < 2) throw new Error('network blip');
+        return new Response(JSON.stringify({ mode: 'none' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(
+      <MemoryRouter>
+        <AuthProvider>
+          <Probe />
+        </AuthProvider>
+      </MemoryRouter>,
+    );
+
+    // The first fetch threw; the retry succeeds and resolves the REAL mode ('none'),
+    // rather than the transient failure forcing mode to 'apikey'.
+    await waitFor(
+      () => expect(screen.getByTestId('probe').textContent).toContain('mode:none'),
+      { timeout: 4000 },
+    );
+    expect(configCalls).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/packages/web/src/hooks/useAuth.tsx
+++ b/packages/web/src/hooks/useAuth.tsx
@@ -114,16 +114,29 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   useEffect(() => {
     let cancelled = false;
     (async () => {
-      let config: AuthConfigResponse;
-      try {
-        const res = await fetch(apiUrl('/api/auth/config'), { credentials: 'include' });
-        config = (await res.json()) as AuthConfigResponse;
-      } catch {
-        // Can't reach the server — treat as unauthenticated so the UI can show an error.
-        if (!cancelled) { setMode('apikey'); setStatus('unauthenticated'); }
-        return;
+      // Retry the config fetch a few times: a transient blip (a 502 while the
+      // server restarts, a momentary network drop) must NOT force the dashboard to
+      // the apikey login on an OIDC deployment — which would also make the OIDC
+      // callback discard its authorization code (AuthCallback bails on non-oidc).
+      let config: AuthConfigResponse | undefined;
+      for (let attempt = 0; attempt < 3 && !cancelled; attempt++) {
+        try {
+          const res = await fetch(apiUrl('/api/auth/config'), { credentials: 'include' });
+          if (!res.ok) throw new Error(`auth config ${res.status}`);
+          config = (await res.json()) as AuthConfigResponse;
+          break;
+        } catch {
+          if (attempt < 2) await new Promise((r) => setTimeout(r, 500 * (attempt + 1)));
+        }
       }
       if (cancelled) return;
+      if (!config) {
+        // Still unreachable after retries — fall back so the UI can surface an
+        // error/login (the server is genuinely down, so OIDC couldn't complete anyway).
+        setMode('apikey');
+        setStatus('unauthenticated');
+        return;
+      }
       setMode(config.mode);
 
       if (config.mode === 'none') {

--- a/packages/web/src/pages/AuthCallback.tsx
+++ b/packages/web/src/pages/AuthCallback.tsx
@@ -29,15 +29,22 @@ export const AuthCallback: React.FC = () => {
     return () => { cancelled = true; };
   }, [mode, completeOidcLogin, navigate]);
 
-  // Server isn't using OIDC (or auth is off) — nothing to complete here.
-  if (mode && mode !== 'oidc') return <Navigate to="/" replace />;
+  // We landed here with an authorization code. If auth resolved to non-OIDC, the
+  // boot config likely mis-resolved (e.g. it failed and fell back to apikey) —
+  // don't silently discard the code; surface an error so the user can retry.
+  const hasOidcCode = new URLSearchParams(window.location.search).has('code');
+
+  // Non-OIDC with nothing pending — we shouldn't be here; go home.
+  if (mode && mode !== 'oidc' && !hasOidcCode) return <Navigate to="/" replace />;
+
+  const stuck = mode !== null && mode !== 'oidc' && hasOidcCode;
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-surface-0 text-text-strong px-4">
       <div className="flex flex-col items-center gap-3 animate-fadein">
-        {error ? (
+        {error || stuck ? (
           <>
-            <p className="text-danger text-sm" role="alert">{error}</p>
+            <p className="text-danger text-sm" role="alert">{error ?? "Couldn't complete sign-in. Please try again."}</p>
             <button
               onClick={() => navigate('/login', { replace: true })}
               className="h-9 px-4 bg-surface-2 border border-border rounded-[9px] text-sm hover:border-primary transition"

--- a/packages/web/src/pages/InstallWizard.tsx
+++ b/packages/web/src/pages/InstallWizard.tsx
@@ -273,7 +273,14 @@ export const InstallWizard: React.FC = () => {
     }
   };
 
-  const updatePort = async (index: number, field: keyof DraftDefaults['ports'][0], value: string | number) => {
+  // Parse a port input into a number, or undefined when cleared/invalid — never
+  // NaN, which would be persisted into the draft and serialize to null.
+  const parsePortInput = (value: string): number | undefined => {
+    const n = parseInt(value, 10);
+    return Number.isFinite(n) ? n : undefined;
+  };
+
+  const updatePort = async (index: number, field: keyof DraftDefaults['ports'][0], value: string | number | undefined) => {
     const updated = [...ports];
     updated[index] = { ...updated[index], [field]: value };
     setPorts(updated);
@@ -897,7 +904,7 @@ services:
                         type="number"
                         placeholder="Host port"
                         value={port.host || ''}
-                        onChange={(e) => updatePort(index, 'host', parseInt(e.target.value))}
+                        onChange={(e) => updatePort(index, 'host', parsePortInput(e.target.value))}
                         className="w-full h-10 bg-surface-0 border border-border rounded-[9px] text-text-strong px-[13px] text-[13px] font-mono outline-none focus:border-primary"
                       />
                     </div>
@@ -906,7 +913,7 @@ services:
                         type="number"
                         placeholder="Container port"
                         value={port.container || ''}
-                        onChange={(e) => updatePort(index, 'container', parseInt(e.target.value))}
+                        onChange={(e) => updatePort(index, 'container', parsePortInput(e.target.value))}
                         className="w-full h-10 bg-surface-0 border border-border rounded-[9px] text-text-strong px-[13px] text-[13px] font-mono outline-none focus:border-primary"
                       />
                     </div>

--- a/packages/web/src/pages/Login.tsx
+++ b/packages/web/src/pages/Login.tsx
@@ -54,7 +54,10 @@ export const Login: React.FC = () => {
 
   // While the auto-redirect (or the post-config 'loading' window for OIDC) is in
   // flight, show a quiet "signing you in" state rather than flashing the button.
-  if (status === 'loading' || autoRedirecting) {
+  // `autoRedirecting` is seeded from `mode`, which is null on the first render, so
+  // also cover the window where mode has resolved to 'oidc' but the effect below
+  // hasn't yet decided whether to redirect or fall back to the manual button.
+  if (status === 'loading' || autoRedirecting || (mode === 'oidc' && !decided.current)) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-surface-0 text-text-strong px-4">
         <div className="flex flex-col items-center gap-3 animate-fadein">


### PR DESCRIPTION
Four confirmed web auth-flow / form findings from the whole-codebase review.

## Transient config-fetch failure locked out OIDC users (`hooks/useAuth.tsx`)
A single failed `/api/auth/config` fetch forced `mode='apikey'` — so a blip (a 502 while the server restarts, a momentary network drop) showed the admin-key form on an OIDC deployment, and (via `AuthCallback`) made the OIDC callback discard its authorization code. The config fetch now **retries** (3 attempts, short backoff) before falling back; the fallback only happens if the server is genuinely unreachable (where OIDC couldn't complete anyway).

## OIDC callback silently dropped the code (`pages/AuthCallback.tsx`)
When `mode` resolved to non-OIDC, the callback did `<Navigate to="/">`, discarding any pending `?code=`. It now surfaces an error (with "Back to sign in") when a code is present but auth didn't resolve as OIDC, instead of silently dropping it.

## InstallWizard wrote `NaN` ports (`pages/InstallWizard.tsx`)
Clearing a port input ran `parseInt('') === NaN`, which was persisted into the draft and serializes to `null`. A new `parsePortInput` parses to `undefined` (never `NaN`).

## Login flashed the SSO button (`pages/Login.tsx`)
`autoRedirecting` was seeded from `mode`, which is `null` on the first render, so the manual "Sign in with SSO" card rendered for one frame before the auto-redirect effect ran. The spinner condition now also covers the window where `mode` resolved to `'oidc'` but the effect hasn't decided yet.

## Tests
An `AuthProvider` config-retry test (transient failure → retry resolves the real mode, not forced apikey). The existing Login test already covers the steady-state no-flash behavior. Full typecheck/lint/build/test gate green (web 140).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Dk3o6ZKgSgrLkQuW9s86L