### PR TITLE
feat: per-app catalog update notifications (#284)

### DIFF
--- a/packages/server/src/__tests__/deployments/update-info.test.ts
+++ b/packages/server/src/__tests__/deployments/update-info.test.ts
@@ -87,6 +87,16 @@ describe('Per-app update notifications (#284)', () => {
     expect(list.items[0].updateAvailable).toBe(false);
   });
 
+  test('a deployment pinned to "latest" is never flagged as out-of-date', async () => {
+    const { drafts, deployments } = makeSystem(['1.0.0', '2.0.0']);
+    await deploy(drafts, deployments, 'latest');
+    const list = await deployments.listDeployments({ page: 1, limit: 10 });
+    // latestVersion is still surfaced, but there's no spurious "update available"
+    // (we don't know the concrete installed version behind "latest").
+    expect(list.items[0].latestVersion).toBe('2.0.0');
+    expect(list.items[0].updateAvailable).toBe(false);
+  });
+
   test('no catalog wired → fields left unset (no enrichment)', async () => {
     const { drafts, deployments } = makeSystem(null);
     await deploy(drafts, deployments, '1.0.0');

--- a/packages/server/src/__tests__/deployments/update-info.test.ts
+++ b/packages/server/src/__tests__/deployments/update-info.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Per-app update notifications (#284): deployment list/detail responses are
+ * annotated with `latestVersion` + `updateAvailable` from the catalog. The
+ * enrichment is fail-safe and a no-op when no catalog is wired.
+ */
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { RealDeploymentService } from '../../services/core/deployment';
+import { MockProvisionerService } from '../../services/core/provisioner';
+import { RealDraftService } from '../../services/core/draft';
+import { RealStorageService } from '../../services/core/storage';
+import { RealRoutingService } from '../../services/core/routing';
+import { MockDockerService } from '../../services/core/docker';
+import type { CatalogService } from '../../services/core/catalog';
+
+type CatalogArg = ConstructorParameters<typeof RealDraftService>[1];
+type JobArg = ConstructorParameters<typeof RealDeploymentService>[1];
+
+function makeCatalog(versions: string[]) {
+  return {
+    getApp: async (appId: string) => ({ id: appId, name: 'Gitea', icon: '🍵' }),
+    getVersionDetail: async () => ({ defaultEnv: [], defaults: { ports: [], volumes: [] } }),
+    getVersions: async () => ({ items: versions.map((v) => ({ version: v, createdAt: '2020-01-01' })), total: versions.length }),
+  };
+}
+function makeValidation() {
+  return { validateDraft: async () => ({ ok: true, errors: [], warnings: [] }), preflightCheck: async () => ({ ok: true, checks: [] }) };
+}
+function makeJobs(): JobArg {
+  return {
+    createJob: async (p: { type: string; deploymentId?: string }) => ({ id: crypto.randomUUID(), type: p.type, status: 'queued', startedAt: new Date().toISOString(), deploymentId: p.deploymentId }),
+    listJobs: async () => [],
+    cancelJob: async () => {},
+    getJob: async () => null,
+    onJobUpdate: () => ({ unsubscribe() {} }),
+    setExecutor: () => {},
+    healthCheck: async () => ({ healthy: true, lastCheck: new Date() }),
+  } as unknown as JobArg;
+}
+const noLogging = { log: async () => {}, onLog: () => ({ unsubscribe() {} }), logJob: async () => {}, logDeployment: async () => {}, healthCheck: async () => ({ healthy: true, lastCheck: new Date() }) } as unknown as ConstructorParameters<typeof RealDeploymentService>[5];
+
+describe('Per-app update notifications (#284)', () => {
+  let dataRoot: string;
+  beforeEach(async () => { dataRoot = await mkdtemp(join(tmpdir(), 'hola-upd-')); });
+  afterEach(async () => { await rm(dataRoot, { recursive: true, force: true }); });
+
+  function makeSystem(catalogVersions: string[] | null) {
+    const storage = new RealStorageService({ holaDir: dataRoot });
+    const catalog = makeCatalog(catalogVersions ?? ['1.0.0']);
+    const drafts = new RealDraftService(storage, catalog as unknown as CatalogArg, makeValidation() as unknown as ConstructorParameters<typeof RealDraftService>[2]);
+    const routing = new RealRoutingService(storage, { baseDomain: 'local.hola' });
+    const deployments = new RealDeploymentService(
+      storage, makeJobs(), new MockDockerService(), drafts, routing, noLogging, new MockProvisionerService(),
+      catalogVersions === null ? undefined : (catalog as unknown as CatalogService),
+    );
+    return { drafts, deployments };
+  }
+
+  async function deploy(drafts: RealDraftService, deployments: RealDeploymentService, version: string) {
+    const { draftId } = await drafts.createDraft({ appId: 'gitea', version });
+    await drafts.updateDraft(draftId, { composeOverride: 'services:\n  gitea:\n    image: gitea/gitea:latest\n' });
+    await drafts.finalizeDraft(draftId);
+    return deployments.createFromDraft({ draftId, name: 'gitea', options: { autoStart: false } });
+  }
+
+  test('flags updateAvailable + latestVersion when the catalog has a newer version', async () => {
+    const { drafts, deployments } = makeSystem(['1.0.0', '2.0.0']);
+    await deploy(drafts, deployments, '1.0.0');
+
+    const list = await deployments.listDeployments({ page: 1, limit: 10 });
+    expect(list.items[0].latestVersion).toBe('2.0.0');
+    expect(list.items[0].updateAvailable).toBe(true);
+
+    const detail = await deployments.getDeployment(list.items[0].id);
+    expect(detail.updateAvailable).toBe(true);
+    expect(detail.latestVersion).toBe('2.0.0');
+  });
+
+  test('no update when installed is already the newest', async () => {
+    const { drafts, deployments } = makeSystem(['1.0.0', '2.0.0']);
+    await deploy(drafts, deployments, '2.0.0');
+    const list = await deployments.listDeployments({ page: 1, limit: 10 });
+    expect(list.items[0].latestVersion).toBe('2.0.0');
+    expect(list.items[0].updateAvailable).toBe(false);
+  });
+
+  test('no catalog wired → fields left unset (no enrichment)', async () => {
+    const { drafts, deployments } = makeSystem(null);
+    await deploy(drafts, deployments, '1.0.0');
+    const list = await deployments.listDeployments({ page: 1, limit: 10 });
+    expect(list.items[0].latestVersion).toBeUndefined();
+    expect(list.items[0].updateAvailable).toBeUndefined();
+  });
+});

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -1346,7 +1346,12 @@ export class RealDeploymentService extends InMemoryDeploymentService {
       const latest = latestByApp.get(item.app);
       if (!latest) continue;
       item.latestVersion = latest;
-      item.updateAvailable = !!item.version && isNewerVersion(latest, item.version);
+      // Only flag an update when the installed version is a concrete, comparable
+      // one. A deployment pinned to the literal "latest" has no known concrete
+      // version to compare against — treating it as 0.0.0 would mark *every*
+      // latest-install as out-of-date — so report "no update available" instead.
+      const installed = item.version;
+      item.updateAvailable = !!installed && installed !== 'latest' && isNewerVersion(latest, installed);
     }
   }
 

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -36,7 +36,7 @@ import type {
   GetLogsResponse,
   LogEntry
 } from '@hola/shared';
-import { checkUpgradePath } from '@hola/shared';
+import { checkUpgradePath, isNewerVersion } from '@hola/shared';
 
 import { getLogger } from '../../lib/logger';
 import { NotFoundError, ConflictError, ValidationError } from '../../middleware/error-mapping';
@@ -47,6 +47,7 @@ import type { JobService, JobContext } from './jobs';
 import { JobCancelledError } from './jobs';
 import type { DockerService } from './docker';
 import type { DraftService, FinalizedArtifacts, FinalizedManifest } from './draft';
+import type { CatalogService } from './catalog';
 import type { RoutingService } from './routing';
 import type { LoggingService } from './logging';
 import type { ProvisionerService, ProvisionResult } from './provisioner';
@@ -664,13 +665,28 @@ abstract class InMemoryDeploymentService implements DeploymentService {
   async listDeployments(request: GetDeploymentsRequest): Promise<GetDeploymentsResponse> {
     await this.ensureLoaded();
     this.logger.info('Listing deployments', { request });
-    return filterAndPaginateDeployments(Array.from(this.deployments.values()), request);
+    const page = filterAndPaginateDeployments(Array.from(this.deployments.values()), request);
+    await this.enrichUpdateInfo(page.items);
+    return page;
   }
 
   async getDeployment(deploymentId: string): Promise<GetDeploymentResponse> {
     await this.ensureLoaded();
     this.logger.info('Getting deployment', { deploymentId });
-    return toDetailResponse(this.requireDeployment(deploymentId));
+    const detail = toDetailResponse(this.requireDeployment(deploymentId));
+    await this.enrichUpdateInfo([detail]);
+    return detail;
+  }
+
+  /**
+   * Annotate deployment responses with catalog update availability (#284):
+   * `latestVersion` + `updateAvailable` from the catalog. Default no-op (the
+   * in-memory/mock service has no catalog); RealDeploymentService overrides it.
+   */
+  protected async enrichUpdateInfo(
+    items: Array<{ app: string; version?: string; latestVersion?: string; updateAvailable?: boolean }>,
+  ): Promise<void> {
+    void items;
   }
 
   async updateDeployment(deploymentId: string, request: PatchDeploymentRequest): Promise<PatchDeploymentResponse> {
@@ -913,7 +929,10 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     private draftService: DraftService,
     private routingService: RoutingService,
     private loggingService: LoggingService,
-    private provisioner: ProvisionerService
+    private provisioner: ProvisionerService,
+    // Optional so existing constructions (and tests) need no change; when present,
+    // deployment responses are annotated with catalog update availability (#284).
+    private catalogService?: CatalogService,
   ) {
     super(jobService);
     // Perform real Compose lifecycle work when a deployment job runs.
@@ -1298,6 +1317,37 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     await log('info', `Restoring app data from pre-upgrade snapshot ${snap.snapshotId}…`);
     await restoreTarGzInto(tarPath, this.appRootFor(deploymentId));
     return true;
+  }
+
+  /**
+   * Annotate deployment responses with catalog update availability (#284): for
+   * each distinct app, look up the newest catalog version and compare it to the
+   * installed `version`. Cheap (the catalog version list is served from the
+   * in-memory cache, no bundle pull). Fail-safe — any catalog error leaves the
+   * fields unset rather than failing the list/detail request.
+   */
+  protected override async enrichUpdateInfo(
+    items: Array<{ app: string; version?: string; latestVersion?: string; updateAvailable?: boolean }>,
+  ): Promise<void> {
+    if (!this.catalogService || items.length === 0) return;
+    const latestByApp = new Map<string, string | undefined>();
+    for (const app of new Set(items.map((i) => i.app))) {
+      try {
+        const { items: versions } = await this.catalogService.getVersions(app);
+        const newest = versions
+          .map((v) => v.version)
+          .reduce<string | undefined>((best, v) => (!best || isNewerVersion(v, best) ? v : best), undefined);
+        latestByApp.set(app, newest);
+      } catch {
+        latestByApp.set(app, undefined); // app not in catalog / catalog down — skip
+      }
+    }
+    for (const item of items) {
+      const latest = latestByApp.get(item.app);
+      if (!latest) continue;
+      item.latestVersion = latest;
+      item.updateAvailable = !!item.version && isNewerVersion(latest, item.version);
+    }
   }
 
   /**

--- a/packages/server/src/services/simple-factory.ts
+++ b/packages/server/src/services/simple-factory.ts
@@ -137,7 +137,7 @@ export function createServices(env: ServiceEnvironment): Services {
       validation,
       routing,
       provisioner,
-      deployments: new RealDeploymentService(storage, jobs, docker, drafts, routing, logging, provisioner),
+      deployments: new RealDeploymentService(storage, jobs, docker, drafts, routing, logging, provisioner, catalog),
     };
   }
 
@@ -198,7 +198,7 @@ export function createServices(env: ServiceEnvironment): Services {
     validation,
     routing,
     provisioner,
-    deployments: new RealDeploymentService(storage, jobs, docker, drafts, routing, logging, provisioner),
+    deployments: new RealDeploymentService(storage, jobs, docker, drafts, routing, logging, provisioner, catalog),
   };
 }
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -640,6 +640,11 @@ export type DeploymentListItem = {
   status: DeploymentStatus;
   uptime?: string;
   version?: string;
+  // Newest catalog version for this app, and whether it's newer than the
+  // installed `version` (per-app update notifications, #284). Derived server-side
+  // from the catalog; absent when the catalog is unavailable.
+  latestVersion?: string;
+  updateAvailable?: boolean;
   resources?: { cpu: string; memory: string };
   ports: string[];
   lastUpdated: string;
@@ -659,6 +664,11 @@ export type DeploymentDetail = {
   status: DeploymentStatus;
   uptime?: string;
   version?: string;
+  // Newest catalog version + whether an update is available (per-app update
+  // notifications, #284). Derived server-side; absent when the catalog is
+  // unavailable.
+  latestVersion?: string;
+  updateAvailable?: boolean;
   url?: string;
   resources: { cpu: string; memory: string; disk?: string };
   ports: string[];

--- a/packages/web/src/pages/DeploymentDetail.tsx
+++ b/packages/web/src/pages/DeploymentDetail.tsx
@@ -290,6 +290,9 @@ export const DeploymentDetail: React.FC = () => {
     { label: 'Deployment ID', value: deployment.id, mono: true },
     { label: 'Status', value: deployment.status },
     ...(deployment.version ? [{ label: 'Version', value: deployment.version, mono: true }] : []),
+    ...(deployment.updateAvailable && deployment.latestVersion
+      ? [{ label: 'Latest', value: `${deployment.latestVersion} (update available)`, mono: true }]
+      : []),
     ...(deployment.uptime ? [{ label: 'Uptime', value: deployment.uptime }] : []),
     { label: 'Last updated', value: deployment.lastUpdated },
     ...(deployment.url ? [{ label: 'URL', value: deployment.url, mono: true }] : []),

--- a/packages/web/src/pages/Deployments.tsx
+++ b/packages/web/src/pages/Deployments.tsx
@@ -9,7 +9,8 @@ import {
   ExternalLink,
   ChevronLeft,
   ChevronRight,
-  AlertTriangle
+  AlertTriangle,
+  ArrowUp
 } from 'lucide-react';
 import type {
   DeploymentStatus,
@@ -304,8 +305,17 @@ export const Deployments: React.FC = () => {
               <div>
                 <StatusBadge status={deployment.status} />
               </div>
-              <div className="font-mono text-[12.5px] text-text-muted truncate">
-                {deployment.version || '—'}
+              <div className="font-mono text-[12.5px] text-text-muted truncate flex items-center gap-1.5">
+                <span className="truncate">{deployment.version || '—'}</span>
+                {deployment.updateAvailable && deployment.latestVersion && (
+                  <span
+                    title={`Update available: ${deployment.latestVersion}`}
+                    className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full bg-primary-weak text-primary text-[10.5px] font-semibold whitespace-nowrap"
+                  >
+                    <ArrowUp className="w-3 h-3" />
+                    {deployment.latestVersion}
+                  </span>
+                )}
               </div>
               <div className="font-mono text-[12px] text-text-muted truncate">
                 {deployment.url || '—'}


### PR DESCRIPTION
## What

Adds the missing **"update available" signal for installed catalog apps**. Hola already had a platform-level update banner (`update-check` → `UpdateAvailableBanner`), but nothing compared a deployed app's installed version to the catalog — the Deployments list/detail only showed the installed version.

> ⚠️ **Stacked on #290 (Phase 0)** — reuses the same catalog-version plumbing. Targets the Phase 0 branch; I'll rebase onto `main` after #290 merges.

## How

- **shared**: `DeploymentListItem` + `DeploymentDetail` gain `latestVersion` + `updateAvailable`.
- **server**: a protected `enrichUpdateInfo` hook — no-op on the in-memory/mock base, overridden by `RealDeploymentService`. For each distinct app it reads the newest catalog version (`catalog.getVersions`, served from the in-memory cache — **no bundle pull**) and compares to the installed version with `isNewerVersion`. **Fail-safe**: any catalog error leaves the fields unset rather than failing the request. The catalog is an **optional 8th constructor arg**, so existing constructions/tests are unchanged; the factory wires it.
- **web**: an "↑ `<latest>`" pill on the Deployments list row, and a "Latest (update available)" row on the deployment detail's Details card.

## Scope / follow-up

Deliberately the **cheap** signal (catalog version list only). A richer "this update is **breaking** / must pass through a waypoint" indicator — using `getVersionDetail().upgrade` + `checkUpgradePath` from #290 — needs a per-app **bundle pull**, which is unsuited to list rendering; that's a natural fast-follow (e.g. an on-demand `GET /api/deployments/:id/update-check` for the detail page). The plumbing (`upgrade` metadata, `checkUpgradePath`) already exists from #290.

## Testing

- enrichment flags `updateAvailable` + `latestVersion` when the catalog is newer;
- no update when already on the newest;
- no catalog wired → fields unset (no enrichment, existing behavior preserved).
- Server (379) + web (147) + typecheck + lint + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)