### PR TITLE
fix(cli): install no longer aborts on preflight warnings (only hard failures)

### DIFF
--- a/packages/cli/src/__tests__/install.test.ts
+++ b/packages/cli/src/__tests__/install.test.ts
@@ -62,6 +62,52 @@ describe('install', () => {
     expect(process.exitCode).toBe(1);
   });
 
+  it('proceeds past preflight WARNINGS (non-strict): warnings are advisory, not fatal', async () => {
+    // e.g. disk under the 2 GB soft threshold, or an unconventional env-var name.
+    const sdk = makeSdk({
+      drafts: {
+        preflight: vi.fn(async () => ({
+          ok: false,
+          checks: [
+            { name: 'disk', status: 'warn', detail: '1.9GB free' },
+            { name: 'env', status: 'warn', detail: "name 'GITEA__server__DOMAIN' should use uppercase" },
+          ],
+        })),
+      },
+    });
+    const res = await runInstall('gitea', { noStream: true, json: true }, { sdk: sdk as unknown as HolaSdk });
+    expect(sdk.calls).toContain('deploy');
+    expect(res?.deploymentId).toBe('dep1');
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('aborts (exit 1, no deploy) on a hard preflight FAIL check even without --strict', async () => {
+    const sdk = makeSdk({
+      drafts: {
+        preflight: vi.fn(async () => ({
+          ok: false,
+          checks: [{ name: 'routing', status: 'fail', detail: "Host 'x' already in use" }],
+        })),
+      },
+    });
+    const res = await runInstall('gitea', { noStream: true }, { sdk: sdk as unknown as HolaSdk });
+    expect(res).toBeUndefined();
+    expect(sdk.deployments.create).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('aborts on preflight warnings under --strict (spotless preflight required)', async () => {
+    const sdk = makeSdk({
+      drafts: {
+        preflight: vi.fn(async () => ({ ok: false, checks: [{ name: 'disk', status: 'warn', detail: '1.9GB free' }] })),
+      },
+    });
+    const res = await runInstall('gitea', { strict: true, noStream: true }, { sdk: sdk as unknown as HolaSdk });
+    expect(res).toBeUndefined();
+    expect(sdk.deployments.create).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
   it('rejects a malformed --set', async () => {
     const sdk = makeSdk();
     const res = await runInstall('gitea', { set: 'NOEQUALS', noStream: true }, { sdk: sdk as unknown as HolaSdk });

--- a/packages/cli/src/lib/deploy-flow.ts
+++ b/packages/cli/src/lib/deploy-flow.ts
@@ -43,7 +43,16 @@ export async function finalizeAndDeploy(
   for (const c of preflight.checks ?? []) {
     if (c.status !== 'pass') out(`  ${c.status}: ${c.name}${c.detail ? ` — ${c.detail}` : ''}`);
   }
-  if (preflight.ok === false) throw new DeployAbort('Preflight failed.');
+  // `preflight.ok` is the server's "everything perfect" flag — it is false on ANY
+  // non-pass check, including advisory WARNINGS (disk under the 2 GB soft threshold,
+  // an image not yet pulled locally, an unconventional env-var name). Those must not
+  // block a normal install — only a hard `fail` check does (Docker down, a port or
+  // routing conflict, an env ERROR). `--strict` still gates on the full `ok` flag
+  // for callers (e.g. CI) that want a spotless preflight.
+  const hardFail = (preflight.checks ?? []).some(c => c.status === 'fail');
+  if (opts.strict ? preflight.ok === false : hardFail) {
+    throw new DeployAbort('Preflight failed.');
+  }
 
   out('Finalizing…');
   await sdk.drafts.finalize(draftId);


### PR DESCRIPTION
## Problem

`hola install` (and any path through `finalizeAndDeploy`) aborted whenever the server's `preflight.ok === false`. But the server computes `ok` as "every check passed" — it is false on **any** non-`pass` check, including advisory **warnings**:

- disk under the 2 GB soft threshold (`warn`),
- an image not yet pulled locally (`warn`),
- an unconventional env-var name (`warn`) — e.g. gitea's idiomatic `GITEA__section__KEY` config-via-env names.

So `hola install` refused perfectly installable apps. **gitea could not be installed at all** (11 env-name warnings), and on a busy host, once free disk dipped under 2 GB, **every** app started failing preflight.

Found by the new catalog-wide e2e sweep (`bin/vm-catalog-test`): most of an 11/13 failure wave traced back to this one gate (gitea via env warnings; the back half of the sweep via a disk `warn` after heavy app images accumulated).

## Fix

A non-strict install now aborts only on a hard `fail` check (Docker down, a port or routing conflict, an env ERROR). Warnings are printed but non-fatal. `--strict` still gates on the full `ok` flag for callers (e.g. CI) that want a spotless preflight.

## Tests

`packages/cli/src/__tests__/install.test.ts`:
- warnings-only preflight proceeds and deploys (non-strict),
- a hard `fail` check aborts even without `--strict`,
- `--strict` aborts on warnings.

14 tests pass; `tsc --noEmit` + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)