### PR TITLE
feat(server): Phase 0 upgrade signaling + skip-guard (#284)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ packages/*/coverage
 # Core dumps (e.g. from a crashed test worker)
 core
 core.*
+# …but the bare `core` pattern also shadows the server's `services/core/` source
+# directory (same name), silently ignoring NEW files added there. Re-include it.
+!packages/server/src/services/core/

--- a/packages/server/src/__tests__/bundles/manifest-upgrade.test.ts
+++ b/packages/server/src/__tests__/bundles/manifest-upgrade.test.ts
@@ -1,0 +1,60 @@
+/**
+ * coerceManifestUpgrade — narrow-shape coercion of the bundle manifest's
+ * optional `upgrade` block (#284 Phase 0). Mirrors the manifest-auth coercion
+ * tests: malformed/unknown fields are dropped, and an all-empty block degrades
+ * to undefined (the app then has no upgrade restrictions).
+ */
+import { describe, test, expect } from 'bun:test';
+
+import { coerceManifestUpgrade } from '../../services/core/manifest-upgrade';
+
+describe('coerceManifestUpgrade', () => {
+  test('returns undefined for non-objects', () => {
+    expect(coerceManifestUpgrade(undefined)).toBeUndefined();
+    expect(coerceManifestUpgrade(null)).toBeUndefined();
+    expect(coerceManifestUpgrade('breaking')).toBeUndefined();
+    expect(coerceManifestUpgrade(['1.0.0'])).toBeUndefined();
+  });
+
+  test('returns undefined when no field survives coercion', () => {
+    expect(coerceManifestUpgrade({})).toBeUndefined();
+    // breaking must be exactly true; falsey/odd values are dropped.
+    expect(coerceManifestUpgrade({ breaking: false })).toBeUndefined();
+    expect(coerceManifestUpgrade({ breaking: 'yes' })).toBeUndefined();
+    // empty/blank strings and arrays don't count.
+    expect(coerceManifestUpgrade({ minFromVersion: '   ', waypoints: [] })).toBeUndefined();
+    // unknown preUpgradeBackup value is dropped.
+    expect(coerceManifestUpgrade({ preUpgradeBackup: 'maybe' })).toBeUndefined();
+  });
+
+  test('carries a full, valid block', () => {
+    expect(
+      coerceManifestUpgrade({
+        breaking: true,
+        minFromVersion: '1.107.2',
+        waypoints: ['1.132.3', '1.135.0'],
+        upgradeNotesUrl: 'https://example.com/notes',
+        preUpgradeBackup: 'required',
+      }),
+    ).toEqual({
+      breaking: true,
+      minFromVersion: '1.107.2',
+      waypoints: ['1.132.3', '1.135.0'],
+      upgradeNotesUrl: 'https://example.com/notes',
+      preUpgradeBackup: 'required',
+    });
+  });
+
+  test('trims strings and filters non-string waypoints', () => {
+    expect(
+      coerceManifestUpgrade({ minFromVersion: '  2.0.0 ', waypoints: ['  1.5.0 ', 42, '', '1.8.0'] }),
+    ).toEqual({ minFromVersion: '2.0.0', waypoints: ['1.5.0', '1.8.0'] });
+  });
+
+  test('keeps only the valid subset of fields', () => {
+    expect(coerceManifestUpgrade({ breaking: true, minFromVersion: 5, preUpgradeBackup: 'none' })).toEqual({
+      breaking: true,
+      preUpgradeBackup: 'none',
+    });
+  });
+});

--- a/packages/server/src/__tests__/deployments/upgrade-skip-guard.test.ts
+++ b/packages/server/src/__tests__/deployments/upgrade-skip-guard.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Promote upgrade skip-guard (#284 Phase 0).
+ *
+ * Verifies RealDeploymentService.promote enforces the target version's upgrade
+ * metadata (minFromVersion floor / required waypoints) BEFORE staging a new
+ * release: an illegal jump is rejected with a typed ValidationError that names
+ * the next safe version, the active release is untouched, and a legal jump
+ * proceeds. The catalog stub returns per-version `upgrade` metadata so the
+ * finalized manifest carries it through draft → finalize → promote.
+ */
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import type { AppUpgradeMeta } from '@hola/shared';
+import { RealDeploymentService } from '../../services/core/deployment';
+import { MockProvisionerService } from '../../services/core/provisioner';
+import { RealDraftService } from '../../services/core/draft';
+import { RealStorageService } from '../../services/core/storage';
+import { RealRoutingService } from '../../services/core/routing';
+import { ValidationError } from '../../middleware/error-mapping';
+import type { DockerService } from '../../services/core/docker';
+
+type CatalogArg = ConstructorParameters<typeof RealDraftService>[1];
+type ValidationArg = ConstructorParameters<typeof RealDraftService>[2];
+type JobArg = ConstructorParameters<typeof RealDeploymentService>[1];
+
+// Per-version upgrade metadata the catalog surfaces for the `immich` fixture.
+const UPGRADE_BY_VERSION: Record<string, AppUpgradeMeta | undefined> = {
+  '1.107.2': undefined,
+  '1.132.3': undefined,
+  '1.137.0': { minFromVersion: '1.107.2', waypoints: ['1.132.3'] },
+};
+
+function makeCatalog(): CatalogArg {
+  return {
+    getApp: async (appId: string) => ({ id: appId, name: 'Immich', icon: '📷' }),
+    getVersionDetail: async (_appId: string, version: string) => ({
+      defaultEnv: [],
+      defaults: { ports: [{ container: 2283, protocol: 'tcp' as const }], volumes: [] },
+      upgrade: UPGRADE_BY_VERSION[version],
+    }),
+  } as unknown as CatalogArg;
+}
+
+function makeValidation(): ValidationArg {
+  return {
+    validateDraft: async () => ({ ok: true, errors: [], warnings: [] }),
+    preflightCheck: async () => ({ ok: true, checks: [] }),
+  } as unknown as ValidationArg;
+}
+
+function makeJobs(): JobArg {
+  const jobs: Array<{ id: string; type: string; status: string; startedAt: string; deploymentId?: string }> = [];
+  return {
+    createJob: async (p: { type: string; deploymentId?: string }) => {
+      const job = { id: crypto.randomUUID(), type: p.type, status: 'queued', startedAt: new Date().toISOString(), deploymentId: p.deploymentId };
+      jobs.push(job);
+      return job;
+    },
+    listJobs: async () => jobs,
+    cancelJob: async () => {},
+    getJob: async () => null,
+    onJobUpdate: () => ({ unsubscribe() {} }),
+    setExecutor: () => {},
+    healthCheck: async () => ({ healthy: true, lastCheck: new Date() }),
+  } as unknown as JobArg;
+}
+
+const noDocker = {} as unknown as DockerService;
+type LoggingArg = ConstructorParameters<typeof RealDeploymentService>[5];
+const noLogging = {
+  log: async () => {},
+  onLog: () => ({ unsubscribe() {} }),
+  logJob: async () => {},
+  logDeployment: async () => {},
+  healthCheck: async () => ({ healthy: true, lastCheck: new Date() }),
+} as unknown as LoggingArg;
+
+describe('Promote upgrade skip-guard (#284 Phase 0)', () => {
+  let dataRoot: string;
+
+  beforeEach(async () => {
+    dataRoot = await mkdtemp(join(tmpdir(), 'hola-skipguard-'));
+  });
+  afterEach(async () => {
+    await rm(dataRoot, { recursive: true, force: true });
+  });
+
+  function makeSystem() {
+    const storage = new RealStorageService({ holaDir: dataRoot });
+    const drafts = new RealDraftService(storage, makeCatalog(), makeValidation());
+    const routing = new RealRoutingService(storage, { baseDomain: 'local.hola' });
+    const deployments = new RealDeploymentService(storage, makeJobs(), noDocker, drafts, routing, noLogging, new MockProvisionerService());
+    return { storage, drafts, routing, deployments };
+  }
+
+  async function finalizedDraft(drafts: RealDraftService, version: string): Promise<string> {
+    const { draftId } = await drafts.createDraft({ appId: 'immich', version });
+    await drafts.updateDraft(draftId, { composeOverride: 'services:\n  immich:\n    image: immich:' + version + '\n' });
+    await drafts.finalizeDraft(draftId);
+    return draftId;
+  }
+
+  test('rejects a promote that skips past a required waypoint', async () => {
+    const { deployments, drafts, storage } = makeSystem();
+    // Land on a version above the floor but below the waypoint.
+    const dep = await deployments.createFromDraft({
+      draftId: await finalizedDraft(drafts, '1.107.2'), name: 'immich', options: { autoStart: false },
+    });
+    const release1 = dep.releaseId;
+
+    // Jump straight to 1.137.0 — must pass through waypoint 1.132.3 first.
+    const target = await finalizedDraft(drafts, '1.137.0');
+    let err: unknown;
+    try {
+      await deployments.promote(dep.deploymentId, { draftId: target, options: { autoStart: false } });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(ValidationError);
+    expect((err as ValidationError).message).toContain('1.132.3');
+
+    // The active release is unchanged — no half-staged promote.
+    expect(await storage.readFileAsString(`deployments/${dep.deploymentId}/current`)).toBe(release1);
+    const releases = await deployments.getReleases(dep.deploymentId);
+    expect(releases).toHaveLength(1);
+    expect(releases[0].status).toBe('active');
+  });
+
+  test('rejects a promote from below the minFromVersion floor', async () => {
+    const { deployments, drafts } = makeSystem();
+    // Pretend an old deployment that predates the floor.
+    const dep = await deployments.createFromDraft({
+      draftId: await finalizedDraft(drafts, '1.100.0'), name: 'immich', options: { autoStart: false },
+    });
+    const target = await finalizedDraft(drafts, '1.137.0');
+    let err: unknown;
+    try {
+      await deployments.promote(dep.deploymentId, { draftId: target, options: { autoStart: false } });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(ValidationError);
+    expect((err as ValidationError).message).toContain('1.107.2');
+  });
+
+  test('allows a legal promote through the waypoint', async () => {
+    const { deployments, drafts, storage } = makeSystem();
+    const dep = await deployments.createFromDraft({
+      draftId: await finalizedDraft(drafts, '1.132.3'), name: 'immich', options: { autoStart: false },
+    });
+
+    // From the waypoint, the jump to 1.137.0 is legal (floor met, no waypoint ahead).
+    const target = await finalizedDraft(drafts, '1.137.0');
+    const promoted = await deployments.promote(dep.deploymentId, { draftId: target, options: { autoStart: false } });
+
+    expect(promoted.releaseId).toBeDefined();
+    expect(await storage.readFileAsString(`deployments/${dep.deploymentId}/current`)).toBe(promoted.releaseId);
+    const releases = await deployments.getReleases(dep.deploymentId);
+    expect(releases.find((r) => r.id === promoted.releaseId)?.status).toBe('active');
+  });
+});

--- a/packages/server/src/__tests__/shared/upgrade-path.test.ts
+++ b/packages/server/src/__tests__/shared/upgrade-path.test.ts
@@ -1,0 +1,85 @@
+/**
+ * checkUpgradePath — the pure skip-guard helper (#284 Phase 0).
+ *
+ * Lives in the server suite because @hola/shared has no test runner of its own
+ * (same arrangement as compareVersions/isNewerVersion, exercised from system/).
+ */
+import { describe, test, expect } from 'bun:test';
+
+import { checkUpgradePath, type AppUpgradeMeta } from '@hola/shared';
+
+describe('checkUpgradePath (#284 Phase 0 skip-guard)', () => {
+  test('passes through when there is no metadata', () => {
+    expect(checkUpgradePath('1.0.0', '2.0.0', undefined)).toEqual({ ok: true });
+    expect(checkUpgradePath('1.0.0', '2.0.0', {})).toEqual({ ok: true });
+  });
+
+  test('passes through when either version is unknown', () => {
+    const meta: AppUpgradeMeta = { minFromVersion: '5.0.0' };
+    expect(checkUpgradePath(undefined, '2.0.0', meta)).toEqual({ ok: true });
+    expect(checkUpgradePath('1.0.0', undefined, meta)).toEqual({ ok: true });
+  });
+
+  test('passes through for a same-version re-promote or a downgrade', () => {
+    const meta: AppUpgradeMeta = { minFromVersion: '5.0.0', waypoints: ['3.0.0'] };
+    expect(checkUpgradePath('2.0.0', '2.0.0', meta)).toEqual({ ok: true });
+    expect(checkUpgradePath('4.0.0', '2.0.0', meta)).toEqual({ ok: true });
+  });
+
+  // --- minFromVersion floor (H2) -------------------------------------------
+
+  test('rejects an upgrade from below the minFromVersion floor', () => {
+    const meta: AppUpgradeMeta = { minFromVersion: '1.107.2' };
+    const r = checkUpgradePath('1.100.0', '1.140.0', meta);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe('min-from-version');
+      expect(r.suggestedVersion).toBe('1.107.2');
+      expect(r.message).toContain('1.107.2');
+      expect(r.message).toContain('1.100.0');
+    }
+  });
+
+  test('allows an upgrade when already at/above the floor', () => {
+    const meta: AppUpgradeMeta = { minFromVersion: '1.107.2' };
+    expect(checkUpgradePath('1.107.2', '1.140.0', meta)).toEqual({ ok: true });
+    expect(checkUpgradePath('1.120.0', '1.140.0', meta)).toEqual({ ok: true });
+  });
+
+  // --- waypoints (H2) ------------------------------------------------------
+
+  test('rejects skipping past a required waypoint and names the next stop', () => {
+    const meta: AppUpgradeMeta = { waypoints: ['1.132.3'] };
+    const r = checkUpgradePath('1.130.0', '1.137.0', meta);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe('waypoint-required');
+      expect(r.suggestedVersion).toBe('1.132.3');
+      expect(r.message).toContain('1.132.3');
+    }
+  });
+
+  test('suggests the LOWEST waypoint still ahead when several are crossed', () => {
+    const meta: AppUpgradeMeta = { waypoints: ['1.135.0', '1.132.3'] };
+    const r = checkUpgradePath('1.130.0', '1.140.0', meta);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.suggestedVersion).toBe('1.132.3');
+  });
+
+  test('allows the upgrade once landed on the waypoint', () => {
+    const meta: AppUpgradeMeta = { waypoints: ['1.132.3'] };
+    expect(checkUpgradePath('1.132.3', '1.137.0', meta)).toEqual({ ok: true });
+  });
+
+  test('ignores waypoints outside the (from, to) window', () => {
+    const meta: AppUpgradeMeta = { waypoints: ['0.9.0', '5.0.0'] };
+    expect(checkUpgradePath('1.0.0', '2.0.0', meta)).toEqual({ ok: true });
+  });
+
+  test('the floor is reported before a waypoint when both fail', () => {
+    const meta: AppUpgradeMeta = { minFromVersion: '1.5.0', waypoints: ['1.8.0'] };
+    const r = checkUpgradePath('1.0.0', '2.0.0', meta);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('min-from-version');
+  });
+});

--- a/packages/server/src/services/core/catalog.ts
+++ b/packages/server/src/services/core/catalog.ts
@@ -13,6 +13,7 @@ import type {
 } from '@hola/shared';
 import { coerceManifestAuth } from './manifest-auth';
 import { coerceConsumes } from './app-registry';
+import { coerceManifestUpgrade } from './manifest-upgrade';
 
 // Shape of remote catalog JSON (minimal for now)
 type RemoteCatalog = {
@@ -188,6 +189,7 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
         };
         auth?: unknown;
         consumes?: unknown;
+        upgrade?: unknown;
         ingress?: { service?: unknown; port?: unknown };
       };
 
@@ -256,6 +258,11 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
       // so new capability names need no server change (ADR 0002).
       const consumes = coerceConsumes(manifest.consumes);
 
+      // Upgrade-safety metadata (#284 Phase 0): drives the server-side skip-guard
+      // on promote and the dashboard's pre-upgrade warning. Coerced narrowly like
+      // `auth`, so unknown fields don't survive into the deploy lifecycle.
+      const upgrade = coerceManifestUpgrade(manifest.upgrade);
+
       // Which compose service is the web/ingress one — the app's bundle manifest
       // declares it as `ingress.service`. Lets the server route to / inject auth
       // env into the right service for a multi-service app whose ingress isn't
@@ -265,7 +272,7 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
           ? manifest.ingress.service.trim()
           : undefined;
 
-      return { ...merged, composeOverride, auth, consumes, ingressService } satisfies GetCatalogAppVersionDetailResponse;
+      return { ...merged, composeOverride, auth, consumes, upgrade, ingressService } satisfies GetCatalogAppVersionDetailResponse;
     } catch (error) {
       this.logger.warn('Failed to read or parse bundle manifest; deferring to mocks', { appId, version, error: error instanceof Error ? error.message : String(error) });
       throw new Error('MANIFEST_UNAVAILABLE', { cause: error });

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -36,9 +36,10 @@ import type {
   GetLogsResponse,
   LogEntry
 } from '@hola/shared';
+import { checkUpgradePath } from '@hola/shared';
 
 import { getLogger } from '../../lib/logger';
-import { NotFoundError, ConflictError } from '../../middleware/error-mapping';
+import { NotFoundError, ConflictError, ValidationError } from '../../middleware/error-mapping';
 import type { HealthCheckable, ServiceHealth } from './types';
 import type { StorageService } from './storage';
 import type { JobService, JobContext } from './jobs';
@@ -544,12 +545,28 @@ abstract class InMemoryDeploymentService implements DeploymentService {
 
   async promote(deploymentId: string, request: PromoteRequest): Promise<CreateDeploymentFromDraftResponse> {
     await this.ensureLoaded();
-    this.requireDeployment(deploymentId);
+    const deployment = this.requireDeployment(deploymentId);
     const releaseId = crypto.randomUUID();
 
     this.logger.info('Promoting new release onto deployment', { deploymentId, releaseId, draftId: request.draftId });
 
     const artifacts = await this.loadFinalizedArtifacts(request.draftId);
+
+    // Upgrade skip-guard (#284 Phase 0): reject an illegal version jump — below a
+    // `minFromVersion` floor or past a required `waypoint` — BEFORE building or
+    // staging the new release, so an unsafe promote fails up front with an
+    // actionable next version rather than booting a half-migrated app. Same-version
+    // re-promotes, downgrades, and apps with no upgrade metadata pass through.
+    const fromVersion = deployment.version;
+    const toVersion = artifacts?.manifest.version;
+    const guard = checkUpgradePath(fromVersion, toVersion, artifacts?.manifest.upgrade);
+    if (!guard.ok) {
+      this.logger.warn('Blocked unsafe promote (upgrade skip-guard)', {
+        deploymentId, fromVersion, toVersion, code: guard.code, suggestedVersion: guard.suggestedVersion,
+      });
+      throw new ValidationError(guard.message, { code: guard.code, fromVersion, toVersion, suggestedVersion: guard.suggestedVersion });
+    }
+
     const { app, release } = await this.buildReleaseFromDraft(artifacts, request, deploymentId, releaseId);
 
     // Reject an unsatisfiable auth requirement before staging the new release, so

--- a/packages/server/src/services/core/draft.ts
+++ b/packages/server/src/services/core/draft.ts
@@ -20,7 +20,8 @@ import type {
   FinalizeDraftResponse,
   AppEnvVar,
   DraftDefaults,
-  AppAuthConfig
+  AppAuthConfig,
+  AppUpgradeMeta
 } from '@hola/shared';
 
 import { createHash } from 'crypto';
@@ -67,6 +68,9 @@ export interface FinalizedManifest {
   // The compose service to route to / inject auth env into; carried so
   // materializeCompose targets the right service for multi-service apps.
   ingressService?: string;
+  // Upgrade-safety metadata (#284 Phase 0) carried from the bundle manifest so
+  // `promote` can enforce the skip-guard against this (target) version.
+  upgrade?: AppUpgradeMeta;
   files: FinalizedManifestFile[];
   checksum: string;
   finalizedAt: string;
@@ -333,6 +337,7 @@ export class RealDraftService implements DraftService {
         auth: defaults.auth,
         consumes: defaults.consumes,
         ingressService: defaults.ingressService,
+        upgrade: defaults.upgrade,
         files: [],
       };
 
@@ -586,6 +591,7 @@ export class RealDraftService implements DraftService {
         auth: draft.auth,
         consumes: draft.consumes,
         ingressService: draft.ingressService,
+        upgrade: draft.upgrade,
         files: specFiles,
       };
 
@@ -666,7 +672,7 @@ export class RealDraftService implements DraftService {
     };
   }
 
-  async getDraftDefaults(appId: string, version?: string): Promise<{ env: AppEnvVar[]; defaults: DraftDefaults; composeOverride: string; auth?: AppAuthConfig; consumes?: string[]; ingressService?: string }> {
+  async getDraftDefaults(appId: string, version?: string): Promise<{ env: AppEnvVar[]; defaults: DraftDefaults; composeOverride: string; auth?: AppAuthConfig; consumes?: string[]; ingressService?: string; upgrade?: AppUpgradeMeta }> {
     try {
       const versionDetail = await this.catalogService.getVersionDetail(appId, version || 'latest');
       return {
@@ -676,6 +682,7 @@ export class RealDraftService implements DraftService {
         auth: versionDetail.auth,
         consumes: versionDetail.consumes,
         ingressService: versionDetail.ingressService,
+        upgrade: versionDetail.upgrade,
       };
     } catch (error) {
       this.logger.warn('Failed to get app defaults, using fallback', { appId, version, error: error instanceof Error ? error.message : String(error) });
@@ -837,6 +844,7 @@ export class MockDraftService implements DraftService {
       ports: draft.ports,
       composeOverride: draft.composeOverride ?? '',
       ingressService: draft.ingressService,
+      upgrade: draft.upgrade,
       files: [],
       checksum: 'mock-checksum',
       finalizedAt: new Date().toISOString(),

--- a/packages/server/src/services/core/manifest-upgrade.ts
+++ b/packages/server/src/services/core/manifest-upgrade.ts
@@ -1,0 +1,48 @@
+import type { AppUpgradeMeta } from '@hola/shared';
+
+/**
+ * Narrow-shape coercion for the bundle manifest's optional `upgrade` block
+ * (#284 Phase 0), mirroring `coerceManifestAuth` / `coerceConsumes`: unknown or
+ * malformed fields are dropped rather than trusted, so a hand-edited manifest
+ * can't smuggle arbitrary shapes into the deploy lifecycle. Returns `undefined`
+ * when nothing valid is present (the app then has no upgrade restrictions).
+ */
+
+function asRecord(v: unknown): Record<string, unknown> | undefined {
+  return v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : undefined;
+}
+
+function asString(v: unknown): string | undefined {
+  return typeof v === 'string' && v.trim().length > 0 ? v.trim() : undefined;
+}
+
+function asStringArray(v: unknown): string[] | undefined {
+  if (!Array.isArray(v)) return undefined;
+  const out = v.filter((x): x is string => typeof x === 'string' && x.trim().length > 0).map((s) => s.trim());
+  return out.length ? out : undefined;
+}
+
+export function coerceManifestUpgrade(value: unknown): AppUpgradeMeta | undefined {
+  const rec = asRecord(value);
+  if (!rec) return undefined;
+
+  const meta: AppUpgradeMeta = {};
+  if (rec.breaking === true) meta.breaking = true;
+
+  const minFrom = asString(rec.minFromVersion);
+  if (minFrom) meta.minFromVersion = minFrom;
+
+  const waypoints = asStringArray(rec.waypoints);
+  if (waypoints) meta.waypoints = waypoints;
+
+  const notes = asString(rec.upgradeNotesUrl);
+  if (notes) meta.upgradeNotesUrl = notes;
+
+  const backup = rec.preUpgradeBackup;
+  if (backup === 'required' || backup === 'recommended' || backup === 'none') {
+    meta.preUpgradeBackup = backup;
+  }
+
+  // Only surface the block when at least one valid field survived coercion.
+  return Object.keys(meta).length > 0 ? meta : undefined;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -112,6 +112,86 @@ export function isNewerVersion(candidate: string, current: string): boolean {
   return compareVersions(candidate, current) > 0;
 }
 
+/**
+ * Upgrade-safety metadata for a catalog app version (#284 Phase 0), declared in
+ * the bundle manifest's `upgrade` block. Lets the server enforce a safe upgrade
+ * path on `promote` and lets the dashboard warn before a breaking upgrade. Our
+ * semver describes impact on the Hola user, so a breaking/migrating release
+ * carries `breaking: true` plus any version-skip guard rails.
+ */
+export type AppUpgradeMeta = {
+  /** This release migrates/breaks — the UI should force an explicit acknowledgement before promoting. */
+  breaking?: boolean;
+  /** Floor: a deployment must already be at/above this version to promote to this one (H2). */
+  minFromVersion?: string;
+  /** Versions a deployment MUST be promoted through one-at-a-time to reach this one (H2). */
+  waypoints?: string[];
+  /** Link to upgrade notes, shown in the promote dialog. */
+  upgradeNotesUrl?: string;
+  /** Whether a pre-upgrade backup is required/recommended before promoting (H7). */
+  preUpgradeBackup?: 'required' | 'recommended' | 'none';
+};
+
+/** Result of {@link checkUpgradePath}: ok, or a rejection with an actionable next step. */
+export type UpgradePathResult =
+  | { ok: true }
+  | {
+      ok: false;
+      code: 'min-from-version' | 'waypoint-required';
+      message: string;
+      /** The version the caller should promote to first, before retrying the target. */
+      suggestedVersion: string;
+    };
+
+/**
+ * Validate a catalog-app upgrade against the target version's upgrade metadata
+ * (#284 Phase 0). Rejects an illegal jump — below the `minFromVersion` floor, or
+ * skipping past a required `waypoint` — with an actionable next version.
+ *
+ * Only enforced for an actual forward upgrade (`toVersion` newer than
+ * `fromVersion`) with both versions and metadata known. Same-version re-promotes,
+ * downgrades/rollbacks, and unknown versions pass through — those paths are the
+ * caller's concern, not a skip-guard's.
+ */
+export function checkUpgradePath(
+  fromVersion: string | undefined,
+  toVersion: string | undefined,
+  meta?: AppUpgradeMeta,
+): UpgradePathResult {
+  if (!meta || !fromVersion || !toVersion) return { ok: true };
+  if (!isNewerVersion(toVersion, fromVersion)) return { ok: true };
+
+  // Floor (H2): the deployment must already be at/above minFromVersion.
+  if (meta.minFromVersion && isNewerVersion(meta.minFromVersion, fromVersion)) {
+    return {
+      ok: false,
+      code: 'min-from-version',
+      message:
+        `This version requires upgrading from at least ${meta.minFromVersion}, but the deployment ` +
+        `is on ${fromVersion}. Upgrade to ${meta.minFromVersion} first, then continue.`,
+      suggestedVersion: meta.minFromVersion,
+    };
+  }
+
+  // Waypoints (H2): can't skip past one. The next required stop is the lowest
+  // waypoint strictly between the current and target versions.
+  const next = (meta.waypoints ?? [])
+    .filter((w) => isNewerVersion(w, fromVersion) && isNewerVersion(toVersion, w))
+    .sort(compareVersions)[0];
+  if (next) {
+    return {
+      ok: false,
+      code: 'waypoint-required',
+      message:
+        `Upgrading ${fromVersion} → ${toVersion} must pass through ${next} first. ` +
+        `Promote to ${next}, let it settle, then continue.`,
+      suggestedVersion: next,
+    };
+  }
+
+  return { ok: true };
+}
+
 // ------------------------------------------------------
 // Common helpers
 // ------------------------------------------------------
@@ -334,6 +414,11 @@ export type GetCatalogAppVersionDetailResponse = {
   // app id (the default heuristic). Sourced from the bundle manifest's
   // `ingress.service`.
   ingressService?: string;
+  // Upgrade-safety metadata declared in the bundle manifest's `upgrade` block
+  // (#284 Phase 0). Drives the server-side skip-guard on `promote` and the
+  // dashboard's pre-upgrade warning. Optional: apps that don't declare it have
+  // no upgrade restrictions.
+  upgrade?: AppUpgradeMeta;
 };
 
 // ------------------------------------------------------
@@ -476,6 +561,10 @@ export type Draft = {
   // apps whose ingress service isn't named after the app id. Seeded from the
   // bundle manifest and carried through finalize (read-only; not user-editable).
   ingressService?: string;
+  // Upgrade-safety metadata seeded from the bundle manifest (#284 Phase 0) and
+  // carried through finalize so `promote` can enforce the skip-guard against the
+  // target version (read-only; not user-editable).
+  upgrade?: AppUpgradeMeta;
   files: Array<{ uploadId: string; name: string; size: number; kind: 'composeOverride' | 'additionalFile' | 'env' | 'secret' }>;
 };
 


### PR DESCRIPTION
## What

**Phase 0 of #284** — the cheap, high-value safety layer for catalog-app upgrades. Adds a machine-readable upgrade-metadata model and **enforces a version skip-guard server-side** on `promote`, so an illegal jump fails up front with an actionable next version instead of booting a half-migrated app.

This is the server-enforced half; the dashboard forced-acknowledgement is deferred (there's no promote UI today — see Notes).

## Changes

**`@hola/shared`**
- `AppUpgradeMeta` — `breaking`, `minFromVersion`, `waypoints[]`, `upgradeNotesUrl`, `preUpgradeBackup`.
- `checkUpgradePath(from, to, meta)` — pure skip-guard. Rejects an upgrade from below the `minFromVersion` floor (H2) or one that skips past a required `waypoint` (H2), returning the safe next version. Only fires for a real forward upgrade; same-version re-promotes, downgrades/rollbacks, and metadata-less apps pass through.

**`@hola/server`**
- `manifest-upgrade.ts` — `coerceManifestUpgrade`, narrow-shape coercion of the bundle manifest's optional `upgrade` block (drops unknown/malformed fields, exactly like `coerceManifestAuth`).
- Surface `upgrade` through `getVersionDetail`, and thread it `draft → finalize → release` (same path as `auth`/`consumes`) so it's immutable and offline-safe.
- `promote` runs the skip-guard **before** building/staging the new release and throws a typed `ValidationError` (with `code`/`suggestedVersion` details) on an illegal jump. The active release is left untouched.

**Repo hygiene**
- `.gitignore`: the bare `core` core-dump pattern also matched the `services/core/` **source** directory, silently ignoring new files added there (this PR's `manifest-upgrade.ts` hit it). Re-included the source dir.

## How an app declares it (bundle `manifest.json`)

```jsonc
"upgrade": {
  "breaking": true,
  "minFromVersion": "1.107.2",
  "waypoints": ["1.132.3"],
  "upgradeNotesUrl": "https://…",
  "preUpgradeBackup": "recommended"
}
```

## Testing

- `checkUpgradePath` unit tests — floor, waypoints (incl. lowest-ahead selection), edge cases, floor-before-waypoint precedence.
- `coerceManifestUpgrade` coercion tests — malformed/unknown fields dropped, empty block → `undefined`.
- End-to-end promote skip-guard — reject-skip-waypoint, reject-below-floor, allow-legal; asserts the active release is unchanged on rejection.
- Full server suite (376 tests) + typecheck + lint + build clean.

## Notes / follow-ups

- **No promote UI today.** `promote` is an internal choke point not yet wired to a REST route/SDK method/dashboard, so the *forced-acknowledgement* UI (the differentiator) isn't buildable here. The metadata is surfaced on the version detail (and SDK type) so that dialog can be added when the promote UI lands.
- **Apps-repo docs** for the new manifest `upgrade` block (the `manifest.json` field table in `try-hola/apps`) are a separate follow-up.
- Phase 1 (pre-upgrade snapshot + data-aware rollback) and #121 (per-app backup hooks) are the next PRs in this series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)