### PR TITLE
fix(web): add promote to the SDK adapter so the Upgrade button works

### DIFF
--- a/packages/web/src/__tests__/api/api-hybrid.test.ts
+++ b/packages/web/src/__tests__/api/api-hybrid.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { api } from '../../utils/api-hybrid';
+import { api as originalApi } from '../../utils/api';
 
 // Test that the hybrid API works and health endpoint is migrated
 describe('Hybrid API - Health Migration', () => {
@@ -24,6 +25,23 @@ describe('Hybrid API - Health Migration', () => {
     expect(api.notifications).toBeDefined();
     expect(api.settings).toBeDefined();
     expect(api.cache).toBeDefined();
+  });
+
+  it('exposes every deployment operation as a function, including promote', () => {
+    // Regression: `promote` was added to the original api client but not the SDK
+    // adapter, and the hybrid api routes deployments to the adapter — so the
+    // dashboard's Upgrade button hit `api.deployments.promote is not a function`.
+    for (const m of ['create', 'list', 'byId', 'update', 'history', 'action', 'promote', 'remove', 'logs']) {
+      expect(typeof (api.deployments as Record<string, unknown>)[m]).toBe('function');
+    }
+  });
+
+  it('hybrid deployments surface has parity with the original api client', () => {
+    // Whichever backend the hybrid routes to must implement everything the
+    // original client does — this catches an adapter that lags behind api.ts.
+    for (const key of Object.keys(originalApi.deployments)) {
+      expect(typeof (api.deployments as Record<string, unknown>)[key]).toBe('function');
+    }
   });
 
   it('should have working cache methods', () => {

--- a/packages/web/src/utils/sdk-adapter.ts
+++ b/packages/web/src/utils/sdk-adapter.ts
@@ -16,6 +16,7 @@ import type {
   GetDeploymentsRequest, GetDeploymentsResponse, GetDeploymentResponse,
   PatchDeploymentRequest, PatchDeploymentResponse,
   PostDeploymentActionRequest, PostDeploymentActionResponse,
+  PromoteDeploymentRequest, PromoteDeploymentResponse,
   GetDeploymentHistoryResponse,
   // Job types
   GetJobsResponse, GetJobResponse, GetLogsResponse, DeleteJobsRequest, DeleteJobsResponse,
@@ -421,8 +422,19 @@ export class SdkAdapter {
     
     action: (deploymentId: string, action: PostDeploymentActionRequest): Promise<PostDeploymentActionResponse> => {
       const path = `/api/deployments/${deploymentId}/actions`;
-      return this.enhancedRequest('POST', path, () => 
+      return this.enhancedRequest('POST', path, () =>
         this.sdk.deployments.action(deploymentId, action), action, false);
+    },
+
+    // Upgrade to a newer catalog version (#284 Phase 2). Carries the current
+    // env/secrets forward, runs the skip-guard + pre-upgrade snapshot, then
+    // switches the active release. Missing here previously meant the hybrid
+    // `api` (which routes deployments to this adapter) had no `promote`, so the
+    // dashboard's Upgrade button threw "deployments.promote is not a function".
+    promote: (deploymentId: string, body: PromoteDeploymentRequest = {}): Promise<PromoteDeploymentResponse> => {
+      const path = `/api/deployments/${deploymentId}/promote`;
+      return this.enhancedRequest('POST', path, () =>
+        this.sdk.deployments.promote(deploymentId, body), body, false);
     },
     
     logs: (deploymentId: string, params?: { since?: string; lines?: number }): Promise<GetLogsResponse> => {


### PR DESCRIPTION
The dashboard's **"Upgrade to \<version\>"** button crashes with `api.deployments.promote is not a function` (see repro).

## Root cause
`promote` (#284 Phase 2) was added to the **original** api client (`api.ts`) but **not** to the **SDK adapter** (`sdk-adapter.ts`). `api-hybrid` routes `deployments` to the adapter (`USE_SDK_FOR.deployments = true`), so the method the dashboard actually calls (`useDeploymentDetailApi` → hybrid `api.deployments.promote`) was `undefined`. It shipped uncaught because the promote flow was e2e-tested via the CLI/API path, not the web button.

## Fix
Add `deployments.promote` to the SDK adapter — mirrors `action` (POST via `enhancedRequest`, deployment-cache invalidation) and calls the existing `sdk.deployments.promote`. `rollback` is unaffected (the web has no rollback caller; it's CLI-only).

## Tests
`api-hybrid.test.ts` now asserts (a) every deployment op — including `promote` — is a function on the hybrid api, and (b) the hybrid deployments surface has **parity** with the original client. The prior test only checked top-level keys (`api.deployments` exists), which is exactly what let this sub-method gap through.

typecheck ✅ · lint ✅ · web tests 151/151 ✅ · build ✅

> Needs a release to reach the host (0.6.36 web has the bug). Recommend folding into the next release along with #318.

🤖 Generated with [Claude Code](https://claude.com/claude-code)