### PR TITLE
chore(release): 0.6.27

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/cli": {
       "name": "@hola/cli",
-      "version": "0.6.26",
+      "version": "0.6.27",
       "bin": {
         "hola": "./bin/hola",
       },
@@ -37,11 +37,11 @@
     },
     "packages/compose": {
       "name": "@hola/compose",
-      "version": "0.6.26",
+      "version": "0.6.27",
     },
     "packages/sdk": {
       "name": "@hola/sdk",
-      "version": "0.6.26",
+      "version": "0.6.27",
       "dependencies": {
         "@hola/shared": "workspace:*",
       },
@@ -55,7 +55,7 @@
     },
     "packages/server": {
       "name": "@hola/server",
-      "version": "0.6.26",
+      "version": "0.6.27",
       "dependencies": {
         "@hola/shared": "workspace:*",
         "jose": "^5.9.6",
@@ -71,7 +71,7 @@
     },
     "packages/shared": {
       "name": "@hola/shared",
-      "version": "0.6.26",
+      "version": "0.6.27",
       "dependencies": {
         "yaml": "^2.9.0",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.6.26",
+  "version": "0.6.27",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.6.26';
+export const CLI_VERSION = '0.6.27';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.6.26",
+  "version": "0.6.27",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.6.26",
+  "version": "0.6.27",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.6.26",
+  "version": "0.6.27",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.6.26",
+  "version": "0.6.27",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Version bump 0.6.26 → 0.6.27 across the published packages (cli, server, sdk, shared, compose) + `cli/src/version.ts` + lockfile. `web` stays `0.0.0` (unversioned). Lockfile verified with `bun install --frozen-lockfile` (no changes).

Merge this, then tag `cli-v0.6.27` (`git tag cli-v0.6.27 && git push origin cli-v0.6.27`) to trigger `cli-release.yml`, which builds + publishes the version-pinned **server** + **web** images, the **CLI** binaries, and the **compose bundle**.

## What ships in 0.6.27 (everything merged since 0.6.26)

**Server**
- #267 — forward-auth restart no longer leaves the deployment in `error` (reuse PATCH resends `mode`)
- #277 — forward-auth restart no longer 403s on the group-binding lookup (completes #267)
- #270 — reject forward-auth apps up front under `HOLA_AUTH_MODE=none`
- #271 — uninstall removes the runtime dir after compose-down (no error tombstone)
- #274 — materialize app + provisioned env into a runtime `.env` so `${VAR}` interpolation works (fixes e.g. mealie's OIDC discovery URL)
- #275 — treat manifest `defaultEnv` as optional (don't drop the bundle compose → undeployable app)
- #276 — surface the deploy-failure reason via the deployment logs endpoint (event-log fallback)

**CLI**
- #272 — `install` no longer aborts on preflight **warnings** (only hard failures); `--strict` keeps the old behavior

**Testing / infra (no runtime impact)**
- #266, #269, #273→#278 — disposable-VM Proxmox e2e framework + catalog-wide sweep (`bin/vm-catalog-test`), and #268 `vm-create --memory`

> Catalog app fixes (try-hola/apps #39/#40/#41 — guacamole/immich/mealie deployability) publish independently as OCI bundles and are already live; they don't depend on this release, though #274 is needed for mealie's SSO to fully wire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)