### PR TITLE
fix(server): materialize app + provisioned env into a runtime .env for ${VAR} interpolation

### DIFF
--- a/packages/server/src/__tests__/deployments/auth-provisioning.test.ts
+++ b/packages/server/src/__tests__/deployments/auth-provisioning.test.ts
@@ -225,6 +225,35 @@ describe('Auth provisioning lifecycle', () => {
     expect(meta.metadata.auth.ref.providerPk).toBe(42);
   });
 
+  test('materializes appEnv + provisioned env into a runtime .env so Compose ${VAR} interpolation resolves', async () => {
+    const sys = makeSystem({ auth: OIDC_AUTH });
+
+    // A draft whose compose DERIVES values via `${VAR}` interpolation: an internal
+    // DB password from the app's own env, and an OIDC discovery URL from the
+    // provisioned issuer (the exact pattern mealie uses). Without a runtime .env
+    // these resolve to blank.
+    const { draftId } = await sys.drafts.createDraft({ appId: 'gitea', version: '1.0.0' });
+    await sys.drafts.updateDraft(draftId, {
+      composeOverride:
+        'services:\n  gitea:\n    image: gitea/gitea:1.21.0\n' +
+        '    environment:\n' +
+        '      DB_PASSWORD: "${POSTGRES_PASSWORD}"\n' +
+        '      OIDC_CONFIG_URL: "${GITEA_OIDC_ISSUER}.well-known/openid-configuration"\n',
+      appEnv: [{ key: 'POSTGRES_PASSWORD', value: 's3cr3t #1', isSecret: true }],
+    });
+    await sys.drafts.finalizeDraft(draftId);
+
+    const created = await sys.deployments.createFromDraft({ draftId, name: 'gitea' });
+    const job = await waitForJob(sys.jobs, created.jobId!);
+    expect(job.status).toBe('completed');
+
+    // The runtime .env carries BOTH the app env and the provisioned auth env, quoted
+    // so a value with a space/`#` survives.
+    const dotenv = await sys.storage.readFileAsString(`deployments/${created.deploymentId}/runtime/.env`);
+    expect(dotenv).toContain('POSTGRES_PASSWORD="s3cr3t #1"');
+    expect(dotenv).toContain('GITEA_OIDC_ISSUER="https://auth.example.com/application/o/gitea-x/"');
+  });
+
   test('native-oidc credentialsFile: writes the provisioned OIDC creds JSON into the data root before start (for a bundle sidecar to render)', async () => {
     const prev = process.env.HOLA_APPS_BIND_ROOT;
     process.env.HOLA_APPS_BIND_ROOT = join(dataRoot, 'apps');

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -213,6 +213,17 @@ function applyActionStatus(deployment: EnhancedDeploymentDetail, action: Deploym
   deployment.lastUpdated = new Date().toISOString();
 }
 
+/**
+ * Render a value for a Compose `.env` line (`KEY=VALUE`). Double-quote and escape
+ * so spaces, `#`, and `$` are preserved literally rather than treated as a comment
+ * or interpolation; collapse newlines (these are single-line values — passwords,
+ * URLs, ids, client secrets). Compose strips the surrounding quotes when loading.
+ */
+function dotenvValue(v: string): string {
+  const s = v.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\$/g, '\\$').replace(/\r?\n/g, ' ');
+  return `"${s}"`;
+}
+
 /** Map a deployment action to the job type that performs it. */
 function mapActionToJobType(action: DeploymentAction): Job['type'] {
   switch (action) {
@@ -970,6 +981,22 @@ export class RealDeploymentService extends InMemoryDeploymentService {
       content,
       hasSecret ? 0o600 : undefined
     );
+
+    // Materialize interpolation variables into a sibling `.env` so Compose can
+    // resolve `${VAR}` references the app's compose makes — both the app's own env
+    // (user/default values from the manifest's `defaultEnv`, e.g. an internal DB
+    // password) and the provisioned auth env (an app that DERIVES a value, e.g.
+    // mealie's `OIDC_CONFIGURATION_URL: "${OIDC_ISSUER_URL}.well-known/..."`).
+    // Without this those `${VAR}` resolve to blank. `docker compose` auto-loads
+    // `.env` from the project directory (the runtime dir we run it in). Auth env
+    // wins on a key clash; written 0600 since it can hold secrets.
+    const appEnv = await this.readActiveAppEnv(deployment);
+    const interp: Record<string, string> = { ...appEnv, ...injectedEnv };
+    const interpKeys = Object.keys(interp);
+    if (interpKeys.length > 0) {
+      const dotenv = interpKeys.map(k => `${k}=${dotenvValue(interp[k])}`).join('\n') + '\n';
+      await this.storageService.writeFile(`deployments/${deployment.id}/runtime/.env`, dotenv, 0o600);
+    }
     return this.runtimeDir(deployment.id);
   }
 
@@ -998,6 +1025,23 @@ export class RealDeploymentService extends InMemoryDeploymentService {
       return manifest.consumes ?? [];
     } catch {
       return [];
+    }
+  }
+
+  /** The active release's app env (manifest `defaultEnv` + any user overrides), as
+   *  a flat map — the source for the runtime `.env` Compose interpolates from. */
+  private async readActiveAppEnv(deployment: EnhancedDeploymentDetail): Promise<Record<string, string>> {
+    const releaseId = deployment.currentReleaseId;
+    if (!releaseId) return {};
+    const manifestPath = `deployments/${deployment.id}/releases/${releaseId}/manifest.json`;
+    if (!(await this.storageService.fileExists(manifestPath))) return {};
+    try {
+      const manifest = JSON.parse(await this.storageService.readFileAsString(manifestPath)) as FinalizedManifest;
+      const out: Record<string, string> = {};
+      for (const e of manifest.appEnv ?? []) out[e.key] = e.value ?? '';
+      return out;
+    } catch {
+      return {};
     }
   }
 


### PR DESCRIPTION
## Problem

An app's compose can reference values through `${VAR}` interpolation:
- its **own env** — user/default values from the manifest's `defaultEnv` (e.g. an internal DB password: `POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"`), and
- a value **derived from provisioned auth env** — e.g. mealie's `OIDC_CONFIGURATION_URL: "${OIDC_ISSUER_URL}.well-known/openid-configuration"`.

But `materializeCompose` only injected the provisioned auth env into the **ingress service's** `environment:` block, and never wrote anything Compose can *interpolate* from. So every such `${VAR}` resolved to **blank**.

Found by the catalog-wide e2e sweep:
- guacamole / mealie Postgres saw a blank password (`POSTGRES_PASSWORD not set, defaulting to blank`),
- mealie's OIDC discovery URL came out malformed and its provider init crashed (`Failed to initialize OpenID Connect Provider`).

This is the root cause behind several "app installs but a `${VAR}` is empty" failures — `defaultEnv` values a user sets in the wizard were silently dropped too.

## Fix

Write a sibling `runtime/.env` (0600) holding the app env **plus** the provisioned env (auth wins on a key clash). `docker compose` auto-loads `.env` from the project directory (the runtime dir we run it in), so `${VAR}` now resolves. Values are double-quoted and escaped for spaces / `#` / `$` / quotes — **verified against the real compose dotenv parser** (`docker compose config`).

`injectEnvironment` (auth env → ingress service environment) is unchanged; the `.env` is additive and enables interpolation/derivation on top.

## Test

`auth-provisioning.test.ts`: a deploy whose compose derives a DB password from `appEnv` and an OIDC config URL from the provisioned issuer now finds both in the runtime `.env` (quoted, surviving a space + `#`). Full server suite: 354 pass; tsc + eslint clean.

Companion: the apps PR try-hola/apps#39 makes guacamole/immich/mealie self-contained for the DB; this server fix additionally unblocks mealie's OIDC and makes wizard `defaultEnv` values actually reach apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)