### PR TITLE
feat(cli): hola update upgrades both the CLI and the server

### DIFF
--- a/packages/cli/src/__tests__/self-update.test.ts
+++ b/packages/cli/src/__tests__/self-update.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mkdtemp, writeFile, readFile, chmod } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { selfUpdateCli, selfUpdateAsset, type SelfUpdateEnv } from '../commands/update/self-update';
+
+const REPO = 'https://github.com/try-hola/hola.git';
+
+/** A buffer big enough to clear selfUpdateCli's "looks corrupt" floor. */
+function binaryBytes(n = 1_500_000): Uint8Array {
+  return new Uint8Array(n);
+}
+
+function makeEnv(over: Partial<SelfUpdateEnv> & { execPath: string }): SelfUpdateEnv {
+  return {
+    platform: 'linux',
+    arch: 'x64',
+    userArgs: ['update', '--host', 'me@vm'],
+    baseEnv: {},
+    fetchImpl: vi.fn(async () => new Response(binaryBytes().buffer as ArrayBuffer, { status: 200 })) as unknown as typeof fetch,
+    spawn: vi.fn(async () => 0),
+    // exit() must never return — throw a sentinel the test can assert on.
+    exit: vi.fn((code: number) => {
+      throw new Error(`__exit__:${code}`);
+    }) as unknown as (code: number) => never,
+    out: () => {},
+    ...over,
+  };
+}
+
+describe('selfUpdateAsset', () => {
+  it('maps supported platforms and rejects the rest', () => {
+    expect(selfUpdateAsset('linux', 'x64')).toBe('hola-linux-x64');
+    expect(selfUpdateAsset('darwin', 'arm64')).toBe('hola-darwin-arm64');
+    expect(selfUpdateAsset('win32', 'x64')).toBeNull();
+    expect(selfUpdateAsset('linux', 'arm')).toBeNull();
+  });
+});
+
+describe('selfUpdateCli', () => {
+  it('skips when already on the latest', async () => {
+    const env = makeEnv({ execPath: '/usr/local/bin/hola' });
+    const outcome = await selfUpdateCli({ repo: REPO, latestVersion: '0.6.24', currentVersion: '0.6.24' }, env);
+    expect(outcome).toBe('skipped');
+    expect(env.fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('returns unsupported when there is no prebuilt binary for the platform', async () => {
+    const env = makeEnv({ execPath: '/usr/local/bin/hola', platform: 'win32' as NodeJS.Platform });
+    const outcome = await selfUpdateCli({ repo: REPO, latestVersion: '0.6.25', currentVersion: '0.6.24' }, env);
+    expect(outcome).toBe('unsupported');
+    expect(env.fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('dry run describes the upgrade without downloading', async () => {
+    const env = makeEnv({ execPath: '/usr/local/bin/hola' });
+    const outcome = await selfUpdateCli({ repo: REPO, latestVersion: '0.6.25', currentVersion: '0.6.24', dryRun: true }, env);
+    expect(outcome).toBe('skipped');
+    expect(env.fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('downloads the right asset, replaces the binary, and re-execs the new one', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'hola-su-'));
+    const bin = join(dir, 'hola');
+    await writeFile(bin, 'OLD-BINARY');
+    await chmod(bin, 0o755);
+
+    const spawn = vi.fn(async () => 0);
+    const env = makeEnv({ execPath: bin, spawn });
+
+    // exit() throws the sentinel, so the call rejects rather than returning.
+    await expect(
+      selfUpdateCli({ repo: REPO, latestVersion: '0.6.25', currentVersion: '0.6.24' }, env),
+    ).rejects.toThrow('__exit__:0');
+
+    // The binary was replaced with the downloaded bytes.
+    const replaced = await readFile(bin);
+    expect(replaced.length).toBeGreaterThan(1_000_000);
+
+    // Re-exec used the same path + user args + the loop-guard env var.
+    expect(spawn).toHaveBeenCalledWith(
+      bin,
+      ['update', '--host', 'me@vm'],
+      expect.objectContaining({ HOLA_SELF_UPDATED: '1' }),
+    );
+
+    // Downloaded the platform-correct release asset.
+    const url = (env.fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(url).toBe('https://github.com/try-hola/hola/releases/download/cli-v0.6.25/hola-linux-x64');
+  });
+
+  it('returns not-writable when the binary directory cannot be written', async () => {
+    // Parent directory does not exist → access(W_OK) fails → not-writable.
+    const env = makeEnv({ execPath: join(tmpdir(), 'hola-absent-dir-xyz', 'hola') });
+    const outcome = await selfUpdateCli({ repo: REPO, latestVersion: '0.6.25', currentVersion: '0.6.24' }, env);
+    expect(outcome).toBe('not-writable');
+    expect(env.spawn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/__tests__/update.test.ts
+++ b/packages/cli/src/__tests__/update.test.ts
@@ -203,6 +203,55 @@ describe('hola update', () => {
     }
   });
 
+  // --- CLI self-update before the server update -----------------------------
+
+  const NEWER = async () => ({ version: '9.9.9', url: 'https://example.com/r' });
+
+  it('self-updates the CLI (when newer) before updating the server', async () => {
+    const runner = makeRunner();
+    const selfUpdate = vi.fn(async () => 'skipped' as const);
+    await runUpdate(
+      { host: 'me@vm', json: true },
+      { prompter: scriptedPrompter({}), runner, fetchLatest: NEWER, selfUpdate },
+    );
+    expect(selfUpdate).toHaveBeenCalledWith(expect.objectContaining({ latestVersion: '9.9.9' }));
+    // It still proceeds to the server update afterwards.
+    expect(runner.calls.some((c) => c.cmd.includes('install.sh'))).toBe(true);
+  });
+
+  it('--no-self-update (selfUpdate=false) skips the CLI self-update', async () => {
+    const runner = makeRunner();
+    const selfUpdate = vi.fn(async () => 'skipped' as const);
+    await runUpdate(
+      { host: 'me@vm', selfUpdate: false, json: true },
+      { prompter: scriptedPrompter({}), runner, fetchLatest: NEWER, selfUpdate },
+    );
+    expect(selfUpdate).not.toHaveBeenCalled();
+    expect(runner.calls.some((c) => c.cmd.includes('install.sh'))).toBe(true);
+  });
+
+  it('a pinned --ref skips the CLI self-update', async () => {
+    const runner = makeRunner();
+    const selfUpdate = vi.fn(async () => 'skipped' as const);
+    await runUpdate(
+      { host: 'me@vm', ref: 'cli-v0.6.25', json: true },
+      { prompter: scriptedPrompter({}), runner, fetchLatest: NEWER, selfUpdate },
+    );
+    expect(selfUpdate).not.toHaveBeenCalled();
+  });
+
+  it('aborts (before touching the host) when the CLI binary is not writable', async () => {
+    const runner = makeRunner();
+    const selfUpdate = vi.fn(async () => 'not-writable' as const);
+    const res = await runUpdate(
+      { host: 'me@vm', json: true },
+      { prompter: scriptedPrompter({}), runner, fetchLatest: NEWER, selfUpdate },
+    );
+    expect(res).toBeUndefined();
+    expect(process.exitCode).toBe(1);
+    expect(runner.calls.some((c) => c.cmd.includes('install.sh'))).toBe(false);
+  });
+
   // --- `--check` ------------------------------------------------------------
 
   it('--check reports installed / latest / updateAvailable without mutating', async () => {

--- a/packages/cli/src/commands/update/self-update.ts
+++ b/packages/cli/src/commands/update/self-update.ts
@@ -1,0 +1,121 @@
+import { access, chmod, rename, unlink, writeFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import { isNewerVersion } from '@hola/shared';
+
+import { colors } from '../../lib/ui';
+
+/**
+ * Outcome of an attempted CLI self-update:
+ *   - `skipped`        already on the latest (or a dry run) — nothing to do.
+ *   - `unsupported`    no prebuilt binary for this OS/arch — can't self-update.
+ *   - `not-writable`   a newer CLI exists but the binary can't be replaced
+ *                      (e.g. installed root-owned under /usr/local/bin).
+ * On a successful replace the new binary is re-exec'd and the process exits, so
+ * this never returns in that case.
+ */
+export type SelfUpdateOutcome = 'skipped' | 'unsupported' | 'not-writable';
+
+/** Injectable environment so the real fs/network/exec can be faked in tests. */
+export interface SelfUpdateEnv {
+  /** Path to the currently running binary (process.execPath). */
+  execPath: string;
+  platform: NodeJS.Platform;
+  arch: string;
+  /** The user-supplied args to re-run after upgrading (process.argv.slice(2)). */
+  userArgs: string[];
+  baseEnv: NodeJS.ProcessEnv;
+  fetchImpl: typeof fetch;
+  /** Spawn the replacement binary; resolves with its exit code. */
+  spawn: (cmd: string, args: string[], env: NodeJS.ProcessEnv) => Promise<number>;
+  exit: (code: number) => never;
+  out: (msg: string) => void;
+}
+
+export interface SelfUpdateArgs {
+  repo: string;
+  latestVersion: string;
+  currentVersion: string;
+  dryRun?: boolean;
+}
+
+/** Release asset name for a platform/arch, or null if unsupported (mirrors cli-install.sh). */
+export function selfUpdateAsset(platform: NodeJS.Platform, arch: string): string | null {
+  const os = platform === 'linux' ? 'linux' : platform === 'darwin' ? 'darwin' : null;
+  const a = arch === 'x64' ? 'x64' : arch === 'arm64' ? 'arm64' : null;
+  return os && a ? `hola-${os}-${a}` : null;
+}
+
+/** Derive the GitHub release-download base from a clone URL (…/hola.git → …/hola). */
+function releaseBase(repo: string): string {
+  return repo.replace(/\.git$/, '');
+}
+
+/**
+ * Upgrade the running `hola` binary in place to `latestVersion`, then re-exec it
+ * to perform the actual work with the new code/version. Downloads the matching
+ * release asset to a temp file in the binary's own directory, marks it
+ * executable, and atomically renames it over the running binary — which is safe
+ * on Linux/macOS, where the kernel keeps the open inode of the running process.
+ * The re-exec carries `HOLA_SELF_UPDATED=1` so the new process doesn't loop.
+ */
+export async function selfUpdateCli(args: SelfUpdateArgs, env: SelfUpdateEnv): Promise<SelfUpdateOutcome> {
+  const { repo, latestVersion, currentVersion, dryRun } = args;
+  if (!isNewerVersion(latestVersion, currentVersion)) return 'skipped';
+
+  const asset = selfUpdateAsset(env.platform, env.arch);
+  if (!asset) {
+    env.out(colors.yellow(`No prebuilt CLI for ${env.platform}/${env.arch}; updating the server only.`));
+    return 'unsupported';
+  }
+
+  const binPath = env.execPath;
+  env.out(colors.dim(`==> Upgrade CLI ${currentVersion} → ${latestVersion}`));
+  if (dryRun) {
+    env.out(`  would download ${asset} and replace ${binPath}`);
+    return 'skipped';
+  }
+
+  // The binary is replaced via a rename within its own directory, so we need to
+  // be able to write that directory — check up front for a clear early abort.
+  const dir = dirname(binPath);
+  try {
+    await access(dir, constants.W_OK);
+  } catch {
+    return 'not-writable';
+  }
+
+  const url = `${releaseBase(repo)}/releases/download/cli-v${latestVersion}/${asset}`;
+  const res = await env.fetchImpl(url, {
+    headers: { 'User-Agent': 'hola-cli' },
+    signal: AbortSignal.timeout(60000),
+  });
+  if (!res.ok || !res.body) {
+    throw new Error(`Downloading the new CLI failed (HTTP ${res.status}) from ${url}`);
+  }
+  const bytes = new Uint8Array(await res.arrayBuffer());
+  // Sanity floor: a real compiled Bun binary is tens of MB; anything tiny is an
+  // error page or a truncated download, not something to chmod +x and run.
+  if (bytes.length < 1_000_000) {
+    throw new Error(`Downloaded CLI looks corrupt (${bytes.length} bytes) from ${url}`);
+  }
+
+  const tmp = join(dir, `.hola-update-${latestVersion}.tmp`);
+  try {
+    await writeFile(tmp, bytes, { mode: 0o755 });
+    await chmod(tmp, 0o755);
+    await rename(tmp, binPath);
+  } catch (err) {
+    await unlink(tmp).catch(() => {});
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'EACCES' || code === 'EPERM' || code === 'EROFS') return 'not-writable';
+    throw err;
+  }
+  env.out(colors.green(`  CLI upgraded to ${latestVersion}.`));
+
+  // Hand off to the freshly installed binary so the rest of the run uses the new
+  // code and version. HOLA_SELF_UPDATED stops it from trying to self-update again.
+  const code = await env.spawn(binPath, env.userArgs, { ...env.baseEnv, HOLA_SELF_UPDATED: '1' });
+  env.exit(code);
+}

--- a/packages/cli/src/commands/update/update.ts
+++ b/packages/cli/src/commands/update/update.ts
@@ -5,6 +5,14 @@ import { parseEnv } from '../../install/render-env';
 import { systemRunner, type Runner } from '../../lib/runner';
 import { createSpinner, formatComposeLine, parseComposePs, renderContainerTable, colors } from '../../lib/ui';
 import { CLI_VERSION } from '../../version';
+import { selfUpdateCli, type SelfUpdateArgs, type SelfUpdateOutcome } from './self-update';
+
+// Self-update touches the real filesystem/network and re-execs the process, so
+// it's suppressed by default under the test runner (the same VITEST guard the SSE
+// client uses); unit tests exercise it via `selfUpdateCli` or an injected stub.
+const IS_TEST =
+  typeof process !== 'undefined' &&
+  !!(process.env.VITEST || process.env.VITEST_WORKER_ID || process.env.NODE_ENV === 'test');
 
 export interface UpdateOptions {
   host?: string;
@@ -19,6 +27,12 @@ export interface UpdateOptions {
   keepAuthMode?: boolean;
   /** Report versions (CLI / installed / latest release) without changing anything. */
   check?: boolean;
+  /**
+   * Set to `false` by `--no-self-update` (via mri negation) to skip upgrading the
+   * CLI binary and only update the server to this CLI's version. Default (enabled)
+   * brings the CLI up to the latest release first, then updates the server to match.
+   */
+  selfUpdate?: boolean;
   dryRun?: boolean;
   json?: boolean;
 }
@@ -119,9 +133,34 @@ async function fetchLatestRelease(
   }
 }
 
+/** Production CLI self-update: real binary path, fetch, spawn, and process exit. */
+function realSelfUpdate(args: SelfUpdateArgs): Promise<SelfUpdateOutcome> {
+  return selfUpdateCli(args, {
+    execPath: process.execPath,
+    platform: process.platform,
+    arch: process.arch,
+    userArgs: process.argv.slice(2),
+    baseEnv: process.env,
+    fetchImpl: fetch,
+    spawn: (cmd, a, env) =>
+      import('node:child_process').then(
+        ({ spawn }) =>
+          new Promise<number>((resolve, reject) => {
+            const child = spawn(cmd, a, { stdio: 'inherit', env });
+            child.on('error', reject);
+            child.on('close', (code) => resolve(code ?? 1));
+          }),
+      ),
+    exit: (code) => process.exit(code),
+    out: (msg) => console.log(msg),
+  });
+}
+
 /**
- * Config-preserving in-place upgrade of an existing install to the invoking CLI's
- * version. Over SSH it preflights the host, reads the current `.env`/VERSION,
+ * Config-preserving in-place upgrade. First self-updates the CLI to the latest
+ * release (unless --no-self-update or a pinned --ref) and re-execs, so the host is
+ * then brought up to that same version. Over SSH it preflights the host, reads the
+ * current `.env`/VERSION,
  * reconciles the auth mode to the Authentik-default baseline (prompting/flag-gated
  * for an explicit `none`), downloads the version-pinned bundle and extracts it over
  * the install dir WITHOUT touching `.env` or the ACME store, re-runs the idempotent
@@ -135,11 +174,14 @@ export async function runUpdate(
     runner?: Runner;
     /** Injectable release lookup for tests / `--check`. */
     fetchLatest?: (repo: string) => Promise<{ version: string; url: string } | null>;
+    /** Injectable CLI self-update (tests); defaults to the real fs/network/re-exec impl. */
+    selfUpdate?: (args: SelfUpdateArgs) => Promise<SelfUpdateOutcome>;
   },
 ): Promise<UpdateResult | UpdateCheckReport | undefined> {
   const prompter = injected?.prompter ?? clackPrompter();
   const runner = injected?.runner ?? systemRunner();
   const fetchLatest = injected?.fetchLatest ?? ((repo: string) => fetchLatestRelease(repo));
+  const selfUpdate = injected?.selfUpdate ?? realSelfUpdate;
   const out = (msg: string) => { if (!opts.json) console.log(msg); };
 
   const host = opts.host;
@@ -195,7 +237,11 @@ export async function runUpdate(
         out(`Latest release:    ${colors.bold(report.latest ?? 'unavailable')}`);
         if (report.updateAvailable) {
           out(`\n${colors.yellow('A newer Hola version')} (${colors.bold(report.latest!)}) is available.`);
-          out(`Run ${colors.cyan(`hola update --host ${host}`)} to upgrade.`);
+          const behindLatest = isNewerVersion(report.latest!, CLI_VERSION);
+          out(
+            `Run ${colors.cyan(`hola update --host ${host}`)} to upgrade` +
+              (behindLatest ? ' the CLI and the server.' : ' the server.'),
+          );
         } else if (report.skew) {
           out(`\n${colors.yellow('Version skew:')} the server (${report.installed}) is older than your CLI (${report.cli}).`);
           out(`Run ${colors.cyan(`hola update --host ${host}`)} to bring it up to the CLI's version.`);
@@ -204,6 +250,43 @@ export async function runUpdate(
         }
       }
       return report;
+    }
+
+    // 0) Self-update the CLI to the latest release, then re-exec so the server
+    //    update runs at that version (so `hola update` brings BOTH up to date).
+    //    Skipped when the user pinned a version (--ref), opted out
+    //    (--no-self-update → selfUpdate === false), or we're already the re-exec'd
+    //    child (HOLA_SELF_UPDATED). Suppressed under the test runner unless a stub
+    //    is injected, so unit runs never touch the network or replace a binary.
+    const selfUpdateActive = !!injected?.selfUpdate || !IS_TEST;
+    if (
+      selfUpdateActive &&
+      opts.selfUpdate !== false &&
+      !opts.ref &&
+      !process.env.HOLA_SELF_UPDATED
+    ) {
+      const latest = await fetchLatest(repo);
+      if (latest && isNewerVersion(latest.version, CLI_VERSION)) {
+        const outcome = await selfUpdate({
+          repo,
+          latestVersion: latest.version,
+          currentVersion: CLI_VERSION,
+          dryRun: opts.dryRun,
+        });
+        // On a successful replace selfUpdate re-execs and never returns; reaching
+        // here means it didn't run. Only a non-writable binary is fatal — the user
+        // must upgrade the CLI out-of-band (or opt out) to avoid a CLI/server skew.
+        if (outcome === 'not-writable') {
+          throw new UpdateAbort(
+            `A newer Hola CLI (${latest.version}) is available, but this binary can't be replaced:\n` +
+              `  ${process.execPath}\n` +
+              `Upgrade the CLI, then re-run update:\n` +
+              `  curl -fsSL https://raw.githubusercontent.com/try-hola/hola/main/cli-install.sh | sh\n` +
+              `Or re-run with write access to that path, or pass --no-self-update to update the ` +
+              `server to v${CLI_VERSION} only.`,
+          );
+        }
+      }
     }
 
     // 1) Preflight (single remote probe → key=value lines). The host pulls

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -51,10 +51,11 @@ prog
 // update — upgrade an existing install to this CLI's version (config-preserving, no wizard)
 prog
   .command('update')
-  .describe('Upgrade an existing host to this CLI’s version over SSH — no wizard, preserves .env')
+  .describe('Upgrade the CLI to the latest release, then the host to match, over SSH — preserves .env')
   .option('--host', 'Target host, e.g. user@vm (required)')
   .option('--repo', 'Hola repo to download release assets from', 'https://github.com/try-hola/hola.git')
-  .option('--ref', `Release tag to install (default cli-v${CLI_VERSION})`)
+  .option('--ref', `Release tag to install (default cli-v${CLI_VERSION}); pinning a ref skips the CLI self-update`)
+  .option('--no-self-update', 'Don’t upgrade the CLI binary; only update the server to this CLI’s version')
   .option('--tarball-url', 'Override the compose-bundle download URL (advanced)')
   .option('--dir', 'Install directory on the host', '/opt/hola')
   .option('--enable-sso', 'For a HOLA_AUTH_MODE=none host: enable Authentik SSO (the new standard)', false)


### PR DESCRIPTION
## Motivation

`hola update` only ever upgraded the **server**, and always to the **CLI's own version**. So a user on an older CLI could never reach the latest release by running `hola update` — and `update --check` misleadingly recommended exactly that. (Reported: `--check` says 0.6.25 is available, but `hola update` re-installs 0.6.24 because the CLI is 0.6.24.)

## What changed

`hola update` now brings **both** up to date in one command:

1. Look up the latest stable release. If the **CLI binary** is behind, download the matching prebuilt asset (`hola-<os>-<arch>`, same mapping as `cli-install.sh`), **atomically replace** the running executable (safe on Linux/macOS — the kernel keeps the running process's open inode), and **re-exec** it with `HOLA_SELF_UPDATED=1`.
2. The re-exec'd (latest) CLI then updates the **server** to match — preserving `.env`/ACME exactly as before.

### Flags & safety

- **`--no-self-update`** — server-only upgrade to the CLI's current version (old behavior).
- **`--ref <tag>`** — pinning a version also skips the self-update.
- **Not-writable binary** (e.g. root-owned under `/usr/local/bin`): `update` **aborts with guidance** to re-run `cli-install.sh` (or with write access), rather than silently producing a CLI/server version skew.
- A download size sanity-check guards against truncated/error-page "binaries".
- Suppressed under the test runner unless a stub is injected, so unit runs never hit the network or replace a binary.

`update --check` guidance now reflects that `update` upgrades the CLI and the server.

## Tests

- **Unit** (`self-update.test.ts`): asset mapping; skip/unsupported/dry-run; download → atomic replace → re-exec (asserts the asset URL, replaced bytes, and re-exec argv + guard env); not-writable.
- **Integration** (`update.test.ts`): self-update runs before the server update; `--no-self-update` and `--ref` skip it; not-writable aborts before touching the host.

`bun run typecheck` ✓ · `bun run lint` ✓ · `bun run test` ✓ (server 349, web 147, cli incl. new) · `bun run build` ✓ · compiled-binary smoke test of `update --help` and `--no-self-update --dry-run` ✓

## Note

This ships in the CLI, so it takes effect for upgrades *from* the release that includes it onward (a CLI without this code won't self-update). Worth a release after merge so it's available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)