### PR TITLE
chore(release): 0.6.24

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "packages/cli": {
       "name": "@hola/cli",
-      "version": "0.6.23",
+      "version": "0.6.24",
       "bin": {
         "hola": "./bin/hola",
       },
@@ -36,11 +36,11 @@
     },
     "packages/compose": {
       "name": "@hola/compose",
-      "version": "0.6.23",
+      "version": "0.6.24",
     },
     "packages/sdk": {
       "name": "@hola/sdk",
-      "version": "0.6.23",
+      "version": "0.6.24",
       "dependencies": {
         "@hola/shared": "workspace:*",
       },
@@ -54,7 +54,7 @@
     },
     "packages/server": {
       "name": "@hola/server",
-      "version": "0.6.23",
+      "version": "0.6.24",
       "dependencies": {
         "@hola/shared": "workspace:*",
         "jose": "^5.9.6",
@@ -70,7 +70,7 @@
     },
     "packages/shared": {
       "name": "@hola/shared",
-      "version": "0.6.23",
+      "version": "0.6.24",
       "dependencies": {
         "yaml": "^2.9.0",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.6.23",
+  "version": "0.6.24",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.6.23';
+export const CLI_VERSION = '0.6.24';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.6.23",
+  "version": "0.6.24",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.6.23",
+  "version": "0.6.24",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.6.23",
+  "version": "0.6.24",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.6.23",
+  "version": "0.6.24",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Patch release **0.6.24** — bundles the whole-codebase review fixes merged in #249–#259.

Bumps `cli`, `compose`, `sdk`, `server`, `shared` from `0.6.23` → `0.6.24` (+ `cli/src/version.ts` and `bun.lock`); `web` stays `0.0.0` by convention. No code changes — version strings only.

Once merged, pushing the `cli-v0.6.24` tag triggers `cli-release.yml`: multi-arch `ghcr.io/try-hola/{server,web}:0.6.24` (+ `:latest`) images, the `hola-compose-0.6.24.tar.gz` bundle, and standalone `hola` CLI binaries (linux x64/arm64, darwin x64/arm64) attached to the GitHub Release.

Verified locally: the release compile command produces a binary reporting `hola, 0.6.24`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Dk3o6ZKgSgrLkQuW9s86L