### PR TITLE
chore(release): 0.6.37

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/cli": {
       "name": "@hola/cli",
-      "version": "0.6.36",
+      "version": "0.6.37",
       "bin": {
         "hola": "./bin/hola",
       },
@@ -37,11 +37,11 @@
     },
     "packages/compose": {
       "name": "@hola/compose",
-      "version": "0.6.36",
+      "version": "0.6.37",
     },
     "packages/sdk": {
       "name": "@hola/sdk",
-      "version": "0.6.36",
+      "version": "0.6.37",
       "dependencies": {
         "@hola/shared": "workspace:*",
       },
@@ -55,7 +55,7 @@
     },
     "packages/server": {
       "name": "@hola/server",
-      "version": "0.6.36",
+      "version": "0.6.37",
       "dependencies": {
         "@hola/shared": "workspace:*",
         "jose": "^5.9.6",
@@ -71,7 +71,7 @@
     },
     "packages/shared": {
       "name": "@hola/shared",
-      "version": "0.6.36",
+      "version": "0.6.37",
       "dependencies": {
         "yaml": "^2.9.0",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.6.36",
+  "version": "0.6.37",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.6.36';
+export const CLI_VERSION = '0.6.37';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.6.36",
+  "version": "0.6.37",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.6.36",
+  "version": "0.6.37",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.6.36",
+  "version": "0.6.37",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.6.36",
+  "version": "0.6.37",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Release **0.6.37**, cutting the deployments version/update fixes (#316).

## What's in it
- **Installed apps show a concrete version** and participate in per-app update detection (drafts/deployment records now persist the resolved catalog version instead of leaving it unset).
- **"Check for updates"** no longer reflows the header — the result is shown in the button itself ("Updates available" / "Up to date").
- **`hola update` prints a "What's new" changelog** for the just-installed version. This is the first release with auto-generated PR-based notes, so upgrading *to* a later version will surface them.

## Release mechanics
Bumps the synced version across `cli`/`compose`/`sdk`/`server`/`shared` (+ `cli/src/version.ts` + `bun.lock`). After merge, the **`cli-v0.6.37`** tag triggers `cli-release.yml` to build & publish `ghcr.io/try-hola/{server,web}:0.6.37` (+ `:latest`), the compose bundle, and the CLI binaries — and, new this release, auto-generate the changelog release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)