### PR TITLE
feat(server): Phase 1 pre-upgrade snapshot + data-aware rollback (#284)

### DIFF
--- a/packages/server/src/__tests__/deployments/snapshot.test.ts
+++ b/packages/server/src/__tests__/deployments/snapshot.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Pre-upgrade snapshot + data-aware rollback (#284 Phase 1).
+ *
+ * Exercises the snapshot primitive end-to-end against a real (temp) app-data
+ * bind root: a gated `promote` tars the app data keyed by the outgoing release,
+ * and a `rollback({ restoreData: true })` stops the containers and restores that
+ * snapshot before bringing the target release back up. Uses the success-
+ * simulating MockDockerService so it runs without a real Docker daemon.
+ */
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtemp, rm, mkdir, writeFile, readFile, readdir } from 'fs/promises';
+import { existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import type { AppUpgradeMeta } from '@hola/shared';
+import { RealDeploymentService } from '../../services/core/deployment';
+import { MockProvisionerService } from '../../services/core/provisioner';
+import { RealDraftService } from '../../services/core/draft';
+import { RealStorageService } from '../../services/core/storage';
+import { RealRoutingService } from '../../services/core/routing';
+import { RealDatabaseService } from '../../services/core/database';
+import { RealLoggingService } from '../../services/core/logging';
+import { RealJobService } from '../../services/core/jobs';
+import { MockDockerService } from '../../services/core/docker';
+
+type CatalogArg = ConstructorParameters<typeof RealDraftService>[1];
+type ValidationArg = ConstructorParameters<typeof RealDraftService>[2];
+
+// Per-version upgrade metadata, settable per test (drives `preUpgradeBackup`).
+let upgradeByVersion: Record<string, AppUpgradeMeta | undefined> = {};
+
+function makeCatalog(): CatalogArg {
+  return {
+    getApp: async (appId: string) => ({ id: appId, name: 'Gitea', icon: '🍵' }),
+    getVersionDetail: async (_appId: string, version: string) => ({
+      defaultEnv: [],
+      defaults: { ports: [{ host: 3000, container: 3000, protocol: 'tcp' as const }], volumes: [] },
+      upgrade: upgradeByVersion[version],
+    }),
+  } as unknown as CatalogArg;
+}
+
+function makeValidation(): ValidationArg {
+  return {
+    validateDraft: async () => ({ ok: true, errors: [], warnings: [] }),
+    preflightCheck: async () => ({ ok: true, checks: [] }),
+  } as unknown as ValidationArg;
+}
+
+const COMPOSE = 'services:\n  gitea:\n    image: gitea/gitea:latest\n';
+
+async function waitForJob(jobs: RealJobService, id: string, timeoutMs = 5000) {
+  const start = Date.now();
+  for (;;) {
+    const job = await jobs.getJob(id);
+    if (job && (job.status === 'completed' || job.status === 'failed')) return job;
+    if (Date.now() - start > timeoutMs) throw new Error(`Job ${id} did not finish (last: ${job?.status})`);
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+describe('Pre-upgrade snapshot + data-aware rollback (#284 Phase 1)', () => {
+  let dataRoot: string;
+  let appsRoot: string;
+  let prevAppsBindRoot: string | undefined;
+
+  beforeEach(async () => {
+    dataRoot = await mkdtemp(join(tmpdir(), 'hola-snap-data-'));
+    appsRoot = await mkdtemp(join(tmpdir(), 'hola-snap-apps-'));
+    prevAppsBindRoot = process.env.HOLA_APPS_BIND_ROOT;
+    process.env.HOLA_APPS_BIND_ROOT = appsRoot;
+    upgradeByVersion = {};
+  });
+
+  afterEach(async () => {
+    if (prevAppsBindRoot === undefined) delete process.env.HOLA_APPS_BIND_ROOT;
+    else process.env.HOLA_APPS_BIND_ROOT = prevAppsBindRoot;
+    await rm(dataRoot, { recursive: true, force: true });
+    await rm(appsRoot, { recursive: true, force: true });
+  });
+
+  function makeSystem() {
+    const storage = new RealStorageService({ holaDir: dataRoot });
+    const database = new RealDatabaseService(storage);
+    const logging = new RealLoggingService(storage);
+    const jobs = new RealJobService(database, logging);
+    const routing = new RealRoutingService(storage, { baseDomain: 'local.hola' });
+    const drafts = new RealDraftService(storage, makeCatalog(), makeValidation());
+    const deployments = new RealDeploymentService(storage, jobs, new MockDockerService(), drafts, routing, logging, new MockProvisionerService());
+    return { storage, jobs, drafts, deployments };
+  }
+
+  async function finalizedDraft(drafts: RealDraftService, version: string): Promise<string> {
+    const { draftId } = await drafts.createDraft({ appId: 'gitea', version });
+    await drafts.updateDraft(draftId, { composeOverride: COMPOSE });
+    await drafts.finalizeDraft(draftId);
+    return draftId;
+  }
+
+  /** Write a single marker file into a deployment's app-data root. */
+  async function writeAppData(deploymentId: string, content: string) {
+    const dir = join(appsRoot, deploymentId);
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, 'state.txt'), content);
+  }
+  async function readAppData(deploymentId: string): Promise<string> {
+    return readFile(join(appsRoot, deploymentId, 'state.txt'), 'utf8');
+  }
+  function snapshotsPath(deploymentId: string) {
+    return join(dataRoot, 'deployments', deploymentId, 'snapshots');
+  }
+
+  test('opt-in promote snapshots the app data, keyed by the outgoing release', async () => {
+    const { drafts, deployments } = makeSystem();
+    const dep = await deployments.createFromDraft({ draftId: await finalizedDraft(drafts, '1.0.0'), name: 'gitea', options: { autoStart: false } });
+    await writeAppData(dep.deploymentId, 'v1-data');
+
+    await deployments.promote(dep.deploymentId, { draftId: await finalizedDraft(drafts, '2.0.0'), snapshot: true, options: { autoStart: false } });
+
+    const snaps = await readdir(snapshotsPath(dep.deploymentId));
+    expect(snaps).toHaveLength(1);
+    expect(existsSync(join(snapshotsPath(dep.deploymentId), snaps[0], 'data.tar.gz'))).toBe(true);
+    const meta = JSON.parse(await readFile(join(snapshotsPath(dep.deploymentId), snaps[0], 'meta.json'), 'utf8'));
+    expect(meta.fromReleaseId).toBe(dep.releaseId); // keyed by the release active at promote time
+    expect(meta.fromVersion).toBe('1.0.0');
+  });
+
+  test('a promote without the flag (and no required backup) takes no snapshot', async () => {
+    const { drafts, deployments } = makeSystem();
+    const dep = await deployments.createFromDraft({ draftId: await finalizedDraft(drafts, '1.0.0'), name: 'gitea', options: { autoStart: false } });
+    await writeAppData(dep.deploymentId, 'v1-data');
+
+    await deployments.promote(dep.deploymentId, { draftId: await finalizedDraft(drafts, '2.0.0'), options: { autoStart: false } });
+
+    expect(existsSync(snapshotsPath(dep.deploymentId))).toBe(false);
+  });
+
+  test('preUpgradeBackup: "required" forces a snapshot even without the flag', async () => {
+    upgradeByVersion = { '2.0.0': { preUpgradeBackup: 'required' } };
+    const { drafts, deployments } = makeSystem();
+    const dep = await deployments.createFromDraft({ draftId: await finalizedDraft(drafts, '1.0.0'), name: 'gitea', options: { autoStart: false } });
+    await writeAppData(dep.deploymentId, 'v1-data');
+
+    await deployments.promote(dep.deploymentId, { draftId: await finalizedDraft(drafts, '2.0.0'), options: { autoStart: false } });
+
+    expect(await readdir(snapshotsPath(dep.deploymentId))).toHaveLength(1);
+  });
+
+  test('a fresh deployment with no app data is promoted without a snapshot', async () => {
+    const { drafts, deployments } = makeSystem();
+    const dep = await deployments.createFromDraft({ draftId: await finalizedDraft(drafts, '1.0.0'), name: 'gitea', options: { autoStart: false } });
+    // No writeAppData — the data root is empty/absent.
+    await deployments.promote(dep.deploymentId, { draftId: await finalizedDraft(drafts, '2.0.0'), snapshot: true, options: { autoStart: false } });
+    expect(existsSync(snapshotsPath(dep.deploymentId))).toBe(false);
+  });
+
+  test('data-aware rollback restores the pre-upgrade app data', async () => {
+    const { jobs, drafts, deployments } = makeSystem();
+    const dep = await deployments.createFromDraft({ draftId: await finalizedDraft(drafts, '1.0.0'), name: 'gitea', options: { autoStart: false } });
+    const release1 = dep.releaseId;
+    await writeAppData(dep.deploymentId, 'v1-data');
+
+    // Upgrade to v2 with a snapshot (captures v1-data keyed by release1)…
+    await deployments.promote(dep.deploymentId, { draftId: await finalizedDraft(drafts, '2.0.0'), snapshot: true, options: { autoStart: false } });
+    // …then the new release "migrates" the data forward.
+    await writeAppData(dep.deploymentId, 'v2-data-migrated');
+
+    // Data-aware rollback to release1 should restore the captured v1 data.
+    const rb = await deployments.rollback(dep.deploymentId, { targetReleaseId: release1, restoreData: true });
+    await waitForJob(jobs, rb.jobId);
+
+    expect(await readAppData(dep.deploymentId)).toBe('v1-data');
+  });
+
+  test('a rollback without restoreData leaves the app data untouched (containers-only)', async () => {
+    const { jobs, drafts, deployments } = makeSystem();
+    const dep = await deployments.createFromDraft({ draftId: await finalizedDraft(drafts, '1.0.0'), name: 'gitea', options: { autoStart: false } });
+    const release1 = dep.releaseId;
+    await writeAppData(dep.deploymentId, 'v1-data');
+    await deployments.promote(dep.deploymentId, { draftId: await finalizedDraft(drafts, '2.0.0'), snapshot: true, options: { autoStart: false } });
+    await writeAppData(dep.deploymentId, 'v2-data-migrated');
+
+    const rb = await deployments.rollback(dep.deploymentId, { targetReleaseId: release1 });
+    await waitForJob(jobs, rb.jobId);
+
+    // No restore requested → the forward-migrated data is left as-is.
+    expect(await readAppData(dep.deploymentId)).toBe('v2-data-migrated');
+  });
+
+  test('retention keeps only the most recent N snapshots', async () => {
+    const { drafts, deployments } = makeSystem();
+    const dep = await deployments.createFromDraft({ draftId: await finalizedDraft(drafts, '1.0.0'), name: 'gitea', options: { autoStart: false } });
+    await writeAppData(dep.deploymentId, 'data');
+
+    // Promote 7 times with a snapshot each; retention bound is 5.
+    for (let i = 2; i <= 8; i++) {
+      await deployments.promote(dep.deploymentId, { draftId: await finalizedDraft(drafts, `${i}.0.0`), snapshot: true, options: { autoStart: false } });
+      await new Promise((r) => setTimeout(r, 5)); // distinct ISO timestamps for ordering
+    }
+    expect((await readdir(snapshotsPath(dep.deploymentId))).length).toBe(5);
+  });
+});

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -40,6 +40,7 @@ import { checkUpgradePath } from '@hola/shared';
 
 import { getLogger } from '../../lib/logger';
 import { NotFoundError, ConflictError, ValidationError } from '../../middleware/error-mapping';
+import { dirHasContents, fileSize, tarGzipDir, restoreTarGzInto } from './snapshot-fs';
 import type { HealthCheckable, ServiceHealth } from './types';
 import type { StorageService } from './storage';
 import type { JobService, JobContext } from './jobs';
@@ -79,7 +80,29 @@ export interface PromoteRequest {
   draftId: string;
   reason?: string;
   options?: { autoStart?: boolean };
+  /**
+   * Take a pre-upgrade app-data snapshot before switching the release (#284
+   * Phase 1). Always taken when the target version declares
+   * `upgrade.preUpgradeBackup: "required"`; this opts in otherwise.
+   */
+  snapshot?: boolean;
 }
+
+/** Per-deployment pre-upgrade snapshot record (#284 Phase 1), stored under
+ *  `deployments/<id>/snapshots/<snapshotId>/meta.json` alongside `data.tar.gz`. */
+interface SnapshotMeta {
+  snapshotId: string;
+  deploymentId: string;
+  /** The release that was active when the snapshot was taken — i.e. the release a
+   *  data-aware rollback to it should restore this snapshot for. */
+  fromReleaseId: string;
+  fromVersion?: string;
+  createdAt: string;
+  sizeBytes: number;
+}
+
+/** Pre-upgrade snapshots kept per deployment (bounded retention; oldest pruned). */
+const SNAPSHOT_RETENTION = 5;
 
 export interface DeploymentService extends HealthCheckable {
   // Deployment lifecycle
@@ -358,6 +381,22 @@ abstract class InMemoryDeploymentService implements DeploymentService {
   }
 
   /**
+   * Capture a pre-upgrade app-data snapshot before a promote switches releases
+   * (#284 Phase 1). Default no-op — the in-memory/mock service has no app data on
+   * disk; RealDeploymentService tars the data root. May throw (the caller decides
+   * fail-closed vs. best-effort based on the target's `preUpgradeBackup`).
+   */
+  protected async capturePreUpgradeSnapshot(
+    deploymentId: string,
+    fromReleaseId: string,
+    fromVersion: string | undefined,
+  ): Promise<void> {
+    void deploymentId;
+    void fromReleaseId;
+    void fromVersion;
+  }
+
+  /**
    * Preflight the app's declared auth requirement against the active auth backend
    * before any deployment state is created (RealDeploymentService overrides this
    * to consult the provisioner). Default no-op — the in-memory/mock service has no
@@ -580,6 +619,26 @@ abstract class InMemoryDeploymentService implements DeploymentService {
     await this.stageReleaseArtifacts(artifacts, deploymentId, release);
     await this.persistRelease(release);
 
+    // Pre-upgrade snapshot (#284 Phase 1): capture the app data BEFORE switching
+    // the release, keyed by the outgoing release so a later data-aware rollback to
+    // it restores this exact state. Always for `preUpgradeBackup: "required"`,
+    // opt-in otherwise. Fail-closed only when required (don't silently upgrade a
+    // stack the operator asked to be snapshotted); best-effort otherwise.
+    const backupRequired = artifacts?.manifest.upgrade?.preUpgradeBackup === 'required';
+    if ((backupRequired || request.snapshot === true) && deployment.currentReleaseId) {
+      try {
+        await this.capturePreUpgradeSnapshot(deploymentId, deployment.currentReleaseId, deployment.version);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (backupRequired) {
+          throw new ValidationError(
+            `Pre-upgrade snapshot failed and this upgrade requires one (preUpgradeBackup: required): ${msg}`,
+          );
+        }
+        this.logger.warn('Pre-upgrade snapshot failed (continuing — not required)', { deploymentId, error: msg });
+      }
+    }
+
     // Atomically switch the active release to the new one.
     await this.promoteRelease(deploymentId, releaseId);
 
@@ -750,6 +809,10 @@ abstract class InMemoryDeploymentService implements DeploymentService {
         action: 'rollback',
         targetReleaseId,
         reason: request.reason,
+        // Data-aware rollback (#284 Phase 1): also restore the pre-upgrade app-data
+        // snapshot taken when this target was last active, so the old image isn't
+        // booted against a forward-migrated schema. Handled in runLifecycleJob.
+        restoreData: request.restoreData === true,
       },
     });
 
@@ -1098,6 +1161,101 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     return `${this.appsBindRoot()}/${deploymentId}`;
   }
 
+  // ---- Pre-upgrade snapshots (#284 Phase 1) --------------------------------
+
+  private snapshotsDir(deploymentId: string): string {
+    return `deployments/${deploymentId}/snapshots`;
+  }
+
+  /**
+   * Snapshot a deployment's app data (file-level tar) keyed by the release that
+   * is active right now (`fromReleaseId`) — the rollback target a later
+   * data-aware rollback restores it for. No-ops when there's no app data yet (a
+   * fresh app has nothing to snapshot). Prunes to the retention bound. The capture
+   * is a live read (crash-consistent); transaction-consistent dumps are the
+   * per-app hooks in #121. Overrides the base hook called from `promote`.
+   */
+  protected override async capturePreUpgradeSnapshot(
+    deploymentId: string,
+    fromReleaseId: string,
+    fromVersion: string | undefined,
+  ): Promise<void> {
+    const appRoot = this.appRootFor(deploymentId);
+    if (!(await dirHasContents(appRoot))) {
+      this.logger.info('No app data to snapshot (fresh deployment)', { deploymentId });
+      return;
+    }
+    const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const snapshotId = `${stamp}-${fromReleaseId.slice(0, 8)}`;
+    const relDir = `${this.snapshotsDir(deploymentId)}/${snapshotId}`;
+    await this.storageService.ensureDir(relDir);
+
+    const tarPath = this.storageService.resolveHolaPath('deployments', deploymentId, 'snapshots', snapshotId, 'data.tar.gz');
+    await tarGzipDir(appRoot, tarPath);
+
+    const meta: SnapshotMeta = {
+      snapshotId,
+      deploymentId,
+      fromReleaseId,
+      fromVersion,
+      createdAt: new Date().toISOString(),
+      sizeBytes: await fileSize(tarPath),
+    };
+    await this.storageService.writeFile(`${relDir}/meta.json`, JSON.stringify(meta, null, 2));
+    this.logger.info('Captured pre-upgrade snapshot', { deploymentId, snapshotId, sizeBytes: meta.sizeBytes });
+    await this.pruneSnapshots(deploymentId);
+  }
+
+  /** Snapshot metadata for a deployment, newest first. */
+  private async listSnapshots(deploymentId: string): Promise<SnapshotMeta[]> {
+    let ids: string[];
+    try {
+      ids = await this.storageService.listDir(this.snapshotsDir(deploymentId));
+    } catch {
+      return [];
+    }
+    const metas: SnapshotMeta[] = [];
+    for (const id of ids) {
+      try {
+        const raw = await this.storageService.readFileAsString(`${this.snapshotsDir(deploymentId)}/${id}/meta.json`);
+        metas.push(JSON.parse(raw) as SnapshotMeta);
+      } catch {
+        // Skip an incomplete/half-written snapshot dir.
+      }
+    }
+    return metas.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+  }
+
+  /** Drop the oldest snapshots beyond the retention bound. */
+  private async pruneSnapshots(deploymentId: string): Promise<void> {
+    const excess = (await this.listSnapshots(deploymentId)).slice(SNAPSHOT_RETENTION);
+    for (const m of excess) {
+      await this.storageService.deleteDir(`${this.snapshotsDir(deploymentId)}/${m.snapshotId}`, true);
+    }
+  }
+
+  /**
+   * Restore the most recent snapshot taken when `targetReleaseId` was active,
+   * replacing the app-data dir. Returns false (with a warning) when none exists —
+   * the caller then proceeds with a containers-only rollback. Callers MUST stop
+   * the app's containers first (the data dir is wiped and replaced).
+   */
+  private async restoreAppDataSnapshot(
+    deploymentId: string,
+    targetReleaseId: string,
+    log: (level: 'info' | 'warn' | 'error' | 'debug', message: string) => Promise<void>,
+  ): Promise<boolean> {
+    const snap = (await this.listSnapshots(deploymentId)).find((m) => m.fromReleaseId === targetReleaseId);
+    if (!snap) {
+      await log('warn', 'No pre-upgrade snapshot for this release — rolling back containers only (app data not restored).');
+      return false;
+    }
+    const tarPath = this.storageService.resolveHolaPath('deployments', deploymentId, 'snapshots', snap.snapshotId, 'data.tar.gz');
+    await log('info', `Restoring app data from pre-upgrade snapshot ${snap.snapshotId}…`);
+    await restoreTarGzInto(tarPath, this.appRootFor(deploymentId));
+    return true;
+  }
+
   /**
    * Publish the app registry feed (ADR 0002): build the canonical list of
    * installed apps and write `registry.json` into the data root of every
@@ -1383,6 +1541,20 @@ export class RealDeploymentService extends InMemoryDeploymentService {
         nextLifecycle = 'active';
       } else {
         // deploy / start / rollback -> pull images, then compose up
+
+        // Data-aware rollback (#284 Phase 1): before bringing the target release
+        // up, stop the current containers and restore the app-data snapshot taken
+        // when the target was last active. Stopping first is essential — we wipe
+        // and replace the data dir, which must not happen under live containers.
+        // No matching snapshot ⇒ a warning + a containers-only rollback (the data
+        // is left as-is rather than failing the rollback outright).
+        if (action === 'rollback' && ctx.payload.restoreData === true) {
+          const targetReleaseId = (ctx.payload.targetReleaseId as string | undefined) ?? deployment.currentReleaseId ?? '';
+          await logBoth('info', 'Data-aware rollback: stopping containers before restoring app data…');
+          await this.dockerService.composeDown(this.runtimeDir(deploymentId), projectName);
+          await this.restoreAppDataSnapshot(deploymentId, targetReleaseId, logBoth);
+        }
+
         const provisioned = await this.provisionAuth(deployment);
         const composeDir = await this.materializeCompose(deployment, provisioned?.env ?? {});
         // Drop the provisioned OIDC creds file into the data root before `up` so a

--- a/packages/server/src/services/core/snapshot-fs.ts
+++ b/packages/server/src/services/core/snapshot-fs.ts
@@ -1,0 +1,59 @@
+/**
+ * Filesystem primitives for pre-upgrade app-data snapshots (#284 Phase 1).
+ *
+ * The server reaches app data directly through the identity bind mount
+ * (`<HOLA_APPS_BIND_ROOT>:<HOLA_APPS_BIND_ROOT>`), so these helpers tar/untar a
+ * host directory in-process. Kept separate from the deployment service so the
+ * I/O is unit-testable on its own. File-level (crash-consistent); transaction-
+ * consistent dumps are the per-app backup hooks tracked in #121.
+ */
+import { spawn } from 'node:child_process';
+import { readdir, rm, mkdir, stat } from 'node:fs/promises';
+
+/** True if `dir` exists and holds at least one entry (a fresh app has nothing to snapshot). */
+export async function dirHasContents(dir: string): Promise<boolean> {
+  try {
+    const entries = await readdir(dir);
+    return entries.length > 0;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return false;
+    throw err;
+  }
+}
+
+/** Size of a file in bytes (0 if it can't be stat'd). */
+export async function fileSize(path: string): Promise<number> {
+  try {
+    return (await stat(path)).size;
+  } catch {
+    return 0;
+  }
+}
+
+function run(cmd: string, args: string[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { stdio: ['ignore', 'ignore', 'pipe'] });
+    let stderr = '';
+    child.stderr?.on('data', (d) => { stderr += String(d); });
+    child.on('error', reject);
+    child.on('close', (code) =>
+      code === 0 ? resolve() : reject(new Error(`${cmd} exited ${code}: ${stderr.trim()}`)),
+    );
+  });
+}
+
+/** Gzip-tar the CONTENTS of `srcDir` into `destFile` (whose parent dir must exist). */
+export async function tarGzipDir(srcDir: string, destFile: string): Promise<void> {
+  await run('tar', ['-czf', destFile, '-C', srcDir, '.']);
+}
+
+/**
+ * Replace `destDir`'s contents with the extracted contents of `srcFile`. The dir
+ * is wiped first so the restore is exact (no stale files from the newer release
+ * left behind) — callers MUST stop the app's containers before calling this.
+ */
+export async function restoreTarGzInto(srcFile: string, destDir: string): Promise<void> {
+  await rm(destDir, { recursive: true, force: true });
+  await mkdir(destDir, { recursive: true });
+  await run('tar', ['-xzf', srcFile, '-C', destDir]);
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1133,6 +1133,13 @@ export type DeploymentDirectoryLayout = {
 export type RollbackRequest = {
   targetReleaseId?: string; // If not specified, rolls back to previous
   reason?: string;
+  /**
+   * Data-aware rollback (#284 Phase 1): also restore the pre-upgrade app-data
+   * snapshot taken when the target release was last active, reverting data + image
+   * together (TrueNAS-style). Off by default (compose/image-only rollback). No
+   * snapshot for the target ⇒ a warning + a containers-only rollback.
+   */
+  restoreData?: boolean;
 };
 
 export type RollbackResponse = {


### PR DESCRIPTION
## What

**Phase 1 of #284** — the safety net for stateful catalog-app upgrades. `promote` now takes a **pre-upgrade snapshot** of the app's data, and `rollback` can **restore data + image together** so the old image isn't booted against a forward-migrated schema (the documented Nextcloud/Immich data-loss trap).

> ⚠️ **Stacked on #290 (Phase 0)** — it consumes the `upgrade.preUpgradeBackup` metadata added there. This PR targets the Phase 0 branch; I'll rebase onto `main` and retarget once #290 merges. Review the [Phase 1 commit] in isolation.

## How

**Pre-upgrade snapshot** (`deployment.ts` + `snapshot-fs.ts`)
- Before a promote switches releases, tar the app's data root (`<HOLA_APPS_BIND_ROOT>/<deploymentId>`) into `deployments/<id>/snapshots/<snapshotId>/{data.tar.gz,meta.json}`, **keyed by the outgoing release** so a later rollback to it restores the right state.
- Hola's bind-mount model means one tar covers *all* of an app's persistence — no DB-dump-vs-volume split, no "host paths not covered" gap.
- **Gated**: always when the target version declares `upgrade.preUpgradeBackup: "required"`; opt-in via `PromoteRequest.snapshot` otherwise. **Fail-closed** only when required (best-effort + warn otherwise).
- **Bounded retention** (last 5). No-ops for a fresh app with no data.
- The capture is a protected hook on the base service (no-op for in-memory/mock), overridden by `RealDeploymentService` — so the 7-arg constructor is unchanged and no test harness breaks.

**Data-aware rollback** (`RollbackRequest.restoreData`)
- Reverts data + image together (TrueNAS "roll back snapshots" toggle). Off by default (compose/image-only).
- Runs as a step in the rollback lifecycle job: **stop containers → restore snapshot into the data dir → bring the target release up.** Stopping first is essential (the dir is wiped and replaced — never under live containers).
- No matching snapshot ⇒ a warning + a containers-only rollback (data left as-is), never a hard failure.

## Consistency note

File-level / **crash-consistent** (a live `tar` of the data dir). Transaction-consistent Postgres dumps are the per-app pre-backup hooks tracked in **#121** (the next PR), which this snapshot primitive will call.

## Reachability

`restoreData` is reachable **today** via the existing `POST /api/deployments/:id/rollback` route. Snapshots fire inside `promote` (the upgrade choke point); `promote` isn't yet wired to a REST/CLI/UI caller, so snapshots become automatic the moment an upgrade flow wires it.

## Testing

`__tests__/deployments/snapshot.test.ts` (real temp `HOLA_APPS_BIND_ROOT`, MockDockerService):
- snapshot capture — opt-in flag, `preUpgradeBackup: required` forces it, not taken by default, fresh-app skip;
- **end-to-end data-aware rollback** — v1 data → promote+snapshot → "migrate" to v2 data → `rollback({restoreData:true})` restores v1 data;
- containers-only rollback leaves migrated data untouched;
- retention bound (7 promotes → 5 kept).
- Full server suite (383) + typecheck + lint + build clean.

## Follow-ups (not in scope)

- #121 backup hooks for transaction-consistent snapshots (next PR).
- Surfacing snapshots/restore in a promote/rollback UI; filling the stubbed `/api/backups` engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)