### PR TITLE
chore(release): 0.6.34

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/cli": {
       "name": "@hola/cli",
-      "version": "0.6.33",
+      "version": "0.6.34",
       "bin": {
         "hola": "./bin/hola",
       },
@@ -37,11 +37,11 @@
     },
     "packages/compose": {
       "name": "@hola/compose",
-      "version": "0.6.33",
+      "version": "0.6.34",
     },
     "packages/sdk": {
       "name": "@hola/sdk",
-      "version": "0.6.33",
+      "version": "0.6.34",
       "dependencies": {
         "@hola/shared": "workspace:*",
       },
@@ -55,7 +55,7 @@
     },
     "packages/server": {
       "name": "@hola/server",
-      "version": "0.6.33",
+      "version": "0.6.34",
       "dependencies": {
         "@hola/shared": "workspace:*",
         "jose": "^5.9.6",
@@ -71,7 +71,7 @@
     },
     "packages/shared": {
       "name": "@hola/shared",
-      "version": "0.6.33",
+      "version": "0.6.34",
       "dependencies": {
         "yaml": "^2.9.0",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.6.33",
+  "version": "0.6.34",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.6.33';
+export const CLI_VERSION = '0.6.34';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.6.33",
+  "version": "0.6.34",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.6.33",
+  "version": "0.6.34",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.6.33",
+  "version": "0.6.34",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.6.33",
+  "version": "0.6.34",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Release **0.6.34**.

Bumps `cli` / `compose` / `sdk` / `server` / `shared` (and `cli/src/version.ts` + `bun.lock`) from 0.6.33. `web` stays `0.0.0` by convention.

### Headline
Ships **#284 Phase 2 — operator-triggered catalog-app upgrade** (merged in #301): `hola upgrade <id>`, `POST /api/deployments/:id/promote`, and a web **Upgrade** button. The upgrade carries the deployment's env/secrets + system overrides forward, and runs the existing skip-guard + pre-upgrade snapshot before switching the release. Includes the two fixes found by VM testing (deployment-version sync after promote; snapshot tolerating live-file/WAL churn).

This is what activates the in-place upgrade path for the Postgres-16/17→18 catalog bundles (guacamole, mealie, paperless-ngx, postiz).

Merge → then tag `cli-v0.6.34` to publish the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
