### PR TITLE
chore(release): 0.6.28

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/cli": {
       "name": "@hola/cli",
-      "version": "0.6.27",
+      "version": "0.6.28",
       "bin": {
         "hola": "./bin/hola",
       },
@@ -37,11 +37,11 @@
     },
     "packages/compose": {
       "name": "@hola/compose",
-      "version": "0.6.27",
+      "version": "0.6.28",
     },
     "packages/sdk": {
       "name": "@hola/sdk",
-      "version": "0.6.27",
+      "version": "0.6.28",
       "dependencies": {
         "@hola/shared": "workspace:*",
       },
@@ -55,7 +55,7 @@
     },
     "packages/server": {
       "name": "@hola/server",
-      "version": "0.6.27",
+      "version": "0.6.28",
       "dependencies": {
         "@hola/shared": "workspace:*",
         "jose": "^5.9.6",
@@ -71,7 +71,7 @@
     },
     "packages/shared": {
       "name": "@hola/shared",
-      "version": "0.6.27",
+      "version": "0.6.28",
       "dependencies": {
         "yaml": "^2.9.0",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.6.27",
+  "version": "0.6.28",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.6.27';
+export const CLI_VERSION = '0.6.28';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.6.27",
+  "version": "0.6.28",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.6.27",
+  "version": "0.6.28",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.6.27",
+  "version": "0.6.28",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.6.27",
+  "version": "0.6.28",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Release **0.6.28**.

Bumps the published packages (cli, server, sdk, shared, compose) 0.6.27 → 0.6.28 (web stays `0.0.0`).

### Included since cli-v0.6.27
- **#281** `fix(server): keep native-oidc explicit IdP endpoint names through manifest coercion` — apps whose manifest maps `authUrl`/`tokenUrl`/`userinfoUrl` (e.g. Postiz's generic OAuth) had those names silently dropped, so the provisioner never injected the endpoint env and the app's login-link endpoint 500'd. This release ships the fix.

Tag `cli-v0.6.28` after merge to build + publish the server/web images, CLI binaries, and compose bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)