### PR TITLE
chore(release): 0.6.32

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/cli": {
       "name": "@hola/cli",
-      "version": "0.6.31",
+      "version": "0.6.32",
       "bin": {
         "hola": "./bin/hola",
       },
@@ -37,11 +37,11 @@
     },
     "packages/compose": {
       "name": "@hola/compose",
-      "version": "0.6.31",
+      "version": "0.6.32",
     },
     "packages/sdk": {
       "name": "@hola/sdk",
-      "version": "0.6.31",
+      "version": "0.6.32",
       "dependencies": {
         "@hola/shared": "workspace:*",
       },
@@ -55,7 +55,7 @@
     },
     "packages/server": {
       "name": "@hola/server",
-      "version": "0.6.31",
+      "version": "0.6.32",
       "dependencies": {
         "@hola/shared": "workspace:*",
         "jose": "^5.9.6",
@@ -71,7 +71,7 @@
     },
     "packages/shared": {
       "name": "@hola/shared",
-      "version": "0.6.31",
+      "version": "0.6.32",
       "dependencies": {
         "yaml": "^2.9.0",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.6.31",
+  "version": "0.6.32",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.6.31';
+export const CLI_VERSION = '0.6.32';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.6.31",
+  "version": "0.6.32",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.6.31",
+  "version": "0.6.32",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.6.31",
+  "version": "0.6.32",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.6.31",
+  "version": "0.6.32",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Release **0.6.32** — bumps the synced package versions (cli/compose/sdk/server/shared + `version.ts`).

Ships the #284 safe-stateful-upgrade series + #121:
- `hola update` pre-upgrade snapshot (platform tier) — #289
- Phase 0 upgrade signaling + server-side skip-guard — #290
- Phase 1 app pre-upgrade snapshot + data-aware rollback — #292
- per-app pre/post-backup hooks (#121) — #293
- per-app catalog update notifications — #294
- Deployments-page reactivity fixes — #295

Validated on a disposable Proxmox VM (combined build → install → reachable; PR5/PR6 API surfaces live). On merge I'll tag `cli-v0.6.32` to trigger the release workflow (images + bundle + CLI binaries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)