### PR TITLE
fix(server): route to the manifest-declared ingress.service for multi-service apps

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -47,7 +47,11 @@ browser ──TLS──▶ Traefik ──▶ web (nginx: SPA + /api proxy) ─�
 - **Ingress is Traefik-only.** Apps are reachable through Traefik routing, not
   by publishing host ports. There is no host-port registry; the Compose
   validator rejects `ports:` exposure (use `expose:` for container-internal
-  ports).
+  ports). The server attaches one **ingress service** to the `hola` network and
+  injects auth env into it; it uses the bundle manifest's `ingress.service`, else
+  the service named after the app id, else the first service. So a multi-service
+  app whose web service is neither named after the app id nor listed first is
+  routed correctly as long as its manifest declares `ingress.service`.
 
 ## Server services
 

--- a/packages/server/src/__tests__/bundles/catalog-compose-override.test.ts
+++ b/packages/server/src/__tests__/bundles/catalog-compose-override.test.ts
@@ -33,6 +33,7 @@ volumes:
 
 const MANIFEST = JSON.stringify({
   name: APP_ID,
+  ingress: { service: 'fixtureapp', port: 80 },
   defaultEnv: [{ key: 'APP_ENV', value: 'production', isSecret: false }],
   defaults: {
     ports: [{ container: 80, protocol: 'tcp' }],
@@ -92,5 +93,8 @@ describe('RealCatalogService composeOverride (#82)', () => {
     expect(detail.composeOverride).toBe(COMPOSE);
     // Defaults are still merged from manifest/compose as before.
     expect(detail.defaults.ports.some(p => p.container === 80)).toBe(true);
+    // The manifest's ingress.service is surfaced so the deploy lifecycle can
+    // route to / inject auth env into the right service.
+    expect(detail.ingressService).toBe('fixtureapp');
   });
 });

--- a/packages/server/src/__tests__/deployments/lifecycle.test.ts
+++ b/packages/server/src/__tests__/deployments/lifecycle.test.ts
@@ -9,6 +9,7 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { parse } from 'yaml';
 import { mkdtemp, rm } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -100,6 +101,40 @@ describe('Deployment lifecycle (real orchestration wiring)', () => {
     expect(materialized).toContain('hola');
     expect(materialized).toContain('aliases');
     expect(materialized).toContain('external: true');
+  });
+
+  test('attaches the manifest-declared ingress service, not the first service', async () => {
+    const storage = new RealStorageService({ holaDir: dataRoot });
+    const database = new RealDatabaseService(storage);
+    const logging = new RealLoggingService(storage);
+    const jobs = new RealJobService(database, logging);
+    const routing = new RealRoutingService(storage, { baseDomain: 'local.hola' });
+    // Catalog declares 'web' as the ingress service for a multi-service app whose
+    // web service is neither named after the app id ('myapp') nor listed first.
+    const catalog = {
+      getApp: async (appId: string) => ({ id: appId, name: 'App', icon: '📦' }),
+      getVersionDetail: async () => ({
+        defaultEnv: [],
+        defaults: { ports: [], volumes: [] },
+        ingressService: 'web',
+      }),
+    } as unknown as CatalogArg;
+    const drafts = new RealDraftService(storage, catalog, makeValidation());
+    const deployments = new RealDeploymentService(storage, jobs, new MockDockerService(), drafts, routing, logging, new MockProvisionerService());
+
+    const multiCompose = 'services:\n  db:\n    image: postgres:16\n  web:\n    image: nginx:1.27\n';
+    const { draftId } = await drafts.createDraft({ appId: 'myapp', version: '1.0.0' });
+    await drafts.updateDraft(draftId, { composeOverride: multiCompose });
+    await drafts.finalizeDraft(draftId);
+    const created = await deployments.createFromDraft({ draftId, name: 'myapp' });
+    const job = await waitForJob(jobs, created.jobId!);
+    expect(job.status).toBe('completed');
+
+    const materialized = await storage.readFileAsString(`deployments/${created.deploymentId}/runtime/docker-compose.yml`);
+    const doc = parse(materialized) as { services: Record<string, { networks?: Record<string, unknown> }> };
+    // The hola network alias landed on 'web' (the declared ingress), not 'db' (first).
+    expect(doc.services.web.networks?.hola).toBeDefined();
+    expect(doc.services.db.networks?.hola).toBeUndefined();
   });
 
   test('stop action runs Compose down and converges to stopped', async () => {

--- a/packages/server/src/services/core/catalog.ts
+++ b/packages/server/src/services/core/catalog.ts
@@ -182,6 +182,7 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
         };
         auth?: unknown;
         consumes?: unknown;
+        ingress?: { service?: unknown; port?: unknown };
       };
 
       const manifest: Manifest = JSON.parse(raw) as unknown as Manifest;
@@ -236,7 +237,16 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
       // so new capability names need no server change (ADR 0002).
       const consumes = coerceConsumes(manifest.consumes);
 
-      return { ...merged, composeOverride, auth, consumes } satisfies GetCatalogAppVersionDetailResponse;
+      // Which compose service is the web/ingress one — the app's bundle manifest
+      // declares it as `ingress.service`. Lets the server route to / inject auth
+      // env into the right service for a multi-service app whose ingress isn't
+      // named after the app id (the default heuristic). Non-empty string only.
+      const ingressService =
+        typeof manifest.ingress?.service === 'string' && manifest.ingress.service.trim()
+          ? manifest.ingress.service.trim()
+          : undefined;
+
+      return { ...merged, composeOverride, auth, consumes, ingressService } satisfies GetCatalogAppVersionDetailResponse;
     } catch (error) {
       this.logger.warn('Failed to read or parse bundle manifest; deferring to mocks', { appId, version, error: error instanceof Error ? error.message : String(error) });
       throw new Error('MANIFEST_UNAVAILABLE', { cause: error });

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -860,11 +860,18 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     // pure, so compute it once up front and reuse it below.
     const rule = this.routingService.generateRule({ deploymentId: deployment.id, appName: deployment.app });
 
+    // The compose service Traefik routes to and that receives injected auth env.
+    // Prefer the manifest-declared ingress service (multi-service apps whose web
+    // service isn't named after the app id), falling back to the app id; the
+    // compose-network helpers fall back further to the first service if neither
+    // names an existing one.
+    const ingressService = (await this.readActiveIngressService(deployment)) ?? deployment.app;
+
     // Attach the ingress service to the Traefik network so the emitted routing
     // config can reach it (the alias must match the routing service name).
     let content = raw;
     try {
-      content = attachToHolaNetwork(raw, { alias: rule.serviceName, ingressService: deployment.app });
+      content = attachToHolaNetwork(raw, { alias: rule.serviceName, ingressService });
     } catch (error) {
       this.logger.warn('Could not attach app to Traefik network; deploying compose as-is', {
         deploymentId: deployment.id,
@@ -877,7 +884,7 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     // auth was never wired (a security-relevant bypass).
     const hasSecret = Object.keys(injectedEnv).length > 0;
     if (hasSecret) {
-      content = injectEnvironment(content, injectedEnv, { ingressService: deployment.app });
+      content = injectEnvironment(content, injectedEnv, { ingressService });
     }
 
     // Resolve the per-app data root: apps declare persistent storage under the
@@ -949,6 +956,20 @@ export class RealDeploymentService extends InMemoryDeploymentService {
       return manifest.consumes ?? [];
     } catch {
       return [];
+    }
+  }
+
+  /** The active release's declared ingress/web compose service, if any. */
+  private async readActiveIngressService(deployment: EnhancedDeploymentDetail): Promise<string | undefined> {
+    const releaseId = deployment.currentReleaseId;
+    if (!releaseId) return undefined;
+    const manifestPath = `deployments/${deployment.id}/releases/${releaseId}/manifest.json`;
+    if (!(await this.storageService.fileExists(manifestPath))) return undefined;
+    try {
+      const manifest = JSON.parse(await this.storageService.readFileAsString(manifestPath)) as FinalizedManifest;
+      return manifest.ingressService;
+    } catch {
+      return undefined;
     }
   }
 

--- a/packages/server/src/services/core/draft.ts
+++ b/packages/server/src/services/core/draft.ts
@@ -64,6 +64,9 @@ export interface FinalizedManifest {
   // Cross-app capabilities consumed (e.g. `app-registry`); carried so the
   // deploy lifecycle can publish the right feeds without re-reading the bundle.
   consumes?: string[];
+  // The compose service to route to / inject auth env into; carried so
+  // materializeCompose targets the right service for multi-service apps.
+  ingressService?: string;
   files: FinalizedManifestFile[];
   checksum: string;
   finalizedAt: string;
@@ -329,6 +332,7 @@ export class RealDraftService implements DraftService {
         composeOverride,
         auth: defaults.auth,
         consumes: defaults.consumes,
+        ingressService: defaults.ingressService,
         files: [],
       };
 
@@ -581,6 +585,7 @@ export class RealDraftService implements DraftService {
         composeOverride: draft.composeOverride ?? '',
         auth: draft.auth,
         consumes: draft.consumes,
+        ingressService: draft.ingressService,
         files: specFiles,
       };
 
@@ -661,7 +666,7 @@ export class RealDraftService implements DraftService {
     };
   }
 
-  async getDraftDefaults(appId: string, version?: string): Promise<{ env: AppEnvVar[]; defaults: DraftDefaults; composeOverride: string; auth?: AppAuthConfig; consumes?: string[] }> {
+  async getDraftDefaults(appId: string, version?: string): Promise<{ env: AppEnvVar[]; defaults: DraftDefaults; composeOverride: string; auth?: AppAuthConfig; consumes?: string[]; ingressService?: string }> {
     try {
       const versionDetail = await this.catalogService.getVersionDetail(appId, version || 'latest');
       return {
@@ -670,6 +675,7 @@ export class RealDraftService implements DraftService {
         composeOverride: versionDetail.composeOverride ?? '',
         auth: versionDetail.auth,
         consumes: versionDetail.consumes,
+        ingressService: versionDetail.ingressService,
       };
     } catch (error) {
       this.logger.warn('Failed to get app defaults, using fallback', { appId, version, error: error instanceof Error ? error.message : String(error) });
@@ -830,6 +836,7 @@ export class MockDraftService implements DraftService {
       appEnv: draft.appEnv,
       ports: draft.ports,
       composeOverride: draft.composeOverride ?? '',
+      ingressService: draft.ingressService,
       files: [],
       checksum: 'mock-checksum',
       finalizedAt: new Date().toISOString(),

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -291,6 +291,11 @@ export type GetCatalogAppVersionDetailResponse = {
   // (e.g. `app-registry`). The server writes the corresponding feed into the
   // app's data root on app-set change; rendering is a bundle bolt-on (ADR 0002).
   consumes?: string[];
+  // The compose service Traefik should route to and that receives injected auth
+  // env, for multi-service apps whose web/ingress service isn't named after the
+  // app id (the default heuristic). Sourced from the bundle manifest's
+  // `ingress.service`.
+  ingressService?: string;
 };
 
 // ------------------------------------------------------
@@ -429,6 +434,10 @@ export type Draft = {
   // Cross-app capabilities consumed (e.g. `app-registry`), seeded from the bundle
   // manifest and carried through finalize (ADR 0002).
   consumes?: string[];
+  // The compose service to route to / inject auth env into, for multi-service
+  // apps whose ingress service isn't named after the app id. Seeded from the
+  // bundle manifest and carried through finalize (read-only; not user-editable).
+  ingressService?: string;
   files: Array<{ uploadId: string; name: string; size: number; kind: 'composeOverride' | 'additionalFile' | 'env' | 'secret' }>;
 };
 


### PR DESCRIPTION
Resolves the deferred ingress-heuristic finding from the whole-codebase review.

## The bug
The server attaches exactly one compose service to the `hola` network (with the Traefik routing alias) and injects the provisioned auth env into it. It selected that service as `services[appId] || <first service>` (`compose-network.ts`). For a multi-service app whose web/ingress service is **neither** named after the app id **nor** listed first, the wrong container got the routing alias **and** the OIDC client id/secret — `https://<app>.<domain>` 502'd (or hit the DB) and SSO was silently unwired, with no way for the app author to correct it.

## The fix — read the field the catalog already declares
App bundle manifests **already** declare `ingress: { service, port }` (every app in `try-hola/apps` has it). The server just ignored it and leaned on the heuristic, which coincidentally matches for every current app — but would break the moment an app's `ingress.service` isn't the app id or the first service. The server now **reads `ingress.service`**, plumbed exactly like the existing `auth`/`consumes` manifest fields:
- coerced in `RealCatalogService.getVersionDetail` (non-empty string),
- carried into the `Draft` and the staged `FinalizedManifest` (seed + finalize, Real + Mock),
- read back at deploy time by `readActiveIngressService` and passed to `attachToHolaNetwork` / `injectEnvironment`.

Fallback chain, unchanged for the common case: **manifest `ingress.service`** → **app id** → **first service**.

## Tests / docs
- Catalog test: a staged manifest's `ingress.service` is surfaced as `ingressService`.
- Lifecycle test: a manifest declaring `ingress.service: 'web'` for a compose listing `db` first → the `hola` alias lands on `web`, not `db`.
- `docs/ARCHITECTURE.md` ingress note.
- Full typecheck/lint/build/test gate green (server 311).

## Companion (try-hola/apps)
Because every current app already declares `ingress.service` correctly, **no app manifest needs to change** — the companion PR there just **documents** the field (it was previously undocumented) so future authors set it, and adds a CI check that every app declares `ingress.service`. Fully backward-compatible: apps without it behave exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Dk3o6ZKgSgrLkQuW9s86L