### PR TITLE
fix(web): tidy deployments table columns (fit version+pill, drop URL column)

### DIFF
--- a/packages/web/src/pages/Deployments.tsx
+++ b/packages/web/src/pages/Deployments.tsx
@@ -34,7 +34,7 @@ const STATUS_FILTERS: { value: DeploymentStatus | 'all'; label: string }[] = [
 ];
 
 const GRID_COLS =
-  'grid grid-cols-[2.4fr_1.1fr_0.9fr_1.9fr_0.9fr_130px] gap-[14px] px-[18px]';
+  'grid grid-cols-[1.6fr_1fr_1.5fr_1.7fr_0.9fr_130px] gap-[14px] px-[18px]';
 
 export const Deployments: React.FC = () => {
   const navigate = useNavigate();
@@ -352,12 +352,12 @@ export const Deployments: React.FC = () => {
               <div>
                 <StatusBadge status={deployment.status} />
               </div>
-              <div className="font-mono text-[12.5px] text-text-muted truncate flex items-center gap-1.5">
-                <span className="truncate">{deployment.version || '—'}</span>
+              <div className="font-mono text-[12.5px] text-text-muted flex items-center gap-1.5 min-w-0">
+                <span className="whitespace-nowrap">{deployment.version || '—'}</span>
                 {deployment.updateAvailable && deployment.latestVersion && (
                   <span
                     title={`Update available: ${deployment.latestVersion}`}
-                    className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full bg-primary-weak text-primary text-[10.5px] font-semibold whitespace-nowrap"
+                    className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full bg-primary-weak text-primary text-[10.5px] font-semibold whitespace-nowrap flex-none"
                   >
                     <ArrowUp className="w-3 h-3" />
                     {deployment.latestVersion}

--- a/packages/web/src/pages/Deployments.tsx
+++ b/packages/web/src/pages/Deployments.tsx
@@ -34,7 +34,7 @@ const STATUS_FILTERS: { value: DeploymentStatus | 'all'; label: string }[] = [
 ];
 
 const GRID_COLS =
-  'grid grid-cols-[1.6fr_1fr_1.5fr_1.7fr_0.9fr_130px] gap-[14px] px-[18px]';
+  'grid grid-cols-[1.8fr_1fr_1.4fr_1.1fr_130px] gap-[14px] px-[18px]';
 
 export const Deployments: React.FC = () => {
   const navigate = useNavigate();
@@ -328,7 +328,6 @@ export const Deployments: React.FC = () => {
             <div>App</div>
             <div>Status</div>
             <div>Version</div>
-            <div>URL</div>
             <div>Updated</div>
             <div className="text-right">Actions</div>
           </div>
@@ -363,9 +362,6 @@ export const Deployments: React.FC = () => {
                     {deployment.latestVersion}
                   </span>
                 )}
-              </div>
-              <div className="font-mono text-[12px] text-text-muted truncate">
-                {deployment.url || '—'}
               </div>
               <div className="text-[12.5px] text-text-faint truncate">
                 {deployment.lastUpdated}


### PR DESCRIPTION
Two Deployments-table layout fixes.

**1. Version + update pill was truncated.** The App-name column was over-wide and Version too narrow, so it clipped to `1.0…` / hid the `↑2.0.0` pill. The version cell also no longer truncates the (short) version number, and the pill is pinned `flex-none`.

**2. Dropped the URL column.** Clicking a row already opens the deployment detail page, which shows the full, untruncated URL — the table's URL column only ever showed a clipped `https://app.hola.get2kno…`. Removing it frees real space. The per-row "Open" action link (which uses `deployment.url`) is unchanged.

Grid now: **App 1.8 · Status 1 · Version 1.4 · Updated 1.1 · Actions 130px** (header and body share `GRID_COLS`, so they stay aligned).

typecheck ✅ · lint ✅ · build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)