### PR TITLE
fix: deliver published app updates (cache by resolved version), remove-dialog 404, logs level-and-above

### DIFF
--- a/packages/server/src/__tests__/bundles/catalog-compose-override.test.ts
+++ b/packages/server/src/__tests__/bundles/catalog-compose-override.test.ts
@@ -97,4 +97,16 @@ describe('RealCatalogService composeOverride (#82)', () => {
     // route to / inject auth env into the right service.
     expect(detail.ingressService).toBe('fixtureapp');
   });
+
+  test('resolves "latest" to the concrete version before pulling (cache keyed by resolved version)', async () => {
+    // The bundle is staged only at mock-bundles/<app>/1.0.0/. Installing "latest"
+    // must resolve to 1.0.0 and pull THAT — the bundle cache must be keyed by the
+    // resolved concrete version, not the literal "latest". Otherwise a server that
+    // cached <app>/latest from an earlier install keeps serving that stale bundle
+    // forever and never picks up a newly published version. (Here, keying by
+    // "latest" would look in the unstaged mock-bundles/<app>/latest/ and fail.)
+    const svc = new RealCatalogService();
+    const detail = await svc.getVersionDetail(APP_ID, 'latest');
+    expect(detail.composeOverride).toBe(COMPOSE);
+  });
 });

--- a/packages/server/src/services/core/catalog.ts
+++ b/packages/server/src/services/core/catalog.ts
@@ -158,8 +158,14 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
     const { getServices } = await import('../simple-factory');
     const bundles = getServices().bundles;
 
-    // Pull and validate bundle
-    const info = await bundles.ensurePulled({ appId, version, ociRef: ref });
+    // Pull and validate bundle. Key the cache by the RESOLVED concrete version
+    // (`v.version`), NOT the meta-version `version` ("latest"). ensurePulled skips
+    // the OCI pull when a cached bundle's compose.yaml+manifest.json already exist,
+    // so caching under `<app>/latest` means a server that installed an app before a
+    // fix was published keeps serving that stale `latest` bundle forever — the new
+    // concrete version never gets pulled. Keying by the concrete version makes every
+    // new release a cache miss, so published fixes actually reach existing servers.
+    const info = await bundles.ensurePulled({ appId, version: v.version, ociRef: ref });
     const validation = await bundles.validateLayout(info.localPath);
     if (!validation.ok) {
       this.logger.warn('Bundle layout invalid; deferring to mocks', { appId, version, errors: validation.errors });

--- a/packages/web/src/components/LogsViewer.tsx
+++ b/packages/web/src/components/LogsViewer.tsx
@@ -34,6 +34,11 @@ interface LogsViewerProps {
   showJobStatus?: boolean;
 }
 
+// Log levels in ascending severity. The level filter is a THRESHOLD ("X and above"),
+// not an exact match — picking "warn" shows warn + error, so you can drop lower-level
+// noise without losing anything more severe.
+const LEVEL_RANK: Record<string, number> = { debug: 0, info: 1, warn: 2, error: 3 };
+
 const getLevelColor = (level: LogLevel) => {
   switch (level) {
     case 'error':
@@ -220,14 +225,16 @@ export const LogsViewer: React.FC<LogsViewerProps> = ({
   };
 
   const services = Array.from(new Set(allLogs.map(log => log.service)));
-  const levels: LogLevel[] = ['info', 'warn', 'error', 'debug'];
+  const levels: LogLevel[] = ['debug', 'info', 'warn', 'error'];
 
   const filteredLogs = allLogs.filter(log => {
     const matchesSearch = searchTerm === '' || 
       log.message.toLowerCase().includes(searchTerm.toLowerCase()) ||
       log.service.toLowerCase().includes(searchTerm.toLowerCase());
     const matchesService = selectedService === 'all' || log.service === selectedService;
-    const matchesLevel = selectedLevel === 'all' || log.level === selectedLevel;
+    // Threshold filter: show the selected level and everything more severe.
+    const matchesLevel = selectedLevel === 'all' ||
+      (LEVEL_RANK[log.level] ?? 0) >= (LEVEL_RANK[selectedLevel] ?? 0);
     
     return matchesSearch && matchesService && matchesLevel;
   });
@@ -408,7 +415,7 @@ export const LogsViewer: React.FC<LogsViewerProps> = ({
             <option value="all">All Levels</option>
             {levels.map(level => (
               <option key={level} value={level} className={getLevelColor(level)}>
-                {level.toUpperCase()}
+                {level.toUpperCase()}{level === 'error' ? '' : ' & up'}
               </option>
             ))}
           </select>

--- a/packages/web/src/pages/Deployments.tsx
+++ b/packages/web/src/pages/Deployments.tsx
@@ -98,8 +98,17 @@ export const Deployments: React.FC = () => {
       setPendingDelete(null);
       await refetch();
     } catch (error) {
-      console.error('Error deleting deployment:', error);
-      setDeleteError(error instanceof Error ? error.message : 'Failed to remove deployment');
+      // A 404 means the deployment is already gone — which is exactly the goal of
+      // remove. The DELETE is idempotent and the client retries it during the slow
+      // teardown, so a retry can land after the record was removed; treat that as
+      // success rather than showing a spurious "deployment not found" in the dialog.
+      if ((error as { statusCode?: number })?.statusCode === 404) {
+        setPendingDelete(null);
+        await refetch();
+      } else {
+        console.error('Error deleting deployment:', error);
+        setDeleteError(error instanceof Error ? error.message : 'Failed to remove deployment');
+      }
     } finally {
       setDeleting(false);
     }


### PR DESCRIPTION
Three user-reported fixes.

### 1. Published app updates never reach servers that already installed the app  *(the headline bug)*
`getVersionDetail` passed the **meta-version `"latest"`** to `bundles.ensurePulled`, so bundles were cached under `<app>/latest`. `ensurePulled` **skips the OCI pull when a cached `compose.yaml` + `manifest.json` already exist** — so a server that installed an app *before* a fix was published kept serving the stale `<app>/latest` bundle **forever**; the newly published concrete version was never pulled.

This is exactly why re-installing Postiz still hit the fixed-and-published bug: the published `postiz:1.0.3` bundle is correct (verified it contains `SKIP_ADD_CUSTOM_SEARCH_ATTRIBUTES`), but the server's `bundles/postiz/latest` cache was stale.

**Fix:** key the cache by the **resolved concrete version** (`v.version`), so every new release is a cache miss → re-pull. + a regression test installing `"latest"`.

*Immediate workaround for an affected server (no new release needed):* `docker compose exec server rm -rf /data/cache/bundles/<app>` then reinstall.

### 2. Remove dialog shows a spurious "deployment not found"
The DELETE is idempotent and the client retries it (network/timeout/5xx) during the **slow synchronous teardown**; a retry can land after the original delete already removed the record → **404**, even though the deletion succeeded (the app *is* gone). `confirmDelete` now treats a 404 as success (close dialog + refetch) instead of surfacing an error. The server keeps returning 404 for unknown deployments (its documented "404 consistency" contract — verified the contract tests still pass).

### 3. Logs level filter is now "and above"
Picking **Warn** shows **Warn + Error** (a severity threshold), so you can drop lower-level noise without losing anything more severe. Options relabeled `<LEVEL> & up`.

### Validation
`bun test` (server 357 pass incl. new regression test), typecheck + lint clean, web build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)