### PR TITLE
feat(testing): catalog-wide e2e sweep — install every app and verify it comes up

### DIFF
--- a/.claude/skills/vm-e2e/SKILL.md
+++ b/.claude/skills/vm-e2e/SKILL.md
@@ -120,6 +120,15 @@ Chromium against the dashboard URL — no in-VM desktop or VNC). Background:
   detects and explains that). Before installing it waits until the server can
   spawn `docker compose` (defeats the docker-spawn `ENOENT` race). Output →
   `logs/vm-e2e-suite/`.
+- **Whole-catalog sweep**: `bin/vm-catalog-test` brings up one
+  `HOLA_AUTH_MODE=authentik` VM and installs **every** catalog app in turn (one at
+  a time), asserting each converges to `running` with its containers up and its
+  front door answering — then uninstalls it. Auth-mode-agnostic (accepts a 200 or a
+  30x/401 redirect to Authentik). Terse one-line-per-app PASS/FAIL on stdout; full
+  per-app logs under `logs/vm-catalog-test/<app>/`. `--apps a,b` / `--skip x` to
+  scope, `--memory MB` for heavy apps, `--restart`/`--lifecycle` to also exercise
+  the lifecycle (needs a server image carrying the #267 fix — see *Advanced*). The
+  per-app checks live in `bin/lib/app-test.sh`, shared with `bin/vm-e2e-suite`.
 - **CLI/integration on the VM**: `bin/vm-test --ssh -- <cmd>` runs create →
   wait-ssh → `<cmd>` on the VM → teardown in one shot.
 - **Just rehearse the whole flow**: `bin/vm-test --dry-run` or

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,12 @@ cover everything. Use them like this:
   runs the whole loop: create VM → `hola bootstrap --host hola-vm-<id>` (the CLI's
   own SSH installer) → verify the stack → `bin/vm-web-check` →
   snapshot-on-fail / destroy-on-pass. Prefer it over hand-stitching the steps.
+- **Deterministic regression suites** — `bin/vm-e2e-suite` asserts the whole
+  single-app product flow on a `mode=none` VM. `bin/vm-catalog-test` installs
+  **every** catalog app on one Authentik VM and verifies each comes up, using the
+  shared per-app test in `bin/lib/app-test.sh` (the single source of truth for
+  install→verify→[restart→stop]→uninstall). Both emit terse PASS/FAIL to stdout and
+  capture per-app detail under `logs/` for drill-down.
 - **Snapshot, don't lose a failure** — `bin/vm-snapshot` (or `bin/vm-test
   --keep-on-fail`) before destroying when a run fails and you want to inspect it.
 - **Destroy is confirmed** — `bin/vm-destroy` requires interactive `yes` (or

--- a/bin/lib/app-test.selftest.sh
+++ b/bin/lib/app-test.selftest.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Self-test for bin/lib/app-test.sh — validates the per-app test CONTROL FLOW with
+# everything stubbed, so it runs in milliseconds with no VM, no Docker, no network.
+# It locks in the properties that are easy to regress in bash:
+#   * one app's failure/skip never aborts the sweep (the errexit-leak class of bug:
+#     a library function must not leak `set -e` state back to the caller's loop);
+#   * required SECRET env vars are auto-filled with generated tokens and the install
+#     retried (so apps like gitea install unattended);
+#   * an app needing NON-secret manual config is reported SKIP, not FAIL;
+#   * a genuinely broken install is reported FAIL at the install stage.
+# Run: bash bin/lib/app-test.selftest.sh   (exit 0 = pass)
+set -euo pipefail
+HERE=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+ROOT_DIR=$(cd "$HERE/../.." && pwd); BIN_DIR="$ROOT_DIR/bin"
+DASHBOARD_URL=https://apps.test; API_KEY=k; DOMAIN_BASE=test; HTTP_TIMEOUT=5
+INSTALL_ATTEMPTS=3; INSTALL_BACKOFF=0
+# shellcheck source=/dev/null
+source "$BIN_DIR/lib/app-test.sh"
+
+# --- stubs: override the leaf functions that touch the VM/CLI ----------------
+# Raw installer: stdout=JSON; errors go to $errf (mirrors `bun … 2>errf`).
+_at_install_exec() {
+  local app=$1 errf=$2; shift 2
+  : > "$errf"
+  case "$app" in
+    gitea)  # requires a secret; succeeds once it's supplied via --set
+      if printf '%s\0' "$@" | grep -qz '^GITEA_RUNNER_REGISTRATION_TOKEN='; then
+        echo '{"status":"completed","deploymentId":"gitea-abc"}'; return 0; fi
+      echo "  error: Secret environment variable 'GITEA_RUNNER_REGISTRATION_TOKEN' is required but empty" >> "$errf"
+      return 1 ;;
+    uptime-kuma) echo '{"status":"completed","deploymentId":"uptime-kuma-def"}'; return 0 ;;
+    vaultwarden) echo '{"status":"completed","deploymentId":"vaultwarden-ghi"}'; return 0 ;;
+    cfgapp)  # needs NON-secret config we won't fabricate -> SKIP
+      echo "  error: Environment variable 'SOME_DOMAIN' is required but empty" >> "$errf"; return 1 ;;
+    badapp)  echo "  error: boom" >> "$errf"; return 1 ;;
+  esac
+}
+at_cli() {  # only `deployments --json` and `uninstall …` are exercised here
+  if [[ "$1 $2" == "deployments --json" ]]; then
+    echo '{"items":[{"id":"gitea-abc","status":"running","url":"https://gitea.test"},
+                    {"id":"uptime-kuma-def","status":"running","url":"https://uptime-kuma.test"},
+                    {"id":"vaultwarden-ghi","status":"running","url":"https://vaultwarden.test"}]}'
+  fi
+}
+at_ssh() {  # uninstall check greps for a leftover container (gone -> 1); verify lists one healthy
+  [[ "$*" == *"grep -q 'hola-"* ]] && return 1
+  echo "hola-${AT_DEPLOY_ID}-app-1	Up 2 minutes (healthy)"
+}
+at_http_code() { echo 200; }
+
+# --- drive the same loop vm-catalog-test uses -------------------------------
+LOG=$(mktemp -d); trap 'rm -rf "$LOG"' EXIT
+declare -a OUTCOME=()
+for app in gitea uptime-kuma vaultwarden cfgapp badapp; do
+  rc=0
+  at_run_app "$app" "$LOG/$app" 2>"$LOG/$app.log" || rc=$?
+  case "$rc" in
+    0) OUTCOME+=("PASS:$app") ;;
+    2) OUTCOME+=("SKIP:$app") ;;
+    *) OUTCOME+=("FAIL:$app:$AT_LAST_STAGE") ;;
+  esac
+done
+
+# --- assertions -------------------------------------------------------------
+expected=(PASS:gitea PASS:uptime-kuma PASS:vaultwarden SKIP:cfgapp FAIL:badapp:install)
+ok=1
+[[ "${#OUTCOME[@]}" == 5 ]] || { echo "FAIL: visited ${#OUTCOME[@]}/5 apps (errexit leak?)"; ok=0; }
+for i in "${!expected[@]}"; do
+  [[ "${OUTCOME[$i]:-}" == "${expected[$i]}" ]] || { echo "FAIL: app $i expected '${expected[$i]}' got '${OUTCOME[$i]:-<none>}'"; ok=0; }
+done
+if [[ "$ok" == 1 ]]; then echo "app-test.selftest: PASS (${OUTCOME[*]})"; else echo "app-test.selftest: FAILED"; exit 1; fi

--- a/bin/lib/app-test.sh
+++ b/bin/lib/app-test.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+# bin/lib/app-test.sh — the deterministic PER-APP test, as sourceable functions.
+#
+# This is the single source of truth for "install one catalog app against an
+# already-bootstrapped Hola server, verify it comes up, optionally exercise its
+# lifecycle, then uninstall it." Both the single-app suite (bin/vm-e2e-suite) and
+# the catalog sweep (bin/vm-catalog-test) source this so they run the EXACT same
+# per-app checks — the catalog sweep is just this test in a loop over the catalog.
+#
+# It is auth-mode-agnostic: the front-door check accepts the healthy response of
+# any mode — 200 (auth.mode:none / native-oidc apps serve directly) OR a 30x/401
+# redirect to Authentik (forward-auth apps are gated at the Traefik edge). The hard
+# "came up correctly" gate is the deployment converging to `running` with its
+# container(s) actually running on the host; the HTTP front door adds ingress
+# confidence on top.
+#
+# SOURCE it (do not execute). The caller MUST set these globals first:
+#   ROOT_DIR        repo root (from bin/_common.sh)
+#   BIN_DIR         repo bin/ (from bin/_common.sh)
+#   VMID            target VM id (for host-side docker/ssh assertions)
+#   DASHBOARD_URL   https://apps.<base>            (server API + dashboard front door)
+#   API_KEY         the server admin API key       (HOLA_TOKEN for the CLI)
+#   DOMAIN_BASE     <base> e.g. 192.168.1.15.sslip.io
+# Optional tunables (seconds unless noted):
+#   INSTALL_TIMEOUT(600) ACTION_TIMEOUT(240) HTTP_TIMEOUT(180) READY_TIMEOUT(180)
+#   INSTALL_ATTEMPTS(3)  INSTALL_BACKOFF(20)
+# Logging helpers log()/warn()/err() come from bin/_common.sh (already sourced).
+
+# Guard against double-sourcing.
+[[ -n "${__APP_TEST_SH_LOADED:-}" ]] && return 0
+__APP_TEST_SH_LOADED=1
+
+# --- per-app timeouts (overridable via env) ---------------------------------
+: "${INSTALL_TIMEOUT:=600}"
+: "${ACTION_TIMEOUT:=240}"
+: "${HTTP_TIMEOUT:=180}"
+: "${READY_TIMEOUT:=180}"
+: "${INSTALL_ATTEMPTS:=3}"
+: "${INSTALL_BACKOFF:=20}"
+
+# Result of the most recent at_install: the deployment id and the app URL the
+# server reports. Read by the other at_* steps and by callers for summaries.
+AT_DEPLOY_ID=""
+AT_APP_URL=""
+
+# --- low-level helpers ------------------------------------------------------
+# Run the working-tree CLI against the VM's server, with the self-signed-TLS
+# bypass and the deterministic admin token. Stdout is the command's stdout.
+at_cli() {
+  NODE_TLS_REJECT_UNAUTHORIZED=0 HOLA_NO_UPDATE_NOTICE=1 \
+    HOLA_API_URL="$DASHBOARD_URL" HOLA_TOKEN="$API_KEY" \
+    bun --cwd "$ROOT_DIR/packages/cli" src/index.ts "$@"
+}
+
+# Run a command on the VM over SSH (quietly). Returns the command's exit code.
+at_ssh() { "$BIN_DIR/vm-ssh" --vmid "$VMID" -- "$@" 2>/dev/null; }
+
+at_http_code() { curl -k -s -o /dev/null -w '%{http_code}' --max-time 10 "$1" 2>/dev/null || echo 000; }
+
+# at_wait_http <url> <code-regex> <timeout> — poll until the front door answers
+# with an acceptable code, or time out. Logs the final code either way.
+at_wait_http() {
+  local url=$1 want=$2 timeout=$3 code deadline; deadline=$(( $(date +%s) + timeout ))
+  while :; do
+    code=$(at_http_code "$url")
+    if [[ "$code" =~ $want ]]; then log "    $url -> HTTP $code"; return 0; fi
+    if [[ $(date +%s) -ge $deadline ]]; then err "    $url -> HTTP $code (timeout after ${timeout}s)"; return 1; fi
+    sleep 5
+  done
+}
+
+# The set of HTTP codes that mean "the ingress route is live and the app answered"
+# regardless of auth mode: 200/201 (served directly), 30x (forward-auth redirect to
+# Authentik, or app's own redirect), 401/403 (gated but routed). 000/5xx = not up.
+AT_HEALTHY_HTTP='^(200|201|30[0-9]|401|403)$'
+
+# Status of a deployment id from the server's deployments list ("" if absent).
+at_deploy_status() {
+  at_cli deployments --json 2>/dev/null \
+    | jq -r --arg id "$1" '.items[]? | select(.id == $id) | .status // empty' 2>/dev/null || true
+}
+
+# Capture server + per-app diagnostics for a failed step (best-effort).
+at_capture_diag() {
+  local logdir=$1 tag=$2
+  at_cli logs "${AT_DEPLOY_ID:-}" > "$logdir/deploy-logs-$tag.txt" 2>/dev/null || true
+  at_ssh 'cd /opt/hola && docker compose logs --since 5m --no-color server' \
+    > "$logdir/server-logs-$tag.txt" 2>/dev/null || true
+  # The app's own containers (compose project is hola-<deploymentId>).
+  [[ -n "${AT_DEPLOY_ID:-}" ]] && at_ssh "docker ps -a --filter 'name=hola-${AT_DEPLOY_ID}' --format '{{.Names}}\t{{.Status}}'" \
+    > "$logdir/app-containers-$tag.txt" 2>/dev/null || true
+}
+
+# --- the deterministic per-app steps ----------------------------------------
+# Each writes detailed output under <logdir> and returns 0 (pass) / non-zero (fail).
+# They are deliberately terse on stdout (one or two log lines) — the detail lives
+# in the files so a sweep over many apps stays scannable.
+
+# Run `hola install <app> [--set …] --json`, stdout = the JSON result, stderr →
+# $errf. Split out as its own function so the harness self-test can override it.
+_at_install_exec() {
+  local app=$1 errf=$2; shift 2   # remaining args are the --set pairs
+  timeout "$INSTALL_TIMEOUT" \
+    env NODE_TLS_REJECT_UNAUTHORIZED=0 HOLA_NO_UPDATE_NOTICE=1 \
+      HOLA_API_URL="$DASHBOARD_URL" HOLA_TOKEN="$API_KEY" \
+      bun --cwd "$ROOT_DIR/packages/cli" src/index.ts install "$app" "$@" --json 2>"$errf"
+}
+
+# at_install <app> <logdir> — install the app, retrying the first deploy on the
+# known docker-spawn ENOENT race. Sets AT_DEPLOY_ID + AT_APP_URL on success.
+# Return codes: 0 = installed, 1 = real failure, 2 = needs manual (non-secret)
+# config so the sweep should SKIP it (sets AT_SKIP_REASON).
+AT_SKIP_REASON=""
+at_install() {
+  local app=$1 logdir=$2
+  AT_DEPLOY_ID=""; AT_APP_URL=""; AT_SKIP_REASON=""
+  # `--set KEY=VALUE` args we accumulate to satisfy required SECRET env vars the
+  # app's manifest demands (generated tokens — safe for secrets; we never invent
+  # values for non-secret required config, which would need real meaning).
+  local -a set_args=()
+  local attempt=0 cfg_tries=0 rc out status backoff="$INSTALL_BACKOFF"
+  # Budget: INSTALL_ATTEMPTS race-retries PLUS up to 5 config-fills (each fill is a
+  # separate immediate retry, not a race-retry, so a multi-secret app converges).
+  while (( attempt < INSTALL_ATTEMPTS )); do
+    attempt=$(( attempt + 1 ))
+    local errf="$logdir/install-$attempt.err"
+    # errexit-safe capture: NEVER toggle global `set -e` here — this is a sourced
+    # library and a leaked errexit state would abort the caller's loop.
+    if out=$(_at_install_exec "$app" "$errf" "${set_args[@]}"); then rc=0; else rc=$?; fi
+    echo "$out" > "$logdir/install-$attempt.json"
+    status=$(echo "$out" | jq -r '.status // empty' 2>/dev/null || true)
+    AT_DEPLOY_ID=$(echo "$out" | jq -r '.deploymentId // empty' 2>/dev/null || true)
+    log "    install attempt $attempt: exit=$rc status=${status:-<none>} deployment=${AT_DEPLOY_ID:-<none>} set=${#set_args[@]}"
+    if [[ "$rc" == 0 && "$status" == "completed" ]]; then
+      AT_APP_URL=$(at_cli deployments --json 2>/dev/null | jq -r --arg id "$AT_DEPLOY_ID" \
+        '.items[]? | select(.id == $id) | .url // empty' || true)
+      [[ -z "$AT_APP_URL" ]] && AT_APP_URL="https://${app}.${DOMAIN_BASE}"
+      return 0
+    fi
+
+    # Auto-fill any required SECRET env vars the validator named, then retry without
+    # consuming a race-retry (so a 3-secret app doesn't exhaust the budget).
+    local newsecret=0 var
+    while IFS= read -r var; do
+      [[ -z "$var" ]] && continue
+      # already supplying this one? (set_args holds "--set" and "VAR=val" elements)
+      if ! printf '%s\0' "${set_args[@]}" 2>/dev/null | grep -qz "^${var}="; then
+        set_args+=(--set "${var}=$(openssl rand -hex 24 2>/dev/null || echo deadbeefcafe$RANDOM)")
+        newsecret=1
+      fi
+    done < <(grep -iE "secret environment variable '[^']+' is required but empty" "$errf" 2>/dev/null \
+             | sed -E "s/.*'([^']+)'.*/\1/")
+    if (( newsecret )) && (( cfg_tries < 5 )); then
+      cfg_tries=$(( cfg_tries + 1 )); attempt=$(( attempt - 1 ))   # this was a config fill, not a race-retry
+      log "    supplied generated secret(s); retrying install (config fill $cfg_tries)"
+      [[ -n "$AT_DEPLOY_ID" ]] && at_cli uninstall "$AT_DEPLOY_ID" --yes >/dev/null 2>&1 || true
+      AT_DEPLOY_ID=""
+      continue
+    fi
+
+    # Non-secret required var → we won't fabricate config; mark for SKIP.
+    local needcfg; needcfg=$(grep -iE "environment variable '[^']+' is required but empty" "$errf" 2>/dev/null \
+             | grep -vi "secret environment variable" | sed -E "s/.*'([^']+)'.*/\1/" | paste -sd, - || true)
+    if [[ -n "$needcfg" ]]; then
+      AT_SKIP_REASON="requires manual config: $needcfg"
+      warn "    $app needs non-secret config ($needcfg) — skipping (not a failure)"
+      [[ -n "$AT_DEPLOY_ID" ]] && at_cli uninstall "$AT_DEPLOY_ID" --yes >/dev/null 2>&1 || true
+      AT_DEPLOY_ID=""
+      return 2
+    fi
+
+    at_capture_diag "$logdir" "install-$attempt"
+    # A failed attempt may have left a record — remove it so a retry starts clean.
+    [[ -n "$AT_DEPLOY_ID" ]] && at_cli uninstall "$AT_DEPLOY_ID" --yes >/dev/null 2>&1 || true
+    AT_DEPLOY_ID=""
+    if (( attempt < INSTALL_ATTEMPTS )); then
+      warn "    install failed — settling ${backoff}s then retrying (known first-deploy ENOENT race)."
+      sleep "$backoff"; backoff=$(( backoff * 2 ))
+    fi
+  done
+  err "    install did not complete after $attempt attempt(s) (see $logdir/install-*.err, server-logs-*.txt)"
+  return 1
+}
+
+# at_verify_up <app> <logdir> — assert the app actually came up: deployment status
+# is `running`, its container(s) are running on the host, and the front door answers
+# with a healthy code for its auth mode.
+at_verify_up() {
+  local app=$1 logdir=$2 ok=1
+  # 1) Deployment converged to running.
+  local st; st=$(at_deploy_status "$AT_DEPLOY_ID")
+  if [[ "$st" == "running" ]]; then log "    deployment $AT_DEPLOY_ID: running"; else err "    deployment $AT_DEPLOY_ID: ${st:-<missing>} (expected running)"; ok=0; fi
+  # 2) Host containers for this deployment are healthy. "Healthy" = Up/running, or
+  # Exited(0) for legitimate one-shot init/migration containers. BAD = Restarting,
+  # Dead, Created (stuck), Exited with a non-zero code, or an (unhealthy) healthcheck.
+  local ps; ps=$(at_ssh "docker ps -a --filter 'name=hola-${AT_DEPLOY_ID}' --format '{{.Names}}\t{{.Status}}'" || true)
+  echo "$ps" > "$logdir/containers.txt"
+  local bad; bad=$(grep -iE 'Restarting|Dead|^[^[:space:]]+[[:space:]]+Created|Exited \([1-9]|\(unhealthy\)' <<<"$ps" || true)
+  if [[ -z "${ps//[[:space:]]/}" ]]; then
+    err "    no host containers found for hola-${AT_DEPLOY_ID}"; ok=0
+  elif [[ -n "$bad" ]]; then
+    err "    unhealthy container(s):"; while read -r l; do [[ -n "$l" ]] && err "      $l"; done <<<"$bad"; ok=0
+  else
+    log "    containers healthy: $(grep -c . <<<"$ps")"
+  fi
+  # 3) Front door answers (mode-agnostic healthy set).
+  log "    app URL: $AT_APP_URL"
+  at_wait_http "$AT_APP_URL" "$AT_HEALTHY_HTTP" "$HTTP_TIMEOUT" || ok=0
+  if [[ "$ok" != 1 ]]; then at_capture_diag "$logdir" "verify"; return 1; fi
+  return 0
+}
+
+# at_restart <app> <logdir> — exercise the restart lifecycle (the #267 path for
+# forward-auth apps): restart, assert it returns to running and stays reachable.
+at_restart() {
+  local app=$1 logdir=$2 rc=0
+  # errexit-safe (no global `set -e` toggle in a sourced library).
+  at_cli restart "$AT_DEPLOY_ID" --json > "$logdir/restart.json" 2>"$logdir/restart.err" || rc=$?
+  # `hola restart --json` prints a human line before the JSON, so slice from `{`.
+  local jstatus dstatus
+  jstatus=$(sed -n '/^{/,$p' "$logdir/restart.json" | jq -r '.status // empty' 2>/dev/null || true)
+  dstatus=$(at_deploy_status "$AT_DEPLOY_ID")
+  log "    restart: exit=$rc job-status=${jstatus:-<none>} deployment-status=${dstatus:-<none>}"
+  if [[ "$rc" != 0 || "$jstatus" != "completed" || "$dstatus" != "running" ]]; then
+    at_capture_diag "$logdir" "restart"
+    err "    restart did not return the deployment to running"
+    return 1
+  fi
+  at_wait_http "$AT_APP_URL" "$AT_HEALTHY_HTTP" "$HTTP_TIMEOUT"
+}
+
+# at_stop <app> <logdir> — stop the deployment and assert it left `running`.
+at_stop() {
+  local app=$1 logdir=$2 rc=0
+  at_cli stop "$AT_DEPLOY_ID" > "$logdir/stop.log" 2>&1 || rc=$?
+  [[ "$rc" == 0 ]] || { err "    stop command failed (exit $rc)"; return 1; }
+  local st; st=$(at_deploy_status "$AT_DEPLOY_ID")
+  log "    post-stop status: ${st:-<missing>}"
+  [[ "$st" != "running" ]]
+}
+
+# at_uninstall <app> <logdir> — uninstall and assert the user-facing outcome: the
+# app's containers are gone from the host. A lingering `error` tombstone record is
+# only a warning (a known, separate server ordering quirk), not a failure.
+at_uninstall() {
+  local app=$1 logdir=$2 rc=0
+  at_cli uninstall "$AT_DEPLOY_ID" --yes > "$logdir/uninstall.log" 2>&1 || rc=$?
+  [[ "$rc" == 0 ]] || { err "    uninstall command failed (exit $rc)"; return 1; }
+  if at_ssh "docker ps -a --format '{{.Names}}' | grep -q 'hola-${AT_DEPLOY_ID}'"; then
+    err "    container(s) for $AT_DEPLOY_ID still present after uninstall"; return 1
+  fi
+  log "    host containers for $AT_DEPLOY_ID removed"
+  local st; st=$(at_deploy_status "$AT_DEPLOY_ID")
+  [[ -n "$st" && "$st" != "absent" ]] && warn "    note: a tombstone record lingers in '$st' state"
+  return 0
+}
+
+# at_run_app <app> <logdir> — the full deterministic per-app test used by the
+# catalog sweep: install -> verify up -> [restart -> verify] -> [stop] -> uninstall.
+# Lifecycle steps are opt-in (the sweep's default is just install/verify/uninstall):
+#   AT_TEST_RESTART=1   also restart and re-verify (the forward-auth #267 path)
+#   AT_TEST_STOP=1      also stop and assert it left running (then uninstall removes it)
+# Always attempts uninstall (even after an earlier failure) so the next app starts
+# from a clean host. Returns 0 only if every attempted step passed. Sets
+# AT_LAST_STAGE to the FIRST stage that failed (for the caller's summary).
+AT_LAST_STAGE=""
+at_run_app() {
+  local app=$1 logdir=$2 failed=0
+  mkdir -p "$logdir"
+  AT_LAST_STAGE=""
+  # Record the first failing stage without clobbering it on later failures.
+  _mark() { [[ "$failed" == 0 ]] && AT_LAST_STAGE="$1"; failed=1; }
+
+  log "  [$app] install"
+  local irc=0; at_install "$app" "$logdir" || irc=$?
+  if [[ "$irc" == 2 ]]; then AT_LAST_STAGE="skip"; return 2; fi   # needs manual config
+  if [[ "$irc" != 0 ]]; then AT_LAST_STAGE="install"; return 1; fi
+
+  log "  [$app] verify up"
+  if ! at_verify_up "$app" "$logdir"; then _mark "verify"; fi
+
+  if [[ "$failed" == 0 && "${AT_TEST_RESTART:-0}" == "1" ]]; then
+    log "  [$app] restart"
+    if ! at_restart "$app" "$logdir"; then _mark "restart"; fi
+  fi
+
+  if [[ "$failed" == 0 && "${AT_TEST_STOP:-0}" == "1" ]]; then
+    log "  [$app] stop"
+    if ! at_stop "$app" "$logdir"; then _mark "stop"; fi
+  fi
+
+  log "  [$app] uninstall"
+  if ! at_uninstall "$app" "$logdir"; then _mark "uninstall"; fi
+
+  return "$failed"
+}

--- a/bin/lib/app-test.sh
+++ b/bin/lib/app-test.sh
@@ -118,19 +118,22 @@ at_install() {
   # app's manifest demands (generated tokens — safe for secrets; we never invent
   # values for non-secret required config, which would need real meaning).
   local -a set_args=()
-  local attempt=0 cfg_tries=0 rc out status backoff="$INSTALL_BACKOFF"
+  local attempt=0 cfg_tries=0 logn=0 rc out status backoff="$INSTALL_BACKOFF"
   # Budget: INSTALL_ATTEMPTS race-retries PLUS up to 5 config-fills (each fill is a
   # separate immediate retry, not a race-retry, so a multi-secret app converges).
   while (( attempt < INSTALL_ATTEMPTS )); do
     attempt=$(( attempt + 1 ))
-    local errf="$logdir/install-$attempt.err"
+    # `logn` is a monotonic per-exec counter so config-fill retries (which reuse the
+    # `attempt` number) don't clobber the previous exec's install-N.err/.json.
+    logn=$(( logn + 1 ))
+    local errf="$logdir/install-$logn.err"
     # errexit-safe capture: NEVER toggle global `set -e` here — this is a sourced
     # library and a leaked errexit state would abort the caller's loop.
     if out=$(_at_install_exec "$app" "$errf" "${set_args[@]}"); then rc=0; else rc=$?; fi
-    echo "$out" > "$logdir/install-$attempt.json"
+    echo "$out" > "$logdir/install-$logn.json"
     status=$(echo "$out" | jq -r '.status // empty' 2>/dev/null || true)
     AT_DEPLOY_ID=$(echo "$out" | jq -r '.deploymentId // empty' 2>/dev/null || true)
-    log "    install attempt $attempt: exit=$rc status=${status:-<none>} deployment=${AT_DEPLOY_ID:-<none>} set=${#set_args[@]}"
+    log "    install try $logn (attempt $attempt/$INSTALL_ATTEMPTS): exit=$rc status=${status:-<none>} deployment=${AT_DEPLOY_ID:-<none>} set=${#set_args[@]}"
     if [[ "$rc" == 0 && "$status" == "completed" ]]; then
       AT_APP_URL=$(at_cli deployments --json 2>/dev/null | jq -r --arg id "$AT_DEPLOY_ID" \
         '.items[]? | select(.id == $id) | .url // empty' || true)
@@ -169,7 +172,7 @@ at_install() {
       return 2
     fi
 
-    at_capture_diag "$logdir" "install-$attempt"
+    at_capture_diag "$logdir" "install-$logn"
     # A failed attempt may have left a record — remove it so a retry starts clean.
     [[ -n "$AT_DEPLOY_ID" ]] && at_cli uninstall "$AT_DEPLOY_ID" --yes >/dev/null 2>&1 || true
     AT_DEPLOY_ID=""
@@ -246,9 +249,17 @@ at_uninstall() {
   local app=$1 logdir=$2 rc=0
   at_cli uninstall "$AT_DEPLOY_ID" --yes > "$logdir/uninstall.log" 2>&1 || rc=$?
   [[ "$rc" == 0 ]] || { err "    uninstall command failed (exit $rc)"; return 1; }
-  if at_ssh "docker ps -a --format '{{.Names}}' | grep -q 'hola-${AT_DEPLOY_ID}'"; then
-    err "    container(s) for $AT_DEPLOY_ID still present after uninstall"; return 1
-  fi
+  # `compose down` of a multi-container stack can lag the API response, so poll for
+  # the containers to actually disappear rather than asserting immediately (avoids a
+  # false "still present" on a slow teardown).
+  local deadline; deadline=$(( $(date +%s) + ${UNINSTALL_TIMEOUT:-45} ))
+  while at_ssh "docker ps -a --format '{{.Names}}' | grep -q 'hola-${AT_DEPLOY_ID}'"; do
+    if [[ $(date +%s) -ge $deadline ]]; then
+      at_ssh "docker ps -a --filter 'name=hola-${AT_DEPLOY_ID}' --format '{{.Names}}\t{{.Status}}'" > "$logdir/uninstall-leftover.txt" 2>/dev/null || true
+      err "    container(s) for $AT_DEPLOY_ID still present ${UNINSTALL_TIMEOUT:-45}s after uninstall"; return 1
+    fi
+    sleep 3
+  done
   log "    host containers for $AT_DEPLOY_ID removed"
   local st; st=$(at_deploy_status "$AT_DEPLOY_ID")
   [[ -n "$st" && "$st" != "absent" ]] && warn "    note: a tombstone record lingers in '$st' state"

--- a/bin/vm-catalog-test
+++ b/bin/vm-catalog-test
@@ -311,15 +311,25 @@ setup_wait_authentik() {
 # Wait until the SERVER container can spawn `docker compose` (defeats the
 # first-deploy ENOENT race deterministically).
 setup_wait_deploy_ready() {
-  log "── waiting for the server to be deploy-ready (can spawn docker compose)"
+  log "── waiting for the server to be deploy-ready (bun can spawn docker compose)"
   if is_dry; then return 0; fi
-  local deadline; deadline=$(( $(date +%s) + DEPLOY_READY_TIMEOUT ))
+  # Probe the EXACT mechanism a deploy uses: the server's bun runtime spawning
+  # `docker` (child_process), not a login shell. A login shell warms up its PATH
+  # before bun's posix_spawn can find `docker`, so the old `command -v docker` probe
+  # passed too early and the first deploys still hit `ENOENT posix_spawn 'docker'`
+  # (notably after a server recreate via --server-image local). Require N consecutive
+  # successes so a flapping warmup race is fully past before we start installing.
+  local deadline streak=0 need=3
+  deadline=$(( $(date +%s) + DEPLOY_READY_TIMEOUT ))
   while :; do
-    if "$BIN_DIR/vm-ssh" --vmid "$VMID" -- 'cd /opt/hola && docker compose exec -T server sh -lc "command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1"' >/dev/null 2>&1; then
-      log "  server can spawn docker compose — deploy-ready"; return 0
+    if "$BIN_DIR/vm-ssh" --vmid "$VMID" -- 'cd /opt/hola && docker compose exec -T server bun -e "process.exit(Bun.spawnSync([\"docker\",\"compose\",\"version\"]).success?0:1)"' >/dev/null 2>&1; then
+      streak=$(( streak + 1 ))
+      if (( streak >= need )); then log "  server bun-spawns docker compose (${streak}x) — deploy-ready"; return 0; fi
+    else
+      streak=0
     fi
     if [[ $(date +%s) -ge $deadline ]]; then err "  server not deploy-ready in time"; return 1; fi
-    sleep 5
+    sleep 3
   done
 }
 

--- a/bin/vm-catalog-test
+++ b/bin/vm-catalog-test
@@ -278,16 +278,20 @@ setup_local_server_image() {
   docker save "$tag" | "$BIN_DIR/vm-ssh" --vmid "$VMID" -- 'docker load' > "$LOG_DIR/server-load.log" 2>&1 \
     || { err "  docker save|load failed (see $LOG_DIR/server-load.log)"; return 1; }
   log "  recreating the server container with the local image…"
-  # CRITICAL: --pull never. Without it, `compose up` re-pulls the published tag from
-  # GHCR and overwrites the image we just loaded — silently testing the RELEASED
-  # server instead of the local build. --pull never forces the loaded local image.
-  "$BIN_DIR/vm-ssh" --vmid "$VMID" -- 'cd /opt/hola && docker compose up -d --no-deps --force-recreate --pull never server' > "$LOG_DIR/server-recreate.log" 2>&1 \
+  # Two musts here:
+  #  * HOLA_VERSION=$ver — the compose ref is `…/server:${HOLA_VERSION:-latest}`, and
+  #    bootstrap exports HOLA_VERSION via up.sh (it is NOT in .env), so a bare
+  #    `docker compose up` would resolve to `:latest` (the wrong/absent tag). Set it
+  #    explicitly so the ref matches the `:$ver` image we built and loaded.
+  #  * --pull never — otherwise `up` re-pulls the published tag from GHCR and
+  #    overwrites the loaded build, silently testing the RELEASED server instead.
+  "$BIN_DIR/vm-ssh" --vmid "$VMID" -- "cd /opt/hola && HOLA_VERSION='$ver' docker compose up -d --no-deps --force-recreate --pull never server" > "$LOG_DIR/server-recreate.log" 2>&1 \
     || { err "  server recreate failed (see $LOG_DIR/server-recreate.log)"; return 1; }
   # Confirm the running server is actually our freshly-loaded image (guard against a
   # silent re-pull): compare the container's image id to the loaded image's id.
   local want got
   want=$(docker image inspect "$tag" --format '{{.Id}}' 2>/dev/null || true)
-  got=$("$BIN_DIR/vm-ssh" --vmid "$VMID" -- "docker inspect --format '{{.Image}}' \$(cd /opt/hola && docker compose ps -q server)" 2>/dev/null | tr -d '\r\n ')
+  got=$("$BIN_DIR/vm-ssh" --vmid "$VMID" -- "docker inspect --format '{{.Image}}' \$(cd /opt/hola && HOLA_VERSION='$ver' docker compose ps -q server)" 2>/dev/null | tr -d '\r\n ')
   if [[ -n "$want" && -n "$got" && "$want" != "$got" ]]; then
     err "  server is NOT running the local image (id mismatch: want ${want:7:12} got ${got:7:12}) — a re-pull slipped through"; return 1
   fi

--- a/bin/vm-catalog-test
+++ b/bin/vm-catalog-test
@@ -32,12 +32,28 @@
 # prunes unused images/volumes so a long run doesn't fill the disk (which would trip
 # the preflight disk check and degrade later apps) — pass --no-prune to disable.
 #
+# CAVEAT — this tests the RELEASED server image. `hola bootstrap` installs the
+# published `ghcr.io/try-hola/server` pinned to the CLI version, so the sweep
+# exercises the LAST RELEASE, not `main`. Server fixes merged-but-unreleased won't
+# be present — e.g. an uninstall that leaves containers is the already-fixed #271,
+# and a forward-auth `--restart` failure is the already-fixed #267, both pending a
+# release. To test current `main`, build a server image and load it onto the VM
+# (the "Advanced — local server/web image" path in the vm-e2e skill), then re-run.
+#
+# Some catalog apps legitimately can't install unattended: a missing required
+# secret that is a real external token (e.g. gitea's runner registration token —
+# a random value is rejected) or a manifest that leaves a needed value blank (an
+# upstream try-hola/apps issue). Those surface as FAIL with the deploy error in the
+# per-app logs — read them to tell a real regression from an app-config gap.
+#
 # Exit code = number of apps that failed (0 = all green). --keep-on-fail snapshots
 # and keeps the VM if any app failed (default: always destroy so reruns stay cheap).
 set -euo pipefail
 source "$(dirname "$0")/_common.sh"
-source "$(dirname "$0")/lib/app-test.sh"
 load_env
+# NOTE: bin/lib/app-test.sh is sourced AFTER the timeout defaults below, so the
+# driver's values win over the library's own `:=` fallbacks (the library defaults
+# only apply when a knob is otherwise unset).
 
 # --- args -------------------------------------------------------------------
 KEEP_ON_FAIL=0; ONLY_APPS=""; SKIP_APPS=""; REF="${HOLA_E2E_REF:-}"; VM_MEMORY=""; PRUNE=1
@@ -66,6 +82,11 @@ BOOTSTRAP_TIMEOUT="${BOOTSTRAP_TIMEOUT:-1200}"   # authentik bootstrap is slower
 AUTHENTIK_TIMEOUT="${AUTHENTIK_TIMEOUT:-420}"
 HTTP_TIMEOUT="${HTTP_TIMEOUT:-240}"              # slow first boots (n8n, immich) need headroom
 DEPLOY_READY_TIMEOUT="${DEPLOY_READY_TIMEOUT:-180}"
+export HTTP_TIMEOUT
+
+# Per-app test library — sourced here (not at the top) so the timeout defaults set
+# above take precedence over the library's own fallback defaults.
+source "$(dirname "$0")/lib/app-test.sh"
 
 # --- paths / per-run state --------------------------------------------------
 LOG_DIR="$ROOT_DIR/logs/vm-catalog-test"

--- a/bin/vm-catalog-test
+++ b/bin/vm-catalog-test
@@ -278,11 +278,22 @@ setup_local_server_image() {
   docker save "$tag" | "$BIN_DIR/vm-ssh" --vmid "$VMID" -- 'docker load' > "$LOG_DIR/server-load.log" 2>&1 \
     || { err "  docker save|load failed (see $LOG_DIR/server-load.log)"; return 1; }
   log "  recreating the server container with the local image…"
-  "$BIN_DIR/vm-ssh" --vmid "$VMID" -- 'cd /opt/hola && docker compose up -d --no-deps --force-recreate server' > "$LOG_DIR/server-recreate.log" 2>&1 \
+  # CRITICAL: --pull never. Without it, `compose up` re-pulls the published tag from
+  # GHCR and overwrites the image we just loaded — silently testing the RELEASED
+  # server instead of the local build. --pull never forces the loaded local image.
+  "$BIN_DIR/vm-ssh" --vmid "$VMID" -- 'cd /opt/hola && docker compose up -d --no-deps --force-recreate --pull never server' > "$LOG_DIR/server-recreate.log" 2>&1 \
     || { err "  server recreate failed (see $LOG_DIR/server-recreate.log)"; return 1; }
+  # Confirm the running server is actually our freshly-loaded image (guard against a
+  # silent re-pull): compare the container's image id to the loaded image's id.
+  local want got
+  want=$(docker image inspect "$tag" --format '{{.Id}}' 2>/dev/null || true)
+  got=$("$BIN_DIR/vm-ssh" --vmid "$VMID" -- "docker inspect --format '{{.Image}}' \$(cd /opt/hola && docker compose ps -q server)" 2>/dev/null | tr -d '\r\n ')
+  if [[ -n "$want" && -n "$got" && "$want" != "$got" ]]; then
+    err "  server is NOT running the local image (id mismatch: want ${want:7:12} got ${got:7:12}) — a re-pull slipped through"; return 1
+  fi
   # Dashboard front door should answer again once the new server is healthy.
   wait_http "$DASHBOARD_URL" '^(200|30[0-9])$' "$HTTP_TIMEOUT" || { err "  server not healthy after swap"; return 1; }
-  log "  local server image is live (built from the working tree)"
+  log "  local server image is live (built from the working tree; image id verified)"
 }
 
 # Authentik must be migrated + serving before forward-auth/native-oidc apps can

--- a/bin/vm-catalog-test
+++ b/bin/vm-catalog-test
@@ -1,0 +1,318 @@
+#!/usr/bin/env bash
+# bin/vm-catalog-test — install EVERY catalog app on one disposable VM and verify
+# each comes up, using the deterministic per-app test (bin/lib/app-test.sh).
+#
+# Usage: bin/vm-catalog-test [--dry-run] [--keep-on-fail] [--vmid VMID]
+#                            [--apps a,b,c] [--skip x,y] [--restart] [--lifecycle]
+#                            [--memory MB] [--ref cli-vX.Y.Z] [-h]
+#
+# Brings up ONE Authentik-mode VM (so apps of every auth mode — none, forward-auth,
+# native-oidc — can provision), then walks the catalog installing each app one at a
+# time: install -> verify it converges to `running` with its containers up and its
+# front door answering -> uninstall -> next. One app is live at a time, so peak RAM
+# stays bounded (core stack + Authentik + the single heaviest app).
+#
+# OUTPUT CONTRACT (the point of this script):
+#   * STDOUT  = terse, one line per app: `PASS <app> (1m12s)` / `FAIL <app> (verify,
+#               3m04s)  logs: logs/vm-catalog-test/<app>/`, then a final summary.
+#               Watch this to monitor a long sweep at a glance.
+#   * STDERR  = the live verbose [vm] trace of setup (create/bootstrap/verify).
+#               Each app's verbose per-step trace is redirected into its own
+#               logs/vm-catalog-test/<app>/run.log (not the terminal).
+#   * FILES   = logs/vm-catalog-test/<app>/* hold the install JSON, server logs,
+#               container states, deploy logs — drill in here when a line says FAIL.
+#   For a pure terse view:  bin/vm-catalog-test 2>logs/vm-catalog-test/setup.log
+#
+# --restart additionally exercises the restart lifecycle on every app (proves the
+# forward-auth restart path, #267, end-to-end across the catalog). --lifecycle goes
+# further: restart + stop + uninstall, covering all three lifecycle fixes
+# (#267 restart, stop, #271 uninstall) per app.
+# --apps limits the sweep to a comma list; --skip excludes one; --memory MB sizes
+# the VM (heavy apps like immich/postiz want headroom).
+#
+# Exit code = number of apps that failed (0 = all green). --keep-on-fail snapshots
+# and keeps the VM if any app failed (default: always destroy so reruns stay cheap).
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+source "$(dirname "$0")/lib/app-test.sh"
+load_env
+
+# --- args -------------------------------------------------------------------
+KEEP_ON_FAIL=0; ONLY_APPS=""; SKIP_APPS=""; REF="${HOLA_E2E_REF:-}"; VM_MEMORY=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1; export DRY_RUN; shift ;;
+    --keep-on-fail) KEEP_ON_FAIL=1; shift ;;
+    --vmid) VM_ID=$2; shift 2 ;;
+    --apps) ONLY_APPS=$2; shift 2 ;;
+    --skip) SKIP_APPS=$2; shift 2 ;;
+    --restart) AT_TEST_RESTART=1; shift ;;
+    --lifecycle) AT_TEST_RESTART=1; AT_TEST_STOP=1; shift ;;
+    --memory) VM_MEMORY=$2; shift 2 ;;
+    --ref) REF=$2; shift 2 ;;
+    -h|--help) grep -E '^# ' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) die "unknown arg: $1" ;;
+  esac
+done
+export AT_TEST_RESTART="${AT_TEST_RESTART:-0}"
+export AT_TEST_STOP="${AT_TEST_STOP:-0}"
+is_dry() { [[ "${DRY_RUN:-0}" == "1" ]]; }
+
+# --- timeouts (seconds) -----------------------------------------------------
+BOOTSTRAP_TIMEOUT="${BOOTSTRAP_TIMEOUT:-1200}"   # authentik bootstrap is slower
+AUTHENTIK_TIMEOUT="${AUTHENTIK_TIMEOUT:-420}"
+HTTP_TIMEOUT="${HTTP_TIMEOUT:-180}"
+DEPLOY_READY_TIMEOUT="${DEPLOY_READY_TIMEOUT:-180}"
+
+# --- paths / per-run state --------------------------------------------------
+LOG_DIR="$ROOT_DIR/logs/vm-catalog-test"
+HOLA_ENV_OUT="$ROOT_DIR/.devcontainer/hola-catalog.env"   # gitignored (hola-*.env)
+mkdir -p "$LOG_DIR"
+
+VMID=""; ALIAS=""; IP=""; DOMAIN_BASE=""; DASHBOARD_URL=""; AUTH_URL=""; API_KEY=""
+
+# --- result tracking --------------------------------------------------------
+declare -a RESULTS=()   # "RESULT<TAB>app<TAB>stage<TAB>seconds"
+FAILED=0
+fmt_dur() { local s=$1; printf '%dm%02ds' $(( s/60 )) $(( s%60 )); }
+
+# Terse one-line-per-app result on STDOUT (what the user watches).
+SKIPPED=0
+emit() {  # emit <PASS|FAIL|SKIP> <app> <stage|reason> <seconds>
+  local res=$1 app=$2 stage=$3 secs=$4 dur; dur=$(fmt_dur "$secs")
+  RESULTS+=("$res"$'\t'"$app"$'\t'"$stage"$'\t'"$secs")
+  case "$res" in
+    PASS) printf 'PASS %-16s (%s)\n' "$app" "$dur" ;;
+    SKIP) printf 'SKIP %-16s (%s) — %s\n' "$app" "$dur" "$stage"; SKIPPED=$((SKIPPED+1)) ;;
+    *)    printf 'FAIL %-16s (%s, %s)  logs: %s\n' "$app" "$stage" "$dur" "logs/vm-catalog-test/$app/"; FAILED=$((FAILED+1)) ;;
+  esac
+}
+
+print_summary() {
+  echo ""
+  echo "================ vm-catalog-test summary ================"
+  local r res app stage secs
+  if (( ${#RESULTS[@]} )); then
+    for r in "${RESULTS[@]}"; do
+      IFS=$'\t' read -r res app stage secs <<<"$r"
+      case "$res" in
+        PASS) printf '  PASS  %-16s %s\n' "$app" "$(fmt_dur "$secs")" ;;
+        SKIP) printf '  SKIP  %-16s %s  (%s)\n' "$app" "$(fmt_dur "$secs")" "$stage" ;;
+        *)    printf '  FAIL  %-16s %s  (%s)\n' "$app" "$(fmt_dur "$secs")" "$stage" ;;
+      esac
+    done
+  else
+    echo "  (no apps tested)"
+  fi
+  echo "  ----"
+  printf '  %d app(s): %d passed, %d failed, %d skipped\n' \
+    "${#RESULTS[@]}" "$(( ${#RESULTS[@]} - FAILED - SKIPPED ))" "$FAILED" "$SKIPPED"
+  echo "  detailed logs: logs/vm-catalog-test/<app>/"
+  echo "========================================================"
+}
+
+# --- teardown trap ----------------------------------------------------------
+cleanup() {
+  local rc=$1
+  print_summary
+  [[ -n "$ALIAS" ]] && remove_ssh_config "$VMID" 2>/dev/null || true
+  [[ -z "$VMID" ]] && exit "$rc"
+  if is_dry; then exit "$rc"; fi
+  if [[ "$FAILED" -ne 0 && "$KEEP_ON_FAIL" == "1" ]]; then
+    warn "failures — keeping VM $VMID and snapshotting for inspection."
+    "$BIN_DIR/vm-snapshot" --vmid "$VMID" --name "catalog-fail-$(date -u +%Y%m%d-%H%M%S)" \
+      --desc "preserved by vm-catalog-test on failure" || true
+    warn "destroy it when done: bin/vm-destroy --vmid $VMID"
+  else
+    log "tearing down VM $VMID"
+    FORCE=1 "$BIN_DIR/vm-destroy" --vmid "$VMID" || warn "teardown failed for VM $VMID — destroy manually."
+  fi
+  exit "$rc"
+}
+abort() { err "$1"; exit 1; }
+
+http_code() { curl -k -s -o /dev/null -w '%{http_code}' --max-time 10 "$1" 2>/dev/null || echo 000; }
+wait_http() {
+  local url=$1 want=$2 timeout=$3 code deadline; deadline=$(( $(date +%s) + timeout ))
+  while :; do
+    code=$(http_code "$url")
+    if [[ "$code" =~ $want ]]; then log "  $url -> HTTP $code"; return 0; fi
+    if [[ $(date +%s) -ge $deadline ]]; then err "  $url -> HTTP $code (timeout after ${timeout}s)"; return 1; fi
+    sleep 5
+  done
+}
+
+# ===========================================================================
+# Setup (one-time): bring up an Authentik-mode VM ready to install apps.
+# ===========================================================================
+setup_create() {
+  log "── creating + booting a disposable VM (Authentik mode)"
+  if is_dry; then VMID="999999"; log "DRY_RUN: bin/vm-create ${VM_MEMORY:+--memory $VM_MEMORY}"; return 0; fi
+  if [[ -n "$VM_MEMORY" ]]; then
+    # main's vm-create has no --memory flag, so size the VM ourselves: clone
+    # without starting, set memory via the Proxmox API, then start.
+    local args=(--no-start); [[ -n "${VM_ID:-}" ]] && args+=(--vmid "$VM_ID")
+    VMID=$("$BIN_DIR/vm-create" "${args[@]}" | tail -1) || return 1
+    [[ -n "$VMID" ]] || return 1
+    local node; node=$(node)
+    log "  setting VM $VMID memory=${VM_MEMORY}MB"
+    proxmox_curl PUT "/nodes/$node/qemu/$VMID/config" --data-urlencode "memory=$VM_MEMORY" >/dev/null || return 1
+    proxmox_curl POST "/nodes/$node/qemu/$VMID/status/start" >/dev/null || return 1
+  else
+    local args=(); [[ -n "${VM_ID:-}" ]] && args=(--vmid "$VM_ID")
+    VMID=$("$BIN_DIR/vm-create" "${args[@]}" | tail -1) || return 1
+    [[ -n "$VMID" ]] || return 1
+  fi
+  # Clear any stale shared-state IP so wait-ssh re-resolves THIS VM's guest-agent IP.
+  state_set VM_IP ""
+  log "  test VM: $VMID"
+}
+
+setup_wait_ssh() {
+  log "── waiting for SSH + resolving IP"
+  if is_dry; then IP="203.0.113.10"; ALIAS="hola-vm-$VMID"; return 0; fi
+  "$BIN_DIR/vm-wait-ssh" --vmid "$VMID" || return 1
+  IP=$(state_get VM_IP); [[ -n "$IP" ]] || { err "  no VM IP after wait-ssh"; return 1; }
+  ALIAS=$(vm_alias "$VMID")
+  log "  VM IP: $IP  (ssh alias: $ALIAS)"
+}
+
+setup_render_env() {
+  log "── rendering Hola .env (HOLA_AUTH_MODE=authentik, sslip.io, self-signed TLS)"
+  DOMAIN_BASE="$IP.sslip.io"
+  DASHBOARD_URL="https://apps.$DOMAIN_BASE"
+  AUTH_URL="https://auth.$DOMAIN_BASE"
+  API_KEY=$( (openssl rand -hex 24 2>/dev/null) || (uuidgen | tr -d '-') )
+  if is_dry; then log "DRY_RUN: would write $HOLA_ENV_OUT (dashboard $DASHBOARD_URL, auth $AUTH_URL)"; return 0; fi
+  # install.sh generates the AUTHENTIK_* secrets idempotently when HOLA_AUTH_MODE=
+  # authentik, so we only set the mode + the auth login domain here.
+  cat > "$HOLA_ENV_OUT" <<EOF
+# Generated by bin/vm-catalog-test for VM $VMID — disposable, self-signed TLS.
+COMPOSE_PROJECT_NAME=hola
+TRAEFIK_HTTP_PORT=80
+TRAEFIK_HTTPS_PORT=443
+TRAEFIK_DASHBOARD_DOMAIN=traefik.$DOMAIN_BASE
+LETSENCRYPT_EMAIL=e2e@example.com
+ACME_CA_SERVER=
+ACME_DNS_PROVIDER=
+HOLA_DOMAIN=apps.$DOMAIN_BASE
+HOLA_BASE_DOMAIN=$DOMAIN_BASE
+HOLA_CATALOG_URL=https://raw.githubusercontent.com/try-hola/apps/main/catalog.json
+HOLA_DEFAULT_TZ=UTC
+HOLA_USE_AUTH=true
+HOLA_API_KEY=$API_KEY
+HOLA_AUTH_MODE=authentik
+HOLA_AUTHENTIK_DOMAIN=auth.$DOMAIN_BASE
+EOF
+  chmod 600 "$HOLA_ENV_OUT"
+  log "  wrote $HOLA_ENV_OUT"
+}
+
+setup_bootstrap() {
+  log "── hola bootstrap over SSH (up to ${BOOTSTRAP_TIMEOUT}s; log: $LOG_DIR/bootstrap.log)"
+  if is_dry; then log "DRY_RUN: hola bootstrap --host $ALIAS --env-file $HOLA_ENV_OUT ${REF:+--ref $REF}"; return 0; fi
+  local args=(bootstrap --host "$ALIAS" --env-file "$HOLA_ENV_OUT")
+  [[ -n "$REF" ]] && args+=(--ref "$REF")
+  timeout "$BOOTSTRAP_TIMEOUT" \
+    bun --cwd "$ROOT_DIR/packages/cli" src/index.ts "${args[@]}" 2>&1 | tee "$LOG_DIR/bootstrap.log"
+  return "${PIPESTATUS[0]}"
+}
+
+setup_verify_stack() {
+  log "── verifying core stack (traefik + server + web + authentik)"
+  if is_dry; then return 0; fi
+  local ps; ps=$("$BIN_DIR/vm-ssh" --vmid "$VMID" -- 'cd /opt/hola && docker compose ps --format "{{.Service}} {{.State}}"' 2>&1 | tee "$LOG_DIR/compose-ps.log") || return 1
+  local svc ok=1
+  for svc in traefik server web; do
+    if grep -qiE "^$svc .*(running|up)" <<<"$ps"; then log "  $svc: running"; else err "  $svc: NOT running"; ok=0; fi
+  done
+  wait_http "$DASHBOARD_URL" '^(200|30[0-9])$' "$HTTP_TIMEOUT" || ok=0
+  [[ "$ok" == 1 ]]
+}
+
+# Authentik must be migrated + serving before forward-auth/native-oidc apps can
+# provision. Wait for its login UI to answer.
+setup_wait_authentik() {
+  log "── waiting for Authentik login UI ($AUTH_URL) — first boot runs migrations"
+  if is_dry; then return 0; fi
+  wait_http "$AUTH_URL" '^(200|30[0-9])$' "$AUTHENTIK_TIMEOUT"
+}
+
+# Wait until the SERVER container can spawn `docker compose` (defeats the
+# first-deploy ENOENT race deterministically).
+setup_wait_deploy_ready() {
+  log "── waiting for the server to be deploy-ready (can spawn docker compose)"
+  if is_dry; then return 0; fi
+  local deadline; deadline=$(( $(date +%s) + DEPLOY_READY_TIMEOUT ))
+  while :; do
+    if "$BIN_DIR/vm-ssh" --vmid "$VMID" -- 'cd /opt/hola && docker compose exec -T server sh -lc "command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1"' >/dev/null 2>&1; then
+      log "  server can spawn docker compose — deploy-ready"; return 0
+    fi
+    if [[ $(date +%s) -ge $deadline ]]; then err "  server not deploy-ready in time"; return 1; fi
+    sleep 5
+  done
+}
+
+# Enumerate the apps to test from the SERVER's catalog (the catalog the server
+# actually sees), honoring --apps / --skip. Echoes a space list of ids.
+resolve_apps() {
+  if is_dry; then
+    local list="${ONLY_APPS:-vaultwarden uptime-kuma gitea}"; echo "${list//,/ }"; return 0
+  fi
+  local ids
+  ids=$(at_cli catalog --json 2>"$LOG_DIR/catalog.err" | jq -r '.items[]?.id' 2>/dev/null || true)
+  [[ -n "$ids" ]] || { err "could not read catalog from the server (see $LOG_DIR/catalog.err)"; return 1; }
+  echo "$ids" | tr '\n' ' ' > "$LOG_DIR/catalog-apps.txt"
+  local app out=()
+  for app in $ids; do
+    if [[ -n "$ONLY_APPS" ]] && [[ ",$ONLY_APPS," != *",$app,"* ]]; then continue; fi
+    if [[ -n "$SKIP_APPS" ]] && [[ ",$SKIP_APPS," == *",$app,"* ]]; then continue; fi
+    out+=("$app")
+  done
+  echo "${out[*]}"
+}
+
+# ===========================================================================
+# Orchestration
+# ===========================================================================
+log "=== vm-catalog-test: install every catalog app, verify it comes up (mode=authentik) ==="
+audit "vm-catalog-test start restart=${AT_TEST_RESTART} dry_run=${DRY_RUN:-0}"
+trap 'cleanup $?' EXIT
+
+setup_create            || abort "create VM"
+setup_wait_ssh          || abort "wait for SSH"
+setup_render_env        || abort "render Hola .env"
+setup_bootstrap         || abort "hola bootstrap"
+setup_verify_stack      || abort "verify core stack"
+setup_wait_authentik    || abort "Authentik not ready"
+setup_wait_deploy_ready || abort "server not deploy-ready"
+
+APPS=$(resolve_apps) || abort "resolve catalog apps"
+[[ -n "$APPS" ]] || abort "no apps to test after filters"
+read -r -a APP_ARR <<<"$APPS"
+log "── testing ${#APP_ARR[@]} app(s): ${APPS}"
+echo "# catalog sweep: ${#APP_ARR[@]} app(s) on VM $VMID (mode=authentik, restart=${AT_TEST_RESTART})"
+
+# Export globals the per-app library reads.
+export ROOT_DIR BIN_DIR VMID DASHBOARD_URL API_KEY DOMAIN_BASE HTTP_TIMEOUT AT_TEST_RESTART AT_TEST_STOP
+
+for app in "${APP_ARR[@]}"; do
+  app_log="$LOG_DIR/$app"; mkdir -p "$app_log"
+  start=$(date +%s)
+  if is_dry; then
+    log "DRY_RUN: at_run_app $app"; emit PASS "$app" "-" 0; continue
+  fi
+  # Verbose per-step trace for THIS app → its own run.log (keeps stdout terse).
+  # errexit-safe call (|| rc=$?) so one app's failure never aborts the sweep.
+  rc=0
+  at_run_app "$app" "$app_log" 2>"$app_log/run.log" || rc=$?
+  secs=$(( $(date +%s) - start ))
+  case "$rc" in
+    0) emit PASS "$app" "-" "$secs" ;;
+    2) emit SKIP "$app" "${AT_SKIP_REASON:-needs config}" "$secs" ;;
+    *) emit FAIL "$app" "${AT_LAST_STAGE:-?}" "$secs" ;;
+  esac
+done
+
+audit "vm-catalog-test done apps=${#APP_ARR[@]} failed=$FAILED"
+exit "$FAILED"

--- a/bin/vm-catalog-test
+++ b/bin/vm-catalog-test
@@ -28,7 +28,9 @@
 # further: restart + stop + uninstall, covering all three lifecycle fixes
 # (#267 restart, stop, #271 uninstall) per app.
 # --apps limits the sweep to a comma list; --skip excludes one; --memory MB sizes
-# the VM (heavy apps like immich/postiz want headroom).
+# the VM (heavy apps like immich/postiz want headroom). Between apps the sweep
+# prunes unused images/volumes so a long run doesn't fill the disk (which would trip
+# the preflight disk check and degrade later apps) — pass --no-prune to disable.
 #
 # Exit code = number of apps that failed (0 = all green). --keep-on-fail snapshots
 # and keeps the VM if any app failed (default: always destroy so reruns stay cheap).
@@ -38,7 +40,7 @@ source "$(dirname "$0")/lib/app-test.sh"
 load_env
 
 # --- args -------------------------------------------------------------------
-KEEP_ON_FAIL=0; ONLY_APPS=""; SKIP_APPS=""; REF="${HOLA_E2E_REF:-}"; VM_MEMORY=""
+KEEP_ON_FAIL=0; ONLY_APPS=""; SKIP_APPS=""; REF="${HOLA_E2E_REF:-}"; VM_MEMORY=""; PRUNE=1
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --dry-run) DRY_RUN=1; export DRY_RUN; shift ;;
@@ -48,6 +50,7 @@ while [[ $# -gt 0 ]]; do
     --skip) SKIP_APPS=$2; shift 2 ;;
     --restart) AT_TEST_RESTART=1; shift ;;
     --lifecycle) AT_TEST_RESTART=1; AT_TEST_STOP=1; shift ;;
+    --no-prune) PRUNE=0; shift ;;
     --memory) VM_MEMORY=$2; shift 2 ;;
     --ref) REF=$2; shift 2 ;;
     -h|--help) grep -E '^# ' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
@@ -61,7 +64,7 @@ is_dry() { [[ "${DRY_RUN:-0}" == "1" ]]; }
 # --- timeouts (seconds) -----------------------------------------------------
 BOOTSTRAP_TIMEOUT="${BOOTSTRAP_TIMEOUT:-1200}"   # authentik bootstrap is slower
 AUTHENTIK_TIMEOUT="${AUTHENTIK_TIMEOUT:-420}"
-HTTP_TIMEOUT="${HTTP_TIMEOUT:-180}"
+HTTP_TIMEOUT="${HTTP_TIMEOUT:-240}"              # slow first boots (n8n, immich) need headroom
 DEPLOY_READY_TIMEOUT="${DEPLOY_READY_TIMEOUT:-180}"
 
 # --- paths / per-run state --------------------------------------------------
@@ -312,6 +315,15 @@ for app in "${APP_ARR[@]}"; do
     2) emit SKIP "$app" "${AT_SKIP_REASON:-needs config}" "$secs" ;;
     *) emit FAIL "$app" "${AT_LAST_STAGE:-?}" "$secs" ;;
   esac
+  # Reclaim disk between apps: the just-uninstalled app's images are now unused, and
+  # without this a long sweep fills the VM disk — which trips the preflight disk
+  # check to `warn` and silently degrades every later app. Images still referenced by
+  # running containers (core stack, Authentik, a kept-on-fail app) are preserved.
+  if [[ "$PRUNE" == 1 ]]; then
+    "$BIN_DIR/vm-ssh" --vmid "$VMID" -- 'docker image prune -af >/dev/null 2>&1; docker volume prune -f >/dev/null 2>&1' 2>/dev/null || true
+    df_free=$("$BIN_DIR/vm-ssh" --vmid "$VMID" -- "df -BG --output=avail / | tail -1 | tr -d ' G'" 2>/dev/null || echo '?')
+    log "  pruned unused images/volumes — ${df_free}G free on / "
+  fi
 done
 
 audit "vm-catalog-test done apps=${#APP_ARR[@]} failed=$FAILED"

--- a/bin/vm-catalog-test
+++ b/bin/vm-catalog-test
@@ -4,6 +4,7 @@
 #
 # Usage: bin/vm-catalog-test [--dry-run] [--keep-on-fail] [--vmid VMID]
 #                            [--apps a,b,c] [--skip x,y] [--restart] [--lifecycle]
+#                            [--server-image released|local] [--no-prune]
 #                            [--memory MB] [--ref cli-vX.Y.Z] [-h]
 #
 # Brings up ONE Authentik-mode VM (so apps of every auth mode — none, forward-auth,
@@ -37,8 +38,9 @@
 # exercises the LAST RELEASE, not `main`. Server fixes merged-but-unreleased won't
 # be present — e.g. an uninstall that leaves containers is the already-fixed #271,
 # and a forward-auth `--restart` failure is the already-fixed #267, both pending a
-# release. To test current `main`, build a server image and load it onto the VM
-# (the "Advanced — local server/web image" path in the vm-e2e skill), then re-run.
+# release. To test current `main` (and any uncommitted server changes) instead,
+# pass `--server-image local`: the sweep builds the server image from the working
+# tree, loads it onto the VM, and runs the catalog against it.
 #
 # Some catalog apps legitimately can't install unattended: a missing required
 # secret that is a real external token (e.g. gitea's runner registration token —
@@ -56,7 +58,7 @@ load_env
 # only apply when a knob is otherwise unset).
 
 # --- args -------------------------------------------------------------------
-KEEP_ON_FAIL=0; ONLY_APPS=""; SKIP_APPS=""; REF="${HOLA_E2E_REF:-}"; VM_MEMORY=""; PRUNE=1
+KEEP_ON_FAIL=0; ONLY_APPS=""; SKIP_APPS=""; REF="${HOLA_E2E_REF:-}"; VM_MEMORY=""; PRUNE=1; SERVER_IMAGE="released"
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --dry-run) DRY_RUN=1; export DRY_RUN; shift ;;
@@ -66,6 +68,7 @@ while [[ $# -gt 0 ]]; do
     --skip) SKIP_APPS=$2; shift 2 ;;
     --restart) AT_TEST_RESTART=1; shift ;;
     --lifecycle) AT_TEST_RESTART=1; AT_TEST_STOP=1; shift ;;
+    --server-image) SERVER_IMAGE=$2; shift 2 ;;   # released (default) | local
     --no-prune) PRUNE=0; shift ;;
     --memory) VM_MEMORY=$2; shift 2 ;;
     --ref) REF=$2; shift 2 ;;
@@ -254,6 +257,34 @@ setup_verify_stack() {
   [[ "$ok" == 1 ]]
 }
 
+# --server-image local: replace the bootstrapped RELEASED server image with one
+# built from the current working tree, so the sweep tests `main` (+ uncommitted
+# server changes) instead of the last release. Build → save → load onto the VM
+# (overwriting the pulled tag) → force-recreate just the server → wait healthy.
+# This turns already-fixed-but-unreleased failures (e.g. #271 uninstall) green.
+setup_local_server_image() {
+  [[ "$SERVER_IMAGE" == "local" ]] || return 0
+  log "── building + loading a LOCAL server image (testing main, not the release)"
+  if is_dry; then log "DRY_RUN: docker build server → save → vm load → recreate server"; return 0; fi
+  # The compose ref is ghcr.io/try-hola/server:$HOLA_VERSION; match it so the
+  # loaded image is the one compose already references (no .env/version juggling).
+  local ver; ver=$("$BIN_DIR/vm-ssh" --vmid "$VMID" -- 'cd /opt/hola && (cat VERSION 2>/dev/null || grep -E "^HOLA_VERSION=" .env | cut -d= -f2-)' 2>/dev/null | tr -d ' \t\r\n')
+  [[ -n "$ver" ]] || { err "  could not read HOLA_VERSION on the VM"; return 1; }
+  local tag="ghcr.io/try-hola/server:$ver"
+  log "  building $tag from $ROOT_DIR (a few minutes)…"
+  docker build -f "$ROOT_DIR/packages/server/Dockerfile" -t "$tag" "$ROOT_DIR" > "$LOG_DIR/server-build.log" 2>&1 \
+    || { err "  server image build failed (see $LOG_DIR/server-build.log)"; return 1; }
+  log "  transferring image to the VM (docker save | docker load)…"
+  docker save "$tag" | "$BIN_DIR/vm-ssh" --vmid "$VMID" -- 'docker load' > "$LOG_DIR/server-load.log" 2>&1 \
+    || { err "  docker save|load failed (see $LOG_DIR/server-load.log)"; return 1; }
+  log "  recreating the server container with the local image…"
+  "$BIN_DIR/vm-ssh" --vmid "$VMID" -- 'cd /opt/hola && docker compose up -d --no-deps --force-recreate server' > "$LOG_DIR/server-recreate.log" 2>&1 \
+    || { err "  server recreate failed (see $LOG_DIR/server-recreate.log)"; return 1; }
+  # Dashboard front door should answer again once the new server is healthy.
+  wait_http "$DASHBOARD_URL" '^(200|30[0-9])$' "$HTTP_TIMEOUT" || { err "  server not healthy after swap"; return 1; }
+  log "  local server image is live (built from the working tree)"
+}
+
 # Authentik must be migrated + serving before forward-auth/native-oidc apps can
 # provision. Wait for its login UI to answer.
 setup_wait_authentik() {
@@ -308,6 +339,7 @@ setup_wait_ssh          || abort "wait for SSH"
 setup_render_env        || abort "render Hola .env"
 setup_bootstrap         || abort "hola bootstrap"
 setup_verify_stack      || abort "verify core stack"
+setup_local_server_image || abort "load local server image"
 setup_wait_authentik    || abort "Authentik not ready"
 setup_wait_deploy_ready || abort "server not deploy-ready"
 

--- a/docs/MCP_VM_TESTING.md
+++ b/docs/MCP_VM_TESTING.md
@@ -220,12 +220,24 @@ containers that exit `0` are tolerated.
 Exit code = number of apps that failed. `--keep-on-fail` snapshots and keeps the
 VM if any app failed (default: always destroy so reruns stay cheap).
 
-> Note on `--restart`/`--lifecycle`: `hola bootstrap` installs the **published**
-> server image, and the forward-auth restart fix (#267) ships in a later release —
-> so restarting a `forward-auth` app on a released image will (correctly) FAIL
-> until that release is out. The default sweep (install + verify + uninstall) works
-> for every app on the released image; reach for the lifecycle flags against a
-> server image that already carries the fix (see *Advanced* in the vm-e2e skill).
+> **Caveat — the sweep tests the RELEASED server image.** `hola bootstrap` installs
+> the published `ghcr.io/try-hola/server` pinned to the CLI version, so the sweep
+> exercises the **last release**, not `main`. Server fixes that are merged but
+> unreleased won't be present — notably an **uninstall that leaves containers** is
+> the already-fixed #271, and a **forward-auth `--restart` failure** is the
+> already-fixed #267, both pending a release. To validate current `main`, build a
+> server image and load it onto the VM (the *Advanced — local server/web image*
+> path in the vm-e2e skill), then re-run.
+>
+> Some catalog apps also can't install fully unattended and will FAIL with the
+> deploy error in their per-app log — read it to separate a real regression from an
+> app-config gap. Two patterns seen in practice: a required secret that must be a
+> **real external token** (e.g. gitea's runner registration token — a generated
+> value is rejected), and a manifest that leaves a needed value **blank** (e.g. a
+> Postgres password not wired, an upstream `try-hola/apps` issue → the app's init
+> container exits non-zero). The harness auto-fills required *secret* env vars with
+> generated tokens and SKIPs apps that need non-secret manual config, but it can't
+> invent a valid external token.
 
 ---
 

--- a/docs/MCP_VM_TESTING.md
+++ b/docs/MCP_VM_TESTING.md
@@ -172,6 +172,61 @@ exact signature and prints the root cause. Robustness: before installing it wait
 until the server can spawn `docker compose` (and retries the first deploy with
 backoff) to defeat the docker-spawn `ENOENT` race.
 
+### Catalog sweep — install EVERY app and verify it comes up
+
+`bin/vm-catalog-test` is the catalog-wide generalization of the single-app suite.
+It brings up **one** `HOLA_AUTH_MODE=authentik` VM (so apps of *every* auth mode —
+`none`, `forward-auth`, `native-oidc` — can provision), then walks the catalog
+running the **deterministic per-app test** (`bin/lib/app-test.sh`) against each
+app, one at a time:
+
+```
+(setup once) create VM → wait-ssh → render authentik .env → bootstrap →
+              verify core stack → wait for Authentik → wait deploy-ready
+(per app)     install → verify it converges to `running` with its containers up
+              and its front door answering → uninstall → next
+```
+
+Only one app is live at a time, so peak RAM stays bounded (core + Authentik + the
+single heaviest app). `bin/lib/app-test.sh` is the **single source of truth** for
+the per-app checks — the sweep is just that test in a loop over `hola catalog`.
+
+The output is built for monitoring a long run, then drilling into failures:
+
+- **STDOUT** = one terse line per app: `PASS uptime-kuma (1m12s)` /
+  `FAIL gitea (verify, 3m04s)  logs: logs/vm-catalog-test/gitea/`, then a summary.
+- **STDERR** = the live verbose setup trace (create/bootstrap/verify).
+- **Files** = `logs/vm-catalog-test/<app>/` holds the install JSON, server logs,
+  container states, and deploy logs — open these when a line says `FAIL`.
+
+```bash
+bin/vm-catalog-test --dry-run               # rehearse the whole sweep, no infra
+bin/vm-catalog-test                         # install + verify EVERY catalog app
+bin/vm-catalog-test 2>logs/vm-catalog-test/setup.log   # pure terse stdout view
+bin/vm-catalog-test --apps gitea,immich     # just these
+bin/vm-catalog-test --skip webtop           # everything except one
+bin/vm-catalog-test --memory 8192           # size the VM for heavy apps
+bin/vm-catalog-test --restart               # also restart each app (exercises #267)
+bin/vm-catalog-test --lifecycle             # restart + stop + uninstall each app
+```
+
+The auth mode is read off the *front door*, not hard-coded per app: the verify
+step accepts any healthy response — `200` (a `none`/`native-oidc` app serving
+directly) **or** a `30x`/`401` redirect to Authentik (a `forward-auth` app gated at
+the Traefik edge). The hard "came up correctly" gate is the deployment converging
+to `running` with its containers healthy on the host; one-shot init/migration
+containers that exit `0` are tolerated.
+
+Exit code = number of apps that failed. `--keep-on-fail` snapshots and keeps the
+VM if any app failed (default: always destroy so reruns stay cheap).
+
+> Note on `--restart`/`--lifecycle`: `hola bootstrap` installs the **published**
+> server image, and the forward-auth restart fix (#267) ships in a later release —
+> so restarting a `forward-auth` app on a released image will (correctly) FAIL
+> until that release is out. The default sweep (install + verify + uninstall) works
+> for every app on the released image; reach for the lifecycle flags against a
+> server image that already carries the fix (see *Advanced* in the vm-e2e skill).
+
 ---
 
 ## Helper command reference
@@ -189,6 +244,7 @@ backoff) to defeat the docker-spawn `ENOENT` race.
 | `bin/vm-reap`     | Find + destroy LEAKED `hola-test*` clones (confirms once) | **yes**     |
 | `bin/vm-test`     | Full create→test→teardown lifecycle (`--dry-run`, `--ssh`) | yes (teardown) |
 | `bin/vm-e2e-suite`| Deterministic product e2e: bootstrap→install→lifecycle→uninstall, asserted | yes (teardown) |
+| `bin/vm-catalog-test`| Install EVERY catalog app on one Authentik VM, verify each comes up (terse stdout, per-app logs) | yes (teardown) |
 
 ¹ `bin/proxmox-build-template` runs on the **Proxmox host** (not the container);
 `--force` replaces an existing template VMID, `--destroy --id N` removes one.


### PR DESCRIPTION
## What

`bin/vm-catalog-test` brings up one `HOLA_AUTH_MODE=authentik` disposable VM and walks the whole catalog, running a **deterministic per-app test** (`bin/lib/app-test.sh`) against each app in turn: **install → verify it converges to `running` with its containers healthy and its front door answering → uninstall → next**. Only one app is live at a time, so peak RAM stays bounded.

`bin/lib/app-test.sh` is the single source of truth for the per-app checks (install / verify / restart / stop / uninstall), auth-mode-agnostic: the front-door check accepts a `200` (none/native-oidc serve directly) or a `30x`/`401` redirect to Authentik (forward-auth gated at the edge). `bin/lib/app-test.selftest.sh` validates the whole control flow fully stubbed (no VM/Docker/network) and runs in milliseconds.

### Output contract
- **STDOUT** = terse one line per app: `PASS uptime-kuma (1m12s)` / `FAIL gitea (install, 6m26s)  logs: …` / `SKIP …` + a summary.
- **STDERR** = the live verbose setup trace.
- **FILES** = `logs/vm-catalog-test/<app>/` hold the install JSON, server logs, container states — drill in on FAIL.

Flags: `--apps`/`--skip` scope, `--memory` sizes the VM, `--restart`/`--lifecycle` exercise the lifecycle, `--no-prune` disables the inter-app image/volume prune, `--dry-run` rehearses with no infra.

## Validated on real hardware (lab Proxmox)

Two full 13-app runs. The sweep found real issues; after fixing the dominant one (preflight-warning abort, companion PR #272) the pass rate went **2/13 → 7/13**:

| | run 1 (no fixes) | run 2 (with #272 + harness hardening) |
|---|---|---|
| passing | 2 | **7** (actual-budget, backrest, homepage, paperless-ngx, postiz, uptime-kuma, webtop) |

The remaining failures are all characterized (and none are sweep bugs):
- **vaultwarden / n8n uninstall** — the already-fixed **#271** (released server image lags `main`).
- **guacamole / immich / mealie** — upstream `try-hola/apps` manifests leave a Postgres password blank → the init container exits non-zero.
- **gitea** — its `gitea-runner` needs a *real* registration token; a generated secret is rejected.
- **n8n verify** — genuinely slow first boot (502 past the timeout).

## Hardening this PR includes (each surfaced by a run)
- Prune unused images/volumes between apps (disk exhaustion was silently degrading the back half via the preflight disk warning).
- Auto-fill required **secret** env vars with generated tokens and retry; SKIP apps needing non-secret manual config.
- Library functions are errexit-safe and never leak `set -e` (a leak aborted the whole sweep on the first failing app — caught by the self-test).
- Poll for asynchronous compose-down on uninstall; monotonic install-log index; correct timeout precedence.

> Companion: **#272** (CLI preflight-warning fix) is what lifts most apps from FAIL→PASS; this branch is based on `main` and doesn't include it. Caveat documented in `docs/MCP_VM_TESTING.md`: the sweep tests the *released* server image, so #267/#271-class failures are expected until those ship — test `main` via a locally-built server image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)