### PR TITLE
fix(server): surface deploy-failure reason via deployment logs (event-log fallback)

### DIFF
--- a/packages/server/src/__tests__/deployments/auth-provisioning.test.ts
+++ b/packages/server/src/__tests__/deployments/auth-provisioning.test.ts
@@ -408,6 +408,25 @@ describe('Auth provisioning lifecycle', () => {
     expect(spy.provisions[1].existingRef?.providerPk).toBe(42);
   });
 
+  test('forward-auth re-deploy (restart) reuses the provider ref and completes', async () => {
+    const FA: AppAuthConfig = { mode: 'forward-auth', forwardAuth: {} };
+    const sys = makeSystem({ auth: FA });
+    const spy = sys.provisioner as SpyProvisioner;
+
+    const created = await sys.deployments.createFromDraft({ draftId: await finalizedDraft(sys.drafts), name: 'gitea' });
+    expect((await waitForJob(sys.jobs, created.jobId!)).status).toBe('completed');
+
+    const restart = await sys.deployments.executeAction(created.deploymentId, { action: 'restart' });
+    const restartJob = await waitForJob(sys.jobs, restart.jobId!);
+
+    // Reproduce the VM finding: does a forward-auth restart complete, reusing the ref?
+    expect(restartJob.status).toBe('completed');
+    expect((await sys.deployments.getDeployment(created.deploymentId)).status).toBe('running');
+    expect(spy.provisions).toHaveLength(2);
+    expect(spy.provisions[1].mode).toBe('forward-auth');
+    expect(spy.provisions[1].existingRef?.providerPk).toBe(7);
+  });
+
   test('deprovision runs on delete but not on stop', async () => {
     const sys = makeSystem({ auth: OIDC_AUTH });
     const spy = sys.provisioner as SpyProvisioner;
@@ -438,6 +457,14 @@ describe('Auth provisioning lifecycle', () => {
     expect((await sys.deployments.getDeployment(created.deploymentId)).status).toBe('error');
     // No compose was materialized (provisioning threw first).
     expect(await sys.storage.fileExists(`deployments/${created.deploymentId}/runtime/docker-compose.yml`)).toBe(false);
+
+    // The deployment logs endpoint must SURFACE the failure reason. A deploy that
+    // dies before any container starts has no container logs (composeLogs is empty),
+    // so the endpoint falls back to the lifecycle event log — otherwise the user
+    // sees an empty result and can't tell why the install failed.
+    const logs = await sys.deployments.getDeploymentLogs(created.deploymentId);
+    const text = logs.items.map(i => i.message).join('\n');
+    expect(text).toMatch(/action '\w+' failed: simulated provisioning failure/i);
   });
 
   test('forward-auth under HOLA_AUTH_MODE=none is rejected up front, creating no error-state deployment', async () => {

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -865,7 +865,19 @@ export class RealDeploymentService extends InMemoryDeploymentService {
       this.projectName(deploymentId),
       options
     );
-    return { items: entries };
+    if (entries.length > 0) return { items: entries };
+
+    // No container logs — the app's containers never started (a deploy that failed
+    // BEFORE `compose up`, e.g. an error in provisionAuth/materializeCompose, or a
+    // stopped/torn-down deployment). composeLogs returns an honest empty snapshot in
+    // that case, which used to hide *why* the deploy failed. Fall back to the
+    // deployment's lifecycle event log (the "Starting action…/Pulling…/action 'X'
+    // failed: <error>" trail logged via logDeployment), so the failure reason is
+    // visible at the endpoint users actually check (`hola logs <id>`).
+    const events = this.loggingService
+      .recentLogs({ kind: 'deployment', id: deploymentId }, options?.tail)
+      .map((e) => ({ timestamp: e.timestamp, service: e.service, level: e.level, message: e.message }));
+    return { items: events };
   }
 
   /** Live stream of the deployment's compose-project container stdout. */


### PR DESCRIPTION
## Problem (follow-up #2 from the catalog sweep)

A deploy that fails **before any container starts** — an error in `provisionAuth` or `materializeCompose` — has no container logs. `getDeploymentLogs` returned only `composeLogs`, which gives an honest-but-**empty** snapshot in that case. So `hola logs <deploymentId>` and the dashboard showed **nothing** about why the install/restart failed.

The failure reason *was* logged (via `logDeployment` to the event ring buffer, and the job log) — but `getDeploymentLogs` never read it back. This is exactly what made the **forward-auth restart** failure so hard to diagnose: the job died at progress 10 with `error: null` and an empty `/logs`.

## Fix

When there are no container logs, fall back to the deployment's **lifecycle event log** (the "Starting action… / Pulling… / action 'X' failed: `<error>`" trail) so the reason is visible at the endpoint users actually check.

## On the forward-auth restart (follow-up #1)

Investigated all three plausible layers — they're each **sound in isolation**:
- **Orchestration**: a new test drives a forward-auth install → restart through the deployment service; it reuses the provider ref (`existingRef.providerPk`) and completes. ✅
- **Provisioner reuse**: the #267 real-Authentik integration test already proves the forward-auth reuse PATCH works. ✅
- **Rehydration**: `metadata.auth.ref` is restored from `metadata.json` on load (full round-trip). ✅

So the VM restart failure isn't reproducible in any test layer, and its actual error was hidden — which is precisely the gap this PR closes. The next step to pinpoint it is a VM run **with this fix**, where `hola logs` will show the real error instead of an empty result.

## Tests

A provisioning-failure deploy now surfaces its reason through `getDeploymentLogs`; forward-auth restart orchestration test added. Full server suite (354) passes; tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)