### PR TITLE
chore(release): 0.6.36

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/cli": {
       "name": "@hola/cli",
-      "version": "0.6.35",
+      "version": "0.6.36",
       "bin": {
         "hola": "./bin/hola",
       },
@@ -37,11 +37,11 @@
     },
     "packages/compose": {
       "name": "@hola/compose",
-      "version": "0.6.35",
+      "version": "0.6.36",
     },
     "packages/sdk": {
       "name": "@hola/sdk",
-      "version": "0.6.35",
+      "version": "0.6.36",
       "dependencies": {
         "@hola/shared": "workspace:*",
       },
@@ -55,7 +55,7 @@
     },
     "packages/server": {
       "name": "@hola/server",
-      "version": "0.6.35",
+      "version": "0.6.36",
       "dependencies": {
         "@hola/shared": "workspace:*",
         "jose": "^5.9.6",
@@ -71,7 +71,7 @@
     },
     "packages/shared": {
       "name": "@hola/shared",
-      "version": "0.6.35",
+      "version": "0.6.36",
       "dependencies": {
         "yaml": "^2.9.0",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.6.35",
+  "version": "0.6.36",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.6.35';
+export const CLI_VERSION = '0.6.36';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.6.35",
+  "version": "0.6.36",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.6.35",
+  "version": "0.6.36",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.6.35",
+  "version": "0.6.36",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.6.35",
+  "version": "0.6.36",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Release **0.6.36**, cutting the deployments-panel operator affordances (#314).

## What's in it
- **Check for updates** — a Deployments-header button that forces an immediate catalog re-check (`POST /api/catalog/refresh?force=true`) + list refetch, so newly-published app versions surface as available updates without waiting out the server's 24h catalog-cache TTL.
- **Clear finished jobs** — a "Clear finished" button in the JobTracker that removes terminal jobs (completed/failed/cancelled), global on the Deployments page and per-deployment on a detail page.

## Release mechanics
Bumps the synced version across `cli`, `compose`, `sdk`, `server`, `shared` (+ `cli/src/version.ts` + `bun.lock`); `web` stays unversioned. After merge, pushing the **`cli-v0.6.36`** tag triggers `cli-release.yml` to build & publish the multi-arch `ghcr.io/try-hola/{server,web}:0.6.36` (+ `:latest`) images, the compose bundle, and the standalone CLI binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)