### PR TITLE
fix(server): keep SSE log streams alive past Bun's 10s idle timeout

### DIFF
--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1701,6 +1701,15 @@ if (shouldAutoStart) {
     port: PORT,
     fetch: handleRequest,
     development: true,
+    // Bun's default idleTimeout is 10s — it closes any connection that sends no
+    // bytes for that long. Our SSE log streams keep themselves alive with a
+    // heartbeat every 15s (createSSEStream), so with the default Bun would close
+    // each stream at ~10s, BEFORE the first heartbeat lands: the client then sees
+    // the body end ("Stream closed"), shows a connection error, reconnects, and
+    // the indicator flaps Live↔Error on a ~10s loop during a deploy. Set the idle
+    // timeout to Bun's max (255s); the 15s heartbeat resets it long before then, so
+    // a live stream survives indefinitely while a genuinely stuck socket still times out.
+    idleTimeout: 255,
   });
 
   console.log(`✅ Hola Server listening on port ${server.port}`);


### PR DESCRIPTION
## Symptom

During a deploy, the log panel's connection indicator **flapped between "connection error" and "Live"** on a ~10s loop — bouncing continuously while watching.

## Root cause

`Bun.serve` defaults `idleTimeout` to **10 seconds**: it closes any connection that sends no bytes for that long. Our deploy log SSE streams keep themselves alive with a **heartbeat every 15s** (`createSSEStream`'s default). With the default idle timeout, Bun closed each stream at ~10s — *before the first heartbeat ever landed*:

- t=0: connect → immediate heartbeat (resets Bun's idle timer)
- t=0→10s: no bytes sent (next heartbeat isn't until t=15s)
- **t=10s: Bun's idleTimeout closes the socket** → browser sees the body end (`done` → "Stream closed") → `connectionState: 'error'` ("connection error") → reconnect (~1s) → "Live" → repeat

nginx (`proxy_read_timeout 3600s`, no buffering) and the client heartbeat watchdog (45s) were both fine — Bun's 10s default was the limiter.

## Fix

Set `idleTimeout: 255` (Bun's max) on `Bun.serve`. The 15s heartbeat resets the timer long before then, so a live stream survives indefinitely, while a genuinely stuck socket still times out.

## Validation

- `bun run typecheck` / `eslint` / `bun run build` — clean.
- Logic is definitive: Bun default (10s) < heartbeat interval (15s) guaranteed a close before the first keep-alive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)