### PR TITLE
fix(server): forward-auth restart no longer 403s on the group-binding lookup (completes #267)

### DIFF
--- a/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
+++ b/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
@@ -517,6 +517,34 @@ describe('RealAuthentikProvisionerService (REST contract)', () => {
     expect(result.ref).toMatchObject({ mode: 'forward-auth', providerPk: 55 });
   });
 
+  test('forward-auth reuse with NO declared groups skips the policy-bindings lookup (scoped token can 403 it)', async () => {
+    // The reuse/restart path calls reconcileForwardAuthGroups WITHOUT an
+    // applicationPk. `GET /api/v3/policies/bindings/` is forbidden for the
+    // least-privilege scoped provisioner token (403). With no groups declared there
+    // is nothing to reconcile, so the lookup must be skipped — otherwise a no-groups
+    // forward-auth RESTART fails in provisionAuth (the real bug surfaced on a VM).
+    installFetch((call) => {
+      if (call.method === 'PATCH' && call.path === '/api/v3/providers/proxy/55/') return json({ pk: 55 });
+      // Stand in for the scoped token: any binding read/list is forbidden.
+      if (call.path.startsWith('/api/v3/policies/bindings/')) return json({ detail: 'permission denied' }, 403);
+      return undefined;
+    });
+    const svc = new RealAuthentikProvisionerService(CONFIG);
+
+    // No forwardAuth.allowedGroups → nothing to reconcile.
+    const result = await svc.provision({
+      deploymentId: 'dep-abcdef0123456789',
+      appName: 'grafana',
+      mode: 'forward-auth',
+      host: 'grafana-2.example.com',
+      existingRef: { mode: 'forward-auth', providerPk: 55, applicationSlug: 'grafana-dep-abcd', outpostPk: 1 },
+    });
+
+    // The bindings lookup must never be attempted (it would 403 and fail the deploy).
+    expect(calls.some(c => c.path.startsWith('/api/v3/policies/bindings/'))).toBe(false);
+    expect(result.ref).toMatchObject({ mode: 'forward-auth', providerPk: 55 });
+  });
+
   test('forward-auth provision binds the declared groups to the application (access restriction)', async () => {
     const bindings: Array<{ target: unknown; group: unknown }> = [];
     installFetch((call) => {

--- a/packages/server/src/services/core/provisioner.ts
+++ b/packages/server/src/services/core/provisioner.ts
@@ -591,11 +591,18 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
     applicationPk?: string,
   ): Promise<void> {
     const names = groupNames.map((g) => g.trim()).filter(Boolean);
-    // Fresh provision with no restriction declared: the app was just created, so
-    // there are no prior bindings to reconcile — leave it open to any
-    // authenticated user (the documented default). Avoids an extra round-trip on
-    // the common path.
-    if (names.length === 0 && applicationPk) return;
+    // No group restriction declared → nothing to reconcile; leave the app open to
+    // any authenticated user (the documented default). Return BEFORE querying
+    // existing bindings. This matters on the reuse path (restart/redeploy), which
+    // calls us WITHOUT an applicationPk: the binding lookup is
+    // `GET /api/v3/policies/bindings/`, which the least-privilege scoped provisioner
+    // token cannot read (403) — so the old `&& applicationPk` guard let a no-groups
+    // RESTART of a forward-auth app fail in provisionAuth (install worked because the
+    // create path passes applicationPk and returned here). Skipping the lookup when
+    // there are no desired groups also can't drop a real restriction: a forward-auth
+    // app that previously had groups and now declares none would simply stay on its
+    // (more-restrictive) bindings — fail-safe, not access-widening.
+    if (names.length === 0) return;
 
     const appPk =
       applicationPk ??


### PR DESCRIPTION
## Problem

A forward-auth **restart**/redeploy reproducibly failed in `provisionAuth` with:

```
Deployment action 'restart' failed: Authentik GET /api/v3/policies/bindings/?target=… failed: 403
```

…while **install** of the same app worked. This is the residual forward-auth restart failure left after #267.

## Root cause

The reuse path calls `reconcileForwardAuthGroups(slug, groups)` **without** an `applicationPk`. The early-return guard was:

```ts
if (names.length === 0 && applicationPk) return;
```

So on **reuse** (no `applicationPk`) with **no declared groups**, it skipped the early return and issued `GET /api/v3/policies/bindings/` — which the server's **least-privilege scoped provisioner token cannot read (403)**, failing the whole restart at progress 10. Install's *create* path passes `applicationPk` and returned early, so it never hit the query. (The #267 integration/contract tests passed because they use the full **admin** token, which *can* read bindings.)

## Fix

Early-return whenever **no groups are declared**, regardless of `applicationPk` — there's nothing to reconcile, so the forbidden lookup is never made. This can't drop a real restriction: an app that previously had groups and now declares none simply stays on its (more-restrictive) bindings — fail-safe.

## How it was found & validated

Surfaced the previously-**hidden** restart error via the new deployment-log fallback (#276 — job-level `action 'restart' failed: …403`), then validated **end-to-end on a real-Authentik VM**: install → restart → deployment `running` (was `error`).

Adds a contract regression: a no-groups forward-auth reuse must not touch `/api/v3/policies/bindings/` (red without the fix, green with). 31 contract tests pass; tsc + eslint clean.

> Note: forward-auth apps that *do* declare `allowedGroups` still need the scoped token to read/write policy bindings — a separate token-scoping gap, not exercised here.

Depends conceptually on #276 (which made this diagnosable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)