### PR TITLE
fix(web): deployments list stays stale across pages after a mutation

### DIFF
--- a/packages/web/src/utils/api.ts
+++ b/packages/web/src/utils/api.ts
@@ -247,9 +247,18 @@ export class ApiClient {
     globalCache.delete(`api:${url}`);
     
     // Remove related cache entries based on path patterns
-    if (path.includes('/deployments/')) {
+    if (path.includes('/deployments')) {
+      // Match both item ops (/deployments/:id — remove, lifecycle actions) and
+      // create (POST /api/deployments), so installing an app or removing one both
+      // refresh every page that lists deployments.
       globalCache.deleteByPattern(/^api:.*\/deployments/);
       globalCache.deleteByPattern(/^api:.*\/summary/); // Dashboard depends on deployments
+      // useDeploymentsApi caches the list under its own `deployments-<params>` keys
+      // (a separate namespace from the `api:` keys above) with a 30s TTL. Without
+      // clearing it here, a mutation on one page (e.g. removing an app on the
+      // Deployments page) leaves another page that lists deployments (e.g. Apps)
+      // serving the stale cached rows until the TTL lapses or a full reload.
+      globalCache.deleteByPattern(/^deployments-/);
     } else if (path.includes('/jobs/')) {
       globalCache.deleteByPattern(/^api:.*\/jobs/);
       globalCache.deleteByPattern(/^api:.*\/summary/); // Dashboard depends on jobs


### PR DESCRIPTION
**Symptom:** remove an app on the Deployments page, then click to the Apps page — the removed app still shows until a browser refresh (and similarly a freshly installed app can lag).

**Cause:** `useDeploymentsApi` caches the list in `globalCache` under its own `deployments-<params>` keys (30s TTL) — a different namespace from the apiClient's `api:${url}` keys. The apiClient's `invalidateCache` cleared only the `api:` keys on a mutation, so the hook's cache (which the Apps page reads with `limit=100`) kept serving stale rows. A browser refresh worked only because it wipes the in-memory cache.

**Fix:** `invalidateCache` now also clears the `deployments-` namespace, and broadens the match to cover create (`POST /api/deployments`) as well as item ops (`/deployments/:id`), so install/remove/lifecycle actions all refresh every page listing deployments — no manual reload.

typecheck + lint + web build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)