### PR TITLE
feat: global SSE event backplane for live list views (#291)

### DIFF
--- a/packages/server/src/__tests__/services/event-bus.test.ts
+++ b/packages/server/src/__tests__/services/event-bus.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Global event bus + emit wiring for the dashboard-wide /api/events stream (#291).
+ *
+ * Verifies the bus fan-out/unsubscribe + error isolation, that RealJobService
+ * publishes `job_update` transitions to it, and that RealDeploymentService emits
+ * `deployment_update` whenever a deployment is persisted (the single chokepoint
+ * for status changes).
+ */
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import type { SSEEvent } from '@hola/shared';
+import { InProcessEventBus } from '../../services/core/event-bus';
+import { RealDeploymentService } from '../../services/core/deployment';
+import { MockProvisionerService } from '../../services/core/provisioner';
+import { RealDraftService } from '../../services/core/draft';
+import { RealStorageService } from '../../services/core/storage';
+import { RealRoutingService } from '../../services/core/routing';
+import { RealDatabaseService } from '../../services/core/database';
+import { RealLoggingService } from '../../services/core/logging';
+import { RealJobService } from '../../services/core/jobs';
+import { MockDockerService } from '../../services/core/docker';
+
+describe('InProcessEventBus', () => {
+  test('delivers to all subscribers and stops after unsubscribe', () => {
+    const bus = new InProcessEventBus();
+    const a: SSEEvent[] = [];
+    const b: SSEEvent[] = [];
+    const subA = bus.subscribe((e) => a.push(e));
+    bus.subscribe((e) => b.push(e));
+
+    const ev: SSEEvent = { type: 'deployment_update', data: { deploymentId: 'd1', status: 'running', lastUpdated: 't' } };
+    bus.emit(ev);
+    expect(a).toEqual([ev]);
+    expect(b).toEqual([ev]);
+
+    subA.unsubscribe();
+    bus.emit(ev);
+    expect(a).toHaveLength(1); // no more after unsubscribe
+    expect(b).toHaveLength(2);
+  });
+
+  test('a throwing subscriber does not break delivery to the others', () => {
+    const bus = new InProcessEventBus();
+    const got: SSEEvent[] = [];
+    bus.subscribe(() => { throw new Error('boom'); });
+    bus.subscribe((e) => got.push(e));
+    const ev: SSEEvent = { type: 'job_update', data: { jobId: 'j1', status: 'completed' } };
+    expect(() => bus.emit(ev)).not.toThrow();
+    expect(got).toEqual([ev]);
+  });
+});
+
+describe('Service emits onto the event bus (#291)', () => {
+  let dataRoot: string;
+  beforeEach(async () => { dataRoot = await mkdtemp(join(tmpdir(), 'hola-evt-')); });
+  afterEach(async () => { await rm(dataRoot, { recursive: true, force: true }); });
+
+  function makeCatalog() {
+    return {
+      getApp: async (appId: string) => ({ id: appId, name: 'Gitea', icon: '🍵' }),
+      getVersionDetail: async () => ({ defaultEnv: [], defaults: { ports: [], volumes: [] } }),
+      getVersions: async () => ({ items: [{ version: '1.0.0', createdAt: 't' }], total: 1 }),
+    };
+  }
+  function makeValidation() {
+    return { validateDraft: async () => ({ ok: true, errors: [], warnings: [] }), preflightCheck: async () => ({ ok: true, checks: [] }) };
+  }
+
+  test('RealJobService publishes job_update transitions (running → completed)', async () => {
+    const storage = new RealStorageService({ holaDir: dataRoot });
+    const database = new RealDatabaseService(storage);
+    const logging = new RealLoggingService(storage);
+    const bus = new InProcessEventBus();
+    const events: SSEEvent[] = [];
+    bus.subscribe((e) => events.push(e));
+
+    const jobs = new RealJobService(database, logging, bus);
+    jobs.setExecutor(async () => true); // succeed immediately
+    const job = await jobs.createJob({ type: 'start', deploymentId: 'd1' });
+
+    // Wait for the job to finish.
+    for (let i = 0; i < 200; i++) {
+      const j = await jobs.getJob(job.id);
+      if (j && (j.status === 'completed' || j.status === 'failed')) break;
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    const jobEvents = events.filter((e) => e.type === 'job_update');
+    expect(jobEvents.some((e) => e.type === 'job_update' && e.data.status === 'completed' && e.data.jobId === job.id)).toBe(true);
+  });
+
+  test('RealDeploymentService emits deployment_update when a deployment is persisted', async () => {
+    const storage = new RealStorageService({ holaDir: dataRoot });
+    const database = new RealDatabaseService(storage);
+    const logging = new RealLoggingService(storage);
+    const jobs = new RealJobService(database, logging);
+    const routing = new RealRoutingService(storage, { baseDomain: 'local.hola' });
+    const drafts = new RealDraftService(storage, makeCatalog() as never, makeValidation() as never);
+    const bus = new InProcessEventBus();
+    const events: SSEEvent[] = [];
+    bus.subscribe((e) => events.push(e));
+
+    const deployments = new RealDeploymentService(storage, jobs, new MockDockerService(), drafts, routing, logging, new MockProvisionerService(), undefined, bus);
+
+    const { draftId } = await drafts.createDraft({ appId: 'gitea', version: '1.0.0' });
+    await drafts.updateDraft(draftId, { composeOverride: 'services:\n  gitea:\n    image: gitea/gitea:latest\n' });
+    await drafts.finalizeDraft(draftId);
+    const dep = await deployments.createFromDraft({ draftId, name: 'gitea', options: { autoStart: false } });
+
+    const depEvents = events.filter((e) => e.type === 'deployment_update');
+    expect(depEvents.length).toBeGreaterThan(0);
+    expect(depEvents.some((e) => e.type === 'deployment_update' && e.data.deploymentId === dep.deploymentId)).toBe(true);
+  });
+});

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1342,6 +1342,25 @@ async function route(url: URL, req: Request): Promise<Response> {
   }
 
   // System Status SSE Stream - Phase 4: Real-time system updates with monitoring service
+  // Global event stream (#291): one authenticated SSE connection per dashboard
+  // that multiplexes job_update + deployment_update events from the in-process
+  // event bus, so list views (Deployments, JobTracker) stay live without polling.
+  // Authenticated by authMiddleware like every other route. Logs keep their own
+  // per-entity streams (they're high-volume and id-scoped); this carries state
+  // transitions only.
+  if (pathname === '/api/events' && req.method === 'GET') {
+    const services = getServices();
+    const stream = createSSEStream({
+      logger,
+      onSubscribe(controller) {
+        controller.heartbeat();
+        const sub = services.eventBus.subscribe((event) => controller.send(event));
+        return () => { sub.unsubscribe(); };
+      },
+    });
+    return new Response(stream, { headers: createSSEHeaders() });
+  }
+
   if (pathname === '/api/system/status/stream' && req.method === 'GET') {
     const stream = createSSEStream({
       logger,

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -48,6 +48,7 @@ import { JobCancelledError } from './jobs';
 import type { DockerService } from './docker';
 import type { DraftService, FinalizedArtifacts, FinalizedManifest } from './draft';
 import type { CatalogService } from './catalog';
+import type { EventBus } from './event-bus';
 import type { RoutingService } from './routing';
 import type { LoggingService } from './logging';
 import type { ProvisionerService, ProvisionResult } from './provisioner';
@@ -933,6 +934,9 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     // Optional so existing constructions (and tests) need no change; when present,
     // deployment responses are annotated with catalog update availability (#284).
     private catalogService?: CatalogService,
+    // Optional global event bus; when wired, status changes emit `deployment_update`
+    // for the dashboard-wide `/api/events` stream (#291).
+    private eventBus?: EventBus,
   ) {
     super(jobService);
     // Perform real Compose lifecycle work when a deployment job runs.
@@ -1930,6 +1934,13 @@ export class RealDeploymentService extends InMemoryDeploymentService {
       `deployments/${deployment.id}/metadata.json`,
       JSON.stringify(deployment, null, 2)
     );
+    // Every durable status change lands here, so this is the single chokepoint to
+    // emit a `deployment_update` onto the global event bus (#291) — driving the
+    // dashboard's live list/detail without polling.
+    this.eventBus?.emit({
+      type: 'deployment_update',
+      data: { deploymentId: deployment.id, status: deployment.status, uptime: deployment.uptime, lastUpdated: deployment.lastUpdated },
+    });
   }
 
   protected override async persistRelease(release: Release): Promise<void> {

--- a/packages/server/src/services/core/event-bus.ts
+++ b/packages/server/src/services/core/event-bus.ts
@@ -1,0 +1,41 @@
+import type { SSEEvent } from '@hola/shared';
+
+/**
+ * Process-wide event bus for the global SSE stream (#291). Services emit typed
+ * `SSEEvent`s (job/deployment/system updates) and the `GET /api/events` handler
+ * fans them out to every connected dashboard, so list views stay live from one
+ * subscription instead of each polling.
+ *
+ * Deliberately tiny and synchronous — a single host, in one process. A throwing
+ * subscriber must not break the others (one stuck SSE client shouldn't wedge the
+ * bus), so `emit` isolates each listener.
+ */
+export type EventListener = (event: SSEEvent) => void;
+
+export interface EventBus {
+  emit(event: SSEEvent): void;
+  subscribe(listener: EventListener): { unsubscribe(): void };
+}
+
+export class InProcessEventBus implements EventBus {
+  private listeners = new Set<EventListener>();
+
+  emit(event: SSEEvent): void {
+    for (const listener of this.listeners) {
+      try {
+        listener(event);
+      } catch {
+        // A broken/slow subscriber must not break delivery to the rest.
+      }
+    }
+  }
+
+  subscribe(listener: EventListener): { unsubscribe(): void } {
+    this.listeners.add(listener);
+    return {
+      unsubscribe: () => {
+        this.listeners.delete(listener);
+      },
+    };
+  }
+}

--- a/packages/server/src/services/core/jobs.ts
+++ b/packages/server/src/services/core/jobs.ts
@@ -10,6 +10,7 @@ import type { HealthCheckable, ServiceHealth } from './types';
 import type { DatabaseService } from './database';
 import { DatabaseJobRepository, type JobRepository, type JobEntity } from './repositories';
 import type { LoggingService } from './logging';
+import type { EventBus } from './event-bus';
 import type { Job as SharedJob, JobStatus as SharedJobStatus, JobType as SharedJobType } from '@hola/shared';
 
 // Simple in-process pub-sub for job updates
@@ -94,7 +95,7 @@ export class RealJobService implements JobService {
   private baseBackoffMs = Number(process.env.HOLA_JOBS_BACKOFF_MS || 500);
   private executor?: JobExecutor;
 
-  constructor(db: DatabaseService, logging: LoggingService) {
+  constructor(db: DatabaseService, logging: LoggingService, private eventBus?: EventBus) {
     this.db = db;
     this.repo = new DatabaseJobRepository(this.db);
     this.logging = logging;
@@ -102,6 +103,20 @@ export class RealJobService implements JobService {
 
   setExecutor(executor: JobExecutor): void {
     this.executor = executor;
+  }
+
+  /**
+   * Emit a job state change to the per-job bus (existing per-id subscribers, e.g.
+   * the job log stream) AND, when wired, to the global event bus that backs the
+   * dashboard-wide `/api/events` stream (#291) — so list views see the transition
+   * without polling.
+   */
+  private notify(id: string, update: JobUpdate): void {
+    this.bus.emit(id, update);
+    this.eventBus?.emit({
+      type: 'job_update',
+      data: { jobId: id, status: update.status, progress: update.progress, finishedAt: update.finishedAt },
+    });
   }
 
   private enqueue(id: string) {
@@ -125,13 +140,13 @@ export class RealJobService implements JobService {
         // If cancelled before start, mark and exit
         await this.repo.updateStatus(id, 'cancelled');
         this.cancelled.delete(id);
-        this.bus.emit(id, { id, status: 'failed', finishedAt: new Date().toISOString() });
+        this.notify(id, { id, status: 'failed', finishedAt: new Date().toISOString() });
         await this.logging.logJob(id, 'warn', 'Job cancelled before start');
         return;
       }
       // Transition to running
       await this.repo.updateStatus(id, 'running');
-      this.bus.emit(id, { id, status: 'running' });
+      this.notify(id, { id, status: 'running' });
       await this.logging.logJob(id, 'info', 'Job started');
 
       // Prefer the registered executor (real work, e.g. Compose lifecycle).
@@ -144,7 +159,7 @@ export class RealJobService implements JobService {
           setProgress: async (percent) => {
             const p = Math.max(0, Math.min(100, Math.round(percent)));
             await this.repo.updateProgress(id, p);
-            this.bus.emit(id, { id, status: 'running', progress: p });
+            this.notify(id, { id, status: 'running', progress: p });
           },
           isCancelled: () => this.cancelled.has(id),
         };
@@ -153,7 +168,7 @@ export class RealJobService implements JobService {
           await this.repo.updateStatus(id, 'completed');
           this.cancelled.delete(id);
           const finishedAt = new Date().toISOString();
-          this.bus.emit(id, { id, status: 'completed', progress: 100, finishedAt });
+          this.notify(id, { id, status: 'completed', progress: 100, finishedAt });
           await this.logging.logJob(id, 'info', 'Job completed');
           return;
         }
@@ -173,7 +188,7 @@ export class RealJobService implements JobService {
           await this.repo.updateStatus(id, 'cancelled');
           this.cancelled.delete(id);
           const finishedAt = new Date().toISOString();
-          this.bus.emit(id, { id, status: 'failed', finishedAt });
+          this.notify(id, { id, status: 'failed', finishedAt });
           await this.logging.logJob(id, 'warn', 'Job cancelled', { step: i });
           return;
         }
@@ -197,24 +212,24 @@ export class RealJobService implements JobService {
 
         const progress = Math.min(100, Math.floor(((i + 1) / steps.length) * 100));
         await this.repo.updateProgress(id, progress);
-        this.bus.emit(id, { id, status: 'running', progress });
+        this.notify(id, { id, status: 'running', progress });
         await this.logging.logJob(id, 'info', steps[i]);
       }
 
       await this.repo.updateStatus(id, 'completed');
       const finishedAt = new Date().toISOString();
-      this.bus.emit(id, { id, status: 'completed', progress: 100, finishedAt });
+      this.notify(id, { id, status: 'completed', progress: 100, finishedAt });
       await this.logging.logJob(id, 'info', 'Job completed');
     } catch (error) {
       const finishedAt = new Date().toISOString();
       if (error instanceof JobCancelledError) {
         await this.repo.updateStatus(id, 'cancelled');
         this.cancelled.delete(id);
-        this.bus.emit(id, { id, status: 'failed', finishedAt });
+        this.notify(id, { id, status: 'failed', finishedAt });
         await this.logging.logJob(id, 'warn', 'Job cancelled');
       } else {
         await this.repo.update(id, { status: 'failed', error: error instanceof Error ? error.message : String(error) });
-        this.bus.emit(id, { id, status: 'failed', finishedAt });
+        this.notify(id, { id, status: 'failed', finishedAt });
         await this.logging.logJob(id, 'error', 'Job failed', { error: error instanceof Error ? error.message : String(error) });
       }
     } finally {
@@ -242,7 +257,7 @@ export class RealJobService implements JobService {
       const orphaned = await this.repo.findByStatus('running');
       for (const j of orphaned) {
         await this.repo.update(j.id, { status: 'failed', error: 'Interrupted by server restart' });
-        this.bus.emit(j.id, { id: j.id, status: 'failed', finishedAt: new Date().toISOString() });
+        this.notify(j.id, { id: j.id, status: 'failed', finishedAt: new Date().toISOString() });
         await this.logging.logJob(j.id, 'error', 'Job failed: interrupted by server restart');
       }
     } catch (e) {
@@ -285,7 +300,7 @@ export class RealJobService implements JobService {
     // Not yet running: finalize now so a dequeued job doesn't sit pending forever.
     await this.repo.updateStatus(id, 'cancelled');
     this.cancelled.delete(id);
-    this.bus.emit(id, { id, status: 'failed', finishedAt: new Date().toISOString() });
+    this.notify(id, { id, status: 'failed', finishedAt: new Date().toISOString() });
   }
 
   async getJob(id: string): Promise<SharedJob | null> {
@@ -334,6 +349,17 @@ export class MockJobService implements JobService {
   private jobs = new Map<string, SharedJob>();
   private timers = new Map<string, NodeJS.Timeout>();
 
+  constructor(private eventBus?: EventBus) {}
+
+  /** Mirror of RealJobService.notify: per-job bus + the global event bus (#291). */
+  private notify(id: string, update: JobUpdate): void {
+    this.bus.emit(id, update);
+    this.eventBus?.emit({
+      type: 'job_update',
+      data: { jobId: id, status: update.status, progress: update.progress, finishedAt: update.finishedAt },
+    });
+  }
+
   async createJob(params: CreateJobParams): Promise<SharedJob> {
     const id = crypto.randomUUID();
     const job: SharedJob = {
@@ -358,11 +384,11 @@ export class MockJobService implements JobService {
       j.status = 'running';
       p = Math.min(100, p + 20);
       j.progress = p;
-      this.bus.emit(id, { id, status: 'running', progress: p });
+      this.notify(id, { id, status: 'running', progress: p });
       if (p >= 100) {
         j.status = 'completed';
         j.finishedAt = new Date().toISOString();
-        this.bus.emit(id, { id, status: 'completed', progress: 100, finishedAt: j.finishedAt });
+        this.notify(id, { id, status: 'completed', progress: 100, finishedAt: j.finishedAt });
         clearInterval(timer);
         this.timers.delete(id);
       }
@@ -376,7 +402,7 @@ export class MockJobService implements JobService {
     if (j) {
       j.status = 'failed';
       j.finishedAt = new Date().toISOString();
-      this.bus.emit(id, { id, status: 'failed', finishedAt: j.finishedAt });
+      this.notify(id, { id, status: 'failed', finishedAt: j.finishedAt });
     }
     const timer = this.timers.get(id);
     if (timer) {
@@ -420,7 +446,7 @@ export class MockJobService implements JobService {
         job.finishedAt = update.finishedAt;
       }
     }
-    this.bus.emit(jobId, update);
+    this.notify(jobId, update);
   }
 
   clearTimers(): void {

--- a/packages/server/src/services/simple-factory.ts
+++ b/packages/server/src/services/simple-factory.ts
@@ -19,6 +19,7 @@ import { RealSystemMonitoringService, MockSystemMonitoringService, type SystemMo
 import { RealUpdateCheckService, MockUpdateCheckService, type UpdateCheckService } from './core/update-check';
 import { RealLoggingService, MockLoggingService, type LoggingService } from './core/logging';
 import { RealJobService, MockJobService, type JobService } from './core/jobs';
+import { InProcessEventBus, type EventBus } from './core/event-bus';
 import { RealCatalogService, MockCatalogService, type CatalogService } from './core/catalog';
 import { RealBundleService, MockBundleService, type BundleService } from './core/bundles';
 import { RealDraftService, MockDraftService, type DraftService } from './core/draft';
@@ -42,6 +43,7 @@ export interface Services {
   updateCheck: UpdateCheckService;
   logging: LoggingService;
   jobs: JobService;
+  eventBus: EventBus;
   catalog: CatalogService;
   bundles: BundleService;
   drafts: DraftService;
@@ -69,7 +71,8 @@ export function createServices(env: ServiceEnvironment): Services {
     const database = new MockDatabaseService();
     // Share the jobs service so deployment history reflects jobs created by
     // create/action/rollback (the deployment service is the single owner).
-    const jobs = new MockJobService();
+    const eventBus = new InProcessEventBus();
+    const jobs = new MockJobService(eventBus);
 
     return {
       storage,
@@ -82,6 +85,7 @@ export function createServices(env: ServiceEnvironment): Services {
       updateCheck: new MockUpdateCheckService(),
       logging: new MockLoggingService(),
       jobs,
+      eventBus,
       catalog: new MockCatalogService(),
       bundles: new MockBundleService(),
       drafts: new MockDraftService(),
@@ -103,11 +107,14 @@ export function createServices(env: ServiceEnvironment): Services {
     // Create logging service with storage dependency
     const logging = new RealLoggingService(storage);
     
+    // Global event bus backing the dashboard-wide /api/events stream (#291).
+    const eventBus = new InProcessEventBus();
+
     // Create jobs service with database and logging dependencies
-    const jobs = new RealJobService(database, logging);
-    
+    const jobs = new RealJobService(database, logging, eventBus);
+
     const catalog = new RealCatalogService();
-    
+
     // Shared routing service owns Traefik rule generation/validation/emission.
     const routing = new RealRoutingService(storage);
 
@@ -131,13 +138,14 @@ export function createServices(env: ServiceEnvironment): Services {
       updateCheck: new MockUpdateCheckService(),
       logging,
       jobs,
+      eventBus,
       catalog,
       bundles: new RealBundleService(storage.resolveHolaPath('cache', 'bundles')),
       drafts,
       validation,
       routing,
       provisioner,
-      deployments: new RealDeploymentService(storage, jobs, docker, drafts, routing, logging, provisioner, catalog),
+      deployments: new RealDeploymentService(storage, jobs, docker, drafts, routing, logging, provisioner, catalog, eventBus),
     };
   }
 
@@ -150,10 +158,13 @@ export function createServices(env: ServiceEnvironment): Services {
   
   // Create logging service with storage dependency
   const logging = new RealLoggingService(storage);
-  
+
+  // Global event bus backing the dashboard-wide /api/events stream (#291).
+  const eventBus = new InProcessEventBus();
+
   // Create jobs service with database and logging dependencies
-  const jobs = new RealJobService(database, logging);
-  
+  const jobs = new RealJobService(database, logging, eventBus);
+
   const catalog = new RealCatalogService();
   
   // Set up auth providers for real auth service. Order matters: the api-key
@@ -192,13 +203,14 @@ export function createServices(env: ServiceEnvironment): Services {
     updateCheck: new RealUpdateCheckService(),
     logging,
     jobs,
+    eventBus,
     catalog,
     bundles: new RealBundleService(storage.resolveHolaPath('cache', 'bundles')),
     drafts,
     validation,
     routing,
     provisioner,
-    deployments: new RealDeploymentService(storage, jobs, docker, drafts, routing, logging, provisioner, catalog),
+    deployments: new RealDeploymentService(storage, jobs, docker, drafts, routing, logging, provisioner, catalog, eventBus),
   };
 }
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -65,6 +65,10 @@ export const API = {
     backup: '/api/settings/backup',
   },
 
+  // Global SSE event stream (#291): job_update + deployment_update transitions,
+  // multiplexed so list views stay live from one connection.
+  events: '/api/events',
+
   system: {
     status: '/api/system/status',
     health: '/api/system/health',

--- a/packages/web/src/components/layout/AppShell.tsx
+++ b/packages/web/src/components/layout/AppShell.tsx
@@ -2,6 +2,7 @@ import React, { ReactNode, useState } from 'react';
 import { Sidebar } from './Sidebar';
 import { Topbar } from './Topbar';
 import { UpdateAvailableBanner } from '../UpdateAvailableBanner';
+import { useGlobalEvents } from '../../hooks/useGlobalEvents';
 
 interface AppShellProps {
   children: ReactNode;
@@ -9,6 +10,9 @@ interface AppShellProps {
 
 export const AppShell: React.FC<AppShellProps> = ({ children }) => {
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
+  // One global SSE subscription for the whole authenticated app (#291) — drives
+  // live list/detail updates so the views don't depend on polling.
+  useGlobalEvents();
 
   return (
     <div className="flex h-screen w-full overflow-hidden bg-surface-0 text-text-strong font-sans">

--- a/packages/web/src/hooks/useDeploymentsApi.ts
+++ b/packages/web/src/hooks/useDeploymentsApi.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import { api } from '../utils/api-hybrid'; // Use hybrid API
 import { globalCache } from '../utils/cache';
-import { onLive } from '../utils/live-bus';
+import { onLive, isLiveConnected } from '../utils/live-bus';
 import type { GetDeploymentsRequest, GetDeploymentsResponse } from '@hola/shared';
 
 // Working StrictMode-compatible hook for deployments using the same pattern as useWorkingApi
@@ -71,14 +71,19 @@ export function useDeploymentsApi(params: GetDeploymentsRequest) {
   // below is a fallback for when SSE isn't connected.
   React.useEffect(() => onLive('deployments', () => { void fetchData(true); }), [fetchData]);
 
-  // While any deployment is mid-transition (installing/updating), poll so the
-  // list reflects the terminal state without a manual reload.
+  // Fallback poll (#291): while a deployment is mid-transition
+  // (installing/updating), poll so the list converges to the terminal state — but
+  // only when the global event stream isn't connected. With the backplane live,
+  // deployment_update events drive convergence and this timer no-ops.
   const hasTransitional = state.data?.items?.some(
     d => d.status === 'installing' || d.status === 'updating'
   ) ?? false;
   React.useEffect(() => {
     if (!hasTransitional) return;
-    const interval = setInterval(() => { void fetchData(true); }, 4000);
+    const interval = setInterval(() => {
+      if (isLiveConnected()) return; // events are driving convergence; skip the poll
+      void fetchData(true);
+    }, 4000);
     return () => clearInterval(interval);
   }, [hasTransitional, fetchData]);
 

--- a/packages/web/src/hooks/useDeploymentsApi.ts
+++ b/packages/web/src/hooks/useDeploymentsApi.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 import { api } from '../utils/api-hybrid'; // Use hybrid API
 import { globalCache } from '../utils/cache';
+import { onLive } from '../utils/live-bus';
 import type { GetDeploymentsRequest, GetDeploymentsResponse } from '@hola/shared';
 
 // Working StrictMode-compatible hook for deployments using the same pattern as useWorkingApi
@@ -64,6 +65,11 @@ export function useDeploymentsApi(params: GetDeploymentsRequest) {
   React.useEffect(() => {
     fetchData();
   }, [fetchData]);
+
+  // Live updates (#291): refetch (cache-bypassing) when the global event stream
+  // reports a deployment change. This is the primary freshness path; the poll
+  // below is a fallback for when SSE isn't connected.
+  React.useEffect(() => onLive('deployments', () => { void fetchData(true); }), [fetchData]);
 
   // While any deployment is mid-transition (installing/updating), poll so the
   // list reflects the terminal state without a manual reload.

--- a/packages/web/src/hooks/useGlobalEvents.ts
+++ b/packages/web/src/hooks/useGlobalEvents.ts
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { useSSE } from './useSSE';
+import { signalLive } from '../utils/live-bus';
+import { globalCache } from '../utils/cache';
+import type { SSEEvent, DeploymentDetail } from '@hola/shared';
+
+/**
+ * The single dashboard-wide subscription to the global event stream (#291).
+ * Mounted once in AppShell: it translates `job_update` / `deployment_update`
+ * events into live-bus signals (so list views refetch) and patches the cached
+ * deployment detail so an open detail page reflects a status change instantly.
+ *
+ * Uses a RELATIVE URL so it resolves against the page origin in production
+ * (same-origin) and the Vite proxy in development — no API-base guesswork.
+ */
+export function useGlobalEvents(): void {
+  const onEvent = React.useCallback((event: SSEEvent) => {
+    if (event.type === 'job_update') {
+      signalLive('jobs');
+    } else if (event.type === 'deployment_update') {
+      const key = `deployment-detail-${event.data.deploymentId}`;
+      const cached = globalCache.get(key);
+      if (cached?.data && typeof cached.data === 'object') {
+        globalCache.set(key, {
+          ...cached,
+          data: {
+            ...(cached.data as DeploymentDetail),
+            status: event.data.status,
+            uptime: event.data.uptime,
+            lastUpdated: event.data.lastUpdated,
+          },
+          timestamp: Date.now(),
+        });
+      }
+      // A deployment status change usually rides alongside a lifecycle job, so
+      // refresh both the deployments list and the job tracker.
+      signalLive('deployments');
+      signalLive('jobs');
+    }
+  }, []);
+
+  useSSE('/api/events', onEvent, {
+    eventTypes: ['job_update', 'deployment_update'],
+    reconnect: true,
+    reconnectDelay: 2000,
+    maxReconnectDelay: 15000,
+  });
+}

--- a/packages/web/src/hooks/useGlobalEvents.ts
+++ b/packages/web/src/hooks/useGlobalEvents.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useSSE } from './useSSE';
-import { signalLive } from '../utils/live-bus';
+import { signalLive, setLiveConnected } from '../utils/live-bus';
 import { globalCache } from '../utils/cache';
 import type { SSEEvent, DeploymentDetail } from '@hola/shared';
 
@@ -39,10 +39,17 @@ export function useGlobalEvents(): void {
     }
   }, []);
 
-  useSSE('/api/events', onEvent, {
+  const sse = useSSE('/api/events', onEvent, {
     eventTypes: ['job_update', 'deployment_update'],
     reconnect: true,
     reconnectDelay: 2000,
     maxReconnectDelay: 15000,
   });
+
+  // Publish connection state so list hooks pause their polling while the
+  // backplane is live (events drive freshness) and resume it only as a fallback.
+  React.useEffect(() => {
+    setLiveConnected(sse.isConnected);
+    return () => setLiveConnected(false);
+  }, [sse.isConnected]);
 }

--- a/packages/web/src/hooks/useJobsApi.ts
+++ b/packages/web/src/hooks/useJobsApi.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import { api } from '../utils/api-hybrid'; // Use hybrid API
 import { globalCache } from '../utils/cache';
-import { onLive } from '../utils/live-bus';
+import { onLive, isLiveConnected } from '../utils/live-bus';
 import type { GetJobsResponse, JobStatus } from '@hola/shared';
 
 interface UseJobsApiParams {
@@ -91,12 +91,16 @@ export function useJobsApi(params: UseJobsApiParams = {}) {
   // transition — the primary freshness path. The poll below is the fallback.
   React.useEffect(() => onLive('jobs', () => { void fetchData(true); }), [fetchData]);
 
-  // Auto-refresh for live updates — force past the short cache so each tick
-  // reflects status transitions rather than re-serving the cached page.
+  // Polling fallback (#291): only runs when the global event stream ISN'T
+  // connected. While the backplane is live, job_update events drive freshness and
+  // this timer no-ops — so we don't poll redundantly.
   React.useEffect(() => {
     if (!autoRefresh) return;
 
-    const interval = setInterval(() => { void fetchData(true); }, refreshInterval);
+    const interval = setInterval(() => {
+      if (isLiveConnected()) return; // events are driving updates; skip the poll
+      void fetchData(true);
+    }, refreshInterval);
     return () => clearInterval(interval);
   }, [fetchData, autoRefresh, refreshInterval]);
 

--- a/packages/web/src/hooks/useJobsApi.ts
+++ b/packages/web/src/hooks/useJobsApi.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 import { api } from '../utils/api-hybrid'; // Use hybrid API
 import { globalCache } from '../utils/cache';
+import { onLive } from '../utils/live-bus';
 import type { GetJobsResponse, JobStatus } from '@hola/shared';
 
 interface UseJobsApiParams {
@@ -85,6 +86,10 @@ export function useJobsApi(params: UseJobsApiParams = {}) {
   React.useEffect(() => {
     fetchData();
   }, [fetchData]);
+
+  // Live updates (#291): refetch when the global event stream reports a job
+  // transition — the primary freshness path. The poll below is the fallback.
+  React.useEffect(() => onLive('jobs', () => { void fetchData(true); }), [fetchData]);
 
   // Auto-refresh for live updates — force past the short cache so each tick
   // reflects status transitions rather than re-serving the cached page.

--- a/packages/web/src/hooks/useLiveUpdates.ts
+++ b/packages/web/src/hooks/useLiveUpdates.ts
@@ -215,12 +215,11 @@ export function useLiveDeploymentStatus(deploymentId?: string) {
     }
   }, [deploymentId]);
 
-  // SSE URL for deployment updates
-  const sseUrl = React.useMemo(() => {
-    if (!deploymentId) return null;
-    const baseUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001';
-    return `${baseUrl}/api/deployments/${deploymentId}/status/stream`;
-  }, [deploymentId]);
+  // Subscribe to the global event stream (#291) and filter for this deployment in
+  // handleSSEEvent — the old per-deployment `/api/deployments/<id>/status/stream`
+  // route never existed server-side (this always fell back to polling). A relative
+  // URL resolves against the page origin (prod) / Vite proxy (dev).
+  const sseUrl = React.useMemo(() => (deploymentId ? '/api/events' : null), [deploymentId]);
 
   const sseState = useSSE(sseUrl, handleSSEEvent, {
     eventTypes: ['deployment_update'],

--- a/packages/web/src/utils/live-bus.ts
+++ b/packages/web/src/utils/live-bus.ts
@@ -1,0 +1,32 @@
+// Client-side fan-out for the global SSE stream (#291). The one `/api/events`
+// subscription (in AppShell) signals which resource changed; list hooks
+// (useDeploymentsApi, useJobsApi) subscribe and refetch, so they stay live
+// without each polling. Tiny and synchronous — a UI-local pub/sub.
+
+export type LiveResource = 'deployments' | 'jobs';
+
+const listeners = new Map<LiveResource, Set<() => void>>();
+
+/** Subscribe to change signals for a resource; returns an unsubscribe fn. */
+export function onLive(resource: LiveResource, cb: () => void): () => void {
+  let set = listeners.get(resource);
+  if (!set) {
+    set = new Set();
+    listeners.set(resource, set);
+  }
+  set.add(cb);
+  return () => {
+    listeners.get(resource)?.delete(cb);
+  };
+}
+
+/** Notify subscribers that a resource changed (a stream event arrived). */
+export function signalLive(resource: LiveResource): void {
+  listeners.get(resource)?.forEach((cb) => {
+    try {
+      cb();
+    } catch {
+      // a broken subscriber must not stop the others
+    }
+  });
+}

--- a/packages/web/src/utils/live-bus.ts
+++ b/packages/web/src/utils/live-bus.ts
@@ -30,3 +30,20 @@ export function signalLive(resource: LiveResource): void {
     }
   });
 }
+
+// --- Connection state -------------------------------------------------------
+// The global /api/events subscription publishes whether it's connected, so list
+// hooks can PAUSE their polling while the backplane is live (events drive
+// freshness) and resume it only as a fallback when SSE drops.
+
+let connected = false;
+
+/** Whether the global event stream is currently connected. */
+export function isLiveConnected(): boolean {
+  return connected;
+}
+
+/** Called by the global subscription when its connection state changes. */
+export function setLiveConnected(value: boolean): void {
+  connected = value;
+}


### PR DESCRIPTION
Closes **#291**.

## Problem

Dashboard list views stayed fresh by **polling**, and the per-deployment SSE hook (`useLiveDeploymentStatus`) pointed at `/api/deployments/<id>/status/stream` — **a route that was never implemented**, so it silently fell back to polling forever. There was no event-driven path and no global stream for list views to subscribe to.

## Solution — one global event stream

**Server**
- `InProcessEventBus` (`services/core/event-bus.ts`): a tiny, synchronous process-wide fan-out of typed `SSEEvent`s, wired into the factory (test/dev/prod) and injected into the job + deployment services. Error-isolated (one stuck subscriber can't wedge the bus).
- `RealJobService` / `MockJobService` publish `job_update` on every transition via a new `notify()` (alongside the existing per-job bus used by log streams).
- `RealDeploymentService` emits `deployment_update` from **`persistDeployment`** — the single chokepoint every durable status change already flows through, so create / action / lifecycle / error are all covered uniformly.
- New authenticated **`GET /api/events`** multiplexes `job_update` + `deployment_update` (it's behind the same `authMiddleware` as every route). Logs keep their high-volume, id-scoped per-entity streams.

**Client**
- One `useGlobalEvents()` subscription in `AppShell`, using a **relative `/api/events`** URL so it resolves same-origin in prod and via the Vite proxy in dev — avoiding the `localhost:3001` fallback that broke the old SSE hooks in production.
- It signals a tiny `live-bus` and patches the cached deployment detail (so an open detail page updates instantly).
- `useDeploymentsApi` / `useJobsApi` refetch (cache-bypassing) on `live-bus` signals — the **primary** freshness path; the existing polling stays as a **fallback** for no-SSE environments.
- Repointed `useLiveDeploymentStatus` from the dead route to the global stream (its handler already filters by `deploymentId`).

## Scope

Polling is kept as a fallback rather than ripped out — events make updates instant, polling covers SSE-down. Tightening/removing the now-redundant polling intervals is a safe follow-up. `system_update` keeps its existing dedicated stream (already works); this stream carries the state transitions that list views need.

## Testing

- Bus: fan-out, unsubscribe, and throwing-subscriber isolation.
- `RealJobService` emits a `completed` `job_update`; `RealDeploymentService` emits `deployment_update` on persist (createFromDraft).
- Server (399) + web (149) + typecheck + lint + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)