### PR TITLE
chore(release): 0.6.35

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/cli": {
       "name": "@hola/cli",
-      "version": "0.6.34",
+      "version": "0.6.35",
       "bin": {
         "hola": "./bin/hola",
       },
@@ -37,11 +37,11 @@
     },
     "packages/compose": {
       "name": "@hola/compose",
-      "version": "0.6.34",
+      "version": "0.6.35",
     },
     "packages/sdk": {
       "name": "@hola/sdk",
-      "version": "0.6.34",
+      "version": "0.6.35",
       "dependencies": {
         "@hola/shared": "workspace:*",
       },
@@ -55,7 +55,7 @@
     },
     "packages/server": {
       "name": "@hola/server",
-      "version": "0.6.34",
+      "version": "0.6.35",
       "dependencies": {
         "@hola/shared": "workspace:*",
         "jose": "^5.9.6",
@@ -71,7 +71,7 @@
     },
     "packages/shared": {
       "name": "@hola/shared",
-      "version": "0.6.34",
+      "version": "0.6.35",
       "dependencies": {
         "yaml": "^2.9.0",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.6.34",
+  "version": "0.6.35",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.6.34';
+export const CLI_VERSION = '0.6.35';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.6.34",
+  "version": "0.6.35",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.6.34",
+  "version": "0.6.35",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.6.34",
+  "version": "0.6.35",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.6.34",
+  "version": "0.6.35",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Release 0.6.35.

Ships **#303** — Hola attaches an RS256 signing key to per-app native-oidc Authentik providers, so JWKS-verifying OIDC clients (Hangar via authlib, and any future native-oidc app) can validate `id_token`s and complete login. Previously per-app providers defaulted to HS256 with an empty JWKS, breaking login regardless of TLS.

Version bump only (cli/compose/sdk/server/shared → 0.6.35, `cli/src/version.ts`, `bun.lock`; `web` stays 0.0.0). On merge, tag `cli-v0.6.35` to publish CLI binaries + server/web images + compose tarball.

Unblocks the try-hola/apps `feat/hangar-oidc` catalog merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)