### PR TITLE
feat(server): add ${HOLA_USER_EMAIL} platform token

### DIFF
--- a/packages/server/src/__tests__/deployments/auth-provisioning.test.ts
+++ b/packages/server/src/__tests__/deployments/auth-provisioning.test.ts
@@ -254,6 +254,119 @@ describe('Auth provisioning lifecycle', () => {
     expect(dotenv).toContain('GITEA_OIDC_ISSUER="https://auth.example.com/application/o/gitea-x/"');
   });
 
+  test('resolves ${HOLA_USER_EMAIL} in the materialized compose to the installing user email + persists installedBy', async () => {
+    const sys = makeSystem();
+    const { draftId } = await sys.drafts.createDraft({ appId: 'gitea', version: '1.0.0' });
+    await sys.drafts.updateDraft(draftId, {
+      composeOverride:
+        'services:\n  gitea:\n    image: gitea/gitea:1.21.0\n' +
+        '    environment:\n' +
+        '      ADMIN_EMAIL: "${HOLA_USER_EMAIL}"\n',
+    });
+    await sys.drafts.finalizeDraft(draftId);
+
+    const created = await sys.deployments.createFromDraft({
+      draftId,
+      name: 'gitea',
+      installedBy: { email: 'operator@example.com', name: 'Operator' },
+    });
+    const job = await waitForJob(sys.jobs, created.jobId!);
+    expect(job.status).toBe('completed');
+
+    const env = await readMaterializedEnv(sys.storage, created.deploymentId);
+    expect(env.ADMIN_EMAIL).toBe('operator@example.com');
+
+    // Persisted on metadata so the async deploy job (no request context) resolves it.
+    const meta = JSON.parse(await sys.storage.readFileAsString(`deployments/${created.deploymentId}/metadata.json`));
+    expect(meta.metadata.installedBy.email).toBe('operator@example.com');
+  });
+
+  test('resolves ${HOLA_USER_EMAIL} to an empty string when the installer has no email (admin-key / CLI install)', async () => {
+    const sys = makeSystem();
+    const { draftId } = await sys.drafts.createDraft({ appId: 'gitea', version: '1.0.0' });
+    await sys.drafts.updateDraft(draftId, {
+      composeOverride:
+        'services:\n  gitea:\n    image: gitea/gitea:1.21.0\n' +
+        '    environment:\n' +
+        '      ADMIN_EMAIL: "${HOLA_USER_EMAIL}"\n',
+    });
+    await sys.drafts.finalizeDraft(draftId);
+
+    // No installedBy — the token must resolve to empty rather than a literal token.
+    const created = await sys.deployments.createFromDraft({ draftId, name: 'gitea' });
+    const job = await waitForJob(sys.jobs, created.jobId!);
+    expect(job.status).toBe('completed');
+
+    const env = await readMaterializedEnv(sys.storage, created.deploymentId);
+    // Resolves to empty (YAML may render an empty scalar as null) — the key point is
+    // it's NOT the literal token. Apps that need a value use the `:-` fallback form.
+    expect(env.ADMIN_EMAIL ?? '').toBe('');
+  });
+
+  test('resolves ${HOLA_USER_EMAIL} in appEnv VALUES too, so a defaultEnv default paired with a compose `:-` fallback works', async () => {
+    const sys = makeSystem();
+    const { draftId } = await sys.drafts.createDraft({ appId: 'gitea', version: '1.0.0' });
+    // The app sets ADMIN_EMAIL's default to the token and reads it back with a
+    // fallback (the Directus pattern) — the token lives in the env VALUE, not the
+    // compose text, so it must be resolved when writing the runtime .env.
+    await sys.drafts.updateDraft(draftId, {
+      composeOverride:
+        'services:\n  gitea:\n    image: gitea/gitea:1.21.0\n' +
+        '    environment:\n' +
+        '      ADMIN_EMAIL: "${ADMIN_EMAIL:-admin@example.com}"\n',
+      appEnv: [{ key: 'ADMIN_EMAIL', value: '${HOLA_USER_EMAIL}', isSecret: false }],
+    });
+    await sys.drafts.finalizeDraft(draftId);
+
+    // With an operator email the .env carries it verbatim (Compose uses it).
+    const withEmail = await sys.deployments.createFromDraft({ draftId, name: 'gitea', installedBy: { email: 'op@example.com' } });
+    expect((await waitForJob(sys.jobs, withEmail.jobId!)).status).toBe('completed');
+    const dotenv = await sys.storage.readFileAsString(`deployments/${withEmail.deploymentId}/runtime/.env`);
+    expect(dotenv).toContain('ADMIN_EMAIL="op@example.com"');
+  });
+
+  test('${HOLA_USER_EMAIL} appEnv default resolves to empty (so the compose `:-` fallback applies) with no installer email', async () => {
+    const sys = makeSystem();
+    const { draftId } = await sys.drafts.createDraft({ appId: 'gitea', version: '1.0.0' });
+    await sys.drafts.updateDraft(draftId, {
+      composeOverride: 'services:\n  gitea:\n    image: gitea/gitea:1.21.0\n',
+      appEnv: [{ key: 'ADMIN_EMAIL', value: '${HOLA_USER_EMAIL}', isSecret: false }],
+    });
+    await sys.drafts.finalizeDraft(draftId);
+
+    const created = await sys.deployments.createFromDraft({ draftId, name: 'gitea' });
+    expect((await waitForJob(sys.jobs, created.jobId!)).status).toBe('completed');
+    const dotenv = await sys.storage.readFileAsString(`deployments/${created.deploymentId}/runtime/.env`);
+    // Present but empty → Compose's `${ADMIN_EMAIL:-…}` fallback takes over.
+    expect(dotenv).toContain('ADMIN_EMAIL=""');
+  });
+
+  test('exposes HOLA_USER_EMAIL as a runtime .env interpolation var so `${HOLA_USER_EMAIL:-fallback}` resolves (the Directus form)', async () => {
+    const sys = makeSystem();
+    const { draftId } = await sys.drafts.createDraft({ appId: 'gitea', version: '1.0.0' });
+    // The recommended form: no wizard field, the fallback lives in the compose and
+    // Compose (not the server) applies it — so the token expression is left intact
+    // in the materialized compose and resolved from the runtime .env variable.
+    await sys.drafts.updateDraft(draftId, {
+      composeOverride:
+        'services:\n  gitea:\n    image: gitea/gitea:1.21.0\n' +
+        '    environment:\n' +
+        '      ADMIN_EMAIL: "${HOLA_USER_EMAIL:-admin@example.com}"\n',
+    });
+    await sys.drafts.finalizeDraft(draftId);
+
+    const created = await sys.deployments.createFromDraft({ draftId, name: 'gitea', installedBy: { email: 'op@example.com' } });
+    expect((await waitForJob(sys.jobs, created.jobId!)).status).toBe('completed');
+
+    // The runtime .env supplies the variable Compose interpolates...
+    const dotenv = await sys.storage.readFileAsString(`deployments/${created.deploymentId}/runtime/.env`);
+    expect(dotenv).toContain('HOLA_USER_EMAIL="op@example.com"');
+    // ...and the `:-` expression is preserved verbatim (NOT text-substituted), so
+    // Compose applies the fallback itself.
+    const raw = await sys.storage.readFileAsString(`deployments/${created.deploymentId}/runtime/docker-compose.yml`);
+    expect(raw).toContain('${HOLA_USER_EMAIL:-admin@example.com}');
+  });
+
   test('native-oidc credentialsFile: writes the provisioned OIDC creds JSON into the data root before start (for a bundle sidecar to render)', async () => {
     const prev = process.env.HOLA_APPS_BIND_ROOT;
     process.env.HOLA_APPS_BIND_ROOT = join(dataRoot, 'apps');

--- a/packages/server/src/__tests__/validation/compose-validate.test.ts
+++ b/packages/server/src/__tests__/validation/compose-validate.test.ts
@@ -355,6 +355,7 @@ services:
     environment:
       DOMAIN: https://\${HOLA_APP_HOST}/
       BASE: \${HOLA_BASE_DOMAIN}
+      ADMIN_EMAIL: \${HOLA_USER_EMAIL}
 `;
       expect(validateComposeDocument(yaml)).toEqual([]);
     });

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -867,7 +867,16 @@ async function route(url: URL, req: Request): Promise<Response> {
     try {
       const body = await req.json().catch(() => ({}));
       const services = getServices();
-      const payload = await services.deployments.createFromDraft(body);
+      // Capture the installing user from the authenticated principal so the async
+      // deploy job (which has no request context) can resolve `${HOLA_USER_EMAIL}`.
+      // Only OIDC-authenticated dashboard users carry an email; admin-key/CLI
+      // principals don't, and the token then resolves empty. Server-supplied — we
+      // ignore any client-sent installedBy.
+      const principal = getPrincipal(req);
+      const installedBy = principal?.email
+        ? { email: principal.email, name: principal.name }
+        : undefined;
+      const payload = await services.deployments.createFromDraft({ ...body, installedBy });
       return json(payload);
     } catch (err) {
       return errorResponse(req, err);

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -52,7 +52,7 @@ import type { EventBus } from './event-bus';
 import type { RoutingService } from './routing';
 import type { LoggingService } from './logging';
 import type { ProvisionerService, ProvisionResult } from './provisioner';
-import { APP_DATA_TOKEN, APP_HOST_TOKEN, BASE_DOMAIN_TOKEN } from '@hola/shared/compose-validate';
+import { APP_DATA_TOKEN, APP_HOST_TOKEN, BASE_DOMAIN_TOKEN, USER_EMAIL_TOKEN } from '@hola/shared/compose-validate';
 import { attachToHolaNetwork, injectEnvironment } from './compose-network';
 import { applyPlatformDefaults } from './compose-defaults';
 import { composeDefaultsConfig } from '../../config/compose-defaults';
@@ -563,6 +563,9 @@ abstract class InMemoryDeploymentService implements DeploymentService {
           createdAt: now,
           owner: 'system',
           tags: [],
+          // Captured from the authenticated principal at create time (the deploy
+          // job runs async without a request context). Feeds `${HOLA_USER_EMAIL}`.
+          ...(request.installedBy ? { installedBy: request.installedBy } : {}),
         },
       };
       this.deployments.set(deploymentId, deployment);
@@ -1089,9 +1092,15 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     // (`<app>.<base-domain>`) and the install base domain. Each app still names
     // its own env key (e.g. `DOMAIN: https://${HOLA_APP_HOST}`); only the value
     // is a token. (${HOLA_APP_DATA} above is the storage equivalent.)
+    // The installing user's email (captured at create time), so an app can seed
+    // its own admin with the operator's identity (e.g. `ADMIN_EMAIL:
+    // "${HOLA_USER_EMAIL}"`). Empty for admin-key/CLI installs — apps that need a
+    // value regardless carry a compose fallback (`"${ADMIN_EMAIL:-…}"`).
+    const userEmail = deployment.metadata.installedBy?.email ?? '';
     content = content
       .replaceAll(APP_HOST_TOKEN, rule.host)
-      .replaceAll(BASE_DOMAIN_TOKEN, rule.domain);
+      .replaceAll(BASE_DOMAIN_TOKEN, rule.domain)
+      .replaceAll(USER_EMAIL_TOKEN, userEmail);
 
     // Apply install-wide operational defaults (restart, log rotation,
     // no-new-privileges hardening, optional TZ/limits) to every service. The app
@@ -1122,10 +1131,24 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     // `.env` from the project directory (the runtime dir we run it in). Auth env
     // wins on a key clash; written 0600 since it can hold secrets.
     const appEnv = await this.readActiveAppEnv(deployment);
-    const interp: Record<string, string> = { ...appEnv, ...injectedEnv };
+    // Expose the installing user's email as a Compose interpolation variable, so an
+    // app can reference it WITH a fallback — `ADMIN_EMAIL: "${HOLA_USER_EMAIL:-…}"` —
+    // and Compose supplies the default when the operator has no email (admin-key/CLI
+    // installs). This is the recommended form: it needs no wizard field and never
+    // dead-ends. (Bare `${HOLA_USER_EMAIL}`, which has no Compose-level fallback, is
+    // additionally text-substituted in the compose/env above.) The `.env` is
+    // interpolation-only — Compose won't inject it into a container that doesn't
+    // reference it — so this doesn't leak the operator's email into every app.
+    const interp: Record<string, string> = { HOLA_USER_EMAIL: userEmail, ...appEnv, ...injectedEnv };
     const interpKeys = Object.keys(interp);
     if (interpKeys.length > 0) {
-      const dotenv = interpKeys.map(k => `${k}=${dotenvValue(interp[k])}`).join('\n') + '\n';
+      // Also resolve `${HOLA_USER_EMAIL}` inside env VALUES, so an app can set it as a
+      // `defaultEnv` default and pair it with a compose fallback. Written verbatim to
+      // `.env`, which Compose reads literally (no recursive interpolation of values),
+      // so the token must be resolved here rather than left for Compose.
+      const dotenv = interpKeys
+        .map(k => `${k}=${dotenvValue(interp[k].replaceAll(USER_EMAIL_TOKEN, userEmail))}`)
+        .join('\n') + '\n';
       await this.storageService.writeFile(`deployments/${deployment.id}/runtime/.env`, dotenv, 0o600);
     }
     return this.runtimeDir(deployment.id);

--- a/packages/shared/src/compose-validate.ts
+++ b/packages/shared/src/compose-validate.ts
@@ -157,11 +157,22 @@ export const APP_DATA_TOKEN = '${HOLA_APP_DATA}';
 export const APP_HOST_TOKEN = '${HOLA_APP_HOST}';
 export const BASE_DOMAIN_TOKEN = '${HOLA_BASE_DOMAIN}';
 
+/**
+ * The email of the dashboard user who installed the app, resolved at deploy time
+ * so an app can seed its own admin account with the operator's identity (e.g.
+ * `ADMIN_EMAIL: "${HOLA_USER_EMAIL}"`). Only populated when the dashboard user
+ * authenticated via OIDC (SSO) — admin-key and CLI installs have no user email,
+ * so it resolves to an empty string. Apps that need a value regardless MUST carry
+ * a compose fallback (e.g. `"${ADMIN_EMAIL:-admin@example.com}"`).
+ */
+export const USER_EMAIL_TOKEN = '${HOLA_USER_EMAIL}';
+
 /** Every `${HOLA_*}` token the server knows how to resolve. */
 export const KNOWN_PLATFORM_TOKENS: readonly string[] = [
   APP_DATA_TOKEN,
   APP_HOST_TOKEN,
   BASE_DOMAIN_TOKEN,
+  USER_EMAIL_TOKEN,
 ];
 
 /**

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1106,6 +1106,11 @@ export type EnhancedDeploymentDetail = DeploymentDetail & {
     owner?: string;
     tags?: string[];
     notes?: string;
+    // The dashboard user who created this deployment, captured from the
+    // authenticated principal at create time (the async deploy job has no request
+    // context). `email` seeds the `${HOLA_USER_EMAIL}` compose token. Only present
+    // for OIDC-authenticated dashboard users; absent for admin-key / CLI installs.
+    installedBy?: { email?: string; name?: string };
     // Auth artifacts provisioned for this deployment (if any), so they can be
     // reused on re-deploy and torn down on delete. Keyed on deploymentId.
     // `middleware` is set for forward-auth apps so the route can be re-emitted
@@ -1125,6 +1130,10 @@ export type CreateDeploymentFromDraftRequest = {
     healthCheckTimeoutMs?: number;
     rollbackOnFailure?: boolean;
   };
+  // The installing user, filled in by the server from the authenticated principal
+  // (not sent by clients). Persisted on the deployment so `${HOLA_USER_EMAIL}` can
+  // resolve in the async deploy job, which runs without a request context.
+  installedBy?: { email?: string; name?: string };
 };
 
 export type CreateDeploymentFromDraftResponse = {


### PR DESCRIPTION
Adds a new install-time platform token, `${HOLA_USER_EMAIL}`, resolving to the email of the dashboard user who installed the app — the same server-side substitution pattern as `${HOLA_APP_HOST}` / `${HOLA_BASE_DOMAIN}` / `${HOLA_APP_DATA}`.

Motivation: Directus (and any app with a bootstrapped local admin) can seed its admin with the operator's identity so SSO "just works" on first login. Directus 1.0.2 uses `ADMIN_EMAIL: "${HOLA_USER_EMAIL:-admin@example.com}"`.

## How it works
- **shared:** `USER_EMAIL_TOKEN` added to `KNOWN_PLATFORM_TOKENS` (validator accepts it — no `UNKNOWN_PLATFORM_TOKEN` warning). `installedBy?: { email?; name? }` added to the deployment metadata + create-from-draft request types.
- **capture:** the `POST /api/deployments` handler reads `getPrincipal(req).email` and threads it into `createFromDraft`, which persists it on `metadata.installedBy`. The deploy lifecycle is async (`runLifecycleJob` has no request context), so the email must be captured at create time.
- **resolve (`materializeCompose`):** three ways, so apps can use whichever fits — (1) bare `${HOLA_USER_EMAIL}` text-substituted in the compose, (2) same token substituted inside env *values* (for a `defaultEnv` default), and (3) `HOLA_USER_EMAIL` exposed as a runtime `.env` interpolation variable so the **recommended** `${HOLA_USER_EMAIL:-fallback}` form works and Compose applies the default.

## Caveat (documented in the token JSDoc)
Only **OIDC-authenticated dashboard** users carry an email. Admin-key and CLI installs have none, so the token resolves empty — apps that need a value MUST carry a compose fallback. The `.env` variable is interpolation-only, so it is **not** injected into containers that don't reference it (no PII leak).

## Compatibility
The `${HOLA_USER_EMAIL:-default}` form resolves to its default on older servers that don't know the token, so catalog apps adopting it degrade gracefully.

## Tests
`compose-validate`: the token is accepted in env. `auth-provisioning`: materialize resolves the bare form (→ email, and → empty with no installer + `installedBy` persisted), the env-value form, and the `.env`-variable `:-` form (variable present, `:-` expression preserved for Compose).

Verified: typecheck ✅ · lint ✅ · web 151/151 ✅ · build ✅ · affected server suites ✅ (the only 2 failing server tests are the pre-existing `#284 Phase 1` snapshot/rollback ones, confirmed failing on clean `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)