### PR TITLE
fix(server): hola restart leaves deployment in error

### DIFF
--- a/docs/findings-restart-bug.md
+++ b/docs/findings-restart-bug.md
@@ -1,0 +1,101 @@
+# Root cause: `hola restart` leaves a deployment in `error`
+
+## Symptom
+
+`hola restart <deploymentId>` reproducibly drives a deployment into `error` state
+with no running container. Server stdout showed a STOP completing ("Compose
+project stopped successfully") but no subsequent "Starting compose project", so it
+looked like the start half of restart never ran.
+
+## What actually happens
+
+`restart` is **not** a down-then-up. `executeAction('restart')`
+(`packages/server/src/services/core/deployment.ts`) enqueues a single `start`-type
+job with `payload.action = 'restart'`. In `runLifecycleJob` the `action === 'restart'`
+branch (deployment.ts:1236) does, in order:
+
+1. `provisionAuth(deployment)` — re-provision the app's Authentik auth artifacts
+2. `materializeCompose(...)` — write the runtime `docker-compose.yml`
+3. `composeUp(...)` — `docker compose up -d` (recreate)
+
+The STOP the tester saw came from a **separate** `stop` action, not from restart.
+The restart itself never reached `composeUp` because **step 1 threw**.
+
+## Evidence (live VM 103, server `ghcr.io/try-hola/server:0.6.26`)
+
+Job record + job logs for the failed restart (`GET /api/jobs/<id>` and `/logs`):
+
+```
+{"id":"job_1782489827615_c38fneygqxo","type":"start","status":"failed","progress":10,"deploymentId":"uptime-kuma-ff425754"}
+
+"Job started"
+"Starting deployment action: restart"
+"Deployment action 'restart' failed: Authentik PATCH /api/v3/providers/proxy/2/ failed: 400"
+"Job failed"
+```
+
+The failure is at the **provisionAuth** step (progress never passes 10), before any
+compose work — which is why server stdout shows zero compose activity for the
+restart job and the container stays gone. The error is logged at the *job* level
+(LoggingService), not in the server's stdout stream, which is why it was invisible
+in `docker compose logs server`.
+
+uptime-kuma uses `forward-auth`, so on every (re)provision the provisioner takes
+the idempotent reuse path in `provisionForwardAuth`
+(`packages/server/src/services/core/provisioner.ts`):
+
+```ts
+await this.api('PATCH', `/api/v3/providers/proxy/${existing.providerPk}/`,
+  { external_host: externalHost });   // <-- 400
+```
+
+Read-only GET of that provider on the VM confirms the trigger:
+
+```json
+{ "pk": 2, "name": "hola-uptime-kuma-uptime-k", "mode": "forward_single",
+  "external_host": "https://uptime-kuma.192.168.1.15.sslip.io", "internal_host": "" }
+```
+
+Authentik's `ProxyProviderSerializer.validate()` validates against
+`attrs.get("mode", ProxyMode.PROXY)`. A **partial** update (PATCH) that omits
+`mode` is therefore validated as `PROXY` mode, and PROXY mode requires a non-empty
+`internal_host`. A forward-auth provider correctly has `internal_host: ""`, so the
+mode-less PATCH is rejected:
+
+```
+HTTP 400 {"internal_host": ["Internal host cannot be empty when forward auth is disabled."]}
+```
+
+The create call (`POST /api/v3/providers/proxy/`) sends `mode: 'forward_single'`
+and succeeds — install works. Only the reuse PATCH omits `mode`, so the failure
+surfaces on the first restart/redeploy of any forward-auth app. (native-oidc apps
+PATCH `/providers/oauth2/` with a different serializer and are unaffected.)
+
+## Fix
+
+Resend `mode: 'forward_single'` on the reuse PATCH so Authentik validates the
+update in forward-auth mode (matching the create payload):
+
+```ts
+await this.api('PATCH', `/api/v3/providers/proxy/${existing.providerPk}/`, {
+  mode: 'forward_single',
+  external_host: externalHost,
+});
+```
+
+With provisionAuth succeeding, restart proceeds to `composeUp` and the deployment
+returns to `running`.
+
+Regression test added in `authentik-contract.test.ts`: the forward-auth reuse path
+PATCHes with `mode: 'forward_single'` and the mock fetch returns 400 if `mode` is
+absent, locking in the contract.
+
+## Secondary observation (benign)
+
+Uninstalling a *failed* deployment logged `docker-compose.yml not found at
+.../runtime/docker-compose.yml` during its stop step. `composeDown`/`composeUp`
+guard with `existsSync(composeFile)` and throw if absent (docker.ts:231). For the
+`delete` action this is tolerated — `runLifecycleJob` only rethrows a down failure
+when `action !== 'delete'` (deployment.ts:1233), and `deleteDeployment` additionally
+wraps the stop in try/catch. So it is a warning, not a blocker, and is out of scope
+for this fix.

--- a/docs/findings-restart-bug.md
+++ b/docs/findings-restart-bug.md
@@ -90,6 +90,36 @@ Regression test added in `authentik-contract.test.ts`: the forward-auth reuse pa
 PATCHes with `mode: 'forward_single'` and the mock fetch returns 400 if `mode` is
 absent, locking in the contract.
 
+## Deterministic validation (real Authentik, local Docker)
+
+The unit contract test mocks `fetch`, so it can't prove the real Authentik
+serializer accepts the payload. An integration test in
+`authentik-provision.it.ts` (`forward-auth reuse (restart/redeploy)`) drives the
+exact reuse path against a **real** Authentik booted in Docker: provision a
+forward-auth provider, then re-provision with the saved ref (the call
+`runLifecycleJob`'s restart branch makes via `provisionAuth`) and a changed host.
+
+Red/green, ~65s per run (`bun test:integration`, gated on Docker):
+
+- **Without the fix** the reuse re-provision fails on
+  `PATCH /api/v3/providers/proxy/<pk>/ failed: 400` — the live bug.
+- **With the fix** it reuses the provider in place, the provider keeps
+  `internal_host: ""` (still forward-auth, not silently flipped to proxy), and the
+  `external_host` is refreshed.
+
+This confirms the fix is complete at the provisioner layer: the reuse PATCH was the
+only failing step. `completeAuthWiring` (the step after `composeUp`) does no
+Authentik work for a forward-auth app — `runPostDeploySetup` is a no-op without an
+`oidc.setup` block, and `activateRoute` only re-emits the Traefik file config — so
+there is no further provisioning failure on the restart path. (A real-VM e2e of the
+full `install → restart → running` loop for a forward-auth app is covered by the
+catalog/lifecycle test harness.)
+
+The integration harness's `waitForApi` was also hardened to wait for the default
+`default-provider-authorization-implicit-consent` flow blueprint (not just the API
+socket), removing a cold-boot race where a fast first test 404'd before Authentik
+finished applying its default flows.
+
 ## Secondary observation (benign)
 
 Uninstalling a *failed* deployment logged `docker-compose.yml not found at

--- a/packages/server/src/__tests__/integration/authentik-provision.it.ts
+++ b/packages/server/src/__tests__/integration/authentik-provision.it.ts
@@ -71,21 +71,42 @@ async function akGet(path: string): Promise<{ status: number; body: unknown }> {
   return { status: res.status, body: text ? JSON.parse(text) : undefined };
 }
 
+// Authentik's default flows/providers are created by a worker blueprint task that
+// lags the API coming up: `/api/v3/admin/version/` answers OK well before
+// `default-provider-authorization-implicit-consent` exists. Every provisioning mode
+// resolves that authorization flow, so gate readiness on its existence too —
+// otherwise a fast first test races the blueprint and 404s. Keeps the suite
+// deterministic regardless of how quickly the API socket opens.
+const AUTHZ_FLOW_SLUG = 'default-provider-authorization-implicit-consent';
+
 async function waitForApi(timeoutMs = 300_000): Promise<void> {
   const start = Date.now();
+  let apiReady = false;
   for (;;) {
     try {
-      const res = await fetch(`${BASE_URL}/api/v3/admin/version/`, {
-        headers: { Authorization: `Bearer ${BOOTSTRAP_TOKEN}` },
-        signal: AbortSignal.timeout(5_000),
-      });
-      if (res.ok) return;
+      if (!apiReady) {
+        const res = await fetch(`${BASE_URL}/api/v3/admin/version/`, {
+          headers: { Authorization: `Bearer ${BOOTSTRAP_TOKEN}` },
+          signal: AbortSignal.timeout(5_000),
+        });
+        apiReady = res.ok;
+      }
+      if (apiReady) {
+        // Default authorization flow blueprint applied yet?
+        const flow = await fetch(`${BASE_URL}/api/v3/flows/instances/${AUTHZ_FLOW_SLUG}/`, {
+          headers: { Authorization: `Bearer ${BOOTSTRAP_TOKEN}` },
+          signal: AbortSignal.timeout(5_000),
+        });
+        if (flow.ok) return;
+      }
     } catch {
       // not up yet
     }
     if (Date.now() - start > timeoutMs) {
       const logs = await sh(`docker logs --tail 40 ${SERVER}`, 15_000);
-      throw new Error(`Authentik API not ready in ${timeoutMs}ms. Last server logs:\n${logs.stdout}\n${logs.stderr}`);
+      throw new Error(
+        `Authentik not ready in ${timeoutMs}ms (api=${apiReady}, default flows pending). Last server logs:\n${logs.stdout}\n${logs.stderr}`,
+      );
     }
     await new Promise(r => setTimeout(r, 3_000));
   }
@@ -196,6 +217,56 @@ describe.skipIf(!dockerOk)('Authentik provisioner (real daemon)', () => {
       body: { providers: number[] };
     };
     expect(after.body.providers).not.toContain(result.ref.providerPk!);
+  }, 120_000);
+
+  // Regression for #267: `hola restart`/redeploy of a forward-auth app re-runs
+  // provisioning with the persisted ref (the idempotent reuse path), which PATCHes
+  // the existing proxy provider. Authentik's ProxyProvider serializer validates the
+  // payload against `attrs.get("mode", ProxyMode.PROXY)`, so a PATCH that omits
+  // `mode` is validated as PROXY — which rejects a forward-auth provider's
+  // (correctly empty) internal_host with HTTP 400. The reuse PATCH must resend
+  // `mode: forward_single`. This drives the real reuse path end-to-end: without the
+  // fix the second provision throws 400; with it, the provider is updated in place.
+  test('forward-auth reuse (restart/redeploy): re-provisioning with the saved ref succeeds and refreshes the host', async () => {
+    const svc = new RealAuthentikProvisionerService(config);
+    const deploymentId = 'dep-fwd-reuse-0003';
+
+    // First install.
+    const first = await svc.provision({
+      deploymentId,
+      appName: 'uptimekuma',
+      mode: 'forward-auth',
+      host: 'uptimekuma.example.com',
+    });
+    expect(first.ref.providerPk).toBeDefined();
+    expect(first.ref.mode).toBe('forward-auth');
+
+    // Restart/redeploy: same deployment, now carrying the persisted ref, and a new
+    // external host (proves the PATCH actually applied). This is the exact call
+    // `runLifecycleJob`'s restart branch makes via `provisionAuth`.
+    const second = await svc.provision({
+      deploymentId,
+      appName: 'uptimekuma',
+      mode: 'forward-auth',
+      host: 'uptimekuma-2.example.com',
+      existingRef: first.ref,
+    });
+
+    // Same provider reused (not a new one), host refreshed, middleware still emitted.
+    expect(second.ref.providerPk).toBe(first.ref.providerPk);
+    expect(second.middleware?.outpostUrl).toBe(BASE_URL);
+
+    const provider = (await akGet(`/api/v3/providers/proxy/${first.ref.providerPk}/`)) as {
+      status: number;
+      body: { external_host: string; internal_host: string; mode: string };
+    };
+    expect(provider.status).toBe(200);
+    expect(provider.body.external_host).toBe('https://uptimekuma-2.example.com');
+    // Still a forward-auth provider (empty internal_host), not silently flipped to proxy.
+    expect(provider.body.internal_host).toBe('');
+
+    await svc.deprovision({ deploymentId, ref: second.ref });
+    expect((await akGet(`/api/v3/providers/proxy/${first.ref.providerPk}/`)).status).toBe(404);
   }, 120_000);
 
   test('scoped-token bootstrap: self-mints a non-superuser token and provisions with it', async () => {

--- a/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
+++ b/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
@@ -474,6 +474,49 @@ describe('RealAuthentikProvisionerService (REST contract)', () => {
     expect(result.ref).toMatchObject({ mode: 'forward-auth', providerPk: 55, outpostPk: 1 });
   });
 
+  test('forward-auth reuse resends mode on the PATCH (Authentik rejects a mode-less partial update with 400)', async () => {
+    // Authentik's ProxyProviderSerializer validates against attrs.get("mode",
+    // ProxyMode.PROXY): a partial update that omits `mode` is validated as PROXY,
+    // which then rejects the (empty) internal_host of a forward-auth provider with
+    // HTTP 400 — the bug that left every restart of a forward-auth app stuck in
+    // `error` before its container was recreated. Fail the PATCH if mode is absent.
+    installFetch((call) => {
+      if (call.method === 'PATCH' && call.path === '/api/v3/providers/proxy/55/') {
+        const mode = (call.body as Record<string, unknown>).mode;
+        if (mode !== 'forward_single') {
+          return json({ internal_host: ['Internal host cannot be empty when forward auth is disabled.'] }, 400);
+        }
+        return json({ pk: 55 });
+      }
+      // Group reconcile on reuse: resolve the existing application, no prior bindings.
+      if (call.method === 'GET' && call.path.startsWith('/api/v3/core/applications/grafana-dep-abcd/')) {
+        return json({ pk: 7 });
+      }
+      if (call.method === 'GET' && call.path.startsWith('/api/v3/policies/bindings/?target=')) {
+        return json({ results: [] });
+      }
+      return undefined;
+    });
+    const svc = new RealAuthentikProvisionerService(CONFIG);
+
+    const result = await svc.provision({
+      deploymentId: 'dep-abcdef0123456789',
+      appName: 'grafana',
+      mode: 'forward-auth',
+      host: 'grafana.example.com',
+      existingRef: { mode: 'forward-auth', providerPk: 55, applicationSlug: 'grafana-dep-abcd', outpostPk: 1 },
+    });
+
+    // Reuse PATCHed the existing provider with mode + refreshed host (no recreate).
+    const patch = calls.find(c => c.method === 'PATCH' && c.path === '/api/v3/providers/proxy/55/')!;
+    expect(patch).toBeDefined();
+    expect((patch.body as Record<string, unknown>).mode).toBe('forward_single');
+    expect((patch.body as Record<string, unknown>).external_host).toBe('https://grafana.example.com');
+    // No new provider was created on the reuse path.
+    expect(calls.some(c => c.method === 'POST' && c.path === '/api/v3/providers/proxy/')).toBe(false);
+    expect(result.ref).toMatchObject({ mode: 'forward-auth', providerPk: 55 });
+  });
+
   test('forward-auth provision binds the declared groups to the application (access restriction)', async () => {
     const bindings: Array<{ target: unknown; group: unknown }> = [];
     installFetch((call) => {

--- a/packages/server/src/services/core/provisioner.ts
+++ b/packages/server/src/services/core/provisioner.ts
@@ -507,7 +507,18 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
     // Idempotent re-provision: reuse the existing proxy provider, refresh its host.
     const existing = input.existingRef;
     if (existing && existing.mode === 'forward-auth' && existing.providerPk != null) {
-      await this.api('PATCH', `/api/v3/providers/proxy/${existing.providerPk}/`, { external_host: externalHost });
+      // Always resend `mode`: Authentik's ProxyProvider serializer validates the
+      // payload against `attrs.get("mode", ProxyMode.PROXY)`, so a partial update
+      // that omits `mode` is validated as PROXY mode — which then rejects the
+      // (correctly empty) `internal_host` of a forward-auth provider with HTTP 400.
+      // Sending `forward_single` (matching the create call) makes the update
+      // validate in forward-auth mode. Without this, every restart of a
+      // forward-auth app fails in provisionAuth before the container is recreated,
+      // leaving the deployment stuck in `error`.
+      await this.api('PATCH', `/api/v3/providers/proxy/${existing.providerPk}/`, {
+        mode: 'forward_single',
+        external_host: externalHost,
+      });
       const reuseSlug = existing.applicationSlug ?? slug;
       // Re-reconcile the group restriction so it tracks manifest changes across redeploys.
       await this.reconcileForwardAuthGroups(reuseSlug, input.forwardAuth?.allowedGroups ?? []);


### PR DESCRIPTION
## Problem

`hola restart <deploymentId>` reproducibly drives a deployment into `error` state with no running container. Reproduced on VM 103 against the published `ghcr.io/try-hola/server:0.6.26` image (uptime-kuma, forward-auth).

## Root cause

`restart` enqueues a single `start`-type job whose `runLifecycleJob` branch re-provisions auth **before** recreating the container. For a `forward-auth` app, `provisionForwardAuth` takes the idempotent reuse path and PATCHes the existing Authentik proxy provider with only `external_host`:

```ts
await this.api('PATCH', `/api/v3/providers/proxy/${pk}/`, { external_host });
```

Authentik's `ProxyProviderSerializer.validate()` validates against `attrs.get("mode", ProxyMode.PROXY)`. A partial update (PATCH) that omits `mode` is validated as **PROXY** mode, which requires a non-empty `internal_host`. A forward-auth provider correctly has `internal_host: ""`, so Authentik rejects it:

```
HTTP 400 {"internal_host": ["Internal host cannot be empty when forward auth is disabled."]}
```

`provisionAuth` threw before `composeUp` ever ran (job progress stuck at 10), so the container was never recreated and the deployment converged to `error`. The "stop completed but start never ran" symptom was a separate `stop` action; the restart aborted in the auth step before any compose work.

Evidence (failed restart job logs on the live VM):

```
"Starting deployment action: restart"
"Deployment action 'restart' failed: Authentik PATCH /api/v3/providers/proxy/2/ failed: 400"
"Job failed"
```

The create call already sends `mode: 'forward_single'` (so install works); only the reuse PATCH omitted it, so the bug surfaces on the first restart/redeploy of any forward-auth app.

## Fix

Resend `mode: 'forward_single'` on the reuse PATCH so Authentik validates the update in forward-auth mode (matching the create payload). Adds a regression test in `authentik-contract.test.ts` whose mock fetch returns 400 if `mode` is absent.

Full analysis: `docs/findings-restart-bug.md`.

## Verification

- `bun --cwd packages/server test src/__tests__/provisioner/authentik-contract.test.ts` → 30 pass
- `tsc --noEmit` clean, `eslint` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)