### PR TITLE
fix(web): Deployments-page reactivity — job identity + live refresh

### DIFF
--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1047,6 +1047,19 @@ async function route(url: URL, req: Request): Promise<Response> {
       const services = getServices();
       const status = statusParam && statusParam !== 'all' ? statusParam as JobStatus : undefined;
       jobs = await services.jobs.listJobs({ deploymentId: deploymentId ?? undefined, status });
+      // Join each job to its owning deployment's name/app so the UI can label a
+      // job by what it acts on (not just "Starting"). One in-memory list + a map
+      // lookup; fail-safe — a join error leaves jobs unenriched.
+      try {
+        const deps = await services.deployments.listDeployments({ page: 1, limit: 1000 });
+        const byId = new Map(deps.items.map(d => [d.id, d]));
+        jobs = jobs.map(j => {
+          const d = j.deploymentId ? byId.get(j.deploymentId) : undefined;
+          return d ? { ...j, deploymentName: d.name, app: d.app } : j;
+        });
+      } catch (joinErr) {
+        logger.warn('Failed to enrich jobs with deployment names', { error: String(joinErr) });
+      }
     } catch (error) {
       logger.error('Failed to list jobs', error as Error);
       jobs = [];

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -576,6 +576,11 @@ export type Job = {
   finishedAt?: string;
   progress?: number;
   deploymentId?: string;
+  // The owning deployment's display name + app id, joined server-side when jobs
+  // are listed so the UI can label a job by what it's acting on (not just its
+  // type). Absent for jobs with no/deleted deployment.
+  deploymentName?: string;
+  app?: string;
 };
 
 export type GetJobsRequest = PageRequest & {

--- a/packages/web/src/__tests__/components/JobStatus.test.tsx
+++ b/packages/web/src/__tests__/components/JobStatus.test.tsx
@@ -64,4 +64,19 @@ describe('JobStatus', () => {
     render(<JobStatus job={deployJob} size="md" />);
     expect(screen.getAllByText(/install/i)).toHaveLength(1);
   });
+
+  it('labels the job by the deployment name when joined (even at sm size)', () => {
+    const job = createJob({ type: 'start', status: 'completed', deploymentName: 'gitea', app: 'gitea' });
+    render(<JobStatus job={job} size="sm" />);
+    // The app/deployment name is the primary label — not a bare "Starting".
+    expect(screen.getByText('gitea')).toBeInTheDocument();
+    // The terminal status is still shown.
+    expect(screen.getByText(/completed/i)).toBeInTheDocument();
+  });
+
+  it('falls back to the action label when there is no deployment name', () => {
+    const job = createJob({ type: 'start', deploymentName: undefined, app: undefined });
+    render(<JobStatus job={job} size="sm" />);
+    expect(screen.getAllByText(/starting/i).length).toBeGreaterThan(0);
+  });
 });

--- a/packages/web/src/components/JobStatus.tsx
+++ b/packages/web/src/components/JobStatus.tsx
@@ -123,13 +123,16 @@ export const JobStatus: React.FC<JobStatusProps> = ({
         <div className="flex items-center space-x-3">
           {getJobStatusIcon(job.status, size)}
           <div className="min-w-0 flex-1">
-            <div className="flex items-center space-x-2">
-              <span className={`font-medium ${textSizeClasses}`}>
-                {getJobTypeLabel(job.type)}
+            <div className="flex items-center space-x-2 min-w-0">
+              {/* Label by WHAT the job acts on (the app/deployment), with the
+                  action as secondary — so a finished install doesn't keep reading
+                  "Starting". Falls back to the action label when unjoined. */}
+              <span className={`font-medium truncate ${textSizeClasses}`}>
+                {job.deploymentName || job.app || getJobTypeLabel(job.type)}
               </span>
-              {job.deploymentId && size !== 'sm' && (
-                <span className={`text-text-muted ${size === 'lg' ? 'text-sm' : 'text-xs'}`}>
-                  #{job.deploymentId}
+              {(job.deploymentName || job.app) && (
+                <span className={`text-text-muted whitespace-nowrap ${size === 'lg' ? 'text-sm' : 'text-xs'}`}>
+                  {getJobTypeLabel(job.type)}
                 </span>
               )}
             </div>

--- a/packages/web/src/hooks/useDeploymentsApi.ts
+++ b/packages/web/src/hooks/useDeploymentsApi.ts
@@ -78,6 +78,8 @@ export function useDeploymentsApi(params: GetDeploymentsRequest) {
 
   return {
     ...state,
-    refetch: fetchData,
+    // Manual refresh bypasses the 30s cache so the button reflects current state
+    // (e.g. after an action) instead of re-serving a recently-cached list.
+    refetch: () => fetchData(true),
   };
 }

--- a/packages/web/src/hooks/useJobsApi.ts
+++ b/packages/web/src/hooks/useJobsApi.ts
@@ -39,13 +39,15 @@ export function useJobsApi(params: UseJobsApiParams = {}) {
     return key;
   }, [deploymentId, status, page, limit]);
 
-  // Fetch data with caching and error handling
-  const fetchData = React.useCallback(async () => {
+  // Fetch data with caching and error handling. `force` bypasses the cache read
+  // so a manual refresh (and the live poll) always re-fetches instead of
+  // re-serving a recently-cached list — otherwise the refresh button looks dead.
+  const fetchData = React.useCallback(async (force = false) => {
     const cached = globalCache.get(cacheKey);
     const now = Date.now();
-    
-    // Check cache (2 second TTL for live updates)
-    if (cached && (now - cached.timestamp) < 2000) {
+
+    // Check cache (2 second TTL for live updates) unless forced
+    if (!force && cached && (now - cached.timestamp) < 2000) {
       setState({
         data: cached.data as GetJobsResponse,
         loading: false,
@@ -84,17 +86,19 @@ export function useJobsApi(params: UseJobsApiParams = {}) {
     fetchData();
   }, [fetchData]);
 
-  // Auto-refresh for live updates
+  // Auto-refresh for live updates — force past the short cache so each tick
+  // reflects status transitions rather than re-serving the cached page.
   React.useEffect(() => {
     if (!autoRefresh) return;
 
-    const interval = setInterval(fetchData, refreshInterval);
+    const interval = setInterval(() => { void fetchData(true); }, refreshInterval);
     return () => clearInterval(interval);
   }, [fetchData, autoRefresh, refreshInterval]);
 
   return {
     ...state,
-    refetch: fetchData,
+    // Manual refresh always bypasses the cache.
+    refetch: () => fetchData(true),
   };
 }
 


### PR DESCRIPTION
## What

Fixes the reported Deployments-page bugs — jobs showing as an unlabeled "list of starting deployments" that never reach completed, and a refresh button that does nothing. **Three surgical fixes**; the broader event-driven architecture (a global SSE backplane) stays tracked in #291.

## Root causes & fixes

**1. Jobs had no identity.** The `JobTracker` rendered each job as just its *type* label ("Starting" for a `start` job), and `JobStatus` at `size="sm"` hid even the `deploymentId` — so the card read as a list of "Starting" with no app name, and a *completed* start-job still showed "Starting" prominently (the status was only a small badge).
- `Job` now carries `deploymentName` + `app`, **joined server-side** in `GET /api/jobs` from the deployment records (one in-memory list + map lookup, fail-safe).
- `JobStatus` labels a job by **what it acts on** (deployment/app name), with the action as secondary — a finished install no longer reads "Starting".

**2. Refresh was a no-op.** Manual `refetch()` honored the per-hook cache (`useJobsApi` 2s, `useDeploymentsApi` 30s) because `force` defaulted to false — a click inside the TTL re-served stale rows. `refetch` now **force-bypasses** the cache; the jobs live-poll forces too, so each 5s tick reflects status transitions instead of a cached page.

## Not in scope (tracked in #291)

The event-driven freshness work — a global `/api/events` SSE stream for list views, and the dead `/api/deployments/:id/status/stream` route `useLiveDeploymentStatus` targets (never implemented server-side, so it always falls back to polling). These fixes make polling + manual refresh actually work; #291 removes polling.

## Testing

- `JobStatus` labels by deployment name at `sm` size and still shows the terminal status; falls back to the action label when unjoined.
- Server (358) + web (149) + typecheck + lint + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)