### PR TITLE
feat(deploy): operator-triggered catalog-app upgrade (promote) — #284 Phase 2

### DIFF
--- a/packages/cli/src/commands/deployments/actions.ts
+++ b/packages/cli/src/commands/deployments/actions.ts
@@ -1,5 +1,5 @@
 import { HolaSdk } from '@hola/sdk';
-import type { GetDeploymentResponse, PostDeploymentActionResponse, RollbackResponse } from '@hola/shared';
+import type { GetDeploymentResponse, PostDeploymentActionResponse, RollbackResponse, PromoteDeploymentResponse } from '@hola/shared';
 
 import { watchJob, reportDeployError } from '../../lib/deploy-flow';
 import { maybeNotifyUpdate } from '../../lib/update-notice';
@@ -47,6 +47,51 @@ export async function runDeploymentAction(
 export interface RollbackOptions extends ActionOptions {
   to?: string;
   reason?: string;
+}
+
+export interface UpgradeOptions extends ActionOptions {
+  /** Target catalog version (default: the deployment's latest available version). */
+  appVersion?: string;
+  /** Force a pre-upgrade snapshot even when the target doesn't require one. */
+  snapshot?: boolean;
+}
+
+/** Upgrade a deployment to a newer catalog version via POST /api/deployments/:id/promote.
+ *  The server carries the current env/secrets forward and runs the upgrade skip-guard +
+ *  pre-upgrade snapshot before switching the active release. */
+export async function runUpgrade(
+  deploymentId: string,
+  opts: UpgradeOptions,
+  injected?: { sdk?: HolaSdk }
+): Promise<PromoteDeploymentResponse | undefined> {
+  const sdk = injected?.sdk ?? new HolaSdk();
+  const out = (m: string) => console.log(m);
+  try {
+    out(`Upgrading ${deploymentId}${opts.appVersion ? ` to ${opts.appVersion}` : ' to the latest version'}…`);
+    const res = (await sdk.deployments.promote(deploymentId, {
+      ...(opts.appVersion ? { version: opts.appVersion } : {}),
+      ...(opts.snapshot ? { snapshot: true } : {}),
+    })) as PromoteDeploymentResponse;
+
+    let status: string | undefined;
+    if (res.jobId && !opts.noStream) {
+      status = await watchJob(sdk, res.jobId, (m) => out(m));
+    } else if (res.jobId) {
+      const job = (await sdk.jobs.byId(res.jobId)) as { status?: string };
+      status = job.status ?? 'queued';
+    }
+
+    if (opts.json) {
+      console.log(JSON.stringify({ ...res, status }, null, 2));
+    } else {
+      out(status ? `Done (${status}).` : 'Done.');
+    }
+    if (status === 'failed') process.exitCode = 1;
+    await maybeNotifyUpdate(sdk, opts);
+    return res;
+  } catch (err) {
+    return reportDeployError(err);
+  }
 }
 
 /** Roll a deployment back via POST /api/deployments/:id/rollback, watching the job. */

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -198,6 +198,22 @@ prog
     await runRollback(deploymentId, streamOpts(opts));
   });
 
+// upgrade — promote a deployment to a newer catalog version (carries env forward,
+// runs the upgrade skip-guard + pre-upgrade snapshot)
+prog
+  .command('upgrade <deploymentId>')
+  .describe('Upgrade a deployment to a newer catalog version')
+  .example('upgrade guacamole-ab12cd34            # to the latest available version')
+  .example('upgrade guacamole-ab12cd34 --app-version 2.0.0')
+  .option('--app-version', 'Target catalog version (default: the latest available)')
+  .option('--snapshot', 'Force a pre-upgrade data snapshot even if the target does not require one', false)
+  .option('--no-stream', 'Do not watch the upgrade job', false)
+  .option('--json', 'Print the result as JSON', false)
+  .action(async (deploymentId, opts) => {
+    const { runUpgrade } = await load(import('./commands/deployments/actions'));
+    await runUpgrade(deploymentId, streamOpts(opts));
+  });
+
 // Fallback banner when no args
 if (process.argv.length <= 2) {
   // Minimal banner when no args. Lead with setup for first-time users, then the

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -11,6 +11,7 @@ import {
   PatchDeploymentRequest, PatchDeploymentResponse,
   PostDeploymentActionRequest, PostDeploymentActionResponse,
   RollbackRequest, RollbackResponse, GetDeploymentHistoryResponse,
+  PromoteDeploymentRequest, PromoteDeploymentResponse,
   // Catalog types
   GetCatalogAppsRequest, GetCatalogAppsResponse, GetCatalogAppResponse,
   GetCatalogAppVersionsResponse, GetCatalogAppVersionDetailResponse,
@@ -115,6 +116,7 @@ export class HolaSdk {
     history: (deploymentId: string, qs?: Record<string, string | number | boolean | undefined>) => this.get<GetDeploymentHistoryResponse>(`${API.deployments.history(deploymentId)}${buildQuery(qs)}`),
     action: (deploymentId: string, action: PostDeploymentActionRequest) => this.post<PostDeploymentActionResponse>(API.deployments.actions(deploymentId), action),
     rollback: (deploymentId: string, rollback: RollbackRequest) => this.post<RollbackResponse>(API.deployments.rollback(deploymentId), rollback),
+    promote: (deploymentId: string, promote: PromoteDeploymentRequest = {}) => this.post<PromoteDeploymentResponse>(API.deployments.promote(deploymentId), promote),
     logs: (deploymentId: string, qs?: Record<string, string | number | boolean | undefined>) => this.get(`${API.deployments.logs(deploymentId)}${buildQuery(qs)}`),
   };
 

--- a/packages/server/src/__tests__/contract/http-error-contract.test.ts
+++ b/packages/server/src/__tests__/contract/http-error-contract.test.ts
@@ -46,6 +46,7 @@ describe('API contract: shared error envelope', () => {
       { method: 'PATCH', path: `/api/deployments/${unknownId}`, body: { env: [] } },
       { method: 'POST', path: `/api/deployments/${unknownId}/actions`, body: { action: 'stop' } },
       { method: 'POST', path: `/api/deployments/${unknownId}/rollback`, body: {} },
+      { method: 'POST', path: `/api/deployments/${unknownId}/promote`, body: {} },
       { method: 'GET', path: `/api/deployments/${unknownId}/history` },
       { method: 'DELETE', path: `/api/deployments/${unknownId}` },
     ];

--- a/packages/server/src/__tests__/deployments/promote-endpoint.test.ts
+++ b/packages/server/src/__tests__/deployments/promote-endpoint.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Promote (upgrade) endpoint — POST /api/deployments/:id/promote (#284 Phase 2).
+ *
+ * Hermetic route-layer tests against the in-process server with mock services.
+ * The full upgrade orchestration (draft → env carry-forward → finalize → promote →
+ * pgautoupgrade migration) is exercised end-to-end on a disposable VM; here we
+ * pin the operator-facing contract: a seeded deployment with no newer catalog
+ * version can't be promoted without an explicit target.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { setupTestServer, teardownTestServer } from '../utils/bun-server';
+
+const baseURL = 'http://localhost:3002';
+
+describe('POST /api/deployments/:id/promote', () => {
+  beforeAll(async () => {
+    await setupTestServer(3002, { NODE_ENV: 'test' });
+  });
+
+  afterAll(async () => {
+    await teardownTestServer();
+  });
+
+  test('400 NO_TARGET_VERSION when the deployment has no newer version and none is given', async () => {
+    // seed-nextcloud is a mock-seeded deployment with no `latestVersion`.
+    const res = await fetch(`${baseURL}/api/deployments/seed-nextcloud/promote`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe('NO_TARGET_VERSION');
+  });
+});

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -969,30 +969,39 @@ async function route(url: URL, req: Request): Promise<Response> {
         );
       }
       // Build the target release from the catalog, then carry the operator's current
-      // env/secrets forward onto the new version's env schema (new keys keep their
-      // catalog defaults; existing keys keep the deployed values).
+      // config forward onto the new version: env values/secrets (merged by key — a key
+      // absent from the deployment keeps the new version's catalog default) and system
+      // overrides. Ports are NOT carried — the new version's compose defines its own.
       const draft = await services.drafts.createDraft({ appId, version: targetVersion });
-      const carried = await services.deployments.getActiveAppEnv(deploymentId);
-      const draftDetail = await services.drafts.getDraft(draft.draftId);
-      const mergedAppEnv = (draftDetail.appEnv ?? []).map(e =>
-        Object.prototype.hasOwnProperty.call(carried, e.key) ? { ...e, value: carried[e.key] } : e,
-      );
-      if (mergedAppEnv.length > 0) {
-        await services.drafts.updateDraft(draft.draftId, { appEnv: mergedAppEnv });
+      try {
+        const carried = await services.deployments.getActiveConfig(deploymentId);
+        const draftDetail = await services.drafts.getDraft(draft.draftId);
+        const mergedAppEnv = (draftDetail.appEnv ?? []).map(e =>
+          Object.prototype.hasOwnProperty.call(carried.appEnv, e.key) ? { ...e, value: carried.appEnv[e.key] } : e,
+        );
+        const patch: PatchDraftRequest = {};
+        if (mergedAppEnv.length > 0) patch.appEnv = mergedAppEnv;
+        if (Object.keys(carried.systemOverrides).length > 0) patch.systemOverrides = carried.systemOverrides;
+        if (Object.keys(patch).length > 0) await services.drafts.updateDraft(draft.draftId, patch);
+        await services.drafts.finalizeDraft(draft.draftId);
+        logger.info('Promoting deployment to new release', {
+          requestId: context?.requestId,
+          deploymentId,
+          appId,
+          targetVersion,
+          draftId: draft.draftId,
+        });
+        const payload: PromoteDeploymentResponse = await services.deployments.promote(deploymentId, {
+          draftId: draft.draftId,
+          snapshot: body.snapshot,
+        });
+        return json(payload);
+      } catch (err) {
+        // The draft for this attempt is orphaned if the upgrade can't proceed
+        // (skip-guard rejection, snapshot failure, …) — delete it so it doesn't linger.
+        await services.drafts.deleteDraft(draft.draftId).catch(() => {});
+        throw err;
       }
-      await services.drafts.finalizeDraft(draft.draftId);
-      logger.info('Promoting deployment to new release', {
-        requestId: context?.requestId,
-        deploymentId,
-        appId,
-        targetVersion,
-        draftId: draft.draftId,
-      });
-      const payload: PromoteDeploymentResponse = await services.deployments.promote(deploymentId, {
-        draftId: draft.draftId,
-        snapshot: body.snapshot,
-      });
-      return json(payload);
     } catch (err) {
       return errorResponse(req, err);
     }

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -43,6 +43,8 @@ import {
   type JobStatus,
   type RollbackRequest,
   type RollbackResponse,
+  type PromoteDeploymentRequest,
+  type PromoteDeploymentResponse,
 } from '@hola/shared';
 
 // Error interface for proper typing
@@ -933,6 +935,63 @@ async function route(url: URL, req: Request): Promise<Response> {
       const body = (await req.json().catch(() => ({}))) as RollbackRequest;
       const services = getServices();
       const payload: RollbackResponse = await services.deployments.rollback(deploymentId, body);
+      return json(payload);
+    } catch (err) {
+      return errorResponse(req, err);
+    }
+  }
+
+  // Deployment promote (upgrade to a newer catalog version) — #284 Phase 2.
+  // One endpoint orchestrates the whole upgrade: resolve the target version, build
+  // a draft from the catalog bundle, carry the deployment's current env/secrets
+  // forward onto the new release, finalize, then promote (which runs the upgrade
+  // skip-guard + pre-upgrade snapshot before switching the active release).
+  const deploymentPromoteMatch = pathname.match(/^\/api\/deployments\/([^/]+)\/promote$/);
+  if (deploymentPromoteMatch && req.method === 'POST') {
+    const deploymentId = deploymentPromoteMatch[1];
+    try {
+      const body = (await req.json().catch(() => ({}))) as PromoteDeploymentRequest;
+      const context = getRequestContext(req);
+      const services = getServices();
+      const detail = await services.deployments.getDeployment(deploymentId);
+      const appId = detail.app;
+      const targetVersion = body.version ?? detail.latestVersion;
+      if (!targetVersion) {
+        return json(
+          {
+            error: {
+              code: 'NO_TARGET_VERSION',
+              message:
+                'No version to promote to — the deployment is already at the latest known version (or the catalog is unavailable). Pass an explicit { "version": "x.y.z" }.',
+            },
+          },
+          { status: 400 },
+        );
+      }
+      // Build the target release from the catalog, then carry the operator's current
+      // env/secrets forward onto the new version's env schema (new keys keep their
+      // catalog defaults; existing keys keep the deployed values).
+      const draft = await services.drafts.createDraft({ appId, version: targetVersion });
+      const carried = await services.deployments.getActiveAppEnv(deploymentId);
+      const draftDetail = await services.drafts.getDraft(draft.draftId);
+      const mergedAppEnv = (draftDetail.appEnv ?? []).map(e =>
+        Object.prototype.hasOwnProperty.call(carried, e.key) ? { ...e, value: carried[e.key] } : e,
+      );
+      if (mergedAppEnv.length > 0) {
+        await services.drafts.updateDraft(draft.draftId, { appEnv: mergedAppEnv });
+      }
+      await services.drafts.finalizeDraft(draft.draftId);
+      logger.info('Promoting deployment to new release', {
+        requestId: context?.requestId,
+        deploymentId,
+        appId,
+        targetVersion,
+        draftId: draft.draftId,
+      });
+      const payload: PromoteDeploymentResponse = await services.deployments.promote(deploymentId, {
+        draftId: draft.draftId,
+        snapshot: body.snapshot,
+      });
       return json(payload);
     } catch (err) {
       return errorResponse(req, err);

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -111,8 +111,8 @@ export interface DeploymentService extends HealthCheckable {
   createFromDraft(request: CreateDeploymentFromDraftRequest): Promise<CreateDeploymentFromDraftResponse>;
   /** Stage a new release from a finalized draft onto an existing deployment and activate it. */
   promote(deploymentId: string, request: PromoteRequest): Promise<CreateDeploymentFromDraftResponse>;
-  /** The active release's resolved app env (key→value), for carrying secrets/config forward across an upgrade. */
-  getActiveAppEnv(deploymentId: string): Promise<Record<string, string>>;
+  /** The active release's carry-forward config (app env incl. secrets + system overrides), for an upgrade. */
+  getActiveConfig(deploymentId: string): Promise<{ appEnv: Record<string, string>; systemOverrides: Record<string, string> }>;
 
   // Deployment management
   listDeployments(request: GetDeploymentsRequest): Promise<GetDeploymentsResponse>;
@@ -289,7 +289,7 @@ abstract class InMemoryDeploymentService implements DeploymentService {
   constructor(protected jobService: JobService) {}
 
   abstract healthCheck(): Promise<ServiceHealth>;
-  abstract getActiveAppEnv(deploymentId: string): Promise<Record<string, string>>;
+  abstract getActiveConfig(deploymentId: string): Promise<{ appEnv: Record<string, string>; systemOverrides: Record<string, string> }>;
 
   // --- persistence hooks (no-ops here; overridden by the real service) ---
   protected async ensureLayout(deploymentId: string): Promise<void> {
@@ -1176,10 +1176,25 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     }
   }
 
-  /** Public accessor for the active release's app env — used by the upgrade flow to
-   *  carry the operator's existing config/secrets forward onto the new release. */
-  async getActiveAppEnv(deploymentId: string): Promise<Record<string, string>> {
-    return this.readActiveAppEnv(this.requireDeployment(deploymentId));
+  /** Public accessor for the active release's carry-forward config — its app env
+   *  (incl. secret values) and system overrides — used by the upgrade flow to carry
+   *  the operator's existing config forward onto the new release. (Ports are NOT
+   *  carried: the new version's compose defines its own container ports.) */
+  async getActiveConfig(deploymentId: string): Promise<{ appEnv: Record<string, string>; systemOverrides: Record<string, string> }> {
+    const deployment = this.requireDeployment(deploymentId);
+    const releaseId = deployment.currentReleaseId;
+    const empty = { appEnv: {} as Record<string, string>, systemOverrides: {} as Record<string, string> };
+    if (!releaseId) return empty;
+    const manifestPath = `deployments/${deployment.id}/releases/${releaseId}/manifest.json`;
+    if (!(await this.storageService.fileExists(manifestPath))) return empty;
+    try {
+      const manifest = JSON.parse(await this.storageService.readFileAsString(manifestPath)) as FinalizedManifest;
+      const appEnv: Record<string, string> = {};
+      for (const e of manifest.appEnv ?? []) appEnv[e.key] = e.value ?? '';
+      return { appEnv, systemOverrides: manifest.systemOverrides ?? {} };
+    } catch {
+      return empty;
+    }
   }
 
   /** The active release's declared ingress/web compose service, if any. */
@@ -1992,9 +2007,9 @@ export class MockDeploymentService extends InMemoryDeploymentService {
     return { healthy: true, lastCheck: new Date() };
   }
 
-  /** Mock has no persisted release manifests; the upgrade flow carries no env in tests. */
-  async getActiveAppEnv(): Promise<Record<string, string>> {
-    return {};
+  /** Mock has no persisted release manifests; the upgrade flow carries no config in tests. */
+  async getActiveConfig(): Promise<{ appEnv: Record<string, string>; systemOverrides: Record<string, string> }> {
+    return { appEnv: {}, systemOverrides: {} };
   }
 
   /** Seed a couple of sample deployments so list views are non-empty out of the box. */

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -611,7 +611,7 @@ abstract class InMemoryDeploymentService implements DeploymentService {
       throw new ValidationError(guard.message, { code: guard.code, fromVersion, toVersion, suggestedVersion: guard.suggestedVersion });
     }
 
-    const { app, release } = await this.buildReleaseFromDraft(artifacts, request, deploymentId, releaseId);
+    const { app, version, release } = await this.buildReleaseFromDraft(artifacts, request, deploymentId, releaseId);
 
     // Reject an unsatisfiable auth requirement before staging the new release, so
     // a promote that switches to a backend-only mode (e.g. forward-auth under
@@ -646,6 +646,19 @@ abstract class InMemoryDeploymentService implements DeploymentService {
 
     // Atomically switch the active release to the new one.
     await this.promoteRelease(deploymentId, releaseId);
+
+    // Sync the deployment's displayed version to the promoted release. promoteRelease
+    // only moves the release pointers (it's shared with rollback and the Release type
+    // carries no version); without this the record (and the UI's "update available")
+    // would still report the pre-upgrade version after a successful promote.
+    if (version) {
+      const promoted = this.requireDeployment(deploymentId);
+      if (promoted.version !== version) {
+        promoted.version = version;
+        this.deployments.set(deploymentId, promoted);
+        await this.persistDeployment(promoted);
+      }
+    }
 
     const jobId = await this.maybeStartJob(deploymentId, releaseId, request.options?.autoStart);
 

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -111,6 +111,8 @@ export interface DeploymentService extends HealthCheckable {
   createFromDraft(request: CreateDeploymentFromDraftRequest): Promise<CreateDeploymentFromDraftResponse>;
   /** Stage a new release from a finalized draft onto an existing deployment and activate it. */
   promote(deploymentId: string, request: PromoteRequest): Promise<CreateDeploymentFromDraftResponse>;
+  /** The active release's resolved app env (key→value), for carrying secrets/config forward across an upgrade. */
+  getActiveAppEnv(deploymentId: string): Promise<Record<string, string>>;
 
   // Deployment management
   listDeployments(request: GetDeploymentsRequest): Promise<GetDeploymentsResponse>;
@@ -287,6 +289,7 @@ abstract class InMemoryDeploymentService implements DeploymentService {
   constructor(protected jobService: JobService) {}
 
   abstract healthCheck(): Promise<ServiceHealth>;
+  abstract getActiveAppEnv(deploymentId: string): Promise<Record<string, string>>;
 
   // --- persistence hooks (no-ops here; overridden by the real service) ---
   protected async ensureLayout(deploymentId: string): Promise<void> {
@@ -1160,6 +1163,12 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     }
   }
 
+  /** Public accessor for the active release's app env — used by the upgrade flow to
+   *  carry the operator's existing config/secrets forward onto the new release. */
+  async getActiveAppEnv(deploymentId: string): Promise<Record<string, string>> {
+    return this.readActiveAppEnv(this.requireDeployment(deploymentId));
+  }
+
   /** The active release's declared ingress/web compose service, if any. */
   private async readActiveIngressService(deployment: EnhancedDeploymentDetail): Promise<string | undefined> {
     const releaseId = deployment.currentReleaseId;
@@ -1968,6 +1977,11 @@ export class MockDeploymentService extends InMemoryDeploymentService {
 
   async healthCheck(): Promise<ServiceHealth> {
     return { healthy: true, lastCheck: new Date() };
+  }
+
+  /** Mock has no persisted release manifests; the upgrade flow carries no env in tests. */
+  async getActiveAppEnv(): Promise<Record<string, string>> {
+    return {};
   }
 
   /** Seed a couple of sample deployments so list views are non-empty out of the box. */

--- a/packages/server/src/services/core/snapshot-fs.ts
+++ b/packages/server/src/services/core/snapshot-fs.ts
@@ -44,7 +44,32 @@ function run(cmd: string, args: string[]): Promise<void> {
 
 /** Gzip-tar the CONTENTS of `srcDir` into `destFile` (whose parent dir must exist). */
 export async function tarGzipDir(srcDir: string, destFile: string): Promise<void> {
-  await run('tar', ['-czf', destFile, '-C', srcDir, '.']);
+  // Snapshotting a *live* data dir races with the app's own writes: a file (e.g. a
+  // postgres WAL segment) can change or vanish between tar's stat and read. GNU tar
+  // reports that as a soft error (exit 1) but still writes a complete, crash-
+  // consistent archive — which is exactly this snapshot's contract (#284/#121).
+  // So suppress the file-changed warning, ignore a file that disappears mid-read,
+  // and treat exit 1 as success; only a fatal error (exit >= 2) fails the snapshot.
+  await runTar([
+    '-czf', destFile,
+    '--warning=no-file-changed',
+    '--ignore-failed-read',
+    '-C', srcDir, '.',
+  ]);
+}
+
+/** Like `run('tar', …)` but tolerant of tar's exit-1 "file changed as we read it"
+ *  (expected when archiving a live data dir); only exit >= 2 is a real failure. */
+function runTar(args: string[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('tar', args, { stdio: ['ignore', 'ignore', 'pipe'] });
+    let stderr = '';
+    child.stderr?.on('data', (d) => { stderr += String(d); });
+    child.on('error', reject);
+    child.on('close', (code) =>
+      code === 0 || code === 1 ? resolve() : reject(new Error(`tar exited ${code}: ${stderr.trim()}`)),
+    );
+  });
 }
 
 /**

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -39,6 +39,7 @@ export const API = {
     logsStream: (deploymentId: string) => `/api/deployments/${deploymentId}/logs/stream`,
     actions: (deploymentId: string) => `/api/deployments/${deploymentId}/actions`,
     rollback: (deploymentId: string) => `/api/deployments/${deploymentId}/rollback`,
+    promote: (deploymentId: string) => `/api/deployments/${deploymentId}/promote`,
   },
 
   jobs: {
@@ -1114,6 +1115,25 @@ export type CreateDeploymentFromDraftResponse = {
   releaseId: string;
   jobId?: string; // If deployment started immediately
 };
+
+/**
+ * Promote (upgrade) an existing deployment to a newer catalog version (#284
+ * Phase 2). The server resolves the target, builds a draft from the catalog
+ * bundle, carries the deployment's current env/secrets forward, finalizes it,
+ * and runs the upgrade skip-guard + pre-upgrade snapshot before switching the
+ * active release. Response is the standard create-from-draft result.
+ */
+export type PromoteDeploymentRequest = {
+  /** Target catalog version. Defaults to the deployment's latest available version. */
+  version?: string;
+  /**
+   * Force a pre-upgrade app-data snapshot even when the target doesn't declare
+   * `upgrade.preUpgradeBackup: "required"` (which always snapshots).
+   */
+  snapshot?: boolean;
+};
+
+export type PromoteDeploymentResponse = CreateDeploymentFromDraftResponse;
 
 // Network and resource types
 export type NetworkMode = 'bridge' | 'host' | 'traefik' | 'none';

--- a/packages/web/src/hooks/useDeploymentDetailApi.ts
+++ b/packages/web/src/hooks/useDeploymentDetailApi.ts
@@ -110,6 +110,18 @@ export function useDeploymentDetailApi(deploymentId: string | undefined) {
     return result;
   }, [deploymentId, cacheKey, fetchData]);
 
+  // Upgrade to a newer catalog version (#284 Phase 2) via POST
+  // /api/deployments/:id/promote. The server carries env/secrets forward and runs
+  // the upgrade skip-guard + pre-upgrade snapshot before switching the release.
+  const upgradeDeployment = React.useCallback(async (body?: { version?: string; snapshot?: boolean }) => {
+    if (!deploymentId || !cacheKey) throw new Error('No deployment ID');
+
+    const result = await api.deployments.promote(deploymentId, body);
+    globalCache.delete(cacheKey);
+    await fetchData();
+    return result;
+  }, [deploymentId, cacheKey, fetchData]);
+
   // Remove the deployment entirely (stop + deprovision auth + release route +
   // delete record + clean storage) via DELETE /api/deployments/:id. The caller
   // navigates away on success since the deployment no longer exists.
@@ -125,6 +137,7 @@ export function useDeploymentDetailApi(deploymentId: string | undefined) {
     refetch: fetchData,
     updateConfiguration,
     executeAction,
+    upgradeDeployment,
     removeDeployment
   };
 }

--- a/packages/web/src/pages/DeploymentDetail.tsx
+++ b/packages/web/src/pages/DeploymentDetail.tsx
@@ -105,6 +105,8 @@ export const DeploymentDetail: React.FC = () => {
   const [showRemoveConfirm, setShowRemoveConfirm] = useState(false);
   const [removing, setRemoving] = useState(false);
   const [removeError, setRemoveError] = useState<string | null>(null);
+  const [showUpgradeConfirm, setShowUpgradeConfirm] = useState(false);
+  const [upgradeError, setUpgradeError] = useState<string | null>(null);
 
   const {
     data: historyData,
@@ -245,22 +247,18 @@ export const DeploymentDetail: React.FC = () => {
     }
   };
 
-  // Upgrade to the latest catalog version. The server carries env/secrets forward
-  // and snapshots first when the target requires it; a breaking target is confirmed.
-  const handleUpgrade = async () => {
+  // Confirmed upgrade to the latest catalog version. The server carries env/secrets +
+  // system overrides forward and snapshots first when the target requires it.
+  const confirmUpgrade = async () => {
     if (!deployment || !deployment.updateAvailable) return;
-    const confirmed = window.confirm(
-      `Upgrade ${deployment.name} to ${deployment.latestVersion}?\n\n` +
-        `Your settings and secrets carry forward. If this release is marked breaking or ` +
-        `requires a backup, Hola takes a pre-upgrade snapshot first (you can roll back to it).`,
-    );
-    if (!confirmed) return;
+    setUpgradeError(null);
     setOperationLoading(prev => ({ ...prev, upgrade: true }));
     try {
       await upgradeDeployment();
+      setShowUpgradeConfirm(false);
     } catch (error) {
       console.error('Error upgrading deployment:', error);
-      window.alert(error instanceof Error ? error.message : 'Upgrade failed');
+      setUpgradeError(error instanceof Error ? error.message : 'Upgrade failed');
     } finally {
       setOperationLoading(prev => ({ ...prev, upgrade: false }));
     }
@@ -831,6 +829,63 @@ export const DeploymentDetail: React.FC = () => {
   return (
     <div className="animate-fadein">
       {/* Removal confirmation dialog */}
+      {showUpgradeConfirm && (
+        <div
+          className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4"
+          onClick={() => { if (!operationLoading.upgrade) setShowUpgradeConfirm(false); }}
+        >
+          <div
+            className="bg-surface-0 rounded-xl border border-border w-full max-w-md overflow-hidden"
+            onClick={(e) => e.stopPropagation()}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="upgrade-dialog-title"
+          >
+            <div className="p-6">
+              <div className="flex items-start gap-3">
+                <div className="w-9 h-9 flex-shrink-0 flex items-center justify-center rounded-full bg-primary-weak text-primary">
+                  <ArrowUpCircle className="w-[18px] h-[18px]" />
+                </div>
+                <div className="min-w-0">
+                  <h2 id="upgrade-dialog-title" className="text-lg font-semibold m-0">
+                    Upgrade {deployment.name} to {deployment.latestVersion}?
+                  </h2>
+                  <p className="mt-1.5 text-sm text-text-muted">
+                    Your settings and secrets carry forward. If this release is marked breaking or
+                    requires a backup, Hola takes a pre-upgrade snapshot first — you can roll back to it.
+                  </p>
+                </div>
+              </div>
+
+              {upgradeError && (
+                <div className="mt-4 flex items-start gap-2 text-sm text-danger bg-danger-weak rounded-[9px] p-3">
+                  <AlertTriangle className="w-4 h-4 flex-shrink-0 mt-0.5" />
+                  <span>{upgradeError}</span>
+                </div>
+              )}
+
+              <div className="mt-6 flex justify-end gap-2.5">
+                <button
+                  onClick={() => setShowUpgradeConfirm(false)}
+                  disabled={operationLoading.upgrade}
+                  className="h-[38px] px-[14px] flex items-center bg-surface-2 text-text-strong border border-border rounded-[9px] text-[13.5px] font-semibold hover:border-primary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={confirmUpgrade}
+                  disabled={operationLoading.upgrade}
+                  className="h-[38px] px-[14px] flex items-center gap-[7px] bg-primary text-white border border-transparent rounded-[9px] text-[13.5px] font-semibold hover:brightness-110 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+                >
+                  {operationLoading.upgrade ? <RotateCw className="w-4 h-4 animate-spin" /> : <ArrowUpCircle className="w-4 h-4" />}
+                  {operationLoading.upgrade ? 'Upgrading…' : `Upgrade to ${deployment.latestVersion}`}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
       {showRemoveConfirm && (
         <div
           className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4"
@@ -915,7 +970,7 @@ export const DeploymentDetail: React.FC = () => {
           <div className="flex gap-2 flex-wrap">
             {deployment.updateAvailable && deployment.latestVersion && (
               <button
-                onClick={handleUpgrade}
+                onClick={() => { setUpgradeError(null); setShowUpgradeConfirm(true); }}
                 disabled={operationLoading.upgrade}
                 title={`Upgrade to ${deployment.latestVersion}`}
                 className="h-[38px] px-[14px] flex items-center gap-[7px] bg-primary text-white border border-primary rounded-[9px] text-[13.5px] font-semibold hover:opacity-90 transition-opacity disabled:opacity-60"

--- a/packages/web/src/pages/DeploymentDetail.tsx
+++ b/packages/web/src/pages/DeploymentDetail.tsx
@@ -23,7 +23,8 @@ import {
   AlertTriangle,
   ChevronLeft,
   ChevronRight,
-  Copy
+  Copy,
+  ArrowUpCircle
 } from 'lucide-react';
 import type {
   AppEnvVar,
@@ -92,6 +93,7 @@ export const DeploymentDetail: React.FC = () => {
     refetch: refetchDeployment,
     updateConfiguration,
     executeAction,
+    upgradeDeployment,
     removeDeployment
   } = useDeploymentDetailApi(deploymentId);
 
@@ -240,6 +242,27 @@ export const DeploymentDetail: React.FC = () => {
       // TODO: Show error message to user
     } finally {
       setOperationLoading(prev => ({ ...prev, [operationKey]: false }));
+    }
+  };
+
+  // Upgrade to the latest catalog version. The server carries env/secrets forward
+  // and snapshots first when the target requires it; a breaking target is confirmed.
+  const handleUpgrade = async () => {
+    if (!deployment || !deployment.updateAvailable) return;
+    const confirmed = window.confirm(
+      `Upgrade ${deployment.name} to ${deployment.latestVersion}?\n\n` +
+        `Your settings and secrets carry forward. If this release is marked breaking or ` +
+        `requires a backup, Hola takes a pre-upgrade snapshot first (you can roll back to it).`,
+    );
+    if (!confirmed) return;
+    setOperationLoading(prev => ({ ...prev, upgrade: true }));
+    try {
+      await upgradeDeployment();
+    } catch (error) {
+      console.error('Error upgrading deployment:', error);
+      window.alert(error instanceof Error ? error.message : 'Upgrade failed');
+    } finally {
+      setOperationLoading(prev => ({ ...prev, upgrade: false }));
     }
   };
 
@@ -890,6 +913,17 @@ export const DeploymentDetail: React.FC = () => {
 
           {/* Actions */}
           <div className="flex gap-2 flex-wrap">
+            {deployment.updateAvailable && deployment.latestVersion && (
+              <button
+                onClick={handleUpgrade}
+                disabled={operationLoading.upgrade}
+                title={`Upgrade to ${deployment.latestVersion}`}
+                className="h-[38px] px-[14px] flex items-center gap-[7px] bg-primary text-white border border-primary rounded-[9px] text-[13.5px] font-semibold hover:opacity-90 transition-opacity disabled:opacity-60"
+              >
+                <ArrowUpCircle className="w-4 h-4" />
+                {operationLoading.upgrade ? 'Upgrading…' : `Upgrade to ${deployment.latestVersion}`}
+              </button>
+            )}
             <button
               onClick={() => handleAction('restart')}
               className="h-[38px] px-[14px] flex items-center gap-[7px] bg-surface-2 text-text-strong border border-border rounded-[9px] text-[13.5px] font-semibold hover:border-primary transition-colors"

--- a/packages/web/src/utils/api.ts
+++ b/packages/web/src/utils/api.ts
@@ -364,6 +364,12 @@ export const api = {
     action: (deploymentId: string, action: { action: 'start' | 'stop' | 'restart' | 'delete' }) =>
       apiClient.post(API.deployments.actions(deploymentId), action),
 
+    // Upgrade to a newer catalog version (#284 Phase 2). The server carries the
+    // current env/secrets forward and runs the upgrade skip-guard + pre-upgrade
+    // snapshot before switching the active release.
+    promote: (deploymentId: string, body?: { version?: string; snapshot?: boolean }) =>
+      apiClient.post(API.deployments.promote(deploymentId), body ?? {}),
+
     // Full teardown: stop + deprovision + release the Traefik route + remove the
     // record (DELETE /api/deployments/:id). The `delete` action only stops compose
     // and leaves the route held, which blocks reinstalling the same app.


### PR DESCRIPTION
Wires the existing (unit-tested but unreachable) `promote()` service method to a real operator-facing flow, so an installed app can be **upgraded to a newer catalog version**. Until now the dashboard showed "update available" but nothing could trigger the upgrade — this closes that #284 Phase 2 gap.

## What's new
- **Server** — `POST /api/deployments/:id/promote` orchestrates the whole upgrade in one endpoint: resolve target version → create a draft from the catalog bundle → **carry the deployment's current env/secrets forward** onto the new version's env schema → finalize → `promote()` (which runs the #284 skip-guard + the #284/#121 pre-upgrade snapshot before switching the release). New `getActiveAppEnv()` accessor exposes the active release's env for carry-over.
- **SDK** — `deployments.promote(id, { version?, snapshot? })`.
- **CLI** — `hola upgrade <deploymentId> [--app-version X] [--snapshot]`, watches the job.
- **Web** — an **"Upgrade to <version>"** button on the deployment detail (shown when an update is available), with a breaking/backup-aware confirm.

## Two bugs found by the disposable-VM upgrade test (guacamole PG16→18 via pgautoupgrade) — fixed here
1. **`promote()` never synced the deployment's `version` field.** It moved the release pointers (`promoteRelease`, shared with rollback; the `Release` type carries no version) but left `version` at the pre-upgrade value, so the record and the UI's "update available" stayed stale after a successful upgrade. Now synced from the promoted release.
2. **The pre-upgrade snapshot raced on live data.** `tar`-ing a live postgres data dir hit `file changed as we read it` (a WAL segment changing mid-read) — exit 1 in GNU tar, a *soft* error that still writes a complete crash-consistent archive — which **aborted required-backup upgrades non-deterministically**. `tarGzipDir` now suppresses the warning, ignores a vanishing file, and treats exit 1 as success (only exit ≥2 fails).

## Verification
- `bun run typecheck` · `lint` · `build` clean; `bun --cwd packages/server test` → 400 pass.
- **End-to-end on a disposable VM:** install guacamole @ PG16 → `hola upgrade` → draft+env-carry+finalize+promote → pre-upgrade snapshot taken → pgautoupgrade `pg_upgrade` 16→18 in place → data intact, containers healthy, `version` → 2.0.0, `updateAvailable` → false. Both fixes re-verified on the same VM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
