### PR TITLE
fix(server): uninstall removes runtime dir before compose down, leaving an error tombstone

### DIFF
--- a/docs/findings-uninstall-tombstone.md
+++ b/docs/findings-uninstall-tombstone.md
@@ -1,0 +1,70 @@
+# Finding: `hola uninstall` leaves an `error`-state tombstone
+
+## Symptom
+
+After `hola uninstall` (server `DeploymentService.deleteDeployment`) the command
+appears to succeed and the containers/data are gone, but a leftover deployment
+record lingers in `error` state. In e2e, `hola deployments` shows a stuck `error`
+entry for the just-deleted app.
+
+## Root cause: a teardown-vs-storage-removal race
+
+`deleteDeployment` (`packages/server/src/services/core/deployment.ts`) tore down
+containers **asynchronously** and then removed storage **immediately**:
+
+1. It called `executeAction(deploymentId, { action: 'stop' })`, which only
+   **enqueues** a lifecycle job and returns — it does not wait for the job to run.
+2. It then deprovisioned auth, deleted the in-memory record, and called
+   `removeStorage(deploymentId)`, which deletes
+   `/data/deployments/<id>/runtime/` (including `docker-compose.yml`).
+
+Steps 1 and 2 race. In practice `removeStorage` wins, so when the still-pending
+`stop` job finally runs `runLifecycleJob`, its `docker compose down` executes
+against an already-deleted runtime dir and fails (`no configuration file
+provided` / `docker-compose.yml not found`).
+
+For a `stop` action the executor treats a `composeDown` failure as fatal
+(`if (!res.success && action !== 'delete') throw`). The `catch` in
+`runLifecycleJob` then sets `deployment.status = 'error'` and **re-persists** the
+record — resurrecting the deployment that `deleteDeployment` had just removed.
+That re-persisted row is the `error` tombstone.
+
+## Fix
+
+Tear the containers down **synchronously, in-line, before** removing storage, and
+never route the delete-time teardown through a fire-and-forget job that can
+re-persist the record.
+
+- Added a protected hook `teardownContainers(deploymentId)` on the in-memory base
+  service (no-op default).
+- `deleteDeployment` now `await`s `teardownContainers(deploymentId)` instead of
+  enqueuing a `stop` job. The teardown completes before `removeStorage`, so
+  `docker compose down` always sees the compose file.
+- `RealDeploymentService` overrides `teardownContainers` to call
+  `dockerService.composeDown(runtimeDir, projectName)` directly. A `composeDown`
+  failure is logged and **tolerated** (deletion always proceeds) and — crucially —
+  this path never touches/persists the deployment record, so it cannot leave an
+  `error` tombstone.
+
+Net effect: the teardown reliably runs against the live runtime dir, deletion is
+unconditional, and no late job can resurrect the deleted deployment.
+
+## Regression test
+
+`packages/server/src/__tests__/deployments/lifecycle.test.ts` →
+`delete runs compose-down before removing the runtime dir, leaving no error
+tombstone`.
+
+It installs a deployment, then deletes it with a `MockDockerService` whose
+`composeDown` mirrors real `docker compose down` (fails when the compose file is
+gone) plus a small delay that makes the old ordering deterministically lose the
+race. It asserts:
+
+- `composeDown` ran exactly once and the compose file still existed at call time
+  (teardown happened before storage removal);
+- the runtime dir is gone and the deployment is fully removed (404);
+- no `error` tombstone remains — in-memory, after rehydrating a fresh service from
+  the same data root, and no failed teardown job lingers for the deployment.
+
+Verified: the test fails 3/3 against the pre-fix code and passes 3/3 with the fix;
+the full server suite (350 tests) stays green.

--- a/packages/server/src/__tests__/deployments/lifecycle.test.ts
+++ b/packages/server/src/__tests__/deployments/lifecycle.test.ts
@@ -11,6 +11,7 @@
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { parse } from 'yaml';
 import { mkdtemp, rm } from 'fs/promises';
+import { existsSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
@@ -182,6 +183,65 @@ describe('Deployment lifecycle (real orchestration wiring)', () => {
     expect(upCalled).toBe(false);
     expect((await deployments.getDeployment(created.deploymentId)).status).toBe('error');
     expect(lines.some(m => m.includes('Image pull failed') && m.includes('denied'))).toBe(true);
+  });
+
+  test('delete runs compose-down before removing the runtime dir, leaving no error tombstone', async () => {
+    // Regression for the uninstall teardown-order race: delete used to enqueue a
+    // fire-and-forget `stop` job and then immediately delete the runtime dir. The
+    // late job's `compose down` then ran against a missing compose file, failed,
+    // and re-persisted the (already removed) deployment with status `error`.
+    const downCalls: Array<{ projectPath: string; composeFileExisted: boolean }> = [];
+    const docker = new MockDockerService();
+    // Mirror real `docker compose down`: it FAILS when the compose file is gone
+    // ("no configuration file provided"). The small delay makes the race
+    // deterministic — under the buggy fire-and-forget ordering, `removeStorage`
+    // always lands before this resolves, so the file is gone and down fails,
+    // reproducing the persisted `error` tombstone. Under the fix, down is awaited
+    // in-line before storage removal, so the file is always present here.
+    docker.composeDown = async (projectPath: string) => {
+      await new Promise(r => setTimeout(r, 50));
+      const composeFileExisted = existsSync(join(projectPath, 'docker-compose.yml'));
+      downCalls.push({ projectPath, composeFileExisted });
+      return composeFileExisted
+        ? { success: true, output: '[mock] stopped and removed' }
+        : { success: false, output: 'no configuration file provided: not found' };
+    };
+
+    const { jobs, drafts, deployments } = makeSystem(docker);
+    const created = await deployments.createFromDraft({ draftId: await finalizedDraft(drafts), name: 'gitea' });
+    await waitForJob(jobs, created.jobId!);
+
+    const runtimeCompose = join(dataRoot, 'deployments', created.deploymentId, 'runtime', 'docker-compose.yml');
+    expect(existsSync(runtimeCompose)).toBe(true);
+
+    await deployments.deleteDeployment(created.deploymentId);
+
+    // compose down ran exactly once, and the compose file still existed when it did
+    // (i.e. teardown happened BEFORE storage removal, not racing after it).
+    expect(downCalls.length).toBe(1);
+    expect(downCalls[0].composeFileExisted).toBe(true);
+
+    // Storage is gone now and the deployment is fully removed (404).
+    expect(existsSync(runtimeCompose)).toBe(false);
+    await expect(deployments.getDeployment(created.deploymentId)).rejects.toThrow();
+
+    // Let any (incorrectly) enqueued late teardown job run to completion, then assert
+    // nothing resurrected the record: no in-memory listing, no persisted error
+    // tombstone, and no failed teardown job lingering for this deployment.
+    await new Promise(r => setTimeout(r, 200));
+
+    const listed = await deployments.listDeployments({});
+    expect(listed.items.some(d => d.id === created.deploymentId)).toBe(false);
+    expect(listed.items.some(d => d.status === 'error')).toBe(false);
+
+    // A fresh service rehydrating from the same data root must not see a tombstone.
+    const rehydrated = makeSystem(new MockDockerService()).deployments;
+    const reListed = await rehydrated.listDeployments({});
+    expect(reListed.items.some(d => d.id === created.deploymentId)).toBe(false);
+    expect(reListed.items.some(d => d.status === 'error')).toBe(false);
+
+    const failedJobs = (await jobs.listJobs({ deploymentId: created.deploymentId, status: 'failed' }));
+    expect(failedJobs.length).toBe(0);
   });
 
   test('lifecycle logs are streamed to the deployment log target', async () => {

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -264,6 +264,17 @@ abstract class InMemoryDeploymentService implements DeploymentService {
   protected async removeStorage(deploymentId: string): Promise<void> {
     void deploymentId;
   }
+  /**
+   * Tear down a deployment's running containers (`docker compose down`).
+   * Base is a no-op; the real service overrides it. Called synchronously during
+   * delete BEFORE {@link removeStorage} so the compose file still exists on disk.
+   * A failure here is non-fatal — deletion must always proceed — and, crucially,
+   * it must NOT re-persist the deployment, so it never leaves an `error` tombstone
+   * for a record that is being removed.
+   */
+  protected async teardownContainers(deploymentId: string): Promise<void> {
+    void deploymentId;
+  }
 
   /** Rehydrate persisted deployments/releases from storage exactly once. */
   protected async ensureLoaded(): Promise<void> {
@@ -583,8 +594,15 @@ abstract class InMemoryDeploymentService implements DeploymentService {
     this.logger.info('Deleting deployment', { deploymentId });
 
     try {
-      // Stop any running containers first
-      await this.executeAction(deploymentId, { action: 'stop' });
+      // Tear down running containers synchronously, in-line, BEFORE we remove the
+      // runtime directory below. Previously this enqueued a fire-and-forget `stop`
+      // job and returned immediately; the job's `docker compose down` then raced
+      // `removeStorage` and frequently ran after the compose file was already
+      // deleted. That failure path re-persisted the (already removed) deployment
+      // with status `error`, leaving a stuck tombstone after a "successful"
+      // uninstall. Running the teardown here guarantees compose-down sees the file
+      // and that no late job can resurrect the record.
+      await this.teardownContainers(deploymentId);
     } catch (error) {
       this.logger.warn('Failed to stop deployment before deletion', {
         deploymentId,
@@ -1411,6 +1429,23 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     await this.routingService.deactivateRoute(deploymentId);
     // The removed app drops out of the registry feed for remaining consumers.
     await this.reconcileAppRegistry();
+  }
+
+  /**
+   * Run `docker compose down` for a deployment in-line during delete. Tolerates a
+   * compose-down failure (e.g. nothing running, or no compose file): deletion must
+   * proceed regardless. Unlike the lifecycle job, it never touches/persists the
+   * deployment record, so it cannot leave an `error` tombstone for a record that is
+   * being removed.
+   */
+  protected override async teardownContainers(deploymentId: string): Promise<void> {
+    const res = await this.dockerService.composeDown(this.runtimeDir(deploymentId), this.projectName(deploymentId));
+    if (!res.success) {
+      this.logger.warn('compose down reported a failure during delete; continuing with teardown', {
+        deploymentId,
+        output: res.output,
+      });
+    }
   }
 
   protected override async onDeprovision(deployment: EnhancedDeploymentDetail): Promise<void> {


### PR DESCRIPTION
## Problem

`hola uninstall` (server `DeploymentService.deleteDeployment`) has an ordering/race bug. It kicked off container teardown **asynchronously** (as a `stop` job) and then **immediately** deleted the deployment's runtime directory:

1. `executeAction(deploymentId, { action: 'stop' })` only **enqueues** a job and returns — it does not wait.
2. `deleteDeployment` then deprovisions auth, drops the in-memory record, and calls `removeStorage`, deleting `/data/deployments/<id>/runtime/` (incl. `docker-compose.yml`).

These race. `removeStorage` usually wins, so the late `stop` job's `docker compose down` runs against a missing compose file and fails. For a `stop` action that failure is fatal, and `runLifecycleJob`'s catch sets `status = 'error'` and **re-persists** the record — resurrecting the just-deleted deployment as a stuck **`error` tombstone**. Observed in e2e: after `uninstall`, `deployments` shows a leftover `error` entry even though containers/data are gone.

## Fix

Tear containers down **synchronously, in-line, before** removing storage, and never route the delete-time teardown through a fire-and-forget job that can re-persist the record.

- New protected hook `teardownContainers(deploymentId)` on the in-memory base service (no-op default).
- `deleteDeployment` now `await`s `teardownContainers` instead of enqueuing a `stop` job, so `compose down` always sees the compose file.
- `RealDeploymentService` overrides it to call `composeDown` directly. A failure is logged and **tolerated** (deletion always proceeds) and this path never touches/persists the deployment record, so it cannot leave a tombstone.

## Test

`packages/server/src/__tests__/deployments/lifecycle.test.ts` → *"delete runs compose-down before removing the runtime dir, leaving no error tombstone"*. Uses a `MockDockerService` whose `composeDown` mirrors real docker (fails when the compose file is gone) plus a small delay that makes the old ordering deterministically lose the race. Asserts: `composeDown` ran once while the compose file still existed; the runtime dir is gone and the deployment is fully removed (404); and no `error` tombstone remains (in-memory, after rehydrating a fresh service, and no failed teardown job lingers).

Verified: fails 3/3 against pre-fix code, passes 3/3 with the fix. Full server suite (350 tests), typecheck, and lint all green.

See `docs/findings-uninstall-tombstone.md` for the full write-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)