### PR TITLE
fix(web): Remove deployment actually removes it, behind a confirm dialog

### DIFF
--- a/packages/web/src/hooks/useDeploymentDetailApi.ts
+++ b/packages/web/src/hooks/useDeploymentDetailApi.ts
@@ -94,25 +94,38 @@ export function useDeploymentDetailApi(deploymentId: string | undefined) {
     return result;
   }, [deploymentId, cacheKey, fetchData]);
 
-  // Execute action
-  const executeAction = React.useCallback(async (action: 'start' | 'stop' | 'restart' | 'delete') => {
+  // Execute a lifecycle action (start/stop/restart). NOT delete — removal is a
+  // full teardown via the DELETE endpoint (see removeDeployment), not a lifecycle
+  // action, otherwise the Traefik route stays held and blocks reinstall.
+  const executeAction = React.useCallback(async (action: 'start' | 'stop' | 'restart') => {
     if (!deploymentId || !cacheKey) throw new Error('No deployment ID');
-    
+
     const request: PostDeploymentActionRequest = { action };
     const result = await api.deployments.action(deploymentId, request);
-    
+
     // Invalidate cache and refetch
     globalCache.delete(cacheKey);
     await fetchData();
-    
+
     return result;
   }, [deploymentId, cacheKey, fetchData]);
 
-  return { 
-    ...state, 
+  // Remove the deployment entirely (stop + deprovision auth + release route +
+  // delete record + clean storage) via DELETE /api/deployments/:id. The caller
+  // navigates away on success since the deployment no longer exists.
+  const removeDeployment = React.useCallback(async () => {
+    if (!deploymentId || !cacheKey) throw new Error('No deployment ID');
+
+    await api.deployments.remove(deploymentId);
+    globalCache.delete(cacheKey);
+  }, [deploymentId, cacheKey]);
+
+  return {
+    ...state,
     refetch: fetchData,
     updateConfiguration,
-    executeAction
+    executeAction,
+    removeDeployment
   };
 }
 

--- a/packages/web/src/pages/DeploymentDetail.tsx
+++ b/packages/web/src/pages/DeploymentDetail.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useParams, Link, useSearchParams } from 'react-router-dom';
+import { useParams, Link, useSearchParams, useNavigate } from 'react-router-dom';
 import { LogsViewer } from '../components/LogsViewer';
 import { JobTracker } from '../components/JobTracker';
 import {
@@ -91,8 +91,18 @@ export const DeploymentDetail: React.FC = () => {
     error,
     refetch: refetchDeployment,
     updateConfiguration,
-    executeAction
+    executeAction,
+    removeDeployment
   } = useDeploymentDetailApi(deploymentId);
+
+  const navigate = useNavigate();
+
+  // Removal confirmation dialog state. Removal is destructive (full teardown +
+  // record deletion), so it's gated behind a confirm step rather than firing on
+  // the first click.
+  const [showRemoveConfirm, setShowRemoveConfirm] = useState(false);
+  const [removing, setRemoving] = useState(false);
+  const [removeError, setRemoveError] = useState<string | null>(null);
 
   const {
     data: historyData,
@@ -216,7 +226,7 @@ export const DeploymentDetail: React.FC = () => {
     setDeploymentOverrides(newOverrides);
   };
 
-  const handleAction = async (action: 'start' | 'stop' | 'restart' | 'delete') => {
+  const handleAction = async (action: 'start' | 'stop' | 'restart') => {
     if (!deployment) return;
 
     const operationKey = `action-${action}`;
@@ -230,6 +240,25 @@ export const DeploymentDetail: React.FC = () => {
       // TODO: Show error message to user
     } finally {
       setOperationLoading(prev => ({ ...prev, [operationKey]: false }));
+    }
+  };
+
+  // Confirmed removal: full teardown via the DELETE endpoint, then back to the
+  // deployments list (the deployment no longer exists, so there's nothing to
+  // show here). On failure we keep the dialog open and surface the error inline.
+  const handleRemove = async () => {
+    if (!deployment) return;
+
+    setRemoving(true);
+    setRemoveError(null);
+    try {
+      await removeDeployment();
+      navigate('/deployments');
+    } catch (error) {
+      console.error('Error removing deployment:', error);
+      setRemoveError(error instanceof Error ? error.message : 'Failed to remove deployment');
+    } finally {
+      setRemoving(false);
     }
   };
 
@@ -775,6 +804,63 @@ export const DeploymentDetail: React.FC = () => {
 
   return (
     <div className="animate-fadein">
+      {/* Removal confirmation dialog */}
+      {showRemoveConfirm && (
+        <div
+          className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4"
+          onClick={() => { if (!removing) setShowRemoveConfirm(false); }}
+        >
+          <div
+            className="bg-surface-0 rounded-xl border border-border w-full max-w-md overflow-hidden"
+            onClick={(e) => e.stopPropagation()}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="remove-dialog-title"
+          >
+            <div className="p-6">
+              <div className="flex items-start gap-3">
+                <div className="w-9 h-9 flex-shrink-0 flex items-center justify-center rounded-full bg-danger-weak text-danger">
+                  <AlertTriangle className="w-[18px] h-[18px]" />
+                </div>
+                <div className="min-w-0">
+                  <h2 id="remove-dialog-title" className="text-lg font-semibold m-0">Remove {deployment.name}?</h2>
+                  <p className="mt-1.5 text-sm text-text-muted">
+                    This permanently removes the deployment: it stops and deletes the
+                    containers, deprovisions SSO, releases the route, and deletes its
+                    data. This can't be undone.
+                  </p>
+                </div>
+              </div>
+
+              {removeError && (
+                <div className="mt-4 flex items-start gap-2 text-sm text-danger bg-danger-weak rounded-[9px] p-3">
+                  <AlertTriangle className="w-4 h-4 flex-shrink-0 mt-0.5" />
+                  <span>{removeError}</span>
+                </div>
+              )}
+
+              <div className="mt-6 flex justify-end gap-2.5">
+                <button
+                  onClick={() => setShowRemoveConfirm(false)}
+                  disabled={removing}
+                  className="h-[38px] px-[14px] flex items-center bg-surface-2 text-text-strong border border-border rounded-[9px] text-[13.5px] font-semibold hover:border-primary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={handleRemove}
+                  disabled={removing}
+                  className="h-[38px] px-[14px] flex items-center gap-[7px] bg-danger text-white border border-transparent rounded-[9px] text-[13.5px] font-semibold hover:brightness-110 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+                >
+                  {removing ? <RotateCw className="w-4 h-4 animate-spin" /> : <Trash2 className="w-4 h-4" />}
+                  {removing ? 'Removing…' : 'Remove'}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Header card */}
       <div className="bg-surface-1 border border-border rounded-[14px] p-[20px_22px] mb-4">
         <div className="flex items-center gap-[15px] flex-wrap">
@@ -823,7 +909,7 @@ export const DeploymentDetail: React.FC = () => {
               Rollback
             </button>
             <button
-              onClick={() => handleAction('delete')}
+              onClick={() => { setRemoveError(null); setShowRemoveConfirm(true); }}
               className="h-[38px] px-[14px] flex items-center gap-[7px] bg-danger-weak text-danger border border-transparent rounded-[9px] text-[13.5px] font-semibold hover:bg-danger hover:text-white transition-colors"
             >
               <Trash2 className="w-4 h-4" />

--- a/packages/web/src/pages/Deployments.tsx
+++ b/packages/web/src/pages/Deployments.tsx
@@ -8,7 +8,8 @@ import {
   Trash2,
   ExternalLink,
   ChevronLeft,
-  ChevronRight
+  ChevronRight,
+  AlertTriangle
 } from 'lucide-react';
 import type {
   DeploymentStatus,
@@ -79,17 +80,30 @@ export const Deployments: React.FC = () => {
     }
   }, [refetch]);
 
+  // Removal is destructive (full teardown + record deletion), so it's gated
+  // behind a confirmation dialog rather than firing on the first click.
+  const [pendingDelete, setPendingDelete] = useState<{ id: string; name: string } | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
   // Removal is a full teardown (stop + deprovision + release route + remove
   // record), distinct from the `stop` action — so it uses the DELETE endpoint,
   // not a lifecycle action, otherwise the route stays held and blocks reinstall.
-  const handleDelete = useCallback(async (deploymentId: string) => {
+  const confirmDelete = useCallback(async () => {
+    if (!pendingDelete) return;
+    setDeleting(true);
+    setDeleteError(null);
     try {
-      await api.deployments.remove(deploymentId);
+      await api.deployments.remove(pendingDelete.id);
+      setPendingDelete(null);
       await refetch();
     } catch (error) {
       console.error('Error deleting deployment:', error);
+      setDeleteError(error instanceof Error ? error.message : 'Failed to remove deployment');
+    } finally {
+      setDeleting(false);
     }
-  }, [refetch]);
+  }, [pendingDelete, refetch]);
 
   // Calculate pagination info
   const totalPages = Math.ceil(totalDeployments / limit);
@@ -98,6 +112,63 @@ export const Deployments: React.FC = () => {
 
   return (
     <div className="animate-fadein">
+      {/* Removal confirmation dialog */}
+      {pendingDelete && (
+        <div
+          className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4"
+          onClick={() => { if (!deleting) setPendingDelete(null); }}
+        >
+          <div
+            className="bg-surface-0 rounded-xl border border-border w-full max-w-md overflow-hidden"
+            onClick={(e) => e.stopPropagation()}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="remove-dialog-title"
+          >
+            <div className="p-6">
+              <div className="flex items-start gap-3">
+                <div className="w-9 h-9 flex-shrink-0 flex items-center justify-center rounded-full bg-danger-weak text-danger">
+                  <AlertTriangle className="w-[18px] h-[18px]" />
+                </div>
+                <div className="min-w-0">
+                  <h2 id="remove-dialog-title" className="text-lg font-semibold m-0">Remove {pendingDelete.name}?</h2>
+                  <p className="mt-1.5 text-sm text-text-muted">
+                    This permanently removes the deployment: it stops and deletes the
+                    containers, deprovisions SSO, releases the route, and deletes its
+                    data. This can't be undone.
+                  </p>
+                </div>
+              </div>
+
+              {deleteError && (
+                <div className="mt-4 flex items-start gap-2 text-sm text-danger bg-danger-weak rounded-[9px] p-3">
+                  <AlertTriangle className="w-4 h-4 flex-shrink-0 mt-0.5" />
+                  <span>{deleteError}</span>
+                </div>
+              )}
+
+              <div className="mt-6 flex justify-end gap-2.5">
+                <button
+                  onClick={() => setPendingDelete(null)}
+                  disabled={deleting}
+                  className="h-[38px] px-[14px] flex items-center bg-surface-2 text-text-strong border border-border rounded-[9px] text-[13.5px] font-semibold hover:border-primary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={confirmDelete}
+                  disabled={deleting}
+                  className="h-[38px] px-[14px] flex items-center gap-[7px] bg-danger text-white border border-transparent rounded-[9px] text-[13.5px] font-semibold hover:brightness-110 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+                >
+                  {deleting ? <RefreshCw className="w-4 h-4 animate-spin" /> : <Trash2 className="w-4 h-4" />}
+                  {deleting ? 'Removing…' : 'Remove'}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Header */}
       <div className="flex items-end gap-3.5 mb-[18px] flex-wrap">
         <div>
@@ -260,7 +331,8 @@ export const Deployments: React.FC = () => {
                   title="Remove"
                   onClick={(e) => {
                     e.stopPropagation();
-                    handleDelete(deployment.id);
+                    setDeleteError(null);
+                    setPendingDelete({ id: deployment.id, name: deployment.name });
                   }}
                   className="w-[30px] h-[30px] flex items-center justify-center rounded-[7px] text-text-muted hover:text-danger hover:bg-danger-weak transition-colors"
                 >


### PR DESCRIPTION
## Problem

Clicking **Remove** on the deployment **detail** page appeared to do nothing — and afterwards the app couldn't be reinstalled.

Root cause: the detail page's Remove button called the lifecycle-action endpoint with `action: 'delete'` (`POST /api/deployments/:id/actions`), which only enqueues a `compose down` and sets status to `stopped`. It **never** deleted the deployment record or released the Traefik route, so:

- the deployment card stayed on screen → "nothing happened",
- the held route blocked reinstalling the app (the list page's own code comment warns about exactly this), and
- any failure was swallowed to `console.error` with no user feedback (the handler had `// TODO: Show error message`).

The **list** page already used the correct `DELETE /api/deployments/:id` endpoint (full teardown via `deleteDeployment`) — but fired on the first click with no confirmation.

## Changes

- **`DeploymentDetail.tsx`** — Remove now opens a **confirmation dialog**; on confirm it calls the real teardown (`api.deployments.remove()` → `DELETE` → stop, deprovision SSO, release route, delete record, clean storage) and navigates back to `/deployments`. On failure the dialog stays open and shows the error **inline**.
- **`useDeploymentDetailApi.ts`** — add `removeDeployment()`; narrow `executeAction` to `start | stop | restart` so the misleading `'delete'` lifecycle path is gone.
- **`Deployments.tsx`** (list) — gate the existing (correct) Remove behind the **same confirmation dialog**, with inline error + in-progress state, for consistency.

The dialog matches the existing `Catalog` modal styling and design tokens, with `role="dialog"`/`aria-modal`, disabled-while-removing, and click-outside-to-cancel.

## Testing

`bun run typecheck` ✓ · `bun run lint` ✓ · `bun run test` ✓ (145/145) · `bun run build` ✓

## Notes / follow-ups (not in this PR)

- Server-side, the `'delete'` branch of `runLifecycleJob` still exists and swallows `compose down` failures; it's now unused by the web UI and could be removed/cleaned up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)