### PR TITLE
fix(server): reject forward-auth apps up front under HOLA_AUTH_MODE=none

### DIFF
--- a/docs/findings-forward-auth-mode-none.md
+++ b/docs/findings-forward-auth-mode-none.md
@@ -1,0 +1,75 @@
+# Findings: forward-auth apps fail messily under `HOLA_AUTH_MODE=none`
+
+## Symptom
+
+With the platform running `HOLA_AUTH_MODE=none` (no Authentik backend), installing
+an app whose manifest declares `auth.mode: forward-auth` (or `native-ldap`) failed
+late and left a tombstone. Discovered via e2e: `uptime-kuma`
+(`auth.mode: forward-auth`) could not be installed under mode `none`.
+
+## Root cause
+
+The deploy lifecycle is async. `createFromDraft` creates the deployment record and
+enqueues a `start` job; the job later runs `runLifecycleJob`, which calls
+`provisionAuth(...)` **before** `materializeCompose`/`composeUp`.
+
+Under `HOLA_AUTH_MODE=none` the active provisioner is `NoneProvisionerService`,
+whose `provision()` intentionally **throws** for modes that need a real auth
+backend (`forward-auth`, `native-ldap`):
+
+> `App "<app>" requires auth mode "<mode>", which needs an auth backend. Set HOLA_AUTH_MODE=authentik to install it.`
+
+That rejection policy is correct — a forward-auth route would be gated by a
+non-existent outpost, so shipping it ungated would expose an app meant to be
+SSO-gated. The bug was purely about **timing**: the rejection happened inside the
+deploy job, *after* a deployment record already existed. So `composeUp` never ran
+and the deployment was left stuck in `error` state (a confusing tombstone) instead
+of the user getting the clear error immediately at install time.
+
+## Fix
+
+Preflight the app's declared auth requirement against the active auth backend
+**before** any deployment record/job is created, reusing the exact same capability
+check and error message the None backend already uses (single-sourced — no
+divergent wording). The policy is unchanged: these apps are still rejected under
+mode `none`; they just fail up front now.
+
+### `packages/server/src/services/core/provisioner.ts`
+- New `ProvisionerService.assertCanProvisionAuthMode(mode, appName)` — a
+  synchronous, side-effect-free precheck. Backends with a real provider
+  (`RealAuthentikProvisionerService`, `MockProvisionerService`) implement it as a
+  no-op; `NoneProvisionerService` throws for `forward-auth`/`native-ldap`.
+- Extracted the rejection into a single module helper
+  `assertModeRunnableWithoutBackend(mode, appName)` (backed by
+  `MODES_REQUIRING_BACKEND`). Both `NoneProvisionerService.assertCanProvisionAuthMode`
+  and its `provision()` (kept as defense-in-depth) call it, so the error wording
+  lives in exactly one place.
+
+### `packages/server/src/services/core/deployment.ts`
+- New protected hook `assertAuthProvisionable(auth, appName)` on the base
+  `InMemoryDeploymentService` (default no-op). `RealDeploymentService` overrides it
+  to call `this.provisioner.assertCanProvisionAuthMode(...)` for the declared mode
+  **and** for a forward-auth fallback when `auth.fallback === 'forward-auth'` —
+  mirroring exactly which modes `provisionAuth` would actually provision.
+- Both `createFromDraft` (install) and `promote` (new release) call the hook right
+  after building the release from the draft and **before** creating any deployment
+  state, routing activation, or job. A rejection therefore throws straight back to
+  the caller (the CLI "Preflight…" step) with the clear message and leaves no
+  `error`-state deployment behind.
+
+## Regression test
+
+`packages/server/src/__tests__/deployments/auth-provisioning.test.ts`:
+- `forward-auth under HOLA_AUTH_MODE=none is rejected up front, creating no
+  error-state deployment` — installs a `forward-auth` app with a real
+  `NoneProvisionerService`, asserts `createFromDraft` rejects with the
+  "...needs an auth backend. Set HOLA_AUTH_MODE=authentik to install it." message,
+  and that no deployment and no job were created.
+- `native-oidc under HOLA_AUTH_MODE=none installs fine` — the contrast case proves
+  the preflight does **not** over-reject modes that can run without a backend.
+
+## Validation
+
+`bun --cwd packages/server typecheck`, `bun run lint`, and the full server suite
+(`bun --cwd packages/server test`, 351 pass) are all green. Not validated
+end-to-end (no VM); this is a server-unit-level fix.

--- a/packages/server/src/__tests__/deployments/auth-provisioning.test.ts
+++ b/packages/server/src/__tests__/deployments/auth-provisioning.test.ts
@@ -23,6 +23,7 @@ import { RealLoggingService } from '../../services/core/logging';
 import { RealJobService } from '../../services/core/jobs';
 import { MockDockerService, type DockerService } from '../../services/core/docker';
 import { ProvisioningError } from '../../middleware/error-mapping';
+import { NoneProvisionerService } from '../../services/core/provisioner';
 import type {
   ProvisionerService,
   ProvisionInput,
@@ -79,6 +80,10 @@ class SpyProvisioner implements ProvisionerService {
 
   async healthCheck() {
     return { healthy: true, lastCheck: new Date() };
+  }
+
+  assertCanProvisionAuthMode(): void {
+    // Spy backs every mode (it has a real provider in these tests).
   }
 
   async provision(input: ProvisionInput): Promise<ProvisionResult> {
@@ -433,6 +438,35 @@ describe('Auth provisioning lifecycle', () => {
     expect((await sys.deployments.getDeployment(created.deploymentId)).status).toBe('error');
     // No compose was materialized (provisioning threw first).
     expect(await sys.storage.fileExists(`deployments/${created.deploymentId}/runtime/docker-compose.yml`)).toBe(false);
+  });
+
+  test('forward-auth under HOLA_AUTH_MODE=none is rejected up front, creating no error-state deployment', async () => {
+    // The None backend (production with no Authentik) cannot gate a forward-auth
+    // route. Installing such an app must fail at create time with the clear,
+    // actionable error — NOT enqueue a deploy job that tombstones the deployment
+    // in `error` state (regression for the uptime-kuma-under-none install bug).
+    const FORWARD_AUTH: AppAuthConfig = { mode: 'forward-auth', forwardAuth: {} };
+    const sys = makeSystem({ auth: FORWARD_AUTH, provisioner: new NoneProvisionerService() });
+    const draftId = await finalizedDraft(sys.drafts);
+
+    await expect(sys.deployments.createFromDraft({ draftId, name: 'gitea' })).rejects.toThrow(
+      'which needs an auth backend. Set HOLA_AUTH_MODE=authentik to install it.',
+    );
+
+    // No deployment record was created at all — nothing left in `error` state, and
+    // no deploy job to run.
+    const list = await sys.deployments.listDeployments({});
+    expect(list.total).toBe(0);
+    expect(list.items).toHaveLength(0);
+    expect(await sys.jobs.listJobs()).toHaveLength(0);
+  });
+
+  test('native-oidc under HOLA_AUTH_MODE=none installs fine (app keeps its own login)', async () => {
+    // Contrast with forward-auth: native-oidc runs without a backend (the app has
+    // its own login), so the None backend must NOT reject it up front.
+    const sys = makeSystem({ auth: OIDC_AUTH, provisioner: new NoneProvisionerService() });
+    const created = await sys.deployments.createFromDraft({ draftId: await finalizedDraft(sys.drafts), name: 'gitea' });
+    expect((await waitForJob(sys.jobs, created.jobId!)).status).toBe('completed');
   });
 
   test('delete tolerates a deprovision failure (orphan logged, delete proceeds)', async () => {

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -334,6 +334,17 @@ abstract class InMemoryDeploymentService implements DeploymentService {
     void app;
   }
 
+  /**
+   * Preflight the app's declared auth requirement against the active auth backend
+   * before any deployment state is created (RealDeploymentService overrides this
+   * to consult the provisioner). Default no-op — the in-memory/mock service has no
+   * real backend to gate against.
+   */
+  protected assertAuthProvisionable(auth: FinalizedManifest['auth'], appName: string): void {
+    void auth;
+    void appName;
+  }
+
   /** Public URL the app is reachable at; the real service derives it from routing. */
   protected appUrl(deploymentId: string, app: string): string | undefined {
     void deploymentId;
@@ -445,6 +456,12 @@ abstract class InMemoryDeploymentService implements DeploymentService {
       });
       const { app, version, release } = await this.buildReleaseFromDraft(artifacts, request, deploymentId, releaseId);
 
+      // Reject an app whose declared auth needs a backend the active provisioner
+      // can't satisfy (e.g. forward-auth under HOLA_AUTH_MODE=none) BEFORE creating
+      // any deployment state — the same check the deploy job's provisionAuth would
+      // hit, but up front so the user gets the clear error instead of a tombstone.
+      this.assertAuthProvisionable(artifacts?.manifest.auth, app);
+
       // Reject a routing (host) conflict before creating any deployment state.
       await this.onBeforeCreate(deploymentId, app);
 
@@ -511,7 +528,13 @@ abstract class InMemoryDeploymentService implements DeploymentService {
     this.logger.info('Promoting new release onto deployment', { deploymentId, releaseId, draftId: request.draftId });
 
     const artifacts = await this.loadFinalizedArtifacts(request.draftId);
-    const { release } = await this.buildReleaseFromDraft(artifacts, request, deploymentId, releaseId);
+    const { app, release } = await this.buildReleaseFromDraft(artifacts, request, deploymentId, releaseId);
+
+    // Reject an unsatisfiable auth requirement before staging the new release, so
+    // a promote that switches to a backend-only mode (e.g. forward-auth under
+    // HOLA_AUTH_MODE=none) fails up front instead of in the deploy job.
+    this.assertAuthProvisionable(artifacts?.manifest.auth, app);
+
     this.releases.set(releaseId, release);
 
     await this.ensureLayout(deploymentId);
@@ -1021,6 +1044,25 @@ export class RealDeploymentService extends InMemoryDeploymentService {
       this.logger.warn('App registry reconcile failed', {
         error: error instanceof Error ? error.message : String(error),
       });
+    }
+  }
+
+  /**
+   * Preflight an app's declared auth requirement against the active auth backend,
+   * BEFORE any deployment record/job is created. Mirrors the modes `provisionAuth`
+   * will actually provision — the declared mode plus a forward-auth fallback when
+   * `auth.fallback` requests one — and delegates the can-we-provision decision to
+   * the provisioner, so an app needing a backend that isn't configured (e.g.
+   * forward-auth under `HOLA_AUTH_MODE=none`) is rejected up front with the
+   * backend's own clear, actionable error instead of tombstoning a deployment in
+   * `error` state. No-op when the app declares no auth block.
+   */
+  protected override assertAuthProvisionable(auth: FinalizedManifest['auth'], appName: string): void {
+    if (!auth) return;
+    this.provisioner.assertCanProvisionAuthMode(auth.mode, appName);
+    const wantsFallback = auth.fallback === 'forward-auth' && auth.mode !== 'forward-auth';
+    if (wantsFallback) {
+      this.provisioner.assertCanProvisionAuthMode('forward-auth', appName);
     }
   }
 

--- a/packages/server/src/services/core/provisioner.ts
+++ b/packages/server/src/services/core/provisioner.ts
@@ -105,6 +105,17 @@ export interface ProvisionerService extends HealthCheckable {
   provision(input: ProvisionInput): Promise<ProvisionResult>;
   deprovision(input: DeprovisionInput): Promise<void>;
   /**
+   * Synchronously assert this backend CAN provision `mode` for `appName`, with no
+   * side effects. Lets the deploy path preflight an app's declared auth requirement
+   * BEFORE any deployment record/job is created, so a mode that needs a backend
+   * which isn't configured (e.g. `forward-auth` under `HOLA_AUTH_MODE=none`) is
+   * rejected up front with a clear, actionable error — instead of tombstoning a
+   * deployment in `error` state when provisioning throws inside the deploy job.
+   * Backends with a real auth provider support every mode (no-op); the None
+   * backend throws for the modes that need a backend.
+   */
+  assertCanProvisionAuthMode(mode: AuthMode, appName: string): void;
+  /**
    * Idempotently ensure a PUBLIC (PKCE) OIDC client for the dashboard itself and
    * return its issuer/clientId. Stable across restarts (keyed on a fixed slug), so
    * re-running reuses the same client. The dashboard is a public SPA client, so no
@@ -238,6 +249,12 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
     } catch (error) {
       return { healthy: false, lastCheck: new Date(), error: error instanceof Error ? error.message : String(error) };
     }
+  }
+
+  assertCanProvisionAuthMode(mode: AuthMode, appName: string): void {
+    // Authentik backs every supported mode.
+    void mode;
+    void appName;
   }
 
   async provision(input: ProvisionInput): Promise<ProvisionResult> {
@@ -1361,6 +1378,12 @@ export class MockProvisionerService implements ProvisionerService {
     return { healthy: true, lastCheck: new Date() };
   }
 
+  assertCanProvisionAuthMode(mode: AuthMode, appName: string): void {
+    // Mock backend (test/dev) accepts every mode.
+    void mode;
+    void appName;
+  }
+
   async provision(input: ProvisionInput): Promise<ProvisionResult> {
     if (input.mode === 'native-oidc' && input.oidc) {
       const slug = slugify(`hola-${input.appName}-${input.deploymentId.slice(0, 8)}`);
@@ -1438,6 +1461,27 @@ export class MockProvisionerService implements ProvisionerService {
 // ---------------------------------------------------------------------------
 
 /**
+ * Auth modes that cannot run without a real auth backend: a `forward-auth` route
+ * would be gated by a non-existent outpost and a `native-ldap` app would have no
+ * bind account. The None backend refuses these.
+ */
+const MODES_REQUIRING_BACKEND: ReadonlySet<AuthMode> = new Set(['forward-auth', 'native-ldap']);
+
+/**
+ * Single source of truth for the None backend's "this mode needs a backend"
+ * rejection, used both as an up-front preflight (`assertCanProvisionAuthMode`,
+ * before any deployment state exists) and at provision time (defense in depth).
+ * Throws the same actionable error so the wording never diverges.
+ */
+function assertModeRunnableWithoutBackend(mode: AuthMode, appName: string): void {
+  if (MODES_REQUIRING_BACKEND.has(mode)) {
+    throw new ProvisioningError(
+      `App "${appName}" requires auth mode "${mode}", which needs an auth backend. Set HOLA_AUTH_MODE=authentik to install it.`
+    );
+  }
+}
+
+/**
  * No-op provisioner for production deployments without an auth backend
  * (`HOLA_AUTH_MODE != authentik`). Issue #110: the Mock provisioner is for
  * test/dev and injects *fake* OIDC creds / a dead forward-auth middleware, which
@@ -1459,12 +1503,14 @@ export class NoneProvisionerService implements ProvisionerService {
     return { healthy: true, lastCheck: new Date() };
   }
 
+  assertCanProvisionAuthMode(mode: AuthMode, appName: string): void {
+    assertModeRunnableWithoutBackend(mode, appName);
+  }
+
   async provision(input: ProvisionInput): Promise<ProvisionResult> {
-    if (input.mode === 'forward-auth' || input.mode === 'native-ldap') {
-      throw new ProvisioningError(
-        `App "${input.appName}" requires auth mode "${input.mode}", which needs an auth backend. Set HOLA_AUTH_MODE=authentik to install it.`
-      );
-    }
+    // Defense in depth: callers should preflight via assertCanProvisionAuthMode,
+    // but never start a stack we can't actually gate.
+    assertModeRunnableWithoutBackend(input.mode, input.appName);
     if (input.mode === 'native-oidc') {
       this.logger.info('No auth backend; skipping native-oidc provisioning — app keeps its own login', {
         deploymentId: input.deploymentId,


### PR DESCRIPTION
## Problem

Under `HOLA_AUTH_MODE=none` (no Authentik backend), installing an app whose manifest declares `auth.mode: forward-auth` (or `native-ldap`) failed **late and messily**. The deploy lifecycle is async: `createFromDraft` created the deployment record and enqueued a `start` job, then the job ran `provisionAuth()` **before** `composeUp()`. The None backend intentionally throws for those modes (they need a real auth backend), so `composeUp` never ran and the deployment was left stuck in `error` state — a confusing tombstone instead of an immediate, actionable error.

Discovered via e2e: `uptime-kuma` (`auth.mode: forward-auth`) could not be installed under mode `none`.

## Fix

The rejection **policy** is correct (a forward-auth route would be gated by a non-existent outpost — shipping it ungated would expose an app meant to be SSO-gated). The bug was **timing**. This change preflights the app's declared auth requirement against the active backend **before** any deployment record/job is created, reusing the None backend's existing capability check and error message (single-sourced — no divergent wording).

- **`provisioner.ts`** — new `ProvisionerService.assertCanProvisionAuthMode(mode, appName)`: a synchronous, side-effect-free precheck. No-op for Authentik/Mock; the None backend throws for `forward-auth`/`native-ldap`. The rejection wording is extracted into one helper (`assertModeRunnableWithoutBackend`) shared by the preflight and `provision()` (kept as defense-in-depth).
- **`deployment.ts`** — new protected `assertAuthProvisionable(auth, appName)` hook (default no-op on the in-memory base; `RealDeploymentService` overrides it to consult the provisioner for the declared mode **and** a forward-auth fallback). `createFromDraft` (install) and `promote` (new release) call it before creating any deployment state/routing/job, so a rejection throws straight to the caller (the CLI "Preflight…" step) and leaves no `error`-state tombstone.

## Regression test

`packages/server/src/__tests__/deployments/auth-provisioning.test.ts`:
- forward-auth under `HOLA_AUTH_MODE=none` is rejected up front with the clear message, and **no** deployment or job is created.
- native-oidc under `HOLA_AUTH_MODE=none` still installs (proves the preflight does not over-reject modes that run without a backend).

## Validation

`bun --cwd packages/server typecheck`, `bun run lint`, and the full server suite (351 pass) are green. **Draft** — not validated end-to-end (no VM); server-unit-level fix only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)