### PR TITLE
fix(server): attach an RS256 signing key to per-app native-oidc providers

### DIFF
--- a/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
+++ b/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
@@ -72,6 +72,11 @@ function installFetch(handler?: (call: RecordedCall) => Response | undefined) {
     if (method === 'POST' && url.pathname === '/api/v3/propertymappings/provider/scope/') {
       return json({ pk: 'roleclaim-pk' }, 201);
     }
+    // A usable signing keypair exists (Authentik ships a default self-signed one),
+    // so the provisioner attaches it for RS256 id_tokens + a populated JWKS.
+    if (method === 'GET' && url.pathname === '/api/v3/crypto/certificatekeypairs/') {
+      return json({ results: [{ pk: 'signkey-pk', name: 'authentik Self-signed Certificate' }] });
+    }
     if (method === 'POST' && url.pathname === '/api/v3/providers/oauth2/') {
       return json({ pk: 42, client_id: body.client_id, client_secret: body.client_secret }, 201);
     }
@@ -152,6 +157,11 @@ describe('RealAuthentikProvisionerService (REST contract)', () => {
     ]);
     expect(pbody.authorization_flow).toBeTruthy();
     expect(pbody.invalidation_flow).toBeTruthy();
+
+    // A signing key is attached so id_tokens are RS256-signed (populated JWKS) —
+    // without it Authentik defaults to HS256 with an empty JWKS and JWKS-verifying
+    // OIDC clients (authlib/Hangar) fail id_token validation with KeyError 'keys'.
+    expect(pbody.signing_key).toBe('signkey-pk');
 
     // Scope mappings were resolved from the polymorphic endpoint and attached, so
     // the OIDC client releases openid/profile/email claims (issue #144). The
@@ -278,6 +288,9 @@ describe('RealAuthentikProvisionerService (REST contract)', () => {
     expect(pm).toContain('scope-openid');
     expect(pm).toContain('scope-profile');
     expect(pm).toContain('scope-email');
+    // Reuse also (re)attaches the signing key, healing a provider first created on
+    // Authentik's HS256 default (empty JWKS) before this fix.
+    expect((patch.body as { signing_key?: string }).signing_key).toBe('signkey-pk');
   });
 
   test('native-oidc resolves scope mappings by managed id when scope_name is absent', async () => {

--- a/packages/server/src/services/core/provisioner.ts
+++ b/packages/server/src/services/core/provisioner.ts
@@ -205,7 +205,8 @@ const PROVISIONER_PERMISSIONS = [
   // Read stages (stages/all) so the recovery flow can append the built-in Login
   // stage — setting a password then signs the operator in automatically.
   'authentik_flows.view_stage',
-  // Read certificate-keypairs to pick a signing key for the dashboard OIDC client.
+  // Read certificate-keypairs to pick a signing key for the dashboard and per-app
+  // OIDC clients (RS256 id_tokens + a populated JWKS).
   'authentik_crypto.view_certificatekeypair',
 ];
 
@@ -329,15 +330,22 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
       // stay permanently degraded — the dashboard path already self-heals this way.
       // Union with what's already attached so a transient re-failure can't wipe a
       // provider's mappings, and mappings we don't manage aren't dropped.
-      const [scopePks, roleClaimPk] = await Promise.all([
+      const [scopePks, roleClaimPk, signingKey] = await Promise.all([
         this.resolveScopeMappingPks(oidc.scopes),
         this.ensureRoleClaimMapping(oidc.roleClaim, reuseSlug, oidc.scopes),
+        this.resolveSigningKeyPk(),
       ]);
       const desired = new Set<string>([...(provider.property_mappings ?? []), ...scopePks]);
       if (roleClaimPk) desired.add(roleClaimPk);
+      // (Re)attach an asymmetric signing key so ID tokens are RS256-signed and the
+      // provider publishes a populated JWKS — a client first provisioned before this
+      // fix (or during a transient crypto-listing failure) would otherwise stay on
+      // Authentik's HS256 default with an empty JWKS, which breaks JWKS-verifying
+      // OIDC clients (authlib et al.) at id_token validation.
       await this.api('PATCH', `/api/v3/providers/oauth2/${existing.providerPk}/`, {
         redirect_uris: redirectUris,
         property_mappings: [...desired],
+        ...(signingKey ? { signing_key: signingKey } : {}),
       });
       this.logger.info('Reused existing OIDC client', { deploymentId: input.deploymentId, providerPk: existing.providerPk });
       return {
@@ -351,15 +359,20 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
     const clientId = randomUUID();
     const clientSecret = randomBytes(32).toString('hex');
 
-    const [authFlow, invalidationFlow, propertyMappings, roleClaimPk] = await Promise.all([
+    const [authFlow, invalidationFlow, propertyMappings, roleClaimPk, signingKey] = await Promise.all([
       this.resolveFlowPk(AUTHZ_FLOW_SLUG, 'authorization'),
       this.resolveFlowPk(INVALIDATION_FLOW_SLUG, 'invalidation'),
       this.resolveScopeMappingPks(oidc.scopes),
       this.ensureRoleClaimMapping(oidc.roleClaim, slug, oidc.scopes),
+      this.resolveSigningKeyPk(),
     ]);
     // Attach the admin-by-group role claim alongside the standard scope mappings.
     const allMappings = roleClaimPk ? [...propertyMappings, roleClaimPk] : propertyMappings;
 
+    // Attach an asymmetric signing key so ID tokens are RS256-signed and the provider
+    // publishes a populated JWKS. Without it Authentik defaults to HS256 with an empty
+    // JWKS, and standards-compliant OIDC clients that verify the id_token via JWKS
+    // (e.g. authlib — Hangar) fail with `KeyError: 'keys'`. Mirrors the dashboard path.
     const provider = await this.api<AuthentikOAuth2Provider>('POST', '/api/v3/providers/oauth2/', {
       name: `hola-${input.appName}-${input.deploymentId.slice(0, 8)}`,
       authorization_flow: authFlow,
@@ -370,6 +383,7 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
       redirect_uris: redirectUris,
       property_mappings: allMappings,
       sub_mode: 'hashed_user_id',
+      ...(signingKey ? { signing_key: signingKey } : {}),
     });
 
     // Create the application; roll back the provider if that fails so we never
@@ -487,7 +501,7 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
       );
       return res.results?.[0]?.pk;
     } catch (error) {
-      this.logger.warn('Could not resolve a signing key for the dashboard client; tokens may be opaque', {
+      this.logger.warn('Could not resolve a signing key for the OIDC client; id_tokens may fall back to HS256 with an empty JWKS', {
         error: error instanceof Error ? error.message : String(error),
       });
       return undefined;


### PR DESCRIPTION
## Problem

`RealAuthentikProvisionerService.provisionOidc` created the per-app Authentik OAuth2 provider **without a `signing_key`**. Authentik then defaults `id_token` signing to **HS256** and serves an **empty JWKS (`{}`)**. Standards-compliant OIDC clients that verify the `id_token` via JWKS — authlib (Hangar) and most libraries — fail at token validation with `KeyError: 'keys'`, so login never completes. This is **independent of TLS** (it fails even with valid ACME certs).

Only `provisionPlatformOidc` (the Hola dashboard client) attached a signing key; per-app native-oidc apps (Hangar, and any future JWKS-verifying app) were left on the broken HS256/empty-JWKS default.

## Fix

Resolve and attach a signing key in `provisionOidc`, on **both**:
- the **fresh-provision** OAuth2-provider `POST`, and
- the **reuse / self-heal** `PATCH` (so providers created before this fix converge on next redeploy).

Mirrors the dashboard path — reuses the existing `resolveSigningKeyPk()` and the already-granted `authentik_crypto.view_certificatekeypair` scope. When no keypair is resolvable it degrades exactly as before (key omitted + warning), so this can't newly break a provision.

## Validation

- **Unit:** provisioner contract mock now serves `/api/v3/crypto/certificatekeypairs/` and asserts `signing_key` is attached on the fresh `POST` and the reuse `PATCH`. Full server suite **400/400 pass**; typecheck + lint clean.
- **End-to-end (disposable VM, server image built from this branch, no manual patching):** installing Hangar 1.4.0 now auto-produces provider `signing_key` → discovery `id_token_signing_alg` = **RS256** → JWKS = **1 key** (was `{}`). The full browser OIDC flow completes: Hangar's own sign-in → top-level Authentik redirect → authenticate → **Hangar dashboard renders as the authenticated operator**, `authenticated:true`, **zero CORS errors**.

## Companion / sequencing

Discovered while validating the try-hola/apps `feat/hangar-oidc` catalog change (Hangar forward-auth → native-oidc). That catalog change is correct and ready, but its login only works end-to-end once **this** server fix ships in a release — otherwise Hangar (and any JWKS-verifying native-oidc app) fails at `id_token` verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)