### PR TITLE
fix(server): keep native-oidc explicit IdP endpoint env names through manifest coercion

### DIFF
--- a/packages/server/src/__tests__/provisioner/manifest-auth.test.ts
+++ b/packages/server/src/__tests__/provisioner/manifest-auth.test.ts
@@ -47,6 +47,36 @@ describe('coerceManifestAuth', () => {
     });
   });
 
+  test('native-oidc env carries the explicit IdP endpoint names (authUrl/tokenUrl/userinfoUrl)', () => {
+    // Regression: these optional names were silently dropped here, so the provisioner
+    // never injected POSTIZ_OAUTH_AUTH_URL/TOKEN_URL/USERINFO_URL and apps that don't
+    // discover endpoints from the issuer (e.g. Postiz) got a half-wired OIDC env and
+    // 500'd on their login-link endpoint.
+    const result = coerceManifestAuth({
+      mode: 'native-oidc',
+      oidc: {
+        redirectPath: '/settings',
+        scopes: ['openid', 'profile', 'email'],
+        env: {
+          issuer: 'POSTIZ_OAUTH_URL',
+          clientId: 'POSTIZ_OAUTH_CLIENT_ID',
+          clientSecret: 'POSTIZ_OAUTH_CLIENT_SECRET',
+          authUrl: 'POSTIZ_OAUTH_AUTH_URL',
+          tokenUrl: 'POSTIZ_OAUTH_TOKEN_URL',
+          userinfoUrl: 'POSTIZ_OAUTH_USERINFO_URL',
+        },
+      },
+    });
+    expect(result?.oidc?.env).toEqual({
+      issuer: 'POSTIZ_OAUTH_URL',
+      clientId: 'POSTIZ_OAUTH_CLIENT_ID',
+      clientSecret: 'POSTIZ_OAUTH_CLIENT_SECRET',
+      authUrl: 'POSTIZ_OAUTH_AUTH_URL',
+      tokenUrl: 'POSTIZ_OAUTH_TOKEN_URL',
+      userinfoUrl: 'POSTIZ_OAUTH_USERINFO_URL',
+    });
+  });
+
   test('native-oidc env without redirectUri is valid (app derives its own redirect URI)', () => {
     const result = coerceManifestAuth({
       mode: 'native-oidc',

--- a/packages/server/src/services/core/manifest-auth.ts
+++ b/packages/server/src/services/core/manifest-auth.ts
@@ -38,14 +38,38 @@ function coerceEnvMap<K extends string>(v: unknown, keys: readonly K[]): Record<
  * Coerce the native-oidc env-var name map. issuer/clientId/clientSecret are
  * required; redirectUri is optional (apps that derive their own redirect URI
  * from their base URL — e.g. Actual Budget — have no env var for it).
+ *
+ * authUrl/tokenUrl/userinfoUrl are optional explicit-endpoint mappings for apps
+ * that DON'T discover the IdP endpoints from the issuer and instead want each
+ * authorize/token/userinfo URL injected as its own env var (e.g. Postiz's
+ * generic OAuth, which throws on boot if POSTIZ_OAUTH_AUTH_URL/TOKEN_URL/
+ * USERINFO_URL are unset). These MUST be carried through here — the provisioner
+ * only injects them when their names survive into the finalized manifest;
+ * dropping them silently left such apps with a half-wired OIDC env (issuer +
+ * client creds but no endpoints), so their login-link endpoint 500'd.
  */
 function coerceOidcEnv(
   v: unknown
-): { issuer: string; clientId: string; clientSecret: string; redirectUri?: string } | undefined {
+):
+  | {
+      issuer: string;
+      clientId: string;
+      clientSecret: string;
+      redirectUri?: string;
+      authUrl?: string;
+      tokenUrl?: string;
+      userinfoUrl?: string;
+    }
+  | undefined {
   const required = coerceEnvMap(v, ['issuer', 'clientId', 'clientSecret'] as const);
   if (!required) return undefined;
-  const redirectUri = asString(asRecord(v)?.redirectUri);
-  return { ...required, ...(redirectUri ? { redirectUri } : {}) };
+  const rec = asRecord(v);
+  const optional: Record<string, string> = {};
+  for (const k of ['redirectUri', 'authUrl', 'tokenUrl', 'userinfoUrl'] as const) {
+    const val = asString(rec?.[k]);
+    if (val) optional[k] = val;
+  }
+  return { ...required, ...optional };
 }
 
 /** Coerce a flat string→string record (e.g. oidc.staticEnv); undefined unless it


### PR DESCRIPTION
## Problem

For a `native-oidc` app whose manifest maps explicit IdP endpoints — `authUrl`/`tokenUrl`/`userinfoUrl` — onto its own env vars, those mappings were **silently dropped** when the manifest was finalized. `coerceOidcEnv` (`manifest-auth.ts`) only carried `issuer`/`clientId`/`clientSecret`/`redirectUri`.

The provisioner's `oidcEnv` injects `…_AUTH_URL`/`…_TOKEN_URL`/`…_USERINFO_URL` only when those names are present in the finalized manifest. So the app received a **half-wired OIDC env** (issuer + client creds, no endpoints).

Concretely for **Postiz** (generic OAuth, which requires `POSTIZ_OAUTH_AUTH_URL`/`TOKEN_URL`/`USERINFO_URL`): `getConfig()` threw `POSTIZ_OAUTH environment variables are not set`, the login-link endpoint returned **500**, and the **"Sign in with Authentik" button did nothing**. The published bundle manifest and the provisioner were both correct — the coercion in the middle was lossy.

## Fix

Carry `authUrl`/`tokenUrl`/`userinfoUrl` through `coerceOidcEnv` alongside the already-optional `redirectUri`. Added a regression test asserting all six names survive coercion.

## Validation

Reproduced + fixed on a disposable Authentik VM (8 GB):
- Before: stored release manifest `oidc.env` had only `issuer`/`clientId`/`clientSecret`; container missing the 3 URL vars; `/api/auth/oauth/GENERIC` → 500.
- After (URLs injected): `/api/auth/oauth/GENERIC` → 200 returning the Authentik authorize URL, and the full OIDC round-trip (button → Authentik login → `?code=…` → backend token exchange) completes.

`bun test` (manifest-auth: 17 pass), `typecheck`, `eslint` all clean.

> Paired with try-hola/apps#43, which fixes the *other* half of the Postiz failure (the backend not starting at all due to Temporal's Postgres-visibility Text search-attribute limit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)