### PR TITLE
feat(cli): pre-upgrade snapshot in `hola update` (#284)

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -193,11 +193,22 @@ hola update --host user@vm          # upgrade to this CLI's version
 hola update --host user@vm --check  # just report CLI / installed / latest versions
 ```
 
-It preflights the host, downloads the version-pinned compose bundle (pinning the
-new `ghcr.io/try-hola` image tags), extracts it over the install dir, and re-runs
-the idempotent installer — which pulls the new images, backfills any newly-required
-`.env` keys, and recreates only the changed services. Use the same `--ref`,
-`--tarball-url`, `--dir`, and `--dry-run` overrides as `hola bootstrap`.
+It preflights the host, takes a **pre-upgrade snapshot** (see below), downloads the
+version-pinned compose bundle (pinning the new `ghcr.io/try-hola` image tags),
+extracts it over the install dir, and re-runs the idempotent installer — which
+pulls the new images, backfills any newly-required `.env` keys, and recreates only
+the changed services. Use the same `--ref`, `--tarball-url`, `--dir`, and
+`--dry-run` overrides as `hola bootstrap`.
+
+**Pre-upgrade snapshot.** Before any change, `update` archives a timestamped
+snapshot of the platform-tier rollback surface — `.env`, the `traefik/acme` cert
+store, and the `hola-data` volume (drafts/deployments/platform state) — to
+`<dir>/backups/pre-update-<version>-<timestamp>.tar.gz` on the host. It's a
+synchronous local archive with no external dependency (it does **not** rely on the
+Backrest app), and it's fail-closed: if the snapshot can't be written the upgrade
+halts. App data lives under app-owned bind mounts and is **not** captured by default
+(it's large and `update` doesn't recreate app stacks); pass `--backup-app-data` to
+include the app-data bind root, or `--no-backup` to skip the snapshot entirely.
 
 Keep the **same install dir** (`--dir`) across upgrades. The Let's Encrypt cert
 store is a dir-relative bind mount (`traefik/acme/acme.json`), so relocating the

--- a/packages/cli/src/__tests__/update.test.ts
+++ b/packages/cli/src/__tests__/update.test.ts
@@ -32,6 +32,10 @@ function makeRunner(opts?: {
     ssh: vi.fn(async (_host: string, cmd: string, o?: { input?: string }) => {
       calls.push({ cmd, input: o?.input });
       if (cmd.includes('command -v')) return { code: 0, stdout: preflight, stderr: '' };
+      // Pre-upgrade snapshot: echo back the archive path behind its marker.
+      if (cmd.includes('HOLA_BACKUP_PATH=')) {
+        return { code: 0, stdout: 'HOLA_BACKUP_PATH=/opt/hola/backups/pre-update-0.6.20-20260101T000000Z.tar.gz\n', stderr: '' };
+      }
       // The combined state read (version + old .env.example + .env) is matched first.
       if (cmd.includes('__HOLA_ENV__')) {
         return { code: 0, stdout: `__HOLA_VERSION__=${version}\n__HOLA_EXAMPLE__\n${oldExample}\n__HOLA_ENV__\n${env}`, stderr: '' };
@@ -59,6 +63,7 @@ describe('hola update', () => {
     expect(res.steps).toEqual([
       'Preflight host',
       'Read current install',
+      'Snapshot current install (.env, traefik/acme, hola-data)',
       'Download Hola 0.6.23 stack into /opt/hola',
       'Check config drift (.env.example vs .env)',
       'Run install.sh',
@@ -68,6 +73,7 @@ describe('hola update', () => {
     expect(res.fromVersion).toBe('0.6.20');
     expect(res.toVersion).toBe('0.6.23');
     expect(res.ssoAction).toBe('already-on');
+    expect(res.backupPath).toBe('/opt/hola/backups/pre-update-0.6.20-20260101T000000Z.tar.gz');
     expect(process.exitCode).toBe(0);
   });
 
@@ -169,6 +175,81 @@ describe('hola update', () => {
     );
     expect(res).toBeUndefined();
     expect(process.exitCode).toBe(1);
+  });
+
+  // --- Pre-upgrade snapshot (#284) ------------------------------------------
+
+  it('snapshots .env + traefik/acme + the hola-data volume before downloading the new bundle', async () => {
+    const runner = makeRunner();
+    await runUpdate({ host: 'me@vm', json: true }, { prompter: scriptedPrompter({}), runner });
+    const backup = runner.calls.find((c) => c.cmd.includes('HOLA_BACKUP_PATH='))!;
+    expect(backup).toBeDefined();
+    // Captures the platform-tier rollback surface: operator config, the ACME cert
+    // store, and the hola-data volume (via docker cp from the running server).
+    expect(backup.cmd).toContain('/opt/hola/.env');
+    expect(backup.cmd).toContain('/opt/hola/traefik/acme');
+    expect(backup.cmd).toContain('docker cp hola-server:/data');
+    expect(backup.cmd).toContain('/opt/hola/backups');
+    // App-data binds are NOT included unless asked.
+    expect(backup.cmd).not.toContain('/srv/hola/apps');
+    // The snapshot precedes the bundle download (the rollback point is the pre-upgrade state).
+    const order = runner.calls.map((c) => c.cmd);
+    expect(order.findIndex((c) => c.includes('HOLA_BACKUP_PATH='))).toBeLessThan(
+      order.findIndex((c) => c.includes('tar xz -C /opt/hola')),
+    );
+  });
+
+  it('--no-backup (backup=false) skips the snapshot entirely', async () => {
+    const runner = makeRunner();
+    const res = (await runUpdate(
+      { host: 'me@vm', backup: false, json: true },
+      { prompter: scriptedPrompter({}), runner },
+    )) as UpdateResult;
+    expect(runner.calls.some((c) => c.cmd.includes('HOLA_BACKUP_PATH='))).toBe(false);
+    expect(res.steps).not.toContain('Snapshot current install (.env, traefik/acme, hola-data)');
+    expect(res.backupPath).toBeNull();
+    // The upgrade still proceeds.
+    expect(runner.calls.some((c) => c.cmd.includes('install.sh'))).toBe(true);
+  });
+
+  it('--backup-app-data also tars the app-data bind root', async () => {
+    const runner = makeRunner();
+    await runUpdate(
+      { host: 'me@vm', backupAppData: true, json: true },
+      { prompter: scriptedPrompter({}), runner },
+    );
+    const backup = runner.calls.find((c) => c.cmd.includes('HOLA_BACKUP_PATH='))!;
+    expect(backup.cmd).toContain('/srv/hola/apps');
+    expect(backup.cmd).toContain('-C "/srv/hola" "apps"');
+  });
+
+  it('honors HOLA_APPS_BIND_ROOT from the host .env for --backup-app-data', async () => {
+    const runner = makeRunner({ env: `${ENV_AUTHENTIK}HOLA_APPS_BIND_ROOT=/data/hola/apps\n` });
+    await runUpdate(
+      { host: 'me@vm', backupAppData: true, json: true },
+      { prompter: scriptedPrompter({}), runner },
+    );
+    const backup = runner.calls.find((c) => c.cmd.includes('HOLA_BACKUP_PATH='))!;
+    expect(backup.cmd).toContain('-C "/data/hola" "apps"');
+  });
+
+  it('fail-closed: a snapshot failure aborts before downloading the new bundle', async () => {
+    const runner = makeRunner();
+    // Make the snapshot command fail.
+    const origSsh = runner.ssh;
+    runner.ssh = vi.fn(async (host: string, cmd: string, o?: { input?: string }) => {
+      if (cmd.includes('HOLA_BACKUP_PATH=')) {
+        runner.calls.push({ cmd, input: o?.input });
+        return { code: 1, stdout: '', stderr: 'no space left on device' };
+      }
+      return origSsh(host, cmd, o);
+    }) as typeof runner.ssh;
+    const res = await runUpdate({ host: 'me@vm', json: true }, { prompter: scriptedPrompter({}), runner });
+    expect(res).toBeUndefined();
+    expect(process.exitCode).toBe(1);
+    // No bundle download and no install.sh after a failed snapshot.
+    expect(runner.calls.some((c) => c.cmd.includes('tar xz -C /opt/hola'))).toBe(false);
+    expect(runner.calls.some((c) => c.cmd.includes('install.sh'))).toBe(false);
   });
 
   // --- Config drift ---------------------------------------------------------

--- a/packages/cli/src/commands/update/update.ts
+++ b/packages/cli/src/commands/update/update.ts
@@ -25,6 +25,15 @@ export interface UpdateOptions {
   enableSso?: boolean;
   /** For an explicit HOLA_AUTH_MODE=none host: keep it off (suppress the prompt/warning). */
   keepAuthMode?: boolean;
+  /**
+   * Take a pre-upgrade local snapshot on the host before re-running install.sh.
+   * Default (enabled); set to `false` by `--no-backup` (via mri negation) to skip
+   * it. The platform stack has no rollback, so this synchronous local archive of
+   * `.env` + `traefik/acme` + the `hola-data` volume is the platform-tier safety net.
+   */
+  backup?: boolean;
+  /** Also include the (potentially large) app-data bind root in the pre-upgrade snapshot. */
+  backupAppData?: boolean;
   /** Report versions (CLI / installed / latest release) without changing anything. */
   check?: boolean;
   /**
@@ -47,6 +56,11 @@ export interface UpdateResult {
   toVersion: string;
   /** What was decided about SSO reconciliation (for an explicit `none` host). */
   ssoAction?: 'enabled' | 'kept-none' | 'already-on' | 'backfilled';
+  /**
+   * Path on the host of the pre-upgrade snapshot archive, or null when no backup
+   * was taken (`--no-backup`, `--dry-run`, or `--check`).
+   */
+  backupPath?: string | null;
   steps: string[];
 }
 
@@ -71,6 +85,11 @@ const DEFAULT_DIR = '/opt/hola';
 const VERSION_MARKER = '__HOLA_VERSION__=';
 const EXAMPLE_MARKER = '__HOLA_EXAMPLE__';
 const ENV_MARKER = '__HOLA_ENV__';
+
+/** Stdout marker the pre-upgrade backup prints so its archive path can be parsed back out. */
+const BACKUP_PATH_MARKER = 'HOLA_BACKUP_PATH=';
+/** Default app-data bind root (mirrors the server's DEFAULT_APPS_BIND_ROOT); overridable via HOLA_APPS_BIND_ROOT. */
+const DEFAULT_APPS_BIND_ROOT = '/srv/hola/apps';
 
 /** Keys install.sh / compose generate or derive on their own — never "missing" config. */
 const AUTO_MANAGED = /^(AUTHENTIK_|COMPOSE_)/;
@@ -162,8 +181,9 @@ function realSelfUpdate(args: SelfUpdateArgs): Promise<SelfUpdateOutcome> {
  * then brought up to that same version. Over SSH it preflights the host, reads the
  * current `.env`/VERSION,
  * reconciles the auth mode to the Authentik-default baseline (prompting/flag-gated
- * for an explicit `none`), downloads the version-pinned bundle and extracts it over
- * the install dir WITHOUT touching `.env` or the ACME store, re-runs the idempotent
+ * for an explicit `none`), takes a pre-upgrade local snapshot on the host (unless
+ * `--no-backup`), downloads the version-pinned bundle and extracts it over the
+ * install dir WITHOUT touching `.env` or the ACME store, re-runs the idempotent
  * installer (which backfills newly-required keys and recreates changed services),
  * and reports old → new. Returns the result, or undefined on failure.
  */
@@ -328,6 +348,35 @@ export async function runUpdate(
       out(`  found install ${fromVersion ? colors.bold(`v${fromVersion}`) : colors.dim('(version unknown)')} at ${composeDir}`);
     }
 
+    // 2.5) Pre-upgrade snapshot (#284). The platform stack has no rollback — VERSION
+    //    is a single marker, with no release history. Before any mutation, archive a
+    //    timestamped local snapshot of the platform-tier rollback surface: `.env`,
+    //    the `traefik/acme` cert store, and the `hola-data` volume (drafts/deploys/
+    //    platform state). Synchronous, on-host, no external dependency (NOT Backrest,
+    //    which is operator-configured/optional/async). App-data binds are large and
+    //    opt-in (`--backup-app-data`). `--no-backup` skips it. A failure here is
+    //    fail-closed: we don't upgrade a stack we couldn't snapshot.
+    let backupPath: string | null = null;
+    if (opts.backup !== false) {
+      const appDataRoot = (config.HOLA_APPS_BIND_ROOT?.trim() || DEFAULT_APPS_BIND_ROOT).replace(/\/+$/, '');
+      const res = await ssh(
+        'Snapshot current install (.env, traefik/acme, hola-data)',
+        backupCmd(composeDir, fromVersion, { appData: !!opts.backupAppData, appDataRoot }),
+        { stream: true },
+      );
+      if (!opts.dryRun) {
+        if (res.code !== 0) {
+          throw new UpdateAbort(
+            `Pre-upgrade snapshot failed (exit ${res.code}). The platform has no rollback, so the ` +
+              `upgrade is halted. Fix the host (disk space / docker access) and retry, or re-run with ` +
+              `--no-backup to upgrade without a snapshot.`,
+          );
+        }
+        backupPath = parseBackupPath(res.stdout);
+        if (backupPath) out(`  ${colors.dim(`snapshot saved to ${backupPath}`)}`);
+      }
+    }
+
     // 3) Reconcile auth mode to the Authentik-default baseline (issue #149). An
     //    unset/blank mode is backfilled automatically by install.sh (no-op here);
     //    an EXPLICIT `none` is surfaced and gated on a choice (flag or prompt).
@@ -420,7 +469,7 @@ export async function runUpdate(
       }
     }
 
-    const result: UpdateResult = { host, dir, ref, fromVersion, toVersion: version, ssoAction, steps };
+    const result: UpdateResult = { host, dir, ref, fromVersion, toVersion: version, ssoAction, backupPath, steps };
     if (opts.json) {
       console.log(JSON.stringify(result, null, 2));
     } else if (opts.dryRun) {
@@ -428,6 +477,7 @@ export async function runUpdate(
     } else {
       const span = fromVersion && fromVersion !== version ? `${colors.bold(`v${fromVersion}`)} → ${colors.bold(`v${version}`)}` : colors.bold(`v${version}`);
       out(`\n${colors.green('✔ Done.')} ${colors.bold(host)} is now on ${span}.`);
+      if (backupPath) out(`  ${colors.dim(`Pre-upgrade snapshot: ${backupPath}`)}`);
       if (ssoAction === 'enabled') out(`  SSO provisioning runs on first boot; retrieve sign-in with ${colors.cyan(`hola credentials --host ${host}`)}.`);
     }
     return result;
@@ -464,6 +514,58 @@ async function decideSso(opts: UpdateOptions, prompter: Prompter): Promise<'enab
     default: 'false',
   });
   return ans === 'true' ? 'enable' : 'keep';
+}
+
+/**
+ * Remote command for the pre-upgrade snapshot: tar `.env`, the `traefik/acme` cert
+ * store, and the `hola-data` volume (captured via `docker cp` from the running
+ * `hola-server` — no extra image pull) into a single timestamped archive under
+ * `<dir>/backups/`, optionally including the app-data bind root. Prints the archive
+ * path behind BACKUP_PATH_MARKER. The `hola-data` capture is best-effort (warns if
+ * the server container isn't running) so operator config is still snapshotted; the
+ * large app-data tree is added straight from its path (no double-copy).
+ */
+function backupCmd(
+  dir: string,
+  fromVersion: string | null,
+  opts: { appData: boolean; appDataRoot: string },
+): string {
+  const safeFrom = (fromVersion ?? 'unknown').replace(/[^A-Za-z0-9._-]/g, '_');
+  const lines = [
+    'set -e',
+    `ts=$(date -u +%Y%m%dT%H%M%SZ)`,
+    `bdir="${dir}/backups"`,
+    `mkdir -p "$bdir"`,
+    `stage=$(mktemp -d)`,
+    `trap 'rm -rf "$stage"' EXIT`,
+    `if [ -f "${dir}/.env" ]; then cp -p "${dir}/.env" "$stage/.env"; fi`,
+    `if [ -d "${dir}/traefik/acme" ]; then cp -a "${dir}/traefik/acme" "$stage/acme"; fi`,
+    `if docker cp hola-server:/data "$stage/hola-data" >/dev/null 2>&1; then :; else echo "WARN: hola-data volume not captured (is hola-server running?)" >&2; fi`,
+    `archive="$bdir/pre-update-${safeFrom}-$ts.tar.gz"`,
+  ];
+  if (opts.appData) {
+    const root = opts.appDataRoot.replace(/\/+$/, '');
+    const parent = root.replace(/\/[^/]+$/, '') || '/';
+    const base = root.slice(root.lastIndexOf('/') + 1);
+    // App data is tarred straight from its path (no staging copy of a large tree).
+    lines.push(
+      `if [ -d "${root}" ]; then tar czf "$archive" -C "$stage" . -C "${parent}" "${base}"; else tar czf "$archive" -C "$stage" .; fi`,
+    );
+  } else {
+    lines.push(`tar czf "$archive" -C "$stage" .`);
+  }
+  lines.push(`echo "${BACKUP_PATH_MARKER}$archive"`);
+  return lines.join('; ');
+}
+
+/** Pull the archive path back out of the backup command's stdout (last marker line wins). */
+function parseBackupPath(stdout: string): string | null {
+  let path: string | null = null;
+  for (const line of stdout.split('\n')) {
+    const t = line.trim();
+    if (t.startsWith(BACKUP_PATH_MARKER)) path = t.slice(BACKUP_PATH_MARKER.length).trim() || null;
+  }
+  return path;
 }
 
 /** Remote command that prints the install's VERSION, old .env.example, and .env behind markers, in one read. */

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -60,6 +60,8 @@ prog
   .option('--dir', 'Install directory on the host', '/opt/hola')
   .option('--enable-sso', 'For a HOLA_AUTH_MODE=none host: enable Authentik SSO (the new standard)', false)
   .option('--keep-auth-mode', 'For a HOLA_AUTH_MODE=none host: keep SSO off (no prompt)', false)
+  .option('--no-backup', 'Skip the pre-upgrade snapshot (.env + traefik/acme + hola-data volume)')
+  .option('--backup-app-data', 'Also include the (large) app-data bind root in the pre-upgrade snapshot', false)
   .option('--check', 'Report CLI / installed / latest versions without changing anything', false)
   .option('--dry-run', 'Print the plan without connecting', false)
   .option('--json', 'Print the result as JSON', false)


### PR DESCRIPTION
## What

`hola update` now takes a **pre-upgrade snapshot** on the host before it changes anything. This is the **platform-tier** instance of the shared pre-upgrade snapshot primitive proposed in #284 (the catalog-app `promote` tier lands separately).

The platform stack has **no rollback** — `VERSION` is a single marker with no release history — yet `update` previously swapped server/web/Traefik images with no safety net. This closes that gap.

## How

Inserted between *read current install* and *auth reconcile* (before any mutation), the snapshot archives the platform-tier rollback surface into `<dir>/backups/pre-update-<version>-<timestamp>.tar.gz`:

- **`.env`** — operator config
- **`traefik/acme`** — the ACME cert store
- **`hola-data` volume** — drafts/deployments/platform state, captured via `docker cp` from the running `hola-server` (no extra image pull)

Design points:
- **Fail-closed.** A snapshot failure halts the upgrade (the platform can't roll back, so we don't upgrade a stack we couldn't snapshot). Override with `--no-backup`.
- **No external dependency.** Deliberately *not* a trigger into Backrest, which is operator-configured, optional, and async. Synchronous local archive only.
- **App data is opt-in.** `update` doesn't recreate app stacks, and app-data binds are large, so they're excluded by default — pass `--backup-app-data` to include the app-data bind root (honors `HOLA_APPS_BIND_ROOT`).
- `hola-data` capture is best-effort (warns, doesn't fail, if `hola-server` isn't running) so operator config is still captured.

## Flags

- `--no-backup` — skip the snapshot entirely
- `--backup-app-data` — also include the (large) app-data bind root

## Testing

- 6 new unit tests: snapshot contents + ordering before download, `--no-backup` skip, `--backup-app-data` (default + `HOLA_APPS_BIND_ROOT`), fail-closed abort.
- `bun run typecheck` / `lint` / `build` clean; full CLI suite green (one pre-existing, env-only timezone test fails identically on `main`).
- Docs: updated the Upgrade section of `docs/OPERATIONS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)