### PR TITLE
feat(server): per-app pre/post-backup hooks (#121)

### DIFF
--- a/packages/server/src/__tests__/bundles/manifest-backup.test.ts
+++ b/packages/server/src/__tests__/bundles/manifest-backup.test.ts
@@ -1,0 +1,45 @@
+/**
+ * coerceManifestBackup — narrow-shape coercion of the bundle manifest's optional
+ * `backup` block (#121). A hook survives only with a service + non-empty exec-form
+ * command; malformed hooks are dropped, and an all-empty block → undefined.
+ */
+import { describe, test, expect } from 'bun:test';
+
+import { coerceManifestBackup } from '../../services/core/manifest-backup';
+
+describe('coerceManifestBackup', () => {
+  test('returns undefined for non-objects / empty', () => {
+    expect(coerceManifestBackup(undefined)).toBeUndefined();
+    expect(coerceManifestBackup(null)).toBeUndefined();
+    expect(coerceManifestBackup('x')).toBeUndefined();
+    expect(coerceManifestBackup({})).toBeUndefined();
+  });
+
+  test('carries a full pre/post hook pair', () => {
+    expect(
+      coerceManifestBackup({
+        preHook: { service: 'db', command: ['sh', '-c', 'pg_dump > /backups/dump.sql'] },
+        postHook: { service: 'db', command: ['rm', '-f', '/backups/dump.sql'] },
+      }),
+    ).toEqual({
+      preHook: { service: 'db', command: ['sh', '-c', 'pg_dump > /backups/dump.sql'] },
+      postHook: { service: 'db', command: ['rm', '-f', '/backups/dump.sql'] },
+    });
+  });
+
+  test('keeps a valid preHook and drops a malformed postHook', () => {
+    expect(
+      coerceManifestBackup({
+        preHook: { service: 'db', command: ['pg_dump'] },
+        postHook: { service: 'db' }, // no command
+      }),
+    ).toEqual({ preHook: { service: 'db', command: ['pg_dump'] } });
+  });
+
+  test('drops a hook missing its service or with an empty/non-string command', () => {
+    expect(coerceManifestBackup({ preHook: { command: ['pg_dump'] } })).toBeUndefined(); // no service
+    expect(coerceManifestBackup({ preHook: { service: 'db', command: [] } })).toBeUndefined(); // empty
+    expect(coerceManifestBackup({ preHook: { service: 'db', command: 'pg_dump' } })).toBeUndefined(); // not array
+    expect(coerceManifestBackup({ preHook: { service: 'db', command: ['ok', 42] } })).toBeUndefined(); // non-string arg
+  });
+});

--- a/packages/server/src/__tests__/deployments/backup-hooks.test.ts
+++ b/packages/server/src/__tests__/deployments/backup-hooks.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Per-app backup hooks around the pre-upgrade snapshot (#121 × #284 Phase 1).
+ *
+ * When an app declares `backup.preHook`/`postHook`, the server runs them in the
+ * app's own containers around the snapshot capture: the preHook before the file
+ * tar (quiesce / pg_dump), the postHook after (cleanup). A preHook failure
+ * propagates so `promote` can fail-closed; the postHook is best-effort. Uses a
+ * recording DockerService over MockDockerService.
+ */
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtemp, rm, mkdir, writeFile, readdir } from 'fs/promises';
+import { existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import type { AppBackupConfig, AppUpgradeMeta } from '@hola/shared';
+import { RealDeploymentService } from '../../services/core/deployment';
+import { MockProvisionerService } from '../../services/core/provisioner';
+import { RealDraftService } from '../../services/core/draft';
+import { RealStorageService } from '../../services/core/storage';
+import { RealRoutingService } from '../../services/core/routing';
+import { RealDatabaseService } from '../../services/core/database';
+import { RealLoggingService } from '../../services/core/logging';
+import { RealJobService } from '../../services/core/jobs';
+import { MockDockerService } from '../../services/core/docker';
+
+type CatalogArg = ConstructorParameters<typeof RealDraftService>[1];
+type ValidationArg = ConstructorParameters<typeof RealDraftService>[2];
+
+let backupConfig: AppBackupConfig | undefined;
+let upgradeConfig: AppUpgradeMeta | undefined;
+
+function makeCatalog(): CatalogArg {
+  return {
+    getApp: async (appId: string) => ({ id: appId, name: 'Postgres App', icon: '🐘' }),
+    getVersionDetail: async () => ({
+      defaultEnv: [],
+      defaults: { ports: [{ host: 3000, container: 3000, protocol: 'tcp' as const }], volumes: [] },
+      backup: backupConfig,
+      upgrade: upgradeConfig,
+    }),
+  } as unknown as CatalogArg;
+}
+
+function makeValidation(): ValidationArg {
+  return {
+    validateDraft: async () => ({ ok: true, errors: [], warnings: [] }),
+    preflightCheck: async () => ({ ok: true, checks: [] }),
+  } as unknown as ValidationArg;
+}
+
+const COMPOSE = 'services:\n  app:\n    image: app:latest\n  db:\n    image: postgres:16\n';
+
+/** Records composeExec calls; can be told to fail a given service's exec. */
+class RecordingDocker extends MockDockerService {
+  calls: Array<{ service: string; command: string[] }> = [];
+  failService?: string;
+  override async composeExec(projectPath: string, projectName: string, service: string, command: string[]) {
+    this.calls.push({ service, command });
+    if (this.failService === service) return { success: false, output: `boom in ${service}` };
+    return super.composeExec(projectPath, projectName, service, command);
+  }
+}
+
+describe('Backup hooks around the pre-upgrade snapshot (#121)', () => {
+  let dataRoot: string;
+  let appsRoot: string;
+  let prevAppsBindRoot: string | undefined;
+  let docker: RecordingDocker;
+
+  beforeEach(async () => {
+    dataRoot = await mkdtemp(join(tmpdir(), 'hola-bh-data-'));
+    appsRoot = await mkdtemp(join(tmpdir(), 'hola-bh-apps-'));
+    prevAppsBindRoot = process.env.HOLA_APPS_BIND_ROOT;
+    process.env.HOLA_APPS_BIND_ROOT = appsRoot;
+    backupConfig = undefined;
+    upgradeConfig = undefined;
+    docker = new RecordingDocker();
+  });
+
+  afterEach(async () => {
+    if (prevAppsBindRoot === undefined) delete process.env.HOLA_APPS_BIND_ROOT;
+    else process.env.HOLA_APPS_BIND_ROOT = prevAppsBindRoot;
+    await rm(dataRoot, { recursive: true, force: true });
+    await rm(appsRoot, { recursive: true, force: true });
+  });
+
+  function makeSystem() {
+    const storage = new RealStorageService({ holaDir: dataRoot });
+    const database = new RealDatabaseService(storage);
+    const logging = new RealLoggingService(storage);
+    const jobs = new RealJobService(database, logging);
+    const routing = new RealRoutingService(storage, { baseDomain: 'local.hola' });
+    const drafts = new RealDraftService(storage, makeCatalog(), makeValidation());
+    const deployments = new RealDeploymentService(storage, jobs, docker, drafts, routing, logging, new MockProvisionerService());
+    return { storage, jobs, drafts, deployments };
+  }
+
+  async function finalizedDraft(drafts: RealDraftService, version: string): Promise<string> {
+    const { draftId } = await drafts.createDraft({ appId: 'pgapp', version });
+    await drafts.updateDraft(draftId, { composeOverride: COMPOSE });
+    await drafts.finalizeDraft(draftId);
+    return draftId;
+  }
+
+  async function withAppData(deploymentId: string) {
+    const dir = join(appsRoot, deploymentId);
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, 'state.txt'), 'data');
+  }
+  function snapshotsPath(deploymentId: string) {
+    return join(dataRoot, 'deployments', deploymentId, 'snapshots');
+  }
+
+  const PG_BACKUP: AppBackupConfig = {
+    preHook: { service: 'db', command: ['sh', '-c', 'pg_dump -U postgres app > /backups/dump.sql'] },
+    postHook: { service: 'db', command: ['rm', '-f', '/backups/dump.sql'] },
+  };
+
+  test('runs preHook then postHook in the declared service around the snapshot', async () => {
+    backupConfig = PG_BACKUP;
+    const { drafts, deployments } = makeSystem();
+    const dep = await deployments.createFromDraft({ draftId: await finalizedDraft(drafts, '1.0.0'), name: 'pgapp', options: { autoStart: false } });
+    await withAppData(dep.deploymentId);
+
+    await deployments.promote(dep.deploymentId, { draftId: await finalizedDraft(drafts, '2.0.0'), snapshot: true, options: { autoStart: false } });
+
+    // Both hooks ran in `db`, pre before post.
+    const hookCalls = docker.calls.filter((c) => c.service === 'db');
+    expect(hookCalls).toHaveLength(2);
+    expect(hookCalls[0].command.join(' ')).toContain('pg_dump');
+    expect(hookCalls[1].command.join(' ')).toContain('rm');
+    // The snapshot was still captured.
+    expect((await readdir(snapshotsPath(dep.deploymentId))).length).toBe(1);
+  });
+
+  test('an app with no backup block runs no hooks', async () => {
+    backupConfig = undefined;
+    const { drafts, deployments } = makeSystem();
+    const dep = await deployments.createFromDraft({ draftId: await finalizedDraft(drafts, '1.0.0'), name: 'pgapp', options: { autoStart: false } });
+    await withAppData(dep.deploymentId);
+
+    await deployments.promote(dep.deploymentId, { draftId: await finalizedDraft(drafts, '2.0.0'), snapshot: true, options: { autoStart: false } });
+
+    expect(docker.calls.filter((c) => c.service === 'db')).toHaveLength(0);
+    expect((await readdir(snapshotsPath(dep.deploymentId))).length).toBe(1);
+  });
+
+  test('a preHook failure under preUpgradeBackup:required fails the promote and writes no snapshot', async () => {
+    backupConfig = PG_BACKUP;
+    upgradeConfig = { preUpgradeBackup: 'required' }; // forces fail-closed
+    docker.failService = 'db'; // pg_dump "fails"
+    const { drafts, deployments } = makeSystem();
+    const dep = await deployments.createFromDraft({ draftId: await finalizedDraft(drafts, '1.0.0'), name: 'pgapp', options: { autoStart: false } });
+    await withAppData(dep.deploymentId);
+
+    // Target requires a backup → a preHook failure is fail-closed (no snapshot flag needed).
+    await expect(
+      deployments.promote(dep.deploymentId, { draftId: await finalizedDraft(drafts, '2.0.0'), options: { autoStart: false } }),
+    ).rejects.toThrow();
+
+    // No snapshot dir was produced (the preHook gated the capture).
+    expect(existsSync(snapshotsPath(dep.deploymentId))).toBe(false);
+  });
+
+  test('a preHook failure WITHOUT required backup warns and continues (snapshot still taken)', async () => {
+    backupConfig = PG_BACKUP;
+    docker.failService = 'db';
+    const { drafts, deployments } = makeSystem();
+    const dep = await deployments.createFromDraft({ draftId: await finalizedDraft(drafts, '1.0.0'), name: 'pgapp', options: { autoStart: false } });
+    await withAppData(dep.deploymentId);
+
+    // Opt-in snapshot, not required → a preHook failure is best-effort: the promote
+    // succeeds. (No snapshot is written because the capture is skipped on preHook
+    // failure, but the upgrade proceeds.)
+    const res = await deployments.promote(dep.deploymentId, { draftId: await finalizedDraft(drafts, '2.0.0'), snapshot: true, options: { autoStart: false } });
+    expect(res.releaseId).toBeDefined();
+    expect(existsSync(snapshotsPath(dep.deploymentId))).toBe(false);
+  });
+});

--- a/packages/server/src/services/core/catalog.ts
+++ b/packages/server/src/services/core/catalog.ts
@@ -14,6 +14,7 @@ import type {
 import { coerceManifestAuth } from './manifest-auth';
 import { coerceConsumes } from './app-registry';
 import { coerceManifestUpgrade } from './manifest-upgrade';
+import { coerceManifestBackup } from './manifest-backup';
 
 // Shape of remote catalog JSON (minimal for now)
 type RemoteCatalog = {
@@ -190,6 +191,7 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
         auth?: unknown;
         consumes?: unknown;
         upgrade?: unknown;
+        backup?: unknown;
         ingress?: { service?: unknown; port?: unknown };
       };
 
@@ -263,6 +265,10 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
       // `auth`, so unknown fields don't survive into the deploy lifecycle.
       const upgrade = coerceManifestUpgrade(manifest.upgrade);
 
+      // Per-app pre/post-backup hooks (#121): run around a snapshot for
+      // transaction-consistent backups. Coerced narrowly like `auth`.
+      const backup = coerceManifestBackup(manifest.backup);
+
       // Which compose service is the web/ingress one — the app's bundle manifest
       // declares it as `ingress.service`. Lets the server route to / inject auth
       // env into the right service for a multi-service app whose ingress isn't
@@ -272,7 +278,7 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
           ? manifest.ingress.service.trim()
           : undefined;
 
-      return { ...merged, composeOverride, auth, consumes, upgrade, ingressService } satisfies GetCatalogAppVersionDetailResponse;
+      return { ...merged, composeOverride, auth, consumes, upgrade, backup, ingressService } satisfies GetCatalogAppVersionDetailResponse;
     } catch (error) {
       this.logger.warn('Failed to read or parse bundle manifest; deferring to mocks', { appId, version, error: error instanceof Error ? error.message : String(error) });
       throw new Error('MANIFEST_UNAVAILABLE', { cause: error });

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -1185,25 +1185,69 @@ export class RealDeploymentService extends InMemoryDeploymentService {
       this.logger.info('No app data to snapshot (fresh deployment)', { deploymentId });
       return;
     }
-    const stamp = new Date().toISOString().replace(/[:.]/g, '-');
-    const snapshotId = `${stamp}-${fromReleaseId.slice(0, 8)}`;
-    const relDir = `${this.snapshotsDir(deploymentId)}/${snapshotId}`;
-    await this.storageService.ensureDir(relDir);
 
-    const tarPath = this.storageService.resolveHolaPath('deployments', deploymentId, 'snapshots', snapshotId, 'data.tar.gz');
-    await tarGzipDir(appRoot, tarPath);
+    // #121 backup hooks: a file-level tar of a live DB is only crash-consistent,
+    // so an app can declare a `preHook` (quiesce / `pg_dump` into a path the tar
+    // captures) and a `postHook` (clean up). The server runs them in the app's own
+    // containers around the capture (ADR 0002 post-deploy command mechanism). Read
+    // from the OUTGOING release's manifest — that's the app currently running.
+    const backup = await this.readReleaseBackupConfig(deploymentId, fromReleaseId);
+    const dir = this.runtimeDir(deploymentId);
+    const projectName = this.projectName(deploymentId);
 
-    const meta: SnapshotMeta = {
-      snapshotId,
-      deploymentId,
-      fromReleaseId,
-      fromVersion,
-      createdAt: new Date().toISOString(),
-      sizeBytes: await fileSize(tarPath),
-    };
-    await this.storageService.writeFile(`${relDir}/meta.json`, JSON.stringify(meta, null, 2));
-    this.logger.info('Captured pre-upgrade snapshot', { deploymentId, snapshotId, sizeBytes: meta.sizeBytes });
-    await this.pruneSnapshots(deploymentId);
+    // preHook failure propagates — `promote` decides fail-closed (when the target
+    // declares `preUpgradeBackup: required`) vs. best-effort. A consistent dump is
+    // worthless if we snapshot anyway.
+    if (backup?.preHook) {
+      this.logger.info('Running backup preHook before snapshot', { deploymentId, service: backup.preHook.service });
+      const res = await this.dockerService.composeExec(dir, projectName, backup.preHook.service, backup.preHook.command);
+      if (!res.success) throw new Error(`backup preHook failed: ${res.output}`);
+    }
+
+    try {
+      const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+      const snapshotId = `${stamp}-${fromReleaseId.slice(0, 8)}`;
+      const relDir = `${this.snapshotsDir(deploymentId)}/${snapshotId}`;
+      await this.storageService.ensureDir(relDir);
+
+      const tarPath = this.storageService.resolveHolaPath('deployments', deploymentId, 'snapshots', snapshotId, 'data.tar.gz');
+      await tarGzipDir(appRoot, tarPath);
+
+      const meta: SnapshotMeta = {
+        snapshotId,
+        deploymentId,
+        fromReleaseId,
+        fromVersion,
+        createdAt: new Date().toISOString(),
+        sizeBytes: await fileSize(tarPath),
+      };
+      await this.storageService.writeFile(`${relDir}/meta.json`, JSON.stringify(meta, null, 2));
+      this.logger.info('Captured pre-upgrade snapshot', { deploymentId, snapshotId, sizeBytes: meta.sizeBytes });
+      await this.pruneSnapshots(deploymentId);
+    } finally {
+      // postHook always runs (clean up the dump), even if the capture threw.
+      // Best-effort — a cleanup failure must not fail the upgrade.
+      if (backup?.postHook) {
+        try {
+          const res = await this.dockerService.composeExec(dir, projectName, backup.postHook.service, backup.postHook.command);
+          if (!res.success) this.logger.warn('backup postHook failed', { deploymentId, output: res.output });
+        } catch (err) {
+          this.logger.warn('backup postHook errored', { deploymentId, error: err instanceof Error ? err.message : String(err) });
+        }
+      }
+    }
+  }
+
+  /** Read the per-app backup hooks (#121) from a release's finalized manifest. */
+  private async readReleaseBackupConfig(deploymentId: string, releaseId: string): Promise<FinalizedManifest['backup']> {
+    const path = `deployments/${deploymentId}/releases/${releaseId}/manifest.json`;
+    if (!(await this.storageService.fileExists(path))) return undefined;
+    try {
+      const manifest = JSON.parse(await this.storageService.readFileAsString(path)) as FinalizedManifest;
+      return manifest.backup;
+    } catch {
+      return undefined;
+    }
   }
 
   /** Snapshot metadata for a deployment, newest first. */

--- a/packages/server/src/services/core/draft.ts
+++ b/packages/server/src/services/core/draft.ts
@@ -21,7 +21,8 @@ import type {
   AppEnvVar,
   DraftDefaults,
   AppAuthConfig,
-  AppUpgradeMeta
+  AppUpgradeMeta,
+  AppBackupConfig
 } from '@hola/shared';
 
 import { createHash } from 'crypto';
@@ -71,6 +72,9 @@ export interface FinalizedManifest {
   // Upgrade-safety metadata (#284 Phase 0) carried from the bundle manifest so
   // `promote` can enforce the skip-guard against this (target) version.
   upgrade?: AppUpgradeMeta;
+  // Per-app pre/post-backup hooks (#121) carried from the bundle manifest so the
+  // snapshot path can run them around the file capture.
+  backup?: AppBackupConfig;
   files: FinalizedManifestFile[];
   checksum: string;
   finalizedAt: string;
@@ -338,6 +342,7 @@ export class RealDraftService implements DraftService {
         consumes: defaults.consumes,
         ingressService: defaults.ingressService,
         upgrade: defaults.upgrade,
+        backup: defaults.backup,
         files: [],
       };
 
@@ -592,6 +597,7 @@ export class RealDraftService implements DraftService {
         consumes: draft.consumes,
         ingressService: draft.ingressService,
         upgrade: draft.upgrade,
+        backup: draft.backup,
         files: specFiles,
       };
 
@@ -672,7 +678,7 @@ export class RealDraftService implements DraftService {
     };
   }
 
-  async getDraftDefaults(appId: string, version?: string): Promise<{ env: AppEnvVar[]; defaults: DraftDefaults; composeOverride: string; auth?: AppAuthConfig; consumes?: string[]; ingressService?: string; upgrade?: AppUpgradeMeta }> {
+  async getDraftDefaults(appId: string, version?: string): Promise<{ env: AppEnvVar[]; defaults: DraftDefaults; composeOverride: string; auth?: AppAuthConfig; consumes?: string[]; ingressService?: string; upgrade?: AppUpgradeMeta; backup?: AppBackupConfig }> {
     try {
       const versionDetail = await this.catalogService.getVersionDetail(appId, version || 'latest');
       return {
@@ -683,6 +689,7 @@ export class RealDraftService implements DraftService {
         consumes: versionDetail.consumes,
         ingressService: versionDetail.ingressService,
         upgrade: versionDetail.upgrade,
+        backup: versionDetail.backup,
       };
     } catch (error) {
       this.logger.warn('Failed to get app defaults, using fallback', { appId, version, error: error instanceof Error ? error.message : String(error) });
@@ -845,6 +852,7 @@ export class MockDraftService implements DraftService {
       composeOverride: draft.composeOverride ?? '',
       ingressService: draft.ingressService,
       upgrade: draft.upgrade,
+      backup: draft.backup,
       files: [],
       checksum: 'mock-checksum',
       finalizedAt: new Date().toISOString(),

--- a/packages/server/src/services/core/manifest-backup.ts
+++ b/packages/server/src/services/core/manifest-backup.ts
@@ -1,0 +1,45 @@
+import type { AppBackupConfig, AppBackupHook } from '@hola/shared';
+
+/**
+ * Narrow-shape coercion for the bundle manifest's optional `backup` block (#121),
+ * mirroring `coerceManifestAuth` / `coerceManifestUpgrade`. A hook is kept only
+ * when it names a service and a non-empty exec-form command (all-string argv);
+ * anything malformed is dropped. Returns `undefined` when neither hook survives.
+ */
+
+function asRecord(v: unknown): Record<string, unknown> | undefined {
+  return v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : undefined;
+}
+
+function asString(v: unknown): string | undefined {
+  return typeof v === 'string' && v.trim().length > 0 ? v.trim() : undefined;
+}
+
+/** A command must be a non-empty array of non-empty strings (exec form, no shell-string). */
+function asCommand(v: unknown): string[] | undefined {
+  if (!Array.isArray(v) || v.length === 0) return undefined;
+  if (!v.every((x) => typeof x === 'string' && x.length > 0)) return undefined;
+  return v as string[];
+}
+
+function coerceHook(value: unknown): AppBackupHook | undefined {
+  const rec = asRecord(value);
+  if (!rec) return undefined;
+  const service = asString(rec.service);
+  const command = asCommand(rec.command);
+  if (!service || !command) return undefined;
+  return { service, command };
+}
+
+export function coerceManifestBackup(value: unknown): AppBackupConfig | undefined {
+  const rec = asRecord(value);
+  if (!rec) return undefined;
+
+  const config: AppBackupConfig = {};
+  const preHook = coerceHook(rec.preHook);
+  if (preHook) config.preHook = preHook;
+  const postHook = coerceHook(rec.postHook);
+  if (postHook) config.postHook = postHook;
+
+  return config.preHook || config.postHook ? config : undefined;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -132,6 +132,29 @@ export type AppUpgradeMeta = {
   preUpgradeBackup?: 'required' | 'recommended' | 'none';
 };
 
+/**
+ * A backup hook command run inside one of the app's own compose services (#121).
+ * `command` is exec-form (argv), run via `docker compose exec <service> …`.
+ */
+export type AppBackupHook = {
+  service: string;
+  command: string[];
+};
+
+/**
+ * Per-app pre/post-backup hooks (#121), declared in the bundle manifest's
+ * `backup` block. A file-level snapshot of a running DB-backed app is only
+ * crash-consistent; the `preHook` quiesces/dumps (e.g. `pg_dump` into a path the
+ * snapshot captures) before the file capture, and the `postHook` cleans up after.
+ * The Hola server runs them around the snapshot (it owns the deploy lifecycle and
+ * the post-deploy command mechanism — ADR 0002). Shared by the pre-upgrade
+ * snapshot (#284) and, later, scheduled Backrest backups.
+ */
+export type AppBackupConfig = {
+  preHook?: AppBackupHook;
+  postHook?: AppBackupHook;
+};
+
 /** Result of {@link checkUpgradePath}: ok, or a rejection with an actionable next step. */
 export type UpgradePathResult =
   | { ok: true }
@@ -419,6 +442,10 @@ export type GetCatalogAppVersionDetailResponse = {
   // dashboard's pre-upgrade warning. Optional: apps that don't declare it have
   // no upgrade restrictions.
   upgrade?: AppUpgradeMeta;
+  // Per-app pre/post-backup hooks (#121) for transaction-consistent snapshots
+  // (e.g. pg_dump before a file-level capture). Optional: most apps (and SQLite)
+  // are fine with crash-consistent file snapshots and omit it.
+  backup?: AppBackupConfig;
 };
 
 // ------------------------------------------------------
@@ -565,6 +592,10 @@ export type Draft = {
   // carried through finalize so `promote` can enforce the skip-guard against the
   // target version (read-only; not user-editable).
   upgrade?: AppUpgradeMeta;
+  // Per-app pre/post-backup hooks (#121) seeded from the bundle manifest and
+  // carried through finalize so the snapshot path can quiesce/dump around the
+  // file capture (read-only; not user-editable).
+  backup?: AppBackupConfig;
   files: Array<{ uploadId: string; name: string; size: number; kind: 'composeOverride' | 'additionalFile' | 'env' | 'secret' }>;
 };
 


### PR DESCRIPTION
## What

Implements **#121** — per-app pre/post-backup hooks for transaction-consistent backups — and wires them into the #284 Phase 1 pre-upgrade snapshot.

A file-level `tar` of a running DB-backed app is **crash-consistent, not transaction-consistent**. Postgres-backed catalog apps (Immich, Postiz, Paperless, Mealie, Guacamole) can need a quiesce/dump first. This adds the hook primitive so an app declares that in its manifest and the server runs it around the snapshot.

> ⚠️ **Stacked on #292 (Phase 1) → #290 (Phase 0)**. Targets the Phase 1 branch; I'll rebase the stack onto `main` as each parent merges.

## How

**Manifest `backup` block** (coerced like `auth`/`upgrade`):
```jsonc
"backup": {
  "preHook":  { "service": "db", "command": ["sh","-c","pg_dump -U postgres app > /backups/dump.sql"] },
  "postHook": { "service": "db", "command": ["rm","-f","/backups/dump.sql"] }
}
```
- `command` is **exec-form** (argv); `manifest-backup.ts` drops anything malformed.
- Surfaced via `getVersionDetail`, threaded `draft → finalize → release`.

**Server runs the hooks** (`capturePreUpgradeSnapshot`):
- `preHook` **before** the file capture, in the app's own container via `docker compose exec` (the ADR 0002 post-deploy command mechanism). The author writes the dump to a path bind-mounted under the app's data root so the snapshot captures it.
- `postHook` **after**, in a `finally` (cleanup runs even if the tar threw); best-effort, never fails the upgrade.
- A **preHook failure propagates** → `promote` is **fail-closed** when the target declares `preUpgradeBackup: required` (a useless dump must not be snapshotted around), and **best-effort** (warn + continue) otherwise.

## Consistency contract

The dump must land under the app's data root (e.g. a `${HOLA_APP_DATA}/backups:/backups` mount + `pg_dump > /backups/dump.sql`) so the file-level snapshot captures it. The hook command runs container-side, so it uses container paths — the server does not rewrite `${HOLA_APP_DATA}` inside hook commands.

## Testing

- Coercion: full pre/post pair, partial (valid pre + malformed post dropped), and malformed-hook rejection (missing service, empty/non-array/non-string command).
- Integration (recording DockerService over MockDockerService): pre-then-post ordering in the declared service; an app with no `backup` block runs no hooks; **fail-closed** under `preUpgradeBackup: required` (promote rejects, no snapshot) vs **best-effort** otherwise (promote succeeds).
- Full server suite (391) + typecheck + lint + build clean.

## Follow-up (not in scope)

- **Backrest scheduled-backup consumer.** #121's other caller needs a trigger path (Backrest → server "snapshot starting") so the same hooks run before restic captures. That's a cross-app mechanism for a separate PR; the reusable primitive (manifest config + `composeExec` around a capture) is in place here.
- Apps-repo: declare `backup` hooks on the Postgres-backed catalog apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)