### PR TITLE
feat(web): force update-check + clear finished jobs in the deployments panel

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -15,6 +15,8 @@ import {
   // Catalog types
   GetCatalogAppsRequest, GetCatalogAppsResponse, GetCatalogAppResponse,
   GetCatalogAppVersionsResponse, GetCatalogAppVersionDetailResponse,
+  // Job types
+  DeleteJobsRequest, DeleteJobsResponse,
   // System types
   GetUpdateCheckResponse
 } from '@hola/shared';
@@ -91,6 +93,9 @@ export class HolaSdk {
     app: (appId: string) => this.get<GetCatalogAppResponse>(API.catalog.appById(appId)),
     versions: (appId: string) => this.get<GetCatalogAppVersionsResponse>(API.catalog.versions(appId)),
     versionDetail: (appId: string, version: string) => this.get<GetCatalogAppVersionDetailResponse>(API.catalog.versionDetail(appId, version)),
+    // Force an immediate re-fetch of the remote catalog (bypasses the refresh-interval
+    // TTL) so newly-published app versions surface as available updates right away.
+    refresh: (force = true) => this.post<{ success: boolean; timestamp: string }>(`${API.catalog.refresh}${buildQuery({ force })}`),
   };
 
   drafts = {
@@ -123,6 +128,9 @@ export class HolaSdk {
   jobs = {
     byId: (jobId: string) => this.get(API.jobs.byId(jobId)),
     logs: (jobId: string, qs?: Record<string, string | number | boolean | undefined>) => this.get(`${API.jobs.logs(jobId)}${buildQuery(qs)}`),
+    // Clear finished (completed/failed/cancelled) jobs, optionally scoped by
+    // deployment and/or a single terminal status. Never removes running/queued jobs.
+    clear: (qs?: DeleteJobsRequest) => this.delete<DeleteJobsResponse>(`${API.jobs.base}${buildQuery(qs as Record<string, string | number | boolean | undefined>)}`),
   };
 
   // --- Core deployment functionality ---

--- a/packages/server/src/__tests__/jobs/clear-jobs.test.ts
+++ b/packages/server/src/__tests__/jobs/clear-jobs.test.ts
@@ -1,0 +1,118 @@
+/**
+ * clearJobs — bulk removal of finished jobs (DELETE /api/jobs).
+ *
+ * Invariants: only terminal jobs (completed/failed/cancelled) are removed;
+ * running/queued jobs are never touched; the clear can be scoped to a single
+ * deployment and/or a single terminal status; and it returns how many it removed.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { RealStorageService } from '../../services/core/storage';
+import { RealDatabaseService } from '../../services/core/database';
+import { RealLoggingService } from '../../services/core/logging';
+import { RealJobService, MockJobService } from '../../services/core/jobs';
+
+function deferred<T = void>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => { resolve = r; });
+  return { promise, resolve };
+}
+
+async function waitFor(predicate: () => Promise<boolean> | boolean, timeoutMs = 5000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (await predicate()) return;
+    await new Promise((r) => setTimeout(r, 20));
+  }
+  throw new Error('timeout waiting for condition');
+}
+
+describe('RealJobService.clearJobs', () => {
+  let dataRoot: string;
+  let storage: RealStorageService;
+  let database: RealDatabaseService;
+  let logging: RealLoggingService;
+
+  beforeEach(async () => {
+    dataRoot = mkdtempSync(join(tmpdir(), 'hola-clearjobs-'));
+    storage = new RealStorageService({ holaDir: dataRoot });
+    database = new RealDatabaseService(storage);
+    await database.initialize();
+    logging = new RealLoggingService(storage);
+  });
+
+  afterEach(() => {
+    rmSync(dataRoot, { recursive: true, force: true });
+  });
+
+  it('removes finished jobs and returns the count, never a running job', async () => {
+    const jobs = new RealJobService(database, logging);
+    jobs.setExecutor(async () => true); // completes immediately
+    const a = await jobs.createJob({ type: 'install', deploymentId: 'dep-a' });
+    const b = await jobs.createJob({ type: 'install', deploymentId: 'dep-b' });
+    await waitFor(async () => (await jobs.getJob(a.id))?.status === 'completed');
+    await waitFor(async () => (await jobs.getJob(b.id))?.status === 'completed');
+
+    // A running job that blocks on a gate so it stays 'running' across the clear.
+    const gate = deferred();
+    jobs.setExecutor(async () => { await gate.promise; return true; });
+    const running = await jobs.createJob({ type: 'install', deploymentId: 'dep-a' });
+    await waitFor(async () => (await jobs.getJob(running.id))?.status === 'running');
+
+    const cleared = await jobs.clearJobs();
+    expect(cleared).toBe(2);
+    expect(await jobs.getJob(a.id)).toBeNull();
+    expect(await jobs.getJob(b.id)).toBeNull();
+    expect((await jobs.getJob(running.id))?.status).toBe('running');
+
+    gate.resolve();
+    await waitFor(async () => (await jobs.getJob(running.id))?.status === 'completed');
+  });
+
+  it('scopes the clear to a single deployment', async () => {
+    const jobs = new RealJobService(database, logging);
+    jobs.setExecutor(async () => true);
+    const a = await jobs.createJob({ type: 'install', deploymentId: 'dep-a' });
+    const b = await jobs.createJob({ type: 'install', deploymentId: 'dep-b' });
+    await waitFor(async () => (await jobs.getJob(a.id))?.status === 'completed');
+    await waitFor(async () => (await jobs.getJob(b.id))?.status === 'completed');
+
+    const cleared = await jobs.clearJobs({ deploymentId: 'dep-a' });
+    expect(cleared).toBe(1);
+    expect(await jobs.getJob(a.id)).toBeNull();
+    expect((await jobs.getJob(b.id))?.status).toBe('completed');
+  });
+
+  it('clears only the requested terminal status', async () => {
+    const jobs = new RealJobService(database, logging);
+    jobs.setExecutor(async () => true);
+    const ok = await jobs.createJob({ type: 'install', deploymentId: 'dep-a' });
+    await waitFor(async () => (await jobs.getJob(ok.id))?.status === 'completed');
+
+    jobs.setExecutor(async () => { throw new Error('boom'); });
+    const bad = await jobs.createJob({ type: 'install', deploymentId: 'dep-a' });
+    await waitFor(async () => (await jobs.getJob(bad.id))?.status === 'failed');
+
+    const cleared = await jobs.clearJobs({ status: 'failed' });
+    expect(cleared).toBe(1);
+    expect((await jobs.getJob(ok.id))?.status).toBe('completed');
+    expect(await jobs.getJob(bad.id)).toBeNull();
+  });
+
+  it('is a no-op when there are no finished jobs', async () => {
+    const jobs = new RealJobService(database, logging);
+    expect(await jobs.clearJobs()).toBe(0);
+  });
+});
+
+describe('MockJobService.clearJobs', () => {
+  it('never removes a queued/running job', async () => {
+    const jobs = new MockJobService();
+    const j = await jobs.createJob({ type: 'install', deploymentId: 'dep-a' });
+    const cleared = await jobs.clearJobs();
+    expect(cleared).toBe(0);
+    expect((await jobs.getJob(j.id))?.status).toBe('queued');
+  });
+});

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -20,6 +20,7 @@ import {
   type PostDeploymentActionRequest,
   type PostDeploymentActionResponse,
   type GetJobsResponse,
+  type DeleteJobsResponse,
   type GetBackupsResponse,
   type CreateBackupRequest,
   type CreateBackupResponse,
@@ -1102,6 +1103,23 @@ async function route(url: URL, req: Request): Promise<Response> {
   }
 
   // Jobs + logs SSE
+  // Clear finished jobs (completed/failed/cancelled). Optional ?deploymentId= and
+  // ?status= narrow the scope; running/queued jobs are never removed.
+  if (pathname === API.jobs.base && req.method === 'DELETE') {
+    const url = new URL(req.url);
+    const deploymentId = url.searchParams.get('deploymentId') ?? undefined;
+    const statusParam = url.searchParams.get('status');
+    const status = statusParam && statusParam !== 'all' ? (statusParam as JobStatus) : undefined;
+    try {
+      const cleared = await getServices().jobs.clearJobs({ deploymentId, status });
+      const payload: DeleteJobsResponse = { cleared };
+      return json(payload);
+    } catch (error) {
+      logger.error('Failed to clear jobs', error as Error);
+      return errorResponse(req, error);
+    }
+  }
+
   // List jobs
   if (pathname === API.jobs.base && req.method === 'GET') {
     const url = new URL(req.url);

--- a/packages/server/src/services/core/jobs.ts
+++ b/packages/server/src/services/core/jobs.ts
@@ -63,10 +63,17 @@ export interface JobService extends HealthCheckable {
   cancelJob(id: string): Promise<void>;
   getJob(id: string): Promise<SharedJob | null>;
   listJobs(filter?: { deploymentId?: string; status?: SharedJobStatus }): Promise<SharedJob[]>;
+  /** Remove finished (completed/failed/cancelled) jobs, optionally scoped to one
+   *  deployment and/or a single terminal status. Never removes running/queued
+   *  jobs. Returns the number of jobs removed. */
+  clearJobs(filter?: { deploymentId?: string; status?: SharedJobStatus }): Promise<number>;
   onJobUpdate(jobId: string, listener: Listener<JobUpdate>): { unsubscribe(): void };
   /** Register the executor that performs real work for jobs (e.g. Compose lifecycle). */
   setExecutor(executor: JobExecutor): void;
 }
+
+// Job states that are safe to clear — never a queued/running job.
+const TERMINAL_JOB_STATUSES: JobEntity['status'][] = ['completed', 'failed', 'cancelled'];
 
 function toShared(job: JobEntity): SharedJob {
   return {
@@ -327,6 +334,35 @@ export class RealJobService implements JobService {
     return filter?.deploymentId ? mapped.filter(j => j.deploymentId === filter.deploymentId) : mapped;
   }
 
+  async clearJobs(filter?: { deploymentId?: string; status?: SharedJobStatus }): Promise<number> {
+    await this.ensureStarted();
+    let statuses = TERMINAL_JOB_STATUSES;
+    if (filter?.status) {
+      const statusMap: Record<SharedJobStatus, JobEntity['status']> = {
+        queued: 'pending',
+        running: 'running',
+        completed: 'completed',
+        failed: 'failed',
+      } as const;
+      const mapped = statusMap[filter.status];
+      // Only terminal statuses are clearable; a queued/running filter clears nothing.
+      statuses = TERMINAL_JOB_STATUSES.includes(mapped) ? [mapped] : [];
+    }
+    let removed = 0;
+    for (const status of statuses) {
+      const jobs = await this.repo.findByStatus(status);
+      for (const job of jobs) {
+        if (filter?.deploymentId && (job.payload?.deploymentId as string | undefined) !== filter.deploymentId) {
+          continue;
+        }
+        await this.repo.delete(job.id);
+        removed++;
+      }
+    }
+    if (removed > 0) this.logger.info('Cleared finished jobs', { removed, ...filter });
+    return removed;
+  }
+
   onJobUpdate(jobId: string, listener: Listener<JobUpdate>): { unsubscribe(): void } {
     return this.bus.on(jobId, listener);
   }
@@ -421,6 +457,21 @@ export class MockJobService implements JobService {
     if (filter?.deploymentId) items = items.filter(j => j.deploymentId === filter.deploymentId);
     // Sort newest first
     return items.sort((a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime());
+  }
+
+  async clearJobs(filter?: { deploymentId?: string; status?: SharedJobStatus }): Promise<number> {
+    let removed = 0;
+    for (const [id, j] of this.jobs) {
+      // Only finished jobs are clearable (the mock models completed/failed).
+      if (j.status !== 'completed' && j.status !== 'failed') continue;
+      if (filter?.status && j.status !== filter.status) continue;
+      if (filter?.deploymentId && j.deploymentId !== filter.deploymentId) continue;
+      const timer = this.timers.get(id);
+      if (timer) { clearInterval(timer); this.timers.delete(id); }
+      this.jobs.delete(id);
+      removed++;
+    }
+    return removed;
   }
 
   onJobUpdate(jobId: string, listener: Listener<JobUpdate>): { unsubscribe(): void } {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -727,6 +727,17 @@ export type GetJobsResponse = PageResponse<Job>;
 
 export type GetJobResponse = Job;
 
+// Bulk-clear finished jobs (DELETE /api/jobs). Only terminal jobs (completed,
+// failed, cancelled) are ever removed — running/queued jobs are never touched.
+// `deploymentId` scopes the clear to one deployment's jobs; `status` narrows it
+// to a specific terminal status (default: all terminal jobs).
+export type DeleteJobsRequest = {
+  deploymentId?: string;
+  status?: JobStatus;
+};
+
+export type DeleteJobsResponse = { cleared: number };
+
 // ------------------------------------------------------
 // Logs (SSE or polling fallback)
 // ------------------------------------------------------

--- a/packages/web/src/components/JobTracker.tsx
+++ b/packages/web/src/components/JobTracker.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Activity, CheckCircle, XCircle, Clock, AlertTriangle, RefreshCw } from 'lucide-react';
+import { Activity, CheckCircle, XCircle, Clock, AlertTriangle, RefreshCw, Trash2 } from 'lucide-react';
 import { JobStatus } from './JobStatus';
 import { useJobsApi } from '../hooks/useJobsApi';
+import { api } from '../utils/api-hybrid';
 import type { Job, SummaryJob } from '@hola/shared';
 
 interface JobTrackerProps {
@@ -54,6 +55,21 @@ export const JobTracker: React.FC<JobTrackerProps> = ({
 
   const summary = getJobSummary();
 
+  // Clear finished (completed/failed) jobs — scoped to this deployment when the
+  // tracker is rendered on a deployment detail, global otherwise. Running/queued
+  // jobs are never removed by the server, so this only declutters the list.
+  const [clearing, setClearing] = React.useState(false);
+  const finishedCount = summary.completed + summary.failed;
+  const handleClearFinished = async () => {
+    setClearing(true);
+    try {
+      await api.jobs.clear(deploymentId ? { deploymentId } : undefined);
+      await refetch();
+    } finally {
+      setClearing(false);
+    }
+  };
+
   if (loading && jobs.length === 0) {
     return (
       <div className={`bg-surface-1 rounded-lg border border-border ${className}`}>
@@ -99,14 +115,27 @@ export const JobTracker: React.FC<JobTrackerProps> = ({
             </div>
           </div>
           
-          <button
-            onClick={refetch}
-            disabled={loading}
-            className="p-2 bg-surface-2 hover:bg-surface-0 rounded transition-colors disabled:opacity-50"
-            title="Refresh jobs"
-          >
-            <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
-          </button>
+          <div className="flex items-center space-x-2">
+            {finishedCount > 0 && (
+              <button
+                onClick={handleClearFinished}
+                disabled={clearing}
+                className="flex items-center gap-1.5 px-2.5 h-9 bg-surface-2 hover:bg-surface-0 rounded text-sm text-text-muted hover:text-text-strong transition-colors disabled:opacity-50"
+                title={`Clear ${finishedCount} finished ${finishedCount === 1 ? 'job' : 'jobs'}`}
+              >
+                {clearing ? <RefreshCw className="w-4 h-4 animate-spin" /> : <Trash2 className="w-4 h-4" />}
+                <span>Clear finished</span>
+              </button>
+            )}
+            <button
+              onClick={refetch}
+              disabled={loading}
+              className="p-2 bg-surface-2 hover:bg-surface-0 rounded transition-colors disabled:opacity-50"
+              title="Refresh jobs"
+            >
+              <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
+            </button>
+          </div>
         </div>
       </div>
 

--- a/packages/web/src/pages/Deployments.tsx
+++ b/packages/web/src/pages/Deployments.tsx
@@ -115,6 +115,27 @@ export const Deployments: React.FC = () => {
     }
   }, [pendingDelete, refetch]);
 
+  // Force an immediate catalog re-check so newly-published app versions surface as
+  // available updates without waiting out the server's refresh-interval TTL. After
+  // the refresh we refetch the (cache-bypassing) deployments list so the server
+  // re-computes each app's `updateAvailable` against the freshly-pulled catalog.
+  const [checkingUpdates, setCheckingUpdates] = useState(false);
+  const [checkResult, setCheckResult] = useState<string | null>(null);
+  const handleCheckUpdates = useCallback(async () => {
+    setCheckingUpdates(true);
+    setCheckResult(null);
+    try {
+      await api.catalog.refresh(true);
+      await refetch();
+      setCheckResult('Catalog up to date');
+    } catch {
+      setCheckResult('Check failed');
+    } finally {
+      setCheckingUpdates(false);
+      setTimeout(() => setCheckResult(null), 4000);
+    }
+  }, [refetch]);
+
   // Calculate pagination info
   const totalPages = Math.ceil(totalDeployments / limit);
   const hasNextPage = page < totalPages;
@@ -189,6 +210,18 @@ export const Deployments: React.FC = () => {
           </p>
         </div>
         <div className="flex-1" />
+        {checkResult && (
+          <span className="self-center text-[12.5px] text-text-muted mr-1">{checkResult}</span>
+        )}
+        <button
+          onClick={handleCheckUpdates}
+          disabled={checkingUpdates}
+          title="Re-check the catalog for newer versions of your installed apps"
+          className="flex items-center gap-2 h-10 px-3.5 bg-surface-1 text-text-strong border border-border rounded-[10px] text-sm font-semibold hover:border-primary transition disabled:opacity-60 disabled:cursor-not-allowed"
+        >
+          <RefreshCw className={`w-[16px] h-[16px] ${checkingUpdates ? 'animate-spin' : ''}`} />
+          <span>{checkingUpdates ? 'Checking…' : 'Check for updates'}</span>
+        </button>
         <Link
           to="/catalog"
           className="flex items-center gap-2 h-10 px-4 bg-primary text-white rounded-[10px] text-sm font-semibold shadow-primary-glow hover:brightness-110 transition"

--- a/packages/web/src/utils/api.ts
+++ b/packages/web/src/utils/api.ts
@@ -313,9 +313,21 @@ export const api = {
     appById: (appId: string) => apiClient.get(API.catalog.appById(appId)),
     
     versions: (appId: string) => apiClient.get(API.catalog.versions(appId)),
-    
-    versionDetail: (appId: string, version: string) => 
+
+    versionDetail: (appId: string, version: string) =>
       apiClient.get(API.catalog.versionDetail(appId, version)),
+
+    // Force an immediate catalog re-fetch (bypasses the server's refresh-interval
+    // TTL) so newly-published versions surface as available updates right away.
+    // A refresh can change which apps have updates, so drop the cached deployment
+    // lists (they carry `updateAvailable`), catalog, and dashboard summary.
+    refresh: async (force = true) => {
+      const res = await apiClient.post(`${API.catalog.refresh}${apiClient.buildQuery({ force })}`);
+      globalCache.deleteByPattern(/^api:.*\/deployments/);
+      globalCache.deleteByPattern(/^api:.*\/catalog/);
+      globalCache.deleteByPattern(/^api:.*\/summary/);
+      return res;
+    },
   },
 
   // Drafts (Install Wizard) with cache invalidation
@@ -390,10 +402,19 @@ export const api = {
     },
     
     byId: (jobId: string) => apiClient.get(API.jobs.byId(jobId), false), // Don't cache job details
-    
+
     logs: (jobId: string, params?: { since?: string; lines?: number }) => {
       const query = apiClient.buildQuery(params || {});
       return apiClient.get(`${API.jobs.logs(jobId)}${query}`, false); // Don't cache logs
+    },
+
+    // Clear finished (completed/failed/cancelled) jobs, optionally scoped by
+    // deployment and/or terminal status. Never removes running/queued jobs.
+    clear: async (params?: { deploymentId?: string; status?: string }) => {
+      const res = await apiClient.delete(`${API.jobs.base}${apiClient.buildQuery(params || {})}`);
+      globalCache.deleteByPattern(/^api:.*\/jobs/);
+      globalCache.deleteByPattern(/^api:.*\/summary/);
+      return res;
     },
   },
 

--- a/packages/web/src/utils/sdk-adapter.ts
+++ b/packages/web/src/utils/sdk-adapter.ts
@@ -18,7 +18,7 @@ import type {
   PostDeploymentActionRequest, PostDeploymentActionResponse,
   GetDeploymentHistoryResponse,
   // Job types
-  GetJobsResponse, GetJobResponse, GetLogsResponse,
+  GetJobsResponse, GetJobResponse, GetLogsResponse, DeleteJobsRequest, DeleteJobsResponse,
   // Backup types  
   GetBackupsResponse, GetBackupResponse, CreateBackupResponse, RestoreBackupResponse, DeleteBackupResponse,
   // Notification types
@@ -313,6 +313,18 @@ export class SdkAdapter {
       const path = `/api/catalog/apps/${appId}/versions/${encodeURIComponent(version)}`;
       return this.getWithCache(path, () => this.sdk.get<GetCatalogAppVersionDetailResponse>(path));
     },
+
+    // Force an immediate catalog re-fetch (bypasses the server's refresh-interval
+    // TTL) so newly-published versions surface as available updates right away.
+    // A refresh can change which apps have updates, so drop the cached deployment
+    // lists (they carry `updateAvailable`), catalog, and dashboard summary.
+    refresh: async (force = true): Promise<{ success: boolean; timestamp: string }> => {
+      const res = await this.sdk.catalog.refresh(force);
+      globalCache.deleteByPattern(/^api:.*\/deployments/);
+      globalCache.deleteByPattern(/^api:.*\/catalog/);
+      globalCache.deleteByPattern(/^api:.*\/summary/);
+      return res;
+    },
   };
 
   // Drafts (Install Wizard) with cache invalidation
@@ -440,8 +452,17 @@ export class SdkAdapter {
       const query = this.buildQuery(params || {});
       const path = `/api/jobs/${jobId}/logs${query}`;
       // Don't cache logs
-      return this.enhancedRequest('GET', path, () => 
+      return this.enhancedRequest('GET', path, () =>
         this.sdk.jobs.logs(jobId, params), undefined, false);
+    },
+
+    // Clear finished (completed/failed/cancelled) jobs, optionally scoped by
+    // deployment and/or terminal status. Never removes running/queued jobs.
+    clear: async (params?: DeleteJobsRequest): Promise<DeleteJobsResponse> => {
+      const res = await this.sdk.jobs.clear(params);
+      globalCache.deleteByPattern(/^api:.*\/jobs/);
+      globalCache.deleteByPattern(/^api:.*\/summary/);
+      return res;
     },
   };
 


### PR DESCRIPTION
Adds two operator affordances to the **Deployments** panel.

## 1. Check for updates
A **Check for updates** button in the Deployments header forces an immediate catalog re-fetch (`POST /api/catalog/refresh?force=true`) and refetches the deployments list so the server re-computes each app's `updateAvailable` against the fresh catalog.

**Why:** the per-app "update available" pill (#294) is driven by the server's in-memory catalog cache, which only re-fetches once it ages past `HOLA_CATALOG_REFRESH_INTERVAL_MS` (**default 24h**) — there's no background poller. So a just-published app version stayed invisible until the TTL lapsed or the server restarted. This gives operators a one-click way to check now.

## 2. Clear finished jobs
A **Clear finished** button in the JobTracker header removes terminal jobs (completed / failed / cancelled) so the list stays readable. It's **scoped to the deployment** when the tracker is rendered on a deployment detail page, and **global** on the Deployments page. Running/queued jobs are never removed. The button only appears when there are finished jobs.

## Full-stack wiring
- **shared:** `DeleteJobsRequest` / `DeleteJobsResponse`.
- **server:** `DELETE /api/jobs?deploymentId=&status=` → `JobService.clearJobs`, which only ever deletes terminal jobs (`TERMINAL_JOB_STATUSES`), optionally scoped by deployment and/or a single terminal status, and returns the count. Implemented in both `RealJobService` (repo-backed) and `MockJobService`.
- **sdk:** `catalog.refresh(force)` and `jobs.clear({ deploymentId?, status? })`.
- **web:** `catalog.refresh` + `jobs.clear` on both the legacy api client and the SDK adapter, each invalidating the affected caches (deployments/catalog/summary on a refresh; jobs/summary on a clear) so the manual actions reflect immediately.

## Tests
`packages/server/src/__tests__/jobs/clear-jobs.test.ts`: removes finished jobs and returns the count **while leaving a running job untouched**, deployment scoping, single-status clear, no-op when nothing is finished, and the Mock invariant that a queued job is never removed.

- typecheck ✅ · lint ✅ · web tests 149/149 ✅ · build ✅
- server suite: new tests pass; the only failures are 2 pre-existing `#284 Phase 1` snapshot/rollback tests that also fail on clean `main` (unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)