### PR TITLE
chore(release): 0.6.26

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "packages/cli": {
       "name": "@hola/cli",
-      "version": "0.6.25",
+      "version": "0.6.26",
       "bin": {
         "hola": "./bin/hola",
       },
@@ -36,11 +36,11 @@
     },
     "packages/compose": {
       "name": "@hola/compose",
-      "version": "0.6.25",
+      "version": "0.6.26",
     },
     "packages/sdk": {
       "name": "@hola/sdk",
-      "version": "0.6.25",
+      "version": "0.6.26",
       "dependencies": {
         "@hola/shared": "workspace:*",
       },
@@ -54,7 +54,7 @@
     },
     "packages/server": {
       "name": "@hola/server",
-      "version": "0.6.25",
+      "version": "0.6.26",
       "dependencies": {
         "@hola/shared": "workspace:*",
         "jose": "^5.9.6",
@@ -70,7 +70,7 @@
     },
     "packages/shared": {
       "name": "@hola/shared",
-      "version": "0.6.25",
+      "version": "0.6.26",
       "dependencies": {
         "yaml": "^2.9.0",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.6.25",
+  "version": "0.6.26",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.6.25';
+export const CLI_VERSION = '0.6.26';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.6.25",
+  "version": "0.6.26",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.6.25",
+  "version": "0.6.26",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.6.25",
+  "version": "0.6.26",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.6.25",
+  "version": "0.6.26",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Release bundling the CLI self-update feature (everything on `main` since `cli-v0.6.25`).

## Included

- **#264** — `feat(cli)`: `hola update` now upgrades the **CLI binary** to the latest release (self-update + re-exec), then brings the **server** up to match — one command updates both. `--no-self-update` keeps the server-only behavior; a non-writable binary aborts with guidance instead of creating a CLI/server skew.

## Version bump

`cli` / `compose` / `sdk` / `server` / `shared` → **0.6.26** (+ `cli/src/version.ts`, `bun.lock`). `web` stays `0.0.0`; root stays `0.2.0`.

## Release flow

After merge, pushing `cli-v0.6.26` triggers `cli-release.yml`: multi-arch server/web images to GHCR, the compose bundle tarball, and the standalone `hola` CLI binaries on the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)