### PR TITLE
chore(release): 0.6.25

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "packages/cli": {
       "name": "@hola/cli",
-      "version": "0.6.24",
+      "version": "0.6.25",
       "bin": {
         "hola": "./bin/hola",
       },
@@ -36,11 +36,11 @@
     },
     "packages/compose": {
       "name": "@hola/compose",
-      "version": "0.6.24",
+      "version": "0.6.25",
     },
     "packages/sdk": {
       "name": "@hola/sdk",
-      "version": "0.6.24",
+      "version": "0.6.25",
       "dependencies": {
         "@hola/shared": "workspace:*",
       },
@@ -54,7 +54,7 @@
     },
     "packages/server": {
       "name": "@hola/server",
-      "version": "0.6.24",
+      "version": "0.6.25",
       "dependencies": {
         "@hola/shared": "workspace:*",
         "jose": "^5.9.6",
@@ -70,7 +70,7 @@
     },
     "packages/shared": {
       "name": "@hola/shared",
-      "version": "0.6.24",
+      "version": "0.6.25",
       "dependencies": {
         "yaml": "^2.9.0",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.6.24",
+  "version": "0.6.25",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.6.24';
+export const CLI_VERSION = '0.6.25';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.6.24",
+  "version": "0.6.25",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.6.24",
+  "version": "0.6.25",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.6.24",
+  "version": "0.6.25",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.6.24",
+  "version": "0.6.25",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Patch release bundling this session's web fixes (everything on `main` since `cli-v0.6.24`).

## Included

- **#261** — `fix(web)`: deployment **Remove** now performs a real teardown (`DELETE /api/deployments/:id`) behind a **confirmation dialog** on both the detail and list pages, instead of a stop-only lifecycle action that left the record and Traefik route behind (which blocked reinstalls).
- **#262** — `fix(web)`: log **SSE streams authenticate** via a fetch transport that sends the OIDC Bearer token, so the Logs tab connects instead of showing a permanent "Connection Error".

## Version bump

`cli` / `compose` / `sdk` / `server` / `shared` → **0.6.25** (plus `cli/src/version.ts` and `bun.lock`). `web` stays `0.0.0`; root stays `0.2.0`.

## Release flow

After this merges, pushing the `cli-v0.6.25` tag triggers `cli-release.yml`: multi-arch server/web images to GHCR, the compose bundle tarball, and the standalone `hola` CLI binaries attached to the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)