### PR TITLE
fix(deploy): persist concrete app version + changelog on update + stable check-for-updates button

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -133,12 +133,23 @@ jobs:
         run: |
           # Create the release if it does not exist, then upload (clobbering) the assets.
           if ! gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            # Auto-generate a PR-based changelog (previous tag auto-detected) so the
+            # release notes are a real "what changed" list. The changelog goes FIRST,
+            # followed by a sentinel comment and the install snippet: `hola update`
+            # prints everything up to the sentinel as the post-upgrade changelog.
+            CHANGELOG="$(gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+              -f tag_name="$GITHUB_REF_NAME" -q .body 2>/dev/null || true)"
+            {
+              if [ -n "$CHANGELOG" ]; then printf '%s\n\n' "$CHANGELOG"; fi
+              printf '<!-- hola:changelog-end -->\n'
+              printf 'Standalone `hola` CLI binaries. Install with:\n'
+              printf '```\n'
+              printf 'curl -fsSL https://raw.githubusercontent.com/%s/main/cli-install.sh | sh\n' "$GITHUB_REPOSITORY"
+              printf '```\n'
+            } > release-notes.md
             gh release create "$GITHUB_REF_NAME" \
               ${{ steps.ver.outputs.prerelease == 'true' && '--prerelease' || '' }} \
               --title "Hola CLI $GITHUB_REF_NAME" \
-              --notes "Standalone \`hola\` CLI binaries. Install with:
-          \`\`\`
-          curl -fsSL https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/main/cli-install.sh | sh
-          \`\`\`"
+              --notes-file release-notes.md
           fi
           gh release upload "$GITHUB_REF_NAME" dist-bin/hola-* --clobber

--- a/packages/cli/src/__tests__/update.test.ts
+++ b/packages/cli/src/__tests__/update.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
-import { runUpdate, type UpdateResult, type UpdateCheckReport } from '../commands/update/update';
+import { runUpdate, fetchReleaseNotes, type UpdateResult, type UpdateCheckReport } from '../commands/update/update';
 import { scriptedPrompter } from '../install/prompter';
 import type { Runner } from '../lib/runner';
 
@@ -347,5 +347,44 @@ describe('hola update', () => {
     expect(res.releaseUrl).toBe('https://example.com/r');
     // No install/extract happened.
     expect(runner.calls.some((c) => c.cmd.includes('install.sh') || c.cmd.includes('tar xz'))).toBe(false);
+  });
+
+  // --- post-update changelog ------------------------------------------------
+
+  const notesResponse = (body: unknown) =>
+    ({ ok: true, json: async () => ({ body, html_url: 'https://example.com/rel' }) }) as unknown as Response;
+
+  it('fetchReleaseNotes returns only the changelog portion before the install sentinel', async () => {
+    const body = "## What's Changed\n- feat: a (#1)\n- fix: b (#2)\n\n<!-- hola:changelog-end -->\nInstall with: ...";
+    const fetchImpl = (async () => notesResponse(body)) as unknown as typeof fetch;
+    const r = await fetchReleaseNotes('https://github.com/try-hola/hola.git', '0.6.36', fetchImpl);
+    expect(r).toEqual({ notes: "## What's Changed\n- feat: a (#1)\n- fix: b (#2)", url: 'https://example.com/rel' });
+  });
+
+  it('fetchReleaseNotes returns null for a release with no sentinel (older release)', async () => {
+    const fetchImpl = (async () => notesResponse('Standalone `hola` CLI binaries. Install with: ...')) as unknown as typeof fetch;
+    expect(await fetchReleaseNotes('https://github.com/try-hola/hola.git', '0.6.1', fetchImpl)).toBeNull();
+  });
+
+  it('prints the "What\'s new" changelog at the end of a successful update', async () => {
+    const runner = makeRunner();
+    const logs: string[] = [];
+    const spy = vi.spyOn(console, 'log').mockImplementation((m?: unknown) => { logs.push(String(m)); });
+    try {
+      await runUpdate(
+        { host: 'me@vm', ref: 'cli-v0.6.23' },
+        {
+          prompter: scriptedPrompter({}),
+          runner,
+          fetchNotes: async (_repo, version) => ({ notes: `- feat: shiny (#7)\n- fix: bug (#8)`, url: `https://example.com/cli-v${version}` }),
+        },
+      );
+    } finally {
+      spy.mockRestore();
+    }
+    const out = logs.join('\n');
+    expect(out).toContain("What's new in v0.6.23");
+    expect(out).toContain('- feat: shiny (#7)');
+    expect(out).toContain('Full notes: https://example.com/cli-v0.6.23');
   });
 });

--- a/packages/cli/src/commands/update/update.ts
+++ b/packages/cli/src/commands/update/update.ts
@@ -119,6 +119,48 @@ interface GitHubRelease {
   html_url: string;
   draft: boolean;
   prerelease: boolean;
+  body?: string;
+}
+
+// Marker the release workflow writes after the auto-generated changelog and before
+// the install snippet, so we print only the changelog portion. A release without it
+// (older, pre-changelog releases) yields no notes rather than dumping install text.
+const CHANGELOG_SENTINEL = '<!-- hola:changelog-end -->';
+
+/** Build the GitHub API URL for a single release by tag, or null for a non-GitHub remote. */
+function releaseByTagApiUrl(repo: string, tag: string): string | null {
+  const m = repo.replace(/\.git$/, '').match(/github\.com[/:]([^/]+)\/([^/]+)$/);
+  if (!m) return null;
+  return `https://api.github.com/repos/${m[1]}/${m[2]}/releases/tags/${tag}`;
+}
+
+/**
+ * Changelog notes for `cli-v<version>` (the portion of the release body before the
+ * install-snippet sentinel) plus the release URL, or null on any failure / a
+ * release with no changelog. Fail-safe: never blocks or fails the update.
+ */
+export async function fetchReleaseNotes(
+  repo: string,
+  version: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<{ notes: string; url: string } | null> {
+  const api = releaseByTagApiUrl(repo, `cli-v${version}`);
+  if (!api) return null;
+  try {
+    const res = await fetchImpl(api, {
+      headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'hola-cli' },
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) return null;
+    const rel = (await res.json()) as { body?: string; html_url?: string };
+    const body = typeof rel.body === 'string' ? rel.body : '';
+    if (!body.includes(CHANGELOG_SENTINEL)) return null;
+    const notes = body.split(CHANGELOG_SENTINEL)[0].trim();
+    if (!notes) return null;
+    return { notes, url: typeof rel.html_url === 'string' ? rel.html_url : '' };
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -194,6 +236,8 @@ export async function runUpdate(
     runner?: Runner;
     /** Injectable release lookup for tests / `--check`. */
     fetchLatest?: (repo: string) => Promise<{ version: string; url: string } | null>;
+    /** Injectable changelog lookup for the post-update "what's new" summary (tests). */
+    fetchNotes?: (repo: string, version: string) => Promise<{ notes: string; url: string } | null>;
     /** Injectable CLI self-update (tests); defaults to the real fs/network/re-exec impl. */
     selfUpdate?: (args: SelfUpdateArgs) => Promise<SelfUpdateOutcome>;
   },
@@ -201,6 +245,7 @@ export async function runUpdate(
   const prompter = injected?.prompter ?? clackPrompter();
   const runner = injected?.runner ?? systemRunner();
   const fetchLatest = injected?.fetchLatest ?? ((repo: string) => fetchLatestRelease(repo));
+  const fetchNotes = injected?.fetchNotes ?? ((repo: string, v: string) => fetchReleaseNotes(repo, v));
   const selfUpdate = injected?.selfUpdate ?? realSelfUpdate;
   const out = (msg: string) => { if (!opts.json) console.log(msg); };
 
@@ -479,6 +524,16 @@ export async function runUpdate(
       out(`\n${colors.green('✔ Done.')} ${colors.bold(host)} is now on ${span}.`);
       if (backupPath) out(`  ${colors.dim(`Pre-upgrade snapshot: ${backupPath}`)}`);
       if (ssoAction === 'enabled') out(`  SSO provisioning runs on first boot; retrieve sign-in with ${colors.cyan(`hola credentials --host ${host}`)}.`);
+
+      // Close with the changelog for the version just installed. Fail-safe: any
+      // lookup error (offline, rate-limited, older release with no changelog) is
+      // swallowed so it never turns a successful upgrade into a noisy tail.
+      const notes = await fetchNotes(repo, version);
+      if (notes) {
+        out(`\n${colors.bold(`What's new in v${version}`)}`);
+        for (const line of notes.notes.split('\n')) out(`  ${line}`);
+        if (notes.url) out(`  ${colors.dim(`Full notes: ${notes.url}`)}`);
+      }
     }
     return result;
   } catch (err) {

--- a/packages/server/src/__tests__/drafts/catalog-compose.test.ts
+++ b/packages/server/src/__tests__/drafts/catalog-compose.test.ts
@@ -31,10 +31,14 @@ function makeCatalog(): CatalogArg {
       // A URL icon for one app, to assert the icon flows through unchanged.
       icon: appId === 'with-compose' ? 'https://cdn.example.com/with-compose.png' : '📦',
     }),
-    getVersionDetail: async (appId: string) =>
-      appId === 'with-compose'
-        ? { defaultEnv: [], defaults: { ports: [], volumes: [] }, composeOverride: WITH_COMPOSE }
-        : { defaultEnv: [], defaults: { ports: [], volumes: [] } },
+    // Resolve "latest"/unset to a concrete pinned version (what the real catalog
+    // does), so a draft can persist a real version for display + update detection.
+    getVersionDetail: async (appId: string, version?: string) => {
+      const resolved = !version || version === 'latest' ? '1.4.1' : version;
+      return appId === 'with-compose'
+        ? { version: resolved, defaultEnv: [], defaults: { ports: [], volumes: [] }, composeOverride: WITH_COMPOSE }
+        : { version: resolved, defaultEnv: [], defaults: { ports: [], volumes: [] } };
+    },
   } as unknown as CatalogArg;
 }
 
@@ -67,6 +71,21 @@ describe('Catalog → draft compose (#82)', () => {
 
     expect(draft.composeOverride).toBe(WITH_COMPOSE);
     expect(draft.composeOverride).toContain('nginx:1.27');
+  });
+
+  test('persists the concrete resolved version when the caller omits one', async () => {
+    // No version supplied → the catalog resolves "latest" to a concrete pin, and
+    // the draft stores THAT (not undefined), so the deployment record shows a real
+    // version and update detection can compare against the catalog.
+    const { draftId } = await drafts.createDraft({ appId: 'with-compose' });
+    const draft = await drafts.getDraft(draftId);
+    expect(draft.version).toBe('1.4.1');
+  });
+
+  test('keeps an explicitly requested concrete version', async () => {
+    const { draftId } = await drafts.createDraft({ appId: 'with-compose', version: '1.3.0' });
+    const draft = await drafts.getDraft(draftId);
+    expect(draft.version).toBe('1.3.0');
   });
 
   test('the seeded compose flows through finalize into the manifest', async () => {

--- a/packages/server/src/services/core/catalog.ts
+++ b/packages/server/src/services/core/catalog.ts
@@ -278,7 +278,7 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
           ? manifest.ingress.service.trim()
           : undefined;
 
-      return { ...merged, composeOverride, auth, consumes, upgrade, backup, ingressService } satisfies GetCatalogAppVersionDetailResponse;
+      return { ...merged, version: v.version, composeOverride, auth, consumes, upgrade, backup, ingressService } satisfies GetCatalogAppVersionDetailResponse;
     } catch (error) {
       this.logger.warn('Failed to read or parse bundle manifest; deferring to mocks', { appId, version, error: error instanceof Error ? error.message : String(error) });
       throw new Error('MANIFEST_UNAVAILABLE', { cause: error });

--- a/packages/server/src/services/core/draft.ts
+++ b/packages/server/src/services/core/draft.ts
@@ -331,7 +331,12 @@ export class RealDraftService implements DraftService {
       const draft: Draft = {
         draftId,
         appId: request.appId,
-        version: request.version,
+        // Persist the concrete resolved version (catalog turned "latest"/unset into
+        // a pinned release) so the finalized manifest and the deployment record
+        // carry a real version — that's what the deployments list shows and what
+        // update detection compares against. Fall back to the raw request only if
+        // the catalog couldn't resolve one.
+        version: defaults.resolvedVersion ?? request.version,
         icon: app.icon,
         displayName: app.name,
         systemOverrides: {},
@@ -678,7 +683,7 @@ export class RealDraftService implements DraftService {
     };
   }
 
-  async getDraftDefaults(appId: string, version?: string): Promise<{ env: AppEnvVar[]; defaults: DraftDefaults; composeOverride: string; auth?: AppAuthConfig; consumes?: string[]; ingressService?: string; upgrade?: AppUpgradeMeta; backup?: AppBackupConfig }> {
+  async getDraftDefaults(appId: string, version?: string): Promise<{ env: AppEnvVar[]; defaults: DraftDefaults; composeOverride: string; auth?: AppAuthConfig; consumes?: string[]; ingressService?: string; upgrade?: AppUpgradeMeta; backup?: AppBackupConfig; resolvedVersion?: string }> {
     try {
       const versionDetail = await this.catalogService.getVersionDetail(appId, version || 'latest');
       return {
@@ -690,6 +695,9 @@ export class RealDraftService implements DraftService {
         ingressService: versionDetail.ingressService,
         upgrade: versionDetail.upgrade,
         backup: versionDetail.backup,
+        // The concrete version the catalog resolved (e.g. "latest" → "1.4.1"), so
+        // the draft persists a real version for display + update detection.
+        resolvedVersion: versionDetail.version,
       };
     } catch (error) {
       this.logger.warn('Failed to get app defaults, using fallback', { appId, version, error: error instanceof Error ? error.message : String(error) });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -423,6 +423,12 @@ export type DraftDefaults = {
 };
 
 export type GetCatalogAppVersionDetailResponse = {
+  // The concrete catalog version this detail resolves to. When the caller asks
+  // for "latest" (the CLI/web default), the server resolves it to the newest
+  // pinned release (e.g. "1.4.1") and reports it here so a draft/deployment can
+  // persist a real version rather than an unknown one — which is what drives the
+  // installed-version display and per-app update detection.
+  version: string;
   defaultEnv: AppEnvVar[];
   defaults: DraftDefaults;
   // The bundle's compose.yaml, used to seed a catalog-created draft's

--- a/packages/web/src/pages/Deployments.tsx
+++ b/packages/web/src/pages/Deployments.tsx
@@ -10,7 +10,8 @@ import {
   ChevronLeft,
   ChevronRight,
   AlertTriangle,
-  ArrowUp
+  ArrowUp,
+  Check
 } from 'lucide-react';
 import type {
   DeploymentStatus,
@@ -119,20 +120,20 @@ export const Deployments: React.FC = () => {
   // available updates without waiting out the server's refresh-interval TTL. After
   // the refresh we refetch the (cache-bypassing) deployments list so the server
   // re-computes each app's `updateAvailable` against the freshly-pulled catalog.
-  const [checkingUpdates, setCheckingUpdates] = useState(false);
-  const [checkResult, setCheckResult] = useState<string | null>(null);
+  // 'idle' | 'checking' | 'done' | 'error'. The transient result is reflected in
+  // the button's own label/icon (fixed width) rather than a separate element, so
+  // nothing is added to the header row and no sibling (e.g. "Install app") reflows.
+  const [checkState, setCheckState] = useState<'idle' | 'checking' | 'done' | 'error'>('idle');
   const handleCheckUpdates = useCallback(async () => {
-    setCheckingUpdates(true);
-    setCheckResult(null);
+    setCheckState('checking');
     try {
       await api.catalog.refresh(true);
       await refetch();
-      setCheckResult('Catalog up to date');
+      setCheckState('done');
     } catch {
-      setCheckResult('Check failed');
+      setCheckState('error');
     } finally {
-      setCheckingUpdates(false);
-      setTimeout(() => setCheckResult(null), 4000);
+      setTimeout(() => setCheckState('idle'), 3000);
     }
   }, [refetch]);
 
@@ -210,17 +211,30 @@ export const Deployments: React.FC = () => {
           </p>
         </div>
         <div className="flex-1" />
-        {checkResult && (
-          <span className="self-center text-[12.5px] text-text-muted mr-1">{checkResult}</span>
-        )}
         <button
           onClick={handleCheckUpdates}
-          disabled={checkingUpdates}
+          disabled={checkState === 'checking'}
           title="Re-check the catalog for newer versions of your installed apps"
-          className="flex items-center gap-2 h-10 px-3.5 bg-surface-1 text-text-strong border border-border rounded-[10px] text-sm font-semibold hover:border-primary transition disabled:opacity-60 disabled:cursor-not-allowed"
+          className="flex items-center justify-center gap-2 h-10 min-w-[186px] px-3.5 bg-surface-1 text-text-strong border border-border rounded-[10px] text-sm font-semibold hover:border-primary transition disabled:opacity-60 disabled:cursor-not-allowed"
         >
-          <RefreshCw className={`w-[16px] h-[16px] ${checkingUpdates ? 'animate-spin' : ''}`} />
-          <span>{checkingUpdates ? 'Checking…' : 'Check for updates'}</span>
+          {checkState === 'checking' ? (
+            <RefreshCw className="w-[16px] h-[16px] animate-spin" />
+          ) : checkState === 'done' ? (
+            <Check className="w-[16px] h-[16px] text-success" />
+          ) : checkState === 'error' ? (
+            <AlertTriangle className="w-[16px] h-[16px] text-danger" />
+          ) : (
+            <RefreshCw className="w-[16px] h-[16px]" />
+          )}
+          <span>
+            {checkState === 'checking'
+              ? 'Checking…'
+              : checkState === 'done'
+                ? (deployments.some(d => d.updateAvailable) ? 'Updates available' : 'Up to date')
+                : checkState === 'error'
+                  ? 'Check failed'
+                  : 'Check for updates'}
+          </span>
         </button>
         <Link
           to="/catalog"


### PR DESCRIPTION
Three fixes to the deployments / version / update experience (follow-ups to #314).

## 1. Deployments show no version — and no updates are ever detected
Root cause (verified against the live host's `metadata.json`): the draft stored the *requested* version, which the dashboard leaves unset, so the finalized manifest and the deployment record had **no `version`**. The list rendered `—`, and `enrichUpdateInfo` saw a non-concrete installed version → `updateAvailable=false` for **every** app (which is why the new "Check for updates" button surfaced nothing).

- **catalog:** `getVersionDetail` now returns the concrete resolved `version` — it already resolved `latest` → newest pin internally; the response type just didn't expose it (new `version` field on `GetCatalogAppVersionDetailResponse`).
- **draft:** `createDraft` persists `defaults.resolvedVersion` (the concrete pin) instead of the raw request, so finalize → the deployment record carry a real version. New installs now show a version and participate in update detection.

> **Note:** already-installed deployments have no stored version and can't be reliably inferred — they're backfilled out-of-band on the host (hangar=1.4.0, etc.).

## 2. "Check for updates" layout jump
The button injected a transient "Catalog up to date" element into the `flex-wrap` header, which wrapped **Install app** to a new line and back a few seconds later. The result is now reflected in the **button's own label/icon** (fixed `min-width`, no element added/removed → no reflow) and reads the real outcome: **"Updates available"** vs **"Up to date"** (or "Check failed").

## 3. Changelog at the end of `hola update`
`hola update` now prints a **"What's new in vX"** changelog when an upgrade succeeds.
- `cli-release.yml` generates PR-based release notes: changelog first, then a `<!-- hola:changelog-end -->` sentinel, then the install snippet.
- The CLI fetches the just-installed release and prints everything before the sentinel. **Fail-safe:** offline / rate-limited / older release (no sentinel) prints nothing — never blocks the upgrade or dumps install text.

Applies from the next release on; already-published releases have no sentinel and are silently skipped.

## Tests
- draft persists the resolved concrete version (and keeps an explicit one)
- `fetchReleaseNotes` extracts only the pre-sentinel changelog, returns null for a sentinel-less release
- `hola update` prints the "What's new" section on a successful upgrade

typecheck ✅ · lint ✅ · web 149/149 ✅ · build ✅ · new server/CLI tests pass. The only server-suite failures are the 2 pre-existing `#284 Phase 1` snapshot/rollback tests that also fail on clean `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)