### PR TITLE
feat(catalog): install from OCI reference + private-registry credentials (multi-catalog slice 1)

### DIFF
--- a/packages/cli/src/commands/install/install.ts
+++ b/packages/cli/src/commands/install/install.ts
@@ -12,6 +12,22 @@ export interface InstallOptions {
   noStream?: boolean;
   json?: boolean;
   strict?: boolean;
+  /** From `--registry-cred`: stored credential id for a private OCI ref install. */
+  registryCred?: string;
+}
+
+/**
+ * Heuristic: does this argument look like a full OCI reference (e.g.
+ * `ghcr.io/acme/app:1.0`) rather than a catalog app id? True when it has a path
+ * separator AND the first segment is a registry host (contains a `.` or `:`, or
+ * is `localhost`). A bare `uptime-kuma` or a Slice-2 `sourceId/appId` is not a
+ * ref, so those keep flowing through the catalog install path.
+ */
+export function looksLikeOciRef(arg: string): boolean {
+  const slash = arg.indexOf('/');
+  if (slash <= 0) return false;
+  const host = arg.slice(0, slash);
+  return host === 'localhost' || /[.:]/.test(host);
 }
 
 /**
@@ -54,29 +70,42 @@ export async function runInstall(
   injected?: { sdk?: HolaSdk }
 ): Promise<DeployResult | undefined> {
   const sdk = injected?.sdk ?? new HolaSdk();
-  const { appId, version } = resolveAppAndVersion(rawAppId, opts.appVersion);
-  const name = opts.name ?? appId;
   const out = (msg: string) => { if (!opts.json) console.log(msg); };
+
+  // Install-by-ref: an OCI reference bypasses the catalog index. The server pulls
+  // + validates the bundle (with the named credential for a private registry) and
+  // seeds a draft, which we then finalize + deploy exactly like a catalog install.
+  const isRef = looksLikeOciRef(rawAppId);
+  const { appId, version } = isRef
+    ? { appId: rawAppId, version: 'latest' }
+    : resolveAppAndVersion(rawAppId, opts.appVersion);
+  const name = opts.name ?? (isRef ? undefined : appId);
 
   try {
     const overrides = parseSet(opts.set);
 
-    out(`Creating draft for ${appId}@${version} (from catalog)`);
-    const draft = (await sdk.drafts.create({ appId, version })) as CreateDraftResponse;
+    let draftId: string;
+    if (isRef) {
+      out(`Creating draft from OCI reference ${rawAppId}${opts.registryCred ? ` (credential: ${opts.registryCred})` : ''}`);
+      draftId = (await sdk.installFromRef({ ociRef: rawAppId, credentialRef: opts.registryCred })).draftId;
+    } else {
+      out(`Creating draft for ${appId}@${version} (from catalog)`);
+      draftId = ((await sdk.drafts.create({ appId, version })) as CreateDraftResponse).draftId;
+    }
 
     // Apply env overrides onto the catalog-seeded appEnv (merge by key).
     if (Object.keys(overrides).length) {
-      const current = (await sdk.drafts.byId(draft.draftId)) as GetDraftResponse;
+      const current = (await sdk.drafts.byId(draftId)) as GetDraftResponse;
       const appEnv: AppEnvVar[] = [...(current.appEnv ?? [])];
       for (const [key, value] of Object.entries(overrides)) {
         const existing = appEnv.find(e => e.key === key);
         if (existing) existing.value = value;
         else appEnv.push({ key, value, isSecret: false });
       }
-      await sdk.drafts.update(draft.draftId, { appEnv });
+      await sdk.drafts.update(draftId, { appEnv });
     }
 
-    const result = await finalizeAndDeploy(sdk, draft.draftId, { name, strict: opts.strict, noStream: opts.noStream }, out);
+    const result = await finalizeAndDeploy(sdk, draftId, { name, strict: opts.strict, noStream: opts.noStream }, out);
 
     if (opts.json) console.log(JSON.stringify(result, null, 2));
     else out(`Done. ${appId} → job status: ${result.status}`);

--- a/packages/cli/src/commands/registry/registry.ts
+++ b/packages/cli/src/commands/registry/registry.ts
@@ -1,0 +1,69 @@
+import { HolaSdk } from '@hola/sdk';
+import type { RegistryCredentialRecord } from '@hola/shared';
+
+export interface RegistryCredOptions {
+  id?: string;
+  registry?: string;
+  username?: string;
+  token?: string;
+  json?: boolean;
+}
+
+/**
+ * Manage stored registry credentials for private OCI pulls (`add | list | rm`).
+ * The token is write-only: it is sent on `add` and never printed back by `list`.
+ * These credentials are used for both the `oras pull` of a package and the Docker
+ * image pull at deploy time; reference one by id with `install … --registry-cred`.
+ */
+export async function runRegistryCred(
+  action: string,
+  opts: RegistryCredOptions,
+  injected?: { sdk?: HolaSdk; args?: string[] }
+): Promise<void> {
+  const sdk = injected?.sdk ?? new HolaSdk();
+  const positional = injected?.args ?? [];
+
+  try {
+    switch (action) {
+      case 'add': {
+        if (!opts.registry || !opts.username || !opts.token) {
+          console.error('registry-cred add requires --registry, --username and --token');
+          process.exitCode = 1;
+          return;
+        }
+        const record = await sdk.registryCredentials.add({
+          registry: opts.registry,
+          username: opts.username,
+          password: opts.token,
+          id: opts.id,
+        });
+        if (opts.json) console.log(JSON.stringify(record, null, 2));
+        else console.log(`Added registry credential '${record.id}' for ${record.registry} (user ${record.username}).`);
+        return;
+      }
+      case 'list': {
+        const { items } = await sdk.registryCredentials.list();
+        if (opts.json) { console.log(JSON.stringify(items, null, 2)); return; }
+        if (!items.length) { console.log('No registry credentials stored.'); return; }
+        const idWidth = Math.max(2, ...items.map((c: RegistryCredentialRecord) => c.id.length));
+        for (const c of items) console.log(`${c.id.padEnd(idWidth)}  ${c.registry}  (${c.username})`);
+        return;
+      }
+      case 'rm':
+      case 'remove': {
+        const id = opts.id ?? positional[0];
+        if (!id) { console.error('registry-cred rm requires a credential id'); process.exitCode = 1; return; }
+        await sdk.registryCredentials.remove(id);
+        console.log(`Removed registry credential '${id}'.`);
+        return;
+      }
+      default:
+        console.error(`Unknown action '${action}'. Use: add | list | rm`);
+        process.exitCode = 1;
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`registry-cred ${action} failed: ${msg}`);
+    process.exitCode = 1;
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -118,17 +118,36 @@ prog
 // also pin a version inline as `hola install <appId>@<version>`.
 prog
   .command('install <appId>')
-  .describe('Install a catalog app: draft from catalog → validate → finalize → deploy → watch')
+  .describe('Install a catalog app, or a package by OCI reference: draft → validate → finalize → deploy → watch')
   .example('install uptime-kuma@1.2.1')
+  .example('install ghcr.io/acme/hola-cms:0.1.0 --registry-cred acme')
   .option('--app-version', 'App version to install (or use <appId>@<version>)', 'latest')
   .option('--name', 'Deployment name (default: the app id)')
   .option('--set', 'Override an env var, KEY=VALUE (repeatable)')
+  .option('--registry-cred', 'Stored registry credential id for a private OCI reference install')
   .option('--strict', 'Fail on validation warnings', false)
   .option('--no-stream', 'Do not watch the deployment job', false)
   .option('--json', 'Print the result as JSON', false)
   .action(async (appId, opts) => {
     const { runInstall } = await load(import('./commands/install/install'));
     await runInstall(appId, streamOpts(opts));
+  });
+
+// registry-cred — manage stored credentials for private OCI pulls
+prog
+  .command('registry-cred <action> [id]')
+  .describe('Manage private registry credentials: add | list | rm')
+  .example('registry-cred add --registry ghcr.io --username acme --token <PAT> --id acme')
+  .example('registry-cred list')
+  .example('registry-cred rm acme')
+  .option('--id', 'Credential id (for add; generated when omitted)')
+  .option('--registry', 'Registry host the credential authorizes, e.g. ghcr.io')
+  .option('--username', 'Registry username')
+  .option('--token', 'Registry token/password (e.g. a GHCR PAT with read:packages)')
+  .option('--json', 'Print raw JSON output', false)
+  .action(async (action, id, opts) => {
+    const { runRegistryCred } = await load(import('./commands/registry/registry'));
+    await runRegistryCred(action, camelKeys(opts), { args: id ? [id] : [] });
   });
 
 // deployments — list installed deployments

--- a/packages/cli/src/lib/deploy-flow.ts
+++ b/packages/cli/src/lib/deploy-flow.ts
@@ -23,7 +23,7 @@ export interface DeployResult {
 export async function finalizeAndDeploy(
   sdk: HolaSdk,
   draftId: string,
-  opts: { name: string; strict?: boolean; noStream?: boolean },
+  opts: { name?: string; strict?: boolean; noStream?: boolean },
   out: (msg: string) => void
 ): Promise<DeployResult> {
   out('Validating…');

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -15,6 +15,9 @@ import {
   // Catalog types
   GetCatalogAppsRequest, GetCatalogAppsResponse, GetCatalogAppResponse,
   GetCatalogAppVersionsResponse, GetCatalogAppVersionDetailResponse,
+  // Registry credentials + install-by-ref (multi-catalog Slice 1)
+  RegistryCredentialRecord, AddRegistryCredentialRequest, ListRegistryCredentialsResponse,
+  InstallFromRefRequest, InstallFromRefResponse,
   // Job types
   DeleteJobsRequest, DeleteJobsResponse,
   // System types
@@ -97,6 +100,19 @@ export class HolaSdk {
     // TTL) so newly-published app versions surface as available updates right away.
     refresh: (force = true) => this.post<{ success: boolean; timestamp: string }>(`${API.catalog.refresh}${buildQuery({ force })}`),
   };
+
+  // Registry credentials for private OCI pulls. The token is write-only: `add`
+  // sends it, `list` never returns it. Instance-level, admin-gated server-side.
+  registryCredentials = {
+    list: () => this.get<ListRegistryCredentialsResponse>(API.registryCredentials.base),
+    add: (data: AddRegistryCredentialRequest) => this.post<RegistryCredentialRecord>(API.registryCredentials.base, data),
+    remove: (id: string) => this.delete<{ success: boolean }>(API.registryCredentials.byId(id)),
+  };
+
+  // Install a package straight from an OCI reference (the escape hatch for
+  // one-offs). Returns the created draft id; finalize + deploy it like any draft.
+  installFromRef = (data: InstallFromRefRequest) =>
+    this.post<InstallFromRefResponse>(API.installFromRef, data);
 
   drafts = {
     create: (data: CreateDraftRequest) => this.post<CreateDraftResponse>(API.drafts.create, data),

--- a/packages/server/src/__tests__/bundles/auth-pull.test.ts
+++ b/packages/server/src/__tests__/bundles/auth-pull.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtemp, rm } from 'fs/promises';
+import { readFileSync, statSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { RealBundleService, bundleCacheKey, type CommandRunner } from '../../services/core/bundles';
+
+describe('bundleCacheKey (cross-source collision guard)', () => {
+  test('the built-in hola source keeps the bare appId; others are namespaced', () => {
+    expect(bundleCacheKey(undefined, 'uptime-kuma')).toBe('uptime-kuma');
+    expect(bundleCacheKey('hola', 'uptime-kuma')).toBe('uptime-kuma');
+    expect(bundleCacheKey('acme', 'uptime-kuma')).toBe('acme__uptime-kuma');
+    expect(bundleCacheKey('(ref)', 'app')).toBe('_ref___app');
+  });
+});
+
+describe('RealBundleService authenticated pull', () => {
+  const dirs: string[] = [];
+  afterEach(async () => {
+    await Promise.all(dirs.splice(0).map((d) => rm(d, { recursive: true, force: true })));
+  });
+
+  async function makeCache() {
+    const base = await mkdtemp(join(tmpdir(), 'hola-bundle-test-'));
+    dirs.push(base);
+    return base;
+  }
+
+  test('writes a scoped 0o600 auth file, keeps the token off argv, and cleans up', async () => {
+    const base = await makeCache();
+    const commands: string[] = [];
+    let authFile: { contents: string; mode: number } | undefined;
+
+    const runner: CommandRunner = async (cmd) => {
+      commands.push(cmd);
+      const m = cmd.match(/--registry-config (\S+)/);
+      if (m) {
+        // Capture the auth file WHILE it exists (ensurePulled removes it in finally).
+        authFile = { contents: readFileSync(m[1], 'utf8'), mode: statSync(m[1]).mode & 0o777 };
+      }
+      return { stdout: '', stderr: '' };
+    };
+
+    const svc = new RealBundleService(base, runner);
+    await svc.ensurePulled({
+      appId: 'cms',
+      version: '0.1.0',
+      source: 'acme',
+      ociRef: 'ghcr.io/acme/cms:0.1.0',
+      credentials: { registry: 'ghcr.io', username: 'bot', password: 'ghp_secret' },
+    });
+
+    const pullCmd = commands.find((c) => c.startsWith('oras pull'))!;
+    expect(pullCmd).toContain('--registry-config');
+    // The secret must never appear on the command line.
+    expect(pullCmd).not.toContain('ghp_secret');
+
+    // The auth file is an owner-only docker config with the base64(user:pass) entry.
+    expect(authFile).toBeDefined();
+    expect(authFile!.mode).toBe(0o600);
+    const parsed = JSON.parse(authFile!.contents);
+    expect(parsed.auths['ghcr.io'].auth).toBe(Buffer.from('bot:ghp_secret').toString('base64'));
+  });
+
+  test('namespaces the cache dir by source', async () => {
+    const base = await makeCache();
+    const runner: CommandRunner = async () => ({ stdout: '', stderr: '' });
+    const svc = new RealBundleService(base, runner);
+
+    const hola = await svc.ensurePulled({ appId: 'app', version: '1.0', ociRef: 'ghcr.io/try-hola/app:1.0' });
+    expect(hola.localPath).toBe(join(base, 'app', '1.0'));
+
+    const acme = await svc.ensurePulled({
+      appId: 'app',
+      version: '1.0',
+      source: 'acme',
+      ociRef: 'ghcr.io/acme/app:1.0',
+      credentials: { registry: 'ghcr.io', username: 'u', password: 'p' },
+    });
+    expect(acme.localPath).toBe(join(base, 'acme__app', '1.0'));
+  });
+
+  test('rejects a non-allowlisted ref unless a matching credential authorizes it', async () => {
+    const base = await makeCache();
+    const runner: CommandRunner = async () => ({ stdout: '', stderr: '' });
+    const svc = new RealBundleService(base, runner);
+
+    // Anonymous pull from a registry outside the base allowlist is blocked.
+    await expect(
+      svc.ensurePulled({ appId: 'app', version: '1.0', source: 'acme', ociRef: 'registry.example.com/acme/app:1.0' })
+    ).rejects.toThrow('REF_NOT_ALLOWED');
+
+    // Supplying a credential for that registry is the operator's consent → allowed.
+    const ok = await svc.ensurePulled({
+      appId: 'app',
+      version: '1.0',
+      source: 'acme',
+      ociRef: 'registry.example.com/acme/app:1.0',
+      credentials: { registry: 'registry.example.com', username: 'u', password: 'p' },
+    });
+    expect(ok.localPath).toBe(join(base, 'acme__app', '1.0'));
+  });
+});

--- a/packages/server/src/__tests__/install/install-from-ref.test.ts
+++ b/packages/server/src/__tests__/install/install-from-ref.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtemp, rm, mkdir, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { validateComposeDocument } from '@hola/shared/compose-validate';
+import { RealStorageService } from '../../services/core/storage';
+import { RealBundleService, bundleCacheKey, type CommandRunner } from '../../services/core/bundles';
+import { RealCatalogService } from '../../services/core/catalog';
+import { RealDraftService } from '../../services/core/draft';
+
+// A pinned, rule-compliant compose the by-ref bundle can seed a draft from.
+const COMPOSE = [
+  'services:',
+  '  web:',
+  '    image: ghcr.io/try-hola/cms@sha256:' + 'a'.repeat(64),
+  '    volumes:',
+  '      - ${HOLA_APP_DATA}/data:/data',
+].join('\n');
+
+const MANIFEST = JSON.stringify({
+  defaultEnv: [{ key: 'ADMIN_TOKEN', value: '', isSecret: true, description: 'Admin token' }],
+  defaults: {},
+});
+
+// Minimal validation service — createDraft never calls it (only validate/finalize do).
+const stubValidation = {
+  async validateDraft() { return { ok: true, errors: [], warnings: [] }; },
+  async preflightCheck() { return { ok: true, checks: [] } as never; },
+};
+
+describe('install from OCI reference', () => {
+  const dirs: string[] = [];
+  afterEach(async () => {
+    await Promise.all(dirs.splice(0).map((d) => rm(d, { recursive: true, force: true })));
+  });
+
+  async function harness() {
+    const holaDir = await mkdtemp(join(tmpdir(), 'hola-ref-test-'));
+    dirs.push(holaDir);
+    const storage = new RealStorageService({ holaDir });
+    const cacheBase = join(holaDir, 'cache', 'bundles');
+    const runner: CommandRunner = async () => ({ stdout: '', stderr: '' });
+    const bundles = new RealBundleService(cacheBase, runner);
+    const catalog = new RealCatalogService(bundles);
+    const drafts = new RealDraftService(storage, catalog, stubValidation);
+    return { cacheBase, drafts };
+  }
+
+  /** Pre-seed a bundle in the cache so ensurePulled treats it as already pulled. */
+  async function seedBundle(cacheBase: string, appId: string, version: string, files: Record<string, string>) {
+    const dir = join(cacheBase, bundleCacheKey('(ref)', appId), version);
+    await mkdir(dir, { recursive: true });
+    for (const [name, content] of Object.entries(files)) await writeFile(join(dir, name), content);
+  }
+
+  test('happy path: seeds a draft from the pulled bundle (bare appId, (ref) source)', async () => {
+    const { cacheBase, drafts } = await harness();
+    await seedBundle(cacheBase, 'cms', '0.1.0', { 'compose.yaml': COMPOSE, 'manifest.json': MANIFEST });
+
+    const res = await drafts.createDraft({ ociRef: 'ghcr.io/try-hola/cms:0.1.0' });
+    const draft = await drafts.getDraft(res.draftId);
+
+    expect(draft.appId).toBe('cms');       // bare — never `sourceId/appId`
+    expect(draft.source).toBe('(ref)');
+    expect(draft.version).toBe('0.1.0');
+    expect(draft.composeOverride).toContain('image: ghcr.io/try-hola/cms@sha256:');
+    expect(draft.appEnv.find((e) => e.key === 'ADMIN_TOKEN')?.isSecret).toBe(true);
+  });
+
+  test('rejects a non-compliant package: a bundle missing manifest.json fails layout validation', async () => {
+    const { cacheBase, drafts } = await harness();
+    // compose only — no manifest.json → INVALID_BUNDLE_LAYOUT from the shared primitive.
+    await seedBundle(cacheBase, 'broken', '0.1.0', { 'compose.yaml': COMPOSE });
+
+    await expect(drafts.createDraft({ ociRef: 'ghcr.io/try-hola/broken:0.1.0' })).rejects.toThrow();
+  });
+
+  test('the strict compose rules that make custom packages safe still apply (host ports rejected)', () => {
+    // Same validator the draft validate/finalize path runs for every source.
+    const bad = 'services:\n  web:\n    image: nginx:1.2.3\n    ports:\n      - "8080:80"\n';
+    const issues = validateComposeDocument(bad);
+    expect(issues.some((i) => /port/i.test(i.code) || /port/i.test(i.message))).toBe(true);
+  });
+});

--- a/packages/server/src/__tests__/registry/registry-credentials.test.ts
+++ b/packages/server/src/__tests__/registry/registry-credentials.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtemp, rm, stat, readFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { RealStorageService } from '../../services/core/storage';
+import { RealRegistryCredentialService } from '../../services/core/registry-credentials';
+
+describe('RealRegistryCredentialService', () => {
+  const dirs: string[] = [];
+  afterEach(async () => {
+    await Promise.all(dirs.splice(0).map((d) => rm(d, { recursive: true, force: true })));
+  });
+
+  async function makeService() {
+    const holaDir = await mkdtemp(join(tmpdir(), 'hola-cred-test-'));
+    dirs.push(holaDir);
+    const storage = new RealStorageService({ holaDir });
+    return { svc: new RealRegistryCredentialService(storage), holaDir };
+  }
+
+  test('add persists a 0o600 file, list redacts the token, resolve returns it', async () => {
+    const { svc, holaDir } = await makeService();
+
+    const record = await svc.add({ id: 'acme', registry: 'ghcr.io', username: 'bot', password: 'ghp_secret' });
+    expect(record).toEqual({ id: 'acme', registry: 'ghcr.io', username: 'bot' });
+
+    // The store file is owner-only and never contains the raw token in plaintext.
+    const storePath = join(holaDir, 'config', 'registry-credentials.json');
+    const mode = (await stat(storePath)).mode & 0o777;
+    expect(mode).toBe(0o600);
+    const raw = await readFile(storePath, 'utf8');
+    expect(raw).not.toContain('ghp_secret');
+
+    // list() never exposes the secret…
+    const listed = await svc.list();
+    expect(listed).toEqual([{ id: 'acme', registry: 'ghcr.io', username: 'bot' }]);
+    expect(JSON.stringify(listed)).not.toContain('ghp_secret');
+
+    // …but resolve() hands the full credential to the pull path.
+    const resolved = await svc.resolve('acme');
+    expect(resolved).toEqual({ registry: 'ghcr.io', username: 'bot', password: 'ghp_secret' });
+  });
+
+  test('generates an id when omitted and rejects duplicates', async () => {
+    const { svc } = await makeService();
+    const a = await svc.add({ registry: 'ghcr.io', username: 'bot', password: 'x' });
+    expect(a.id).toMatch(/^cred_/);
+
+    await expect(svc.add({ id: a.id, registry: 'ghcr.io', username: 'bot', password: 'y' })).rejects.toThrow('CREDENTIAL_ID_EXISTS');
+  });
+
+  test('remove deletes and 404s an unknown id; resolve of unknown is undefined', async () => {
+    const { svc } = await makeService();
+    await svc.add({ id: 'acme', registry: 'ghcr.io', username: 'bot', password: 'x' });
+
+    await svc.remove('acme');
+    expect(await svc.list()).toEqual([]);
+    expect(await svc.resolve('acme')).toBeUndefined();
+    await expect(svc.remove('acme')).rejects.toThrow('CREDENTIAL_NOT_FOUND');
+  });
+
+  test('persists across service instances (rehydrates from disk)', async () => {
+    const holaDir = await mkdtemp(join(tmpdir(), 'hola-cred-test-'));
+    dirs.push(holaDir);
+    const storage = new RealStorageService({ holaDir });
+
+    await new RealRegistryCredentialService(storage).add({ id: 'acme', registry: 'ghcr.io', username: 'bot', password: 'x' });
+    const reloaded = await new RealRegistryCredentialService(storage).resolve('acme');
+    expect(reloaded?.password).toBe('x');
+  });
+});

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -46,6 +46,10 @@ import {
   type RollbackResponse,
   type PromoteDeploymentRequest,
   type PromoteDeploymentResponse,
+  type AddRegistryCredentialRequest,
+  type ListRegistryCredentialsResponse,
+  type InstallFromRefRequest,
+  type InstallFromRefResponse,
 } from '@hola/shared';
 
 // Error interface for proper typing
@@ -487,6 +491,72 @@ async function route(url: URL, req: Request): Promise<Response> {
     }
   }
 
+  // ===== REGISTRY CREDENTIAL ROUTES =====
+  // Instance-level, admin-gated (behind the same auth middleware as every /api
+  // route). Secrets are write-only: the token is never returned to clients.
+  if (pathname === API.registryCredentials.base && req.method === 'GET') {
+    try {
+      const items = await getServices().registryCredentials.list();
+      return json({ items } satisfies ListRegistryCredentialsResponse);
+    } catch (error) {
+      logger.error('Failed to list registry credentials', error as Error);
+      return json({ error: { code: 'CREDENTIAL_LIST_FAILED', message: 'Failed to list registry credentials' } }, { status: 500 });
+    }
+  }
+
+  if (pathname === API.registryCredentials.base && req.method === 'POST') {
+    try {
+      const body = (await req.json().catch(() => ({}))) as Partial<AddRegistryCredentialRequest>;
+      if (!body.registry || !body.username || !body.password) {
+        return json({ error: { code: 'MISSING_FIELDS', message: 'registry, username and password are required' } }, { status: 400 });
+      }
+      const record = await getServices().registryCredentials.add(body as AddRegistryCredentialRequest);
+      return json(record, { status: 201 });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const status = message === 'CREDENTIAL_ID_EXISTS' ? 409 : 500;
+      logger.warn('Failed to add registry credential', { error: message });
+      return json({ error: { code: 'CREDENTIAL_ADD_FAILED', message } }, { status });
+    }
+  }
+
+  const credMatch = pathname.match(/^\/api\/registry-credentials\/([^/]+)$/);
+  if (credMatch && req.method === 'DELETE') {
+    const id = decodeURIComponent(credMatch[1]);
+    try {
+      await getServices().registryCredentials.remove(id);
+      return json({ success: true });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (message === 'CREDENTIAL_NOT_FOUND') return notFound();
+      logger.error('Failed to remove registry credential', error as Error);
+      return json({ error: { code: 'CREDENTIAL_REMOVE_FAILED', message: 'Failed to remove registry credential' } }, { status: 500 });
+    }
+  }
+
+  // ===== INSTALL FROM OCI REFERENCE =====
+  // The escape hatch for one-off private/first-party packages. Builds a by-ref
+  // draft (pull → validate → seed) via the same primitive catalog installs use;
+  // the caller then finalizes + deploys the returned draft like any other.
+  if (pathname === API.installFromRef && req.method === 'POST') {
+    try {
+      const body = (await req.json().catch(() => ({}))) as Partial<InstallFromRefRequest>;
+      if (!body.ociRef) {
+        return json({ error: { code: 'MISSING_OCI_REF', message: 'ociRef is required' } }, { status: 400 });
+      }
+      const payload = await getServices().drafts.createDraft({
+        ociRef: body.ociRef,
+        credentialRef: body.credentialRef,
+        version: body.version,
+      });
+      return json({ draftId: payload.draftId } satisfies InstallFromRefResponse);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.warn('Install-from-ref failed', { error: message });
+      return json({ error: { code: 'INSTALL_FROM_REF_FAILED', message } }, { status: 400 });
+    }
+  }
+
   // ===== DRAFT ROUTES =====
   // Draft creation
   if (pathname === API.drafts.create && req.method === 'POST') {
@@ -502,8 +572,8 @@ async function route(url: URL, req: Request): Promise<Response> {
         version: body.version 
       });
 
-      if (!body.appId) {
-        return json({ error: { code: 'MISSING_APP_ID', message: 'appId is required' } }, { status: 400 });
+      if (!body.appId && !body.ociRef) {
+        return json({ error: { code: 'MISSING_APP_ID', message: 'appId or ociRef is required' } }, { status: 400 });
       }
 
       const services = getServices();

--- a/packages/server/src/services/core/bundles.ts
+++ b/packages/server/src/services/core/bundles.ts
@@ -1,7 +1,8 @@
 import { exec } from 'child_process';
 import { promisify } from 'util';
-import { mkdirSync, existsSync, rmSync, statSync } from 'fs';
+import { mkdirSync, existsSync, rmSync, statSync, mkdtempSync, writeFileSync } from 'fs';
 import { join } from 'path';
+import { tmpdir } from 'os';
 import { getLogger } from '../../lib/logger';
 import { getHolaDataDir } from '../../config/paths';
 import type { ServiceHealth, HealthCheckable } from './types';
@@ -16,22 +17,53 @@ export type BundleInfo = {
   sizeBytes?: number;
 };
 
+/**
+ * Credentials for a private OCI pull. Server-internal — NEVER serialized to
+ * clients or written to logs. `registry` is the host (optionally host/path) the
+ * credential authorizes; it both extends the pull allowlist and keys the auth
+ * file entry. Resolved from a stored RegistryCredentialRecord by the caller.
+ */
+export interface PullCredentials {
+  registry: string;
+  username: string;
+  password: string;
+}
+
+export type EnsurePulledOpts = {
+  appId: string;
+  version: string;
+  ociRef: string;
+  /**
+   * Catalog source id (default `hola`). Namespaces the bundle cache so two
+   * sources publishing the same appId/version can't alias each other. The `hola`
+   * default keeps the on-disk path byte-identical to the single-source layout.
+   */
+  source?: string;
+  /** When set, authenticate the `oras pull` for a private registry. */
+  credentials?: PullCredentials;
+};
+
 export interface BundleService {
-  ensurePulled(opts: { appId: string; version: string; ociRef: string }): Promise<BundleInfo>;
+  ensurePulled(opts: EnsurePulledOpts): Promise<BundleInfo>;
   validateLayout(bundlePath: string): Promise<{ ok: boolean; errors: string[]; warnings: string[] }>;
   verifySignature?(bundlePath: string): Promise<{ verified: boolean; error?: string }>;
   cleanup?(): Promise<{ evicted: number; freedBytes: number }>;
   healthCheck(): Promise<ServiceHealth>;
 }
 
+/** Command runner seam so tests can stub the `oras`/`cosign` invocations. */
+export type CommandRunner = (cmd: string) => Promise<{ stdout: string; stderr: string }>;
+
 export class RealBundleService implements BundleService, HealthCheckable {
   private logger = getLogger().child({ service: 'RealBundleService' });
   private baseCache: string;
   private cacheManager: BundleCacheManager;
+  private run: CommandRunner;
 
-  constructor(baseCache = join(getHolaDataDir(), 'cache', 'bundles')) {
+  constructor(baseCache = join(getHolaDataDir(), 'cache', 'bundles'), run: CommandRunner = execAsync) {
     this.baseCache = baseCache;
     this.cacheManager = new BundleCacheManager(baseCache);
+    this.run = run;
   }
 
   async healthCheck(): Promise<ServiceHealth> {
@@ -43,19 +75,28 @@ export class RealBundleService implements BundleService, HealthCheckable {
     }
   }
 
-  async ensurePulled(opts: { appId: string; version: string; ociRef: string }): Promise<BundleInfo> {
-    this.enforceAllowlist(opts.ociRef);
+  async ensurePulled(opts: EnsurePulledOpts): Promise<BundleInfo> {
+    // A registered credential's registry extends the allowlist: registering it is
+    // the operator's explicit consent to pull from that registry. Anonymous pulls
+    // to a non-baseline registry stay blocked.
+    this.enforceAllowlist(opts.ociRef, opts.credentials ? [opts.credentials.registry] : []);
+
+    // Source-qualify the cache key so two sources can't alias the same
+    // appId/version. `hola` (the built-in source) keeps the bare appId key, so the
+    // on-disk path is byte-identical to the pre-multi-catalog layout (no re-pull).
+    const cacheKey = bundleCacheKey(opts.source, opts.appId);
+
     // Protect this bundle from eviction while we pull and return it: cleanup()
     // runs inside ensurePulled, so a concurrent pull could otherwise rmSync a
     // bundle dir that's mid-pull/in-use. (The cache's "never evict in-use" guard
     // was previously dead because nothing ever marked a bundle in-use.)
-    this.cacheManager.markInUse(opts.appId, opts.version);
+    this.cacheManager.markInUse(cacheKey, opts.version);
     try {
-      const dest = join(this.baseCache, sanitize(opts.appId), sanitize(opts.version));
+      const dest = join(this.baseCache, sanitize(cacheKey), sanitize(opts.version));
       mkdirSync(dest, { recursive: true });
 
       // Touch cache entry for LRU tracking
-      this.cacheManager.touch(opts.appId, opts.version);
+      this.cacheManager.touch(cacheKey, opts.version);
 
       // If already has compose.yaml and manifest.json, assume cached
       if (existsSync(join(dest, 'compose.yaml')) && existsSync(join(dest, 'manifest.json'))) {
@@ -70,15 +111,27 @@ export class RealBundleService implements BundleService, HealthCheckable {
       // Run cache cleanup before pulling new content
       await this.cleanup();
 
+      // For a private pull, materialize a scoped docker-config auth file and pass
+      // it via `--registry-config` rather than putting the token on argv (which
+      // would leak via `ps`) or in ~/.docker/config.json. Removed in `finally`.
+      let authDir: string | undefined;
+      const flags: string[] = ['--include-subject'];
+      if (opts.credentials) {
+        authDir = this.writeRegistryAuth(opts.credentials);
+        flags.push(`--registry-config ${shellEscape(join(authDir, 'config.json'))}`);
+      }
+
       // oras pull to a temp dir then move is ideal; for simplicity, pull into dest
-      const pullCmd = `oras pull --include-subject ${shellEscape(opts.ociRef)} -o ${shellEscape(dest)}`;
-      this.logger.info('Pulling OCI bundle via ORAS', { ref: opts.ociRef, dest });
+      const pullCmd = `oras pull ${flags.join(' ')} ${shellEscape(opts.ociRef)} -o ${shellEscape(dest)}`;
+      this.logger.info('Pulling OCI bundle via ORAS', { ref: opts.ociRef, dest, authenticated: Boolean(opts.credentials) });
       try {
-        const { stdout, stderr } = await execAsync(pullCmd);
+        const { stdout, stderr } = await this.run(pullCmd);
         this.logger.debug('ORAS pull output', { stdout: stdout?.slice(0, 500), stderr: stderr?.slice(0, 500) });
       } catch (error) {
         this.logger.error('ORAS pull failed', error as Error, { ref: opts.ociRef });
         throw new Error('ORAS_PULL_FAILED', { cause: error });
+      } finally {
+        if (authDir) { try { rmSync(authDir, { recursive: true, force: true }); } catch { /* best effort */ } }
       }
 
       // Optional signature verify-if-present
@@ -95,8 +148,22 @@ export class RealBundleService implements BundleService, HealthCheckable {
 
       return { localPath: dest, ...this.safeStat(dest) };
     } finally {
-      this.cacheManager.markNotInUse(opts.appId, opts.version);
+      this.cacheManager.markNotInUse(cacheKey, opts.version);
     }
+  }
+
+  /**
+   * Write a scoped docker-config auth file (0o600, in a private temp dir) for a
+   * single registry so `oras pull --registry-config` can authenticate without
+   * touching ~/.docker/config.json. Caller removes the returned dir when done.
+   */
+  private writeRegistryAuth(creds: PullCredentials): string {
+    const dir = mkdtempSync(join(tmpdir(), 'hola-oras-'));
+    const host = registryHost(creds.registry);
+    const auth = Buffer.from(`${creds.username}:${creds.password}`, 'utf8').toString('base64');
+    const config = { auths: { [host]: { auth } } };
+    writeFileSync(join(dir, 'config.json'), JSON.stringify(config), { mode: 0o600 });
+    return dir;
   }
 
   async validateLayout(bundlePath: string): Promise<{ ok: boolean; errors: string[]; warnings: string[] }> {
@@ -117,7 +184,7 @@ export class RealBundleService implements BundleService, HealthCheckable {
   async verifySignature(bundlePath: string): Promise<{ verified: boolean; error?: string }> {
     try {
       // Check if cosign is available
-      await execAsync('cosign version');
+      await this.run('cosign version');
       
       // For now, just return verified=true since we don't have a specific signature to verify
       // In a real implementation, this would verify against a known public key
@@ -147,13 +214,17 @@ export class RealBundleService implements BundleService, HealthCheckable {
 
   // Helpers
   private async getOrasVersion(): Promise<string> {
-    const { stdout } = await execAsync('oras version');
+    const { stdout } = await this.run('oras version');
     const m = stdout.match(/oras\s+([^\s]+)/i);
     return m ? m[1] : stdout.trim();
   }
 
-  private enforceAllowlist(ref: string): void {
-    const allowed = catalogConfig.registryAllowlist;
+  private enforceAllowlist(ref: string, extraAllowed: string[] = []): void {
+    // Base allowlist (e.g. ghcr.io/try-hola/*) plus any registries the operator
+    // authorized by registering a credential/source for them. Match by
+    // glob/host-prefix (never substring) so `ghcr.io.evil.com` can't slip past a
+    // `ghcr.io` entry.
+    const allowed = [...catalogConfig.registryAllowlist, ...extraAllowed];
     const ok = allowed.some(pattern => matchesAllowlist(pattern, ref));
     if (!ok) {
       throw new Error(`REF_NOT_ALLOWED: ${ref}`);
@@ -175,9 +246,9 @@ export class MockBundleService implements BundleService {
 
   constructor(private basePath = join(getHolaDataDir(), 'mock-bundles')) {}
 
-  async ensurePulled(opts: { appId: string; version: string; ociRef: string }): Promise<BundleInfo> {
-    this.logger.debug('Mock ensurePulled', opts);
-    const p = join(this.basePath, sanitize(opts.appId), sanitize(opts.version));
+  async ensurePulled(opts: EnsurePulledOpts): Promise<BundleInfo> {
+    this.logger.debug('Mock ensurePulled', { appId: opts.appId, version: opts.version, source: opts.source });
+    const p = join(this.basePath, sanitize(bundleCacheKey(opts.source, opts.appId)), sanitize(opts.version));
     return { localPath: p };
   }
   async validateLayout(bundlePath: string) {
@@ -191,6 +262,22 @@ export class MockBundleService implements BundleService {
 
 // Utilities
 function sanitize(s: string): string { return s.replace(/[^a-zA-Z0-9._-]/g, '_'); }
+
+/**
+ * Cache directory key for a bundle. The built-in `hola` source (and an
+ * unspecified source) keeps the bare appId so the on-disk cache layout is
+ * unchanged from the single-source era; every other source is prefixed so it
+ * can't collide with a hola app (or another source) publishing the same appId.
+ */
+export function bundleCacheKey(source: string | undefined, appId: string): string {
+  const s = (source || 'hola').trim();
+  return s === 'hola' ? appId : `${sanitize(s)}__${appId}`;
+}
+
+/** The registry host (drop any path/tag) used as the docker-config auths key. */
+function registryHost(registry: string): string {
+  return registry.trim().split('/')[0];
+}
 
 function matchesAllowlist(pattern: string, ref: string): boolean {
   // Convert simple glob like ghcr.io/org/* to regex start match

--- a/packages/server/src/services/core/catalog.ts
+++ b/packages/server/src/services/core/catalog.ts
@@ -1,5 +1,8 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import { getLogger } from '../../lib/logger';
 import type { ServiceHealth, HealthCheckable } from './types';
+import type { PullCredentials, BundleService } from './bundles';
 import { catalogConfig } from '../../config/catalog';
 import { parseComposeDefaults, mergeDefaults } from './compose-parser';
 import type {
@@ -69,11 +72,39 @@ function pickLatestVersion(versions: CatalogVersionEntry[]): CatalogVersionEntry
   })[0];
 }
 
+/**
+ * Derive an appId slug + version from an OCI package reference. e.g.
+ * `ghcr.io/acme/hola-cms:0.1.0` → `{ appId: 'hola-cms', version: '0.1.0' }`.
+ * A digest-only ref (`…@sha256:…`) yields version `latest`; an untagged ref too.
+ */
+export function parseOciRef(ref: string): { appId: string; version: string } {
+  let s = ref.trim();
+  let version = 'latest';
+  const at = s.indexOf('@');
+  if (at >= 0) s = s.slice(0, at); // ignore digest for the version label
+  const lastSlash = s.lastIndexOf('/');
+  const lastColon = s.lastIndexOf(':');
+  if (lastColon > lastSlash) {
+    version = s.slice(lastColon + 1) || 'latest';
+    s = s.slice(0, lastColon);
+  }
+  const name = s.slice(s.lastIndexOf('/') + 1);
+  const appId = name.replace(/[^a-zA-Z0-9._-]/g, '-') || 'app';
+  return { appId, version };
+}
+
 export interface CatalogService {
   listApps(req: GetCatalogAppsRequest): Promise<GetCatalogAppsResponse>;
   getApp(appId: string): Promise<GetCatalogAppResponse>;
   getVersions(appId: string): Promise<GetCatalogAppVersionsResponse>;
   getVersionDetail(appId: string, version: string): Promise<GetCatalogAppVersionDetailResponse>;
+  /**
+   * Resolve a version detail directly from an OCI package reference, bypassing
+   * the catalog index (Slice 1 install-by-ref). Pulls + validates + coerces the
+   * bundle exactly like a catalog install so the strict rules apply to one-offs
+   * too. `credentials` authenticate a private-registry pull.
+   */
+  getVersionDetailByRef(ociRef: string, credentials?: PullCredentials): Promise<GetCatalogAppVersionDetailResponse & { appId: string }>;
   refresh(force?: boolean): Promise<void>;
 }
 
@@ -81,6 +112,10 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
   private logger = getLogger().child({ service: 'RealCatalogService' });
   private cache: { data: RemoteCatalog | null; ts: number; etag?: string; lastModified?: string } = { data: null, ts: 0 };
   private inflight?: Promise<void>;
+
+  /** Optional injected bundle service (tests). Production resolves it lazily from
+   *  the service factory to avoid a circular import at module load. */
+  constructor(private bundlesOverride?: BundleService) {}
 
   async healthCheck(): Promise<ServiceHealth> {
     try {
@@ -138,7 +173,7 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
     return { items, total: items.length };
   }
 
-  async getVersionDetail(appId: string, version: string): Promise<GetCatalogAppVersionDetailResponse> {
+  async getVersionDetail(appId: string, version: string, credentials?: PullCredentials, source?: string): Promise<GetCatalogAppVersionDetailResponse> {
     // Locate app/version with OCI ref
     const data = await this.ensureLoaded();
     const app = data.apps.find(a => a.id === appId);
@@ -156,10 +191,6 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
     const ref = v.refs?.oci;
     if (!ref) throw new Error('NO_OCI_REF');
 
-    // Lazy import to avoid circular deps at module load
-    const { getServices } = await import('../simple-factory');
-    const bundles = getServices().bundles;
-
     // Pull and validate bundle. Key the cache by the RESOLVED concrete version
     // (`v.version`), NOT the meta-version `version` ("latest"). ensurePulled skips
     // the OCI pull when a cached bundle's compose.yaml+manifest.json already exist,
@@ -167,18 +198,42 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
     // fix was published keeps serving that stale `latest` bundle forever — the new
     // concrete version never gets pulled. Keying by the concrete version makes every
     // new release a cache miss, so published fixes actually reach existing servers.
-    const info = await bundles.ensurePulled({ appId, version: v.version, ociRef: ref });
+    return this.pullValidateBuild({ appId, source, version: v.version, ociRef: ref, credentials });
+  }
+
+  async getVersionDetailByRef(ociRef: string, credentials?: PullCredentials): Promise<GetCatalogAppVersionDetailResponse & { appId: string }> {
+    const { appId, version } = parseOciRef(ociRef);
+    // A dedicated `(ref)` source namespaces the by-ref bundle cache away from any
+    // catalog source and never collides with the reserved `hola` id.
+    const detail = await this.pullValidateBuild({ appId, source: '(ref)', version, ociRef, credentials });
+    return { ...detail, appId };
+  }
+
+  /**
+   * Shared pull → validate → coerce for both the catalog and by-ref install
+   * paths. Reuses the bundle service (oras pull + allowlist + optional creds) and
+   * the strict layout check, so every source is held to the same rules.
+   */
+  private async pullValidateBuild(opts: { appId: string; source?: string; version: string; ociRef: string; credentials?: PullCredentials }): Promise<GetCatalogAppVersionDetailResponse> {
+    // Injected in tests; otherwise lazy-imported to avoid a circular dep at load.
+    const bundles = this.bundlesOverride ?? (await import('../simple-factory')).getServices().bundles;
+
+    const info = await bundles.ensurePulled({ appId: opts.appId, version: opts.version, ociRef: opts.ociRef, source: opts.source, credentials: opts.credentials });
     const validation = await bundles.validateLayout(info.localPath);
     if (!validation.ok) {
-      this.logger.warn('Bundle layout invalid; deferring to mocks', { appId, version, errors: validation.errors });
+      this.logger.warn('Bundle layout invalid', { appId: opts.appId, version: opts.version, errors: validation.errors });
       throw new Error('INVALID_BUNDLE_LAYOUT');
     }
+    return this.buildDetailFromBundle(info.localPath, opts.version);
+  }
 
-    // Try to read manifest.json for defaults; if missing or invalid, defer to mocks by throwing
+  /**
+   * Read + coerce a pulled bundle's manifest.json/compose.yaml into a version
+   * detail. Throws MANIFEST_UNAVAILABLE if the bundle can't be parsed.
+   */
+  private buildDetailFromBundle(localPath: string, version: string): GetCatalogAppVersionDetailResponse {
     try {
-      const { readFileSync } = await import('fs');
-      const { join } = await import('path');
-      const manifestPath = join(info.localPath, 'manifest.json');
+      const manifestPath = join(localPath, 'manifest.json');
       const raw = readFileSync(manifestPath, 'utf8');
 
       // Define a narrow manifest shape we accept
@@ -240,13 +295,13 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
       };
 
       // Parse compose.yaml to get additional defaults
-      const composeDefaults = parseComposeDefaults(info.localPath);
+      const composeDefaults = parseComposeDefaults(localPath);
 
       // Carry the raw compose.yaml through so a catalog-created draft can be
       // deployed without the user pasting compose. Same file the parser reads;
       // a missing/unreadable compose throws here and falls through to the same
       // catch (MANIFEST_UNAVAILABLE) + draft-side fallback — no new failure mode.
-      const composeOverride = readFileSync(join(info.localPath, 'compose.yaml'), 'utf8');
+      const composeOverride = readFileSync(join(localPath, 'compose.yaml'), 'utf8');
 
       // Merge compose and manifest defaults (manifest takes precedence)
       const merged = mergeDefaults(composeDefaults, manifestDefaults, manifestEnv);
@@ -278,9 +333,9 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
           ? manifest.ingress.service.trim()
           : undefined;
 
-      return { ...merged, version: v.version, composeOverride, auth, consumes, upgrade, backup, ingressService } satisfies GetCatalogAppVersionDetailResponse;
+      return { ...merged, version, composeOverride, auth, consumes, upgrade, backup, ingressService } satisfies GetCatalogAppVersionDetailResponse;
     } catch (error) {
-      this.logger.warn('Failed to read or parse bundle manifest; deferring to mocks', { appId, version, error: error instanceof Error ? error.message : String(error) });
+      this.logger.warn('Failed to read or parse bundle manifest', { version, error: error instanceof Error ? error.message : String(error) });
       throw new Error('MANIFEST_UNAVAILABLE', { cause: error });
     }
   }
@@ -397,6 +452,9 @@ export class MockCatalogService implements CatalogService {
     throw new Error('APP_NOT_FOUND');
   }
   async getVersionDetail(): Promise<GetCatalogAppVersionDetailResponse> {
+    throw new Error('VERSION_NOT_FOUND');
+  }
+  async getVersionDetailByRef(): Promise<GetCatalogAppVersionDetailResponse & { appId: string }> {
     throw new Error('VERSION_NOT_FOUND');
   }
   async refresh(): Promise<void> { /* no-op */ }

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -47,6 +47,8 @@ import type { JobService, JobContext } from './jobs';
 import { JobCancelledError } from './jobs';
 import type { DockerService } from './docker';
 import type { DraftService, FinalizedArtifacts, FinalizedManifest } from './draft';
+import type { RegistryCredentialService } from './registry-credentials';
+import type { PullCredentials } from './bundles';
 import type { CatalogService } from './catalog';
 import type { EventBus } from './event-bus';
 import type { RoutingService } from './routing';
@@ -956,6 +958,9 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     // Optional global event bus; when wired, status changes emit `deployment_update`
     // for the dashboard-wide `/api/events` stream (#291).
     private eventBus?: EventBus,
+    // Optional; resolves a release's credentialRef → registry secret so a private
+    // app's runtime image can be pulled at deploy time. Absent ⇒ anonymous pulls.
+    private registryCredentials?: RegistryCredentialService,
   ) {
     super(jobService);
     // Perform real Compose lifecycle work when a deployment job runs.
@@ -1197,6 +1202,33 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     } catch {
       return {};
     }
+  }
+
+  /**
+   * Resolve the registry credential (if any) recorded on the active release, so
+   * the runtime image can be pulled from a private registry. Returns undefined
+   * when the app has no credentialRef (the common anonymous case). A credentialRef
+   * that no longer resolves (credential deleted after install) throws with a clear
+   * message rather than surfacing a raw docker auth error later.
+   */
+  private async resolveRegistryAuth(deployment: EnhancedDeploymentDetail): Promise<PullCredentials[] | undefined> {
+    const releaseId = deployment.currentReleaseId;
+    if (!releaseId) return undefined;
+    const manifestPath = `deployments/${deployment.id}/releases/${releaseId}/manifest.json`;
+    if (!(await this.storageService.fileExists(manifestPath))) return undefined;
+    let credentialRef: string | undefined;
+    try {
+      const manifest = JSON.parse(await this.storageService.readFileAsString(manifestPath)) as FinalizedManifest;
+      credentialRef = manifest.credentialRef;
+    } catch {
+      return undefined;
+    }
+    if (!credentialRef) return undefined;
+    const creds = await this.registryCredentials?.resolve(credentialRef);
+    if (!creds) {
+      throw new Error(`Registry credential not found: ${credentialRef}. Re-add it in Settings → Registry Credentials.`);
+    }
+    return [creds];
   }
 
   /** Public accessor for the active release's carry-forward config — its app env
@@ -1696,7 +1728,8 @@ export class RealDeploymentService extends InMemoryDeploymentService {
         // freshly materialized compose, so changed env/labels (e.g. updated OIDC
         // wiring) would silently never reach the app. `up -d` recreates only the
         // services whose config changed, using the already-present images.
-        const res = await this.dockerService.composeUp(composeDir, projectName);
+        const registryAuth = await this.resolveRegistryAuth(deployment);
+        const res = await this.dockerService.composeUp(composeDir, projectName, registryAuth);
         output = res.output;
         if (!res.success) throw new Error(res.output);
         if (provisioned) await this.completeAuthWiring(deployment, provisioned, projectName, logBoth);
@@ -1726,8 +1759,10 @@ export class RealDeploymentService extends InMemoryDeploymentService {
 
         // Pull first (generous timeout) so `up` isn't gated on download time —
         // large stacks like Postiz used to be SIGKILLed mid-pull by up's 2-min cap.
+        // Resolve any private-registry credential once for both pull and up.
+        const registryAuth = await this.resolveRegistryAuth(deployment);
         await logBoth('info', 'Pulling images (first install can take several minutes)…');
-        const pull = await this.dockerService.composePull(composeDir, projectName);
+        const pull = await this.dockerService.composePull(composeDir, projectName, registryAuth);
         if (!pull.success) throw new Error(`Image pull failed: ${pull.output}`);
         await ctx.setProgress(60);
 
@@ -1735,7 +1770,7 @@ export class RealDeploymentService extends InMemoryDeploymentService {
         // irreversible step) if the job was cancelled during the long pull.
         if (ctx.isCancelled()) throw new JobCancelledError();
 
-        const res = await this.dockerService.composeUp(composeDir, projectName);
+        const res = await this.dockerService.composeUp(composeDir, projectName, registryAuth);
         output = res.output;
         if (!res.success) throw new Error(res.output);
         if (provisioned) await this.completeAuthWiring(deployment, provisioned, projectName, logBoth);

--- a/packages/server/src/services/core/docker.ts
+++ b/packages/server/src/services/core/docker.ts
@@ -7,10 +7,12 @@
 
 import { exec, execFile } from 'child_process';
 import { promisify } from 'util';
-import { existsSync } from 'fs';
+import { existsSync, mkdtempSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
+import { tmpdir } from 'os';
 import { getLogger } from '../../lib/logger';
 import type { ServiceHealth, HealthCheckable } from './types';
+import type { PullCredentials } from './bundles';
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
@@ -57,8 +59,8 @@ export interface DockerService {
   /** Pull all images for a project ahead of `up`, with a generous timeout.
    *  Image pulls for large multi-service apps (e.g. Postiz) routinely exceed the
    *  short `up` timeout; pulling first means `up` only has to start local images. */
-  composePull(projectPath: string, projectName: string): Promise<{ success: boolean; output: string }>;
-  composeUp(projectPath: string, projectName: string): Promise<{ success: boolean; output: string }>;
+  composePull(projectPath: string, projectName: string, registryAuth?: PullCredentials[]): Promise<{ success: boolean; output: string }>;
+  composeUp(projectPath: string, projectName: string, registryAuth?: PullCredentials[]): Promise<{ success: boolean; output: string }>;
   composeDown(projectPath: string, projectName: string): Promise<{ success: boolean; output: string }>;
   composePs(projectPath: string, projectName: string): Promise<ComposeProject>;
   composeRestart(projectPath: string, projectName: string, serviceName?: string): Promise<{ success: boolean; output: string }>;
@@ -158,9 +160,28 @@ export class RealDockerService implements DockerService, HealthCheckable {
     return info.available;
   }
 
-  async composePull(projectPath: string, projectName: string): Promise<{ success: boolean; output: string }> {
+  /**
+   * Materialize a scoped DOCKER_CONFIG dir (0o600 config.json) authenticating the
+   * given private registries, and return the env to pass to a docker invocation.
+   * Never touches ~/.docker/config.json; caller removes the dir when done. Returns
+   * undefined (and no temp dir) when there are no credentials.
+   */
+  private makeRegistryAuthEnv(registryAuth?: PullCredentials[]): { env?: NodeJS.ProcessEnv; dir?: string } {
+    if (!registryAuth || registryAuth.length === 0) return {};
+    const dir = mkdtempSync(join(tmpdir(), 'hola-docker-'));
+    const auths: Record<string, { auth: string }> = {};
+    for (const c of registryAuth) {
+      const host = c.registry.trim().split('/')[0];
+      auths[host] = { auth: Buffer.from(`${c.username}:${c.password}`, 'utf8').toString('base64') };
+    }
+    writeFileSync(join(dir, 'config.json'), JSON.stringify({ auths }), { mode: 0o600 });
+    return { env: { ...process.env, DOCKER_CONFIG: dir }, dir };
+  }
+
+  async composePull(projectPath: string, projectName: string, registryAuth?: PullCredentials[]): Promise<{ success: boolean; output: string }> {
+    const { env, dir } = this.makeRegistryAuthEnv(registryAuth);
     try {
-      this.logger.info('Pulling compose images', { projectPath, projectName });
+      this.logger.info('Pulling compose images', { projectPath, projectName, authenticated: Boolean(dir) });
 
       const composeFile = join(projectPath, 'docker-compose.yml');
       if (!existsSync(composeFile)) {
@@ -173,7 +194,7 @@ export class RealDockerService implements DockerService, HealthCheckable {
       const { stdout, stderr } = await execFileAsync(
         'docker',
         ['compose', '-f', composeFile, '-p', projectName, 'pull', '--quiet'],
-        { cwd: projectPath, timeout: 1_800_000, maxBuffer: 16 * 1024 * 1024 }
+        { cwd: projectPath, timeout: 1_800_000, maxBuffer: 16 * 1024 * 1024, env }
       );
       const output = [stdout, stderr].filter(Boolean).join('\n');
       this.logger.info('Compose images pulled', { projectName, output: output.substring(0, 1000) });
@@ -185,10 +206,13 @@ export class RealDockerService implements DockerService, HealthCheckable {
       const output = [e.stdout, e.stderr, e.message].filter(Boolean).join('\n') || String(error);
       this.logger.error('Failed to pull compose images', error instanceof Error ? error : undefined, { projectName });
       return { success: false, output };
+    } finally {
+      if (dir) { try { rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ } }
     }
   }
 
-  async composeUp(projectPath: string, projectName: string): Promise<{ success: boolean; output: string }> {
+  async composeUp(projectPath: string, projectName: string, registryAuth?: PullCredentials[]): Promise<{ success: boolean; output: string }> {
+    const { env, dir } = this.makeRegistryAuthEnv(registryAuth);
     try {
       this.logger.info('Starting compose project', { projectPath, projectName });
 
@@ -199,18 +223,19 @@ export class RealDockerService implements DockerService, HealthCheckable {
 
       // Images are pre-pulled by composePull, so `up` only starts local images.
       // The 5-minute timeout covers container creation for large stacks (it is
-      // no longer gated on download time).
+      // no longer gated on download time). A scoped DOCKER_CONFIG is passed as a
+      // fallback so a recreate that needs to pull still authenticates.
       const { stdout, stderr } = await execAsync(
         `docker compose -f "${composeFile}" -p "${projectName}" up -d`,
-        { cwd: projectPath, timeout: 300000 } // 5 minute timeout
+        { cwd: projectPath, timeout: 300000, env } // 5 minute timeout
       );
-      
+
       const output = [stdout, stderr].filter(Boolean).join('\n');
       this.logger.info('Compose project started successfully', {
         projectName,
         output: output.substring(0, 1000), // Truncate for logging
       });
-      
+
       return { success: true, output };
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
@@ -218,8 +243,10 @@ export class RealDockerService implements DockerService, HealthCheckable {
         projectPath,
         projectName,
       });
-      
+
       return { success: false, output: errorMessage };
+    } finally {
+      if (dir) { try { rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ } }
     }
   }
 
@@ -663,13 +690,13 @@ export class MockDockerService implements DockerService {
     return true;
   }
 
-  async composePull(projectPath: string, projectName: string): Promise<{ success: boolean; output: string }> {
-    this.logger.debug('Mock compose pull', { projectPath, projectName });
+  async composePull(projectPath: string, projectName: string, registryAuth?: PullCredentials[]): Promise<{ success: boolean; output: string }> {
+    this.logger.debug('Mock compose pull', { projectPath, projectName, authenticated: Boolean(registryAuth?.length) });
     return { success: true, output: `[mock] Project ${projectName} images pulled` };
   }
 
-  async composeUp(projectPath: string, projectName: string): Promise<{ success: boolean; output: string }> {
-    this.logger.debug('Mock compose up', { projectPath, projectName });
+  async composeUp(projectPath: string, projectName: string, registryAuth?: PullCredentials[]): Promise<{ success: boolean; output: string }> {
+    this.logger.debug('Mock compose up', { projectPath, projectName, authenticated: Boolean(registryAuth?.length) });
     return { success: true, output: `[mock] Project ${projectName} created and started` };
   }
 

--- a/packages/server/src/services/core/draft.ts
+++ b/packages/server/src/services/core/draft.ts
@@ -33,6 +33,7 @@ import { validateComposeDocument } from '@hola/shared/compose-validate';
 import type { HealthCheckable, ServiceHealth } from './types';
 import type { StorageService } from './storage';
 import type { CatalogService } from './catalog';
+import type { RegistryCredentialService } from './registry-credentials';
 
 /**
  * Shape of `drafts/<id>/finalized/manifest.json` produced by `finalizeDraft`.
@@ -56,6 +57,11 @@ export interface FinalizedManifest {
   // catalog at create time.
   icon?: string;
   displayName?: string;
+  // Catalog source the app came from (defaults to `hola`) and the registry
+  // credential id used to pull it — carried so the deploy lifecycle can pull the
+  // runtime image from a private registry and check the right source for updates.
+  source?: string;
+  credentialRef?: string;
   systemOverrides: Record<string, string>;
   appEnv: AppEnvVar[];
   ports: Array<{ host?: number; container: number; protocol: 'tcp' | 'udp' }>;
@@ -186,7 +192,10 @@ export class RealDraftService implements DraftService {
   constructor(
     private storageService: StorageService,
     private catalogService: CatalogService,
-    private validationService: ValidationService
+    private validationService: ValidationService,
+    // Resolves a credentialRef → registry secret for the install-by-ref path.
+    // Optional so existing wiring/tests that don't need private pulls still work.
+    private registryCredentials?: RegistryCredentialService
   ) {}
 
   async healthCheck(): Promise<ServiceHealth> {
@@ -312,7 +321,17 @@ export class RealDraftService implements DraftService {
   async createDraft(request: CreateDraftRequest): Promise<CreateDraftResponse> {
     await this.ensureLoaded();
     const draftId = crypto.randomUUID();
-    this.logger.info('Creating draft', { draftId, appId: request.appId, version: request.version });
+
+    // Install-by-ref path (Slice 1): seed the draft straight from a pulled OCI
+    // package instead of a catalog index entry. Shares the same pull→validate
+    // primitive so the strict compose rules still apply.
+    if (request.ociRef) {
+      return this.createDraftFromRef(draftId, request);
+    }
+
+    if (!request.appId) throw new ValidationError('appId or ociRef is required');
+    const source = request.source ?? 'hola';
+    this.logger.info('Creating draft', { draftId, appId: request.appId, version: request.version, source });
 
     try {
       // Get app info from catalog
@@ -337,6 +356,9 @@ export class RealDraftService implements DraftService {
         // update detection compares against. Fall back to the raw request only if
         // the catalog couldn't resolve one.
         version: defaults.resolvedVersion ?? request.version,
+        // Catalog source the app came from (defaults to the built-in `hola`).
+        source,
+        credentialRef: request.credentialRef,
         icon: app.icon,
         displayName: app.name,
         systemOverrides: {},
@@ -387,6 +409,79 @@ export class RealDraftService implements DraftService {
       return response;
     } catch (error) {
       this.logger.error('Failed to create draft', error as Error, { draftId, appId: request.appId });
+      throw error;
+    }
+  }
+
+  /**
+   * Build a draft directly from an OCI package reference (install-by-ref). The
+   * bundle is pulled + validated by the same catalog primitive; a private ref is
+   * authenticated with the stored credential named by `request.credentialRef`.
+   * The resolved appId (a slug from the ref), source sentinel `(ref)`, and
+   * credentialRef are persisted so the deploy lifecycle can pull the runtime
+   * image with the same credential.
+   */
+  private async createDraftFromRef(draftId: string, request: CreateDraftRequest): Promise<CreateDraftResponse> {
+    const ociRef = request.ociRef!;
+    this.logger.info('Creating draft from OCI ref', { draftId, ociRef, credentialRef: request.credentialRef });
+    try {
+      let credentials;
+      if (request.credentialRef) {
+        credentials = await this.registryCredentials?.resolve(request.credentialRef);
+        if (!credentials) throw new ValidationError(`Unknown registry credential: ${request.credentialRef}`);
+      }
+
+      const detail = await this.catalogService.getVersionDetailByRef(ociRef, credentials);
+      const appId = detail.appId;
+
+      const composeOverride = detail.composeOverride ?? '';
+      assertComposeParses(composeOverride, 'oci bundle');
+
+      const draft: Draft = {
+        draftId,
+        appId,
+        version: detail.version,
+        source: '(ref)',
+        credentialRef: request.credentialRef,
+        icon: '📦',
+        displayName: appId,
+        systemOverrides: {},
+        appEnv: detail.defaultEnv,
+        ports: detail.defaults.ports,
+        composeOverride,
+        auth: detail.auth,
+        consumes: detail.consumes,
+        ingressService: detail.ingressService,
+        upgrade: detail.upgrade,
+        backup: detail.backup,
+        files: [],
+      };
+
+      const now = new Date().toISOString();
+      const record: DraftRecord = {
+        draft,
+        status: 'draft',
+        createdAt: now,
+        updatedAt: now,
+        fileChecksums: {},
+        filePaths: {},
+      };
+
+      this.drafts.set(draftId, record);
+      this.fileContents.set(draftId, new Map());
+      await this.storageService.ensureDir(`drafts/${draftId}`);
+      await this.persistRecord(record);
+
+      this.logger.info('Draft created from ref successfully', { draftId, appId, version: detail.version });
+      return {
+        draftId,
+        app: { id: appId, name: draft.displayName ?? appId, icon: draft.icon ?? '📦' },
+        systemEnv: [],
+        appEnv: detail.defaultEnv,
+        defaults: detail.defaults,
+      };
+    } catch (error) {
+      this.logger.error('Failed to create draft from ref', error as Error, { draftId, ociRef });
       throw error;
     }
   }
@@ -633,7 +728,10 @@ export class RealDraftService implements DraftService {
       // `icon`/`displayName` are presentation, not part of the deployable spec,
       // so they're added outside canonicalSpec — keeping the checksum a pure
       // function of the spec.
-      const manifest = { ...canonicalSpec, icon: draft.icon, displayName: draft.displayName, checksum, finalizedAt };
+      // `source`/`credentialRef` are install-time routing metadata (which catalog
+      // source + which registry credential), not deployable content, so they live
+      // outside canonicalSpec and don't perturb the checksum — like icon/displayName.
+      const manifest = { ...canonicalSpec, icon: draft.icon, displayName: draft.displayName, source: draft.source, credentialRef: draft.credentialRef, checksum, finalizedAt };
       await this.storageService.writeFile(
         `${finalizedDir}/manifest.json`,
         JSON.stringify(manifest, null, 2)
@@ -732,10 +830,15 @@ export class MockDraftService implements DraftService {
   async createDraft(request: CreateDraftRequest): Promise<CreateDraftResponse> {
     const draftId = crypto.randomUUID();
     this.logger.info('Mock: Creating draft', { draftId, request });
+    // appId is optional on the wire (the install-by-ref path supplies ociRef); the
+    // mock derives a placeholder id so its Draft/response stay well-formed.
+    const appId = request.appId ?? 'mock-app';
     const draft: Draft = {
       draftId,
-      appId: request.appId,
+      appId,
       version: request.version,
+      source: request.source ?? (request.ociRef ? '(ref)' : 'hola'),
+      credentialRef: request.credentialRef,
       icon: '📦',
       displayName: 'Mock App',
       systemOverrides: {},
@@ -749,7 +852,7 @@ export class MockDraftService implements DraftService {
 
     return {
       draftId,
-      app: { id: request.appId, name: draft.displayName ?? 'Mock App', icon: draft.icon ?? '📦' },
+      app: { id: appId, name: draft.displayName ?? 'Mock App', icon: draft.icon ?? '📦' },
       systemEnv: [],
       appEnv: draft.appEnv,
       defaults: { ports: draft.ports, volumes: [{ hostPath: './data', containerPath: '/data', readOnly: false }] },

--- a/packages/server/src/services/core/registry-credentials.ts
+++ b/packages/server/src/services/core/registry-credentials.ts
@@ -1,0 +1,177 @@
+/**
+ * Registry Credential Service — Slice 1 (multi-catalog)
+ *
+ * Stores registry credentials (e.g. a GHCR PAT with read:packages) used to pull
+ * private OCI packages and their runtime images. Instance-level and admin-gated:
+ * there is no per-user tenancy in Hola, so a single curated set lives on disk.
+ *
+ * The secret token is persisted server-side only (config/registry-credentials.json,
+ * mode 0o600, matching the inline-secret pattern used by system-settings.json) and
+ * is NEVER returned to clients or written to logs. Clients see only the id, registry,
+ * and username needed to pick a credential; `resolve(id)` hands the full secret to
+ * the pull path (bundles + docker) and nowhere else.
+ */
+
+import { randomUUID } from 'crypto';
+import { getLogger } from '../../lib/logger';
+import type { HealthCheckable, ServiceHealth } from './types';
+import type { StorageService } from './storage';
+import type { PullCredentials } from './bundles';
+import type {
+  RegistryCredentialRecord,
+  AddRegistryCredentialRequest,
+} from '@hola/shared';
+
+/** On-disk credential record. The token is base64-encoded, never logged. */
+interface StoredCredential {
+  id: string;
+  registry: string;
+  username: string;
+  /** base64(token). Kept off logs; decoded only in resolve(). */
+  passwordB64: string;
+}
+
+interface CredentialFile {
+  credentials: StoredCredential[];
+}
+
+export interface RegistryCredentialService extends HealthCheckable {
+  add(req: AddRegistryCredentialRequest): Promise<RegistryCredentialRecord>;
+  list(): Promise<RegistryCredentialRecord[]>;
+  remove(id: string): Promise<void>;
+  /** Full credential (incl. secret) for the pull path. Undefined if unknown. */
+  resolve(id: string): Promise<PullCredentials | undefined>;
+}
+
+const STORE_PATH = 'config/registry-credentials.json';
+const FILE_MODE = 0o600;
+
+function redact(c: StoredCredential): RegistryCredentialRecord {
+  return { id: c.id, registry: c.registry, username: c.username };
+}
+
+export class RealRegistryCredentialService implements RegistryCredentialService {
+  private logger = getLogger().child({ service: 'RegistryCredentialService' });
+
+  constructor(private storage: StorageService) {}
+
+  async healthCheck(): Promise<ServiceHealth> {
+    try {
+      await this.load();
+      return { healthy: true, lastCheck: new Date() };
+    } catch (error) {
+      return { healthy: false, lastCheck: new Date(), error: error instanceof Error ? error.message : String(error) };
+    }
+  }
+
+  private async load(): Promise<CredentialFile> {
+    if (!(await this.storage.fileExists(STORE_PATH))) {
+      return { credentials: [] };
+    }
+    try {
+      const raw = await this.storage.readFileAsString(STORE_PATH);
+      const parsed = JSON.parse(raw) as CredentialFile;
+      if (!parsed || !Array.isArray(parsed.credentials)) return { credentials: [] };
+      return parsed;
+    } catch (error) {
+      this.logger.warn('Failed to read registry credentials; treating as empty', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return { credentials: [] };
+    }
+  }
+
+  private async save(file: CredentialFile): Promise<void> {
+    // 0o600 so the token file is owner-only, like the deployment .env files.
+    await this.storage.writeFile(STORE_PATH, JSON.stringify(file, null, 2), FILE_MODE);
+  }
+
+  async add(req: AddRegistryCredentialRequest): Promise<RegistryCredentialRecord> {
+    const registry = (req.registry || '').trim();
+    const username = (req.username || '').trim();
+    if (!registry) throw new Error('REGISTRY_REQUIRED');
+    if (!username) throw new Error('USERNAME_REQUIRED');
+    if (!req.password) throw new Error('PASSWORD_REQUIRED');
+
+    const file = await this.load();
+    const id = (req.id || '').trim() || `cred_${randomUUID().slice(0, 8)}`;
+    if (file.credentials.some(c => c.id === id)) {
+      throw new Error('CREDENTIAL_ID_EXISTS');
+    }
+    const record: StoredCredential = {
+      id,
+      registry,
+      username,
+      passwordB64: Buffer.from(req.password, 'utf8').toString('base64'),
+    };
+    file.credentials.push(record);
+    await this.save(file);
+    // Log the id/registry only — never the token.
+    this.logger.info('Registry credential added', { id, registry });
+    return redact(record);
+  }
+
+  async list(): Promise<RegistryCredentialRecord[]> {
+    const file = await this.load();
+    return file.credentials.map(redact);
+  }
+
+  async remove(id: string): Promise<void> {
+    const file = await this.load();
+    const next = file.credentials.filter(c => c.id !== id);
+    if (next.length === file.credentials.length) throw new Error('CREDENTIAL_NOT_FOUND');
+    await this.save({ credentials: next });
+    this.logger.info('Registry credential removed', { id });
+  }
+
+  async resolve(id: string): Promise<PullCredentials | undefined> {
+    const file = await this.load();
+    const c = file.credentials.find(x => x.id === id);
+    if (!c) return undefined;
+    return {
+      registry: c.registry,
+      username: c.username,
+      password: Buffer.from(c.passwordB64, 'base64').toString('utf8'),
+    };
+  }
+}
+
+/** In-memory credential store for tests/dev (no disk, no real secrets). */
+export class MockRegistryCredentialService implements RegistryCredentialService {
+  private creds = new Map<string, StoredCredential>();
+
+  async healthCheck(): Promise<ServiceHealth> {
+    return { healthy: true, lastCheck: new Date() };
+  }
+
+  async add(req: AddRegistryCredentialRequest): Promise<RegistryCredentialRecord> {
+    const id = (req.id || '').trim() || `cred_${randomUUID().slice(0, 8)}`;
+    if (this.creds.has(id)) throw new Error('CREDENTIAL_ID_EXISTS');
+    const record: StoredCredential = {
+      id,
+      registry: req.registry,
+      username: req.username,
+      passwordB64: Buffer.from(req.password ?? '', 'utf8').toString('base64'),
+    };
+    this.creds.set(id, record);
+    return redact(record);
+  }
+
+  async list(): Promise<RegistryCredentialRecord[]> {
+    return [...this.creds.values()].map(redact);
+  }
+
+  async remove(id: string): Promise<void> {
+    if (!this.creds.delete(id)) throw new Error('CREDENTIAL_NOT_FOUND');
+  }
+
+  async resolve(id: string): Promise<PullCredentials | undefined> {
+    const c = this.creds.get(id);
+    if (!c) return undefined;
+    return {
+      registry: c.registry,
+      username: c.username,
+      password: Buffer.from(c.passwordB64, 'base64').toString('utf8'),
+    };
+  }
+}

--- a/packages/server/src/services/simple-factory.ts
+++ b/packages/server/src/services/simple-factory.ts
@@ -22,6 +22,7 @@ import { RealJobService, MockJobService, type JobService } from './core/jobs';
 import { InProcessEventBus, type EventBus } from './core/event-bus';
 import { RealCatalogService, MockCatalogService, type CatalogService } from './core/catalog';
 import { RealBundleService, MockBundleService, type BundleService } from './core/bundles';
+import { RealRegistryCredentialService, MockRegistryCredentialService, type RegistryCredentialService } from './core/registry-credentials';
 import { RealDraftService, MockDraftService, type DraftService } from './core/draft';
 import { RealValidationService, MockValidationService, type ValidationService } from './core/validation';
 import { RealRoutingService, MockRoutingService, type RoutingService } from './core/routing';
@@ -46,6 +47,7 @@ export interface Services {
   eventBus: EventBus;
   catalog: CatalogService;
   bundles: BundleService;
+  registryCredentials: RegistryCredentialService;
   drafts: DraftService;
   validation: ValidationService;
   routing: RoutingService;
@@ -88,6 +90,7 @@ export function createServices(env: ServiceEnvironment): Services {
       eventBus,
       catalog: new MockCatalogService(),
       bundles: new MockBundleService(),
+      registryCredentials: new MockRegistryCredentialService(),
       drafts: new MockDraftService(),
       validation: new MockValidationService(),
       routing: new MockRoutingService(),
@@ -121,8 +124,11 @@ export function createServices(env: ServiceEnvironment): Services {
     // Create shared validation service instance to avoid duplication
     const validation = new RealValidationService(docker, systemMonitoring, storage, routing);
 
+    // Registry credentials for private OCI pulls (shared by drafts + deployments).
+    const registryCredentials = new RealRegistryCredentialService(storage);
+
     // Shared draft service: the deployment service builds releases from its finalized artifacts.
-    const drafts = new RealDraftService(storage, catalog, validation);
+    const drafts = new RealDraftService(storage, catalog, validation, registryCredentials);
 
     // Mock provisioner in development for safety (no calls to a real auth platform).
     const provisioner = new MockProvisionerService();
@@ -141,11 +147,12 @@ export function createServices(env: ServiceEnvironment): Services {
       eventBus,
       catalog,
       bundles: new RealBundleService(storage.resolveHolaPath('cache', 'bundles')),
+      registryCredentials,
       drafts,
       validation,
       routing,
       provisioner,
-      deployments: new RealDeploymentService(storage, jobs, docker, drafts, routing, logging, provisioner, catalog, eventBus),
+      deployments: new RealDeploymentService(storage, jobs, docker, drafts, routing, logging, provisioner, catalog, eventBus, registryCredentials),
     };
   }
 
@@ -181,8 +188,11 @@ export function createServices(env: ServiceEnvironment): Services {
   // Create shared validation service instance to avoid duplication
   const validation = new RealValidationService(docker, systemMonitoring, storage, routing);
 
+  // Registry credentials for private OCI pulls (shared by drafts + deployments).
+  const registryCredentials = new RealRegistryCredentialService(storage);
+
   // Shared draft service: the deployment service builds releases from its finalized artifacts.
-  const drafts = new RealDraftService(storage, catalog, validation);
+  const drafts = new RealDraftService(storage, catalog, validation, registryCredentials);
 
   // Provision auth artifacts against the configured platform. When no backend is
   // configured (mode != authentik) use the real no-op provisioner — NOT the Mock,
@@ -206,11 +216,12 @@ export function createServices(env: ServiceEnvironment): Services {
     eventBus,
     catalog,
     bundles: new RealBundleService(storage.resolveHolaPath('cache', 'bundles')),
+    registryCredentials,
     drafts,
     validation,
     routing,
     provisioner,
-    deployments: new RealDeploymentService(storage, jobs, docker, drafts, routing, logging, provisioner, catalog, eventBus),
+    deployments: new RealDeploymentService(storage, jobs, docker, drafts, routing, logging, provisioner, catalog, eventBus, registryCredentials),
   };
 }
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -21,6 +21,17 @@ export const API = {
       `/api/catalog/apps/${appId}/versions/${encodeURIComponent(version)}`
   },
 
+  // Registry credentials for private OCI pulls (GHCR PAT etc.). Instance-level,
+  // admin-gated. Secrets are stored server-side and never returned to clients.
+  registryCredentials: {
+    base: '/api/registry-credentials',
+    byId: (id: string) => `/api/registry-credentials/${id}`,
+  },
+
+  // Install a package directly by OCI reference (the escape hatch for one-offs,
+  // and the shared primitive every catalog install builds on).
+  installFromRef: '/api/install-from-ref',
+
   drafts: {
     create: '/api/drafts',
     byId: (draftId: string) => `/api/drafts/${draftId}`,
@@ -392,6 +403,55 @@ export type CatalogApp = {
 export type GetCatalogAppsRequest = PageRequest & {
   query?: string;
   category?: string;
+  // Restrict the listing to a single catalog source id (Slice 2). Omitted =>
+  // merge across all enabled sources. The built-in public catalog is `hola`.
+  source?: string;
+};
+
+// ------------------------------------------------------
+// Registry credentials (private OCI pulls)
+// ------------------------------------------------------
+
+/**
+ * A stored registry credential, as returned to clients. The password/token is
+ * NEVER serialized — only the metadata needed to pick a credential is exposed.
+ * `registry` is the host (optionally host/path) the credential authorizes, e.g.
+ * `ghcr.io` or `ghcr.io/acme`.
+ */
+export type RegistryCredentialRecord = {
+  id: string;
+  registry: string;
+  username: string;
+};
+
+export type AddRegistryCredentialRequest = {
+  registry: string;
+  username: string;
+  /** The secret token (e.g. a GHCR PAT with read:packages). Write-only. */
+  password: string;
+  /** Optional stable id; the server generates one when omitted. */
+  id?: string;
+};
+
+export type ListRegistryCredentialsResponse = {
+  items: RegistryCredentialRecord[];
+};
+
+/**
+ * Install a package straight from an OCI reference (e.g.
+ * `ghcr.io/acme/hola-cms:0.1.0`), bypassing the catalog index. `credentialRef`
+ * names a stored RegistryCredentialRecord used for both the `oras pull` and the
+ * runtime image pull when the ref points at a private registry.
+ */
+export type InstallFromRefRequest = {
+  ociRef: string;
+  credentialRef?: string;
+  name?: string;
+  version?: string;
+};
+
+export type InstallFromRefResponse = {
+  draftId: string;
 };
 
 export type GetCatalogAppsResponse = PageResponse<CatalogApp>;
@@ -580,6 +640,14 @@ export type Draft = {
   draftId: string;
   appId: string;
   version?: string;
+  // Catalog source id this draft's app came from (defaults to `hola`). Carried
+  // through finalize so the deployment record knows which source to check for
+  // updates and, with `credentialRef`, how to authenticate the runtime image pull.
+  source?: string;
+  // Stored registry credential id used to pull this app's bundle + runtime image
+  // from a private registry. Seeded from the install request; carried through
+  // finalize (read-only; not user-editable). Never contains the secret itself.
+  credentialRef?: string;
   // App icon (emoji or image URL) and product display name seeded from the
   // catalog and carried through finalize, so the deployment can persist both
   // without a live catalog lookup at render time.
@@ -610,7 +678,20 @@ export type Draft = {
   files: Array<{ uploadId: string; name: string; size: number; kind: 'composeOverride' | 'additionalFile' | 'env' | 'secret' }>;
 };
 
-export type CreateDraftRequest = { appId: string; version?: string };
+export type CreateDraftRequest = {
+  // Catalog install path: the app id (bare, e.g. `uptime-kuma`). Optional only
+  // because the install-by-ref path supplies `ociRef` instead.
+  appId?: string;
+  version?: string;
+  // Catalog source id the app comes from (Slice 2). Defaults to `hola` (the
+  // built-in public catalog) so existing bare-appId callers are unaffected.
+  source?: string;
+  // Install-by-ref path (Slice 1): a full OCI package reference. When present,
+  // the draft is seeded directly from the pulled bundle rather than the index.
+  ociRef?: string;
+  // Stored registry credential id used to pull `ociRef` / the source's packages.
+  credentialRef?: string;
+};
 export type CreateDraftResponse = {
   draftId: string;
   app: { id: string; name: string; icon: string };

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -38,6 +38,8 @@ function App() {
                         <Route path="/dashboard" element={<Dashboard />} />
                         <Route path="/catalog" element={<Catalog />} />
                         <Route path="/catalog/:appId/install" element={<InstallWizard />} />
+                        {/* Install-by-ref: same wizard, draft seeded from an OCI ref (?ref=&cred=) */}
+                        <Route path="/install/ref" element={<InstallWizard />} />
                         <Route path="/deployments" element={<Deployments />} />
                         <Route path="/deployments/:deploymentId" element={<DeploymentDetail />} />
                         <Route path="/backups" element={<Backups />} />

--- a/packages/web/src/pages/Catalog.tsx
+++ b/packages/web/src/pages/Catalog.tsx
@@ -7,15 +7,98 @@ import {
   Download,
   RefreshCw,
   AlertCircle,
+  Terminal,
+  X,
 } from 'lucide-react';
 import type {
   CatalogApp,
   GetCatalogAppsRequest,
+  RegistryCredentialRecord,
 } from '@hola/shared';
 import { useCatalogAppsApi, useCatalogAppVersionsApi } from '../hooks/useCatalogApi';
 import { AppIcon } from '../components/ui/AppIcon';
+import { api } from '../utils/api-hybrid';
 
 const categories = ['All', 'Productivity', 'Home Automation', 'Media', 'Monitoring', 'Security', 'Database', 'Infrastructure', 'Networking'];
+
+/**
+ * Modal to install a package straight from an OCI reference (the escape hatch for
+ * one-off private/first-party packages). Picks an optional stored credential for a
+ * private registry, then routes into the same install wizard as a catalog install.
+ */
+const InstallFromRefModal: React.FC<{ isOpen: boolean; onClose: () => void }> = ({ isOpen, onClose }) => {
+  const navigate = useNavigate();
+  const [ref, setRef] = useState('');
+  const [credentialRef, setCredentialRef] = useState('');
+  const [creds, setCreds] = useState<RegistryCredentialRecord[]>([]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setRef(''); setCredentialRef('');
+    api.registryCredentials.list().then(r => setCreds(r.items)).catch(() => setCreds([]));
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const submit = () => {
+    const trimmed = ref.trim();
+    if (!trimmed) return;
+    const params = new URLSearchParams({ ref: trimmed });
+    if (credentialRef) params.set('cred', credentialRef);
+    onClose();
+    navigate(`/install/ref?${params.toString()}`);
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+      <div className="bg-surface-0 rounded-xl border border-border w-full max-w-lg overflow-hidden">
+        <div className="flex items-center justify-between p-6 border-b border-border">
+          <h2 className="text-lg font-semibold">Install from OCI reference</h2>
+          <button onClick={onClose} className="text-text-muted hover:text-text-strong transition-colors">
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+        <div className="p-6 space-y-4">
+          <div>
+            <label className="block text-sm font-medium mb-1.5">Package reference</label>
+            <input
+              autoFocus
+              type="text"
+              value={ref}
+              onChange={(e) => setRef(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') submit(); }}
+              placeholder="ghcr.io/acme/hola-cms:0.1.0"
+              className="w-full h-[38px] bg-surface-1 border border-border rounded-lg px-3 text-[13.5px] text-text-strong outline-none focus:border-primary"
+            />
+            <p className="mt-1.5 text-xs text-text-muted">The loose-OCI package ref (compose.yaml + manifest.json). Validated against the same strict rules as catalog apps.</p>
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1.5">Registry credential (for private registries)</label>
+            <select
+              value={credentialRef}
+              onChange={(e) => setCredentialRef(e.target.value)}
+              className="w-full h-[38px] bg-surface-1 border border-border rounded-lg px-3 text-[13.5px] text-text-strong outline-none focus:border-primary"
+            >
+              <option value="">None (public)</option>
+              {creds.map(c => <option key={c.id} value={c.id}>{c.id} — {c.registry}</option>)}
+            </select>
+            <p className="mt-1.5 text-xs text-text-muted">Manage credentials in Settings → Registry Credentials.</p>
+          </div>
+        </div>
+        <div className="flex items-center justify-end gap-2 p-6 border-t border-border bg-surface-1">
+          <button onClick={onClose} className="px-4 py-2 rounded-lg text-text-muted hover:text-text-strong transition-colors">Cancel</button>
+          <button
+            onClick={submit}
+            disabled={!ref.trim()}
+            className="bg-primary text-primary-contrast px-5 py-2 rounded-lg font-medium hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Continue
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
 
 type AppDetailModalProps = {
   app: CatalogApp;
@@ -177,6 +260,7 @@ export const Catalog: React.FC = () => {
   const [selectedAppId, setSelectedAppId] = useState<string | null>(null);
   const [currentPage, setCurrentPage] = useState(parseInt(searchParams.get('page') || '1', 10));
   const [appsPerPage] = useState(12);
+  const [showRefModal, setShowRefModal] = useState(false);
 
   // Build API request parameters
   const apiParams = useMemo(() => {
@@ -260,6 +344,13 @@ export const Catalog: React.FC = () => {
           </p>
         </div>
         <div className="flex-1" />
+        <button
+          onClick={() => setShowRefModal(true)}
+          className="h-[38px] px-3.5 flex items-center gap-2 bg-surface-1 border border-border rounded-[9px] text-[13px] font-medium text-text-muted hover:text-text-strong transition-colors"
+        >
+          <Terminal className="w-4 h-4" />
+          Install from reference
+        </button>
         <div className="relative flex items-center">
           <Search className="absolute left-[11px] w-4 h-4 text-text-faint pointer-events-none" />
           <input
@@ -271,6 +362,8 @@ export const Catalog: React.FC = () => {
           />
         </div>
       </div>
+
+      <InstallFromRefModal isOpen={showRefModal} onClose={() => setShowRefModal(false)} />
 
       {/* Category chips */}
       <div className="flex gap-2 flex-wrap mb-5">

--- a/packages/web/src/pages/InstallWizard.tsx
+++ b/packages/web/src/pages/InstallWizard.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import { ChevronRight, Check, Upload, X, Plus, AlertTriangle, Eye, EyeOff, RotateCw, FileText, Code, Download, Wand2 } from 'lucide-react';
 import { AppIcon } from '../components/ui/AppIcon';
 import type {
@@ -25,7 +25,14 @@ const steps = [
 
 export const InstallWizard: React.FC = () => {
   const { appId } = useParams();
+  const [searchParams] = useSearchParams();
   const navigate = useNavigate();
+
+  // Install-by-ref mode: `/install/ref?ref=<oci>&cred=<credentialId>`. The wizard
+  // is otherwise identical — the draft is seeded from the pulled bundle instead of
+  // a catalog index entry.
+  const ociRef = searchParams.get('ref') || undefined;
+  const credentialRef = searchParams.get('cred') || undefined;
   const [currentStep, setCurrentStep] = useState(0);
   
   // Draft API hooks
@@ -69,7 +76,7 @@ export const InstallWizard: React.FC = () => {
 
   // Real app metadata, resolved from the catalog when the draft is created.
   // Falls back to the route's appId for the brief window before the draft loads.
-  const app = createDraftHook.data?.app ?? { id: appId ?? '', name: appId ?? 'app', icon: '📦' };
+  const app = createDraftHook.data?.app ?? { id: appId ?? ociRef ?? '', name: appId ?? ociRef ?? 'app', icon: '📦' };
   // The catalog version this draft pins (defaults to 'latest' when unversioned).
   const version = draftApi.data?.version ?? 'latest';
 
@@ -94,12 +101,14 @@ export const InstallWizard: React.FC = () => {
   // `data` is set races dozens of duplicate createDraft calls).
   const creatingDraftRef = React.useRef(false);
   useEffect(() => {
-    if (!appId || createDraftHook.data || creatingDraftRef.current) return;
+    if ((!appId && !ociRef) || createDraftHook.data || creatingDraftRef.current) return;
     creatingDraftRef.current = true;
 
     const initializeDraft = async () => {
       try {
-        const result = await createDraftHook.createDraft({ appId });
+        const result = ociRef
+          ? await createDraftHook.createDraft({ ociRef, credentialRef })
+          : await createDraftHook.createDraft({ appId });
 
         // Update state with draft data. Float required-but-empty secrets to the
         // top so the operator sees what they must fill first (env order doesn't
@@ -123,7 +132,7 @@ export const InstallWizard: React.FC = () => {
     };
 
     initializeDraft();
-  }, [appId, createDraftHook]); // Include the whole hook object
+  }, [appId, ociRef, credentialRef, createDraftHook]); // Include the whole hook object
 
   // Update draft data helper function
   const updateDraftData = React.useCallback(async (updates: PatchDraftRequest) => {

--- a/packages/web/src/pages/Settings.tsx
+++ b/packages/web/src/pages/Settings.tsx
@@ -14,13 +14,119 @@ import {
 } from 'lucide-react';
 import type {
   SystemEnvVar,
-  GetBackupSettingsResponse
+  GetBackupSettingsResponse,
+  RegistryCredentialRecord
 } from '@hola/shared';
 import { useSettingsApi } from '../hooks/useSettingsApi';
 import { useBackupSettingsApi } from '../hooks/useSettingsApi';
 import { useSystemStatusApi } from '../hooks/useSettingsApi';
 import { useTheme, type ThemePref } from '../hooks/useTheme';
 import { useAuth } from '../hooks/useAuth';
+import { api } from '../utils/api-hybrid';
+
+/**
+ * Manage registry credentials for private OCI pulls (a GHCR PAT etc.). The token
+ * is write-only: it's sent on add and never returned by the list. Used for both
+ * `oras pull` of a package and the runtime image pull at deploy time; referenced
+ * by id from a catalog source or `install … --registry-cred`.
+ */
+const RegistryCredentialsCard: React.FC<{ inputClass: string; labelClass: string }> = ({ inputClass, labelClass }) => {
+  const [items, setItems] = useState<RegistryCredentialRecord[]>([]);
+  const [adding, setAdding] = useState(false);
+  const [id, setId] = useState('');
+  const [registry, setRegistry] = useState('');
+  const [username, setUsername] = useState('');
+  const [token, setToken] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const refresh = React.useCallback(() => {
+    api.registryCredentials.list().then(r => setItems(r.items)).catch(() => setItems([]));
+  }, []);
+  React.useEffect(() => { refresh(); }, [refresh]);
+
+  const add = async () => {
+    if (!registry.trim() || !username.trim() || !token) { setErr('Registry, username and token are required.'); return; }
+    setBusy(true); setErr(null);
+    try {
+      await api.registryCredentials.add({ registry: registry.trim(), username: username.trim(), password: token, id: id.trim() || undefined });
+      setId(''); setRegistry(''); setUsername(''); setToken(''); setAdding(false);
+      refresh();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Failed to add credential');
+    } finally { setBusy(false); }
+  };
+
+  const remove = async (credId: string) => {
+    setBusy(true); setErr(null);
+    try { await api.registryCredentials.remove(credId); refresh(); }
+    catch (e) { setErr(e instanceof Error ? e.message : 'Failed to remove credential'); }
+    finally { setBusy(false); }
+  };
+
+  return (
+    <div className="bg-surface-1 border border-border rounded-card p-5">
+      <div className="font-semibold text-[15px] mb-1">Registry Credentials</div>
+      <p className="text-[13px] text-text-muted mb-3.5">
+        Tokens for pulling private catalog packages and their images (e.g. a GHCR PAT with <code>read:packages</code>). Stored server-side and never shown again.
+      </p>
+
+      {err && (
+        <div className="bg-danger-weak border border-danger/20 text-danger rounded-card p-3 text-[13px] mb-3 flex items-center gap-2">
+          <AlertTriangle className="w-4 h-4 flex-none" />
+          <span>{err}</span>
+        </div>
+      )}
+
+      {items.length > 0 && (
+        <div className="flex flex-col gap-2 mb-3">
+          {items.map(c => (
+            <div key={c.id} className="flex items-center justify-between bg-surface-0 border border-border rounded-lg px-3 py-2">
+              <div className="text-[13px]">
+                <span className="font-medium text-text-strong">{c.id}</span>
+                <span className="text-text-muted"> — {c.registry} ({c.username})</span>
+              </div>
+              <button onClick={() => remove(c.id)} disabled={busy} className="text-text-muted hover:text-danger transition-colors disabled:opacity-50" aria-label={`Remove ${c.id}`}>
+                <X className="w-4 h-4" />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {adding ? (
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <div className={labelClass}>Registry</div>
+            <input value={registry} onChange={(e) => setRegistry(e.target.value)} placeholder="ghcr.io" className={inputClass} />
+          </div>
+          <div>
+            <div className={labelClass}>Credential id (optional)</div>
+            <input value={id} onChange={(e) => setId(e.target.value)} placeholder="acme" className={inputClass} />
+          </div>
+          <div>
+            <div className={labelClass}>Username</div>
+            <input value={username} onChange={(e) => setUsername(e.target.value)} placeholder="acme-bot" className={inputClass} />
+          </div>
+          <div>
+            <div className={labelClass}>Token</div>
+            <input type="password" value={token} onChange={(e) => setToken(e.target.value)} placeholder="ghp_…" className={inputClass} />
+          </div>
+          <div className="col-span-2 flex items-center gap-2">
+            <button onClick={add} disabled={busy} className="bg-primary text-primary-contrast px-4 py-2 rounded-lg text-[13px] font-medium hover:bg-primary/90 transition-colors disabled:opacity-50 flex items-center gap-2">
+              <Save className="w-4 h-4" /> Save credential
+            </button>
+            <button onClick={() => { setAdding(false); setErr(null); }} className="px-4 py-2 rounded-lg text-[13px] text-text-muted hover:text-text-strong transition-colors">Cancel</button>
+          </div>
+        </div>
+      ) : (
+        <button onClick={() => setAdding(true)} className="flex items-center gap-2 text-[13px] font-medium text-primary hover:opacity-80 transition-opacity">
+          <Plus className="w-4 h-4" /> Add credential
+        </button>
+      )}
+    </div>
+  );
+};
 
 export const Settings: React.FC = () => {
   // API hooks for data management
@@ -547,6 +653,9 @@ export const Settings: React.FC = () => {
             </div>
           </div>
         ) : null}
+
+        {/* Registry credentials for private OCI pulls (multi-catalog) */}
+        <RegistryCredentialsCard inputClass={inputClass} labelClass={labelClass} />
 
         {/* Identity management notice */}
         <div className="bg-surface-1 border border-border rounded-card p-5 flex items-start gap-3">

--- a/packages/web/src/utils/api-hybrid.ts
+++ b/packages/web/src/utils/api-hybrid.ts
@@ -51,6 +51,10 @@ export const api = {
     ? sdkAdapter.drafts
     : originalApi.drafts,
 
+  // Registry credentials + install-by-ref (multi-catalog Slice 1) — SDK-only.
+  registryCredentials: sdkAdapter.registryCredentials,
+  installFromRef: sdkAdapter.installFromRef,
+
   // Deployment endpoints - not migrated yet
   deployments: USE_SDK_FOR.deployments
     ? sdkAdapter.deployments

--- a/packages/web/src/utils/sdk-adapter.ts
+++ b/packages/web/src/utils/sdk-adapter.ts
@@ -7,6 +7,9 @@ import type {
   HealthResponse, GetSummaryResponse, GetMeResponse,
   // Catalog types
   GetCatalogAppsResponse, GetCatalogAppResponse, GetCatalogAppVersionsResponse, GetCatalogAppVersionDetailResponse,
+  // Registry credentials + install-by-ref (multi-catalog Slice 1)
+  AddRegistryCredentialRequest, ListRegistryCredentialsResponse, RegistryCredentialRecord,
+  InstallFromRefRequest, InstallFromRefResponse,
   // Draft types  
   CreateDraftRequest, CreateDraftResponse, GetDraftResponse, 
   PatchDraftRequest, PatchDraftResponse, ValidateDraftResponse, FinalizeDraftResponse,
@@ -327,6 +330,27 @@ export class SdkAdapter {
       return res;
     },
   };
+
+  // Registry credentials for private OCI pulls. Token is write-only; list never
+  // returns it. Mutations drop the cached list so the UI reflects changes.
+  registryCredentials = {
+    list: (): Promise<ListRegistryCredentialsResponse> =>
+      this.getWithCache('/api/registry-credentials', () => this.sdk.registryCredentials.list()),
+    add: async (data: AddRegistryCredentialRequest): Promise<RegistryCredentialRecord> => {
+      const res = await this.sdk.registryCredentials.add(data);
+      globalCache.deleteByPattern(/^api:.*\/registry-credentials/);
+      return res;
+    },
+    remove: async (id: string): Promise<{ success: boolean }> => {
+      const res = await this.sdk.registryCredentials.remove(id);
+      globalCache.deleteByPattern(/^api:.*\/registry-credentials/);
+      return res;
+    },
+  };
+
+  // Install a package straight from an OCI reference (escape hatch for one-offs).
+  installFromRef = (data: InstallFromRefRequest): Promise<InstallFromRefResponse> =>
+    this.enhancedRequest('POST', '/api/install-from-ref', () => this.sdk.installFromRef(data), data, false);
 
   // Drafts (Install Wizard) with cache invalidation
   drafts = {


### PR DESCRIPTION
## Multi-catalog — Slice 1: install from OCI reference + private-registry credentials

First of two stacked PRs adding multi-catalog support. This one extracts the
underlying "install a package by OCI ref" into a reusable primitive and adds stored
registry credentials for private pulls — the foundation Slice 2 (custom catalog
sources, #TBD) builds on. **The public catalog is unchanged and still works with
zero config.**

### What's new
- **`RegistryCredentialService`** (Real/Mock): add/list/remove/resolve, persisted to
  `config/registry-credentials.json` (`0o600`). Tokens are **write-only** — never
  returned to clients or written to logs.
- **Shared pull primitive**: `RealBundleService.ensurePulled` gains `source` +
  optional `credentials`, threading a scoped `oras --registry-config` auth file
  (`0o600`, temp, cleaned up in `finally`) so tokens stay **off argv**. The base
  registry allowlist is extended per-pull by the credential's registry (host/glob
  match, never substring — guards `ghcr.io.evil.com`).
- **Cache namespaced by source** (`<source>__<appId>`); the built-in `hola` source
  keeps the bare `appId`, so existing public-catalog bundles don't re-pull.
- **`getVersionDetailByRef(ociRef, creds)`** reuses the same pull → validate →
  coerce path (`buildDetailFromBundle`) as catalog installs, so the strict compose
  rules apply to one-offs too.
- **Draft**: `createDraft` branches on `ociRef` to seed a draft straight from the
  bundle (bare `appId` slug, source `(ref)`, `credentialRef` carried through
  finalize).
- **Deploy**: the runtime image pull authenticates via a scoped `DOCKER_CONFIG`
  built from the release's `credentialRef`; a since-deleted credential fails with a
  clear message rather than a raw docker auth error.
- **Surfaces**: `POST /api/install-from-ref` + `/api/registry-credentials`; SDK
  `installFromRef` + `registryCredentials`; CLI `hola install <oci-ref>
  --registry-cred` and `hola registry-cred add|list|rm`; web "Install from
  reference" action + a Settings → Registry Credentials pane (install-by-ref reuses
  the existing wizard via `/install/ref`).

### Design note
- **Sources model** (full shape lands in Slice 2): a source is a `catalog.json`
  (unchanged schema) plus optional private-registry auth. The public catalog is the
  seeded, verified `hola` source; users append `custom`-trust sources. Apps merge
  keyed `<sourceId>/<appId>` for display/collision only — the wire `appId` stays
  **bare** with a separate `source` field, so no routes or persisted records
  migrate.
- **Trust / auth**: a stored credential (referenced by `credentialRef`)
  authenticates both the `oras` package pull and the Docker image pull. Registering
  a credential is the explicit consent that extends the pull allowlist to that
  registry.
- **Per-user vs instance — INSTANCE-LEVEL, admin-gated.** The codebase has a single
  `Principal` model with no per-user data partitioning (deployments/drafts/config
  are all global), so sources and credentials are one curated set for the whole
  instance.

### Compatibility note
The bundle cache path gains a `<source>__` prefix for non-`hola` sources, so
already-installed **custom / by-ref** apps re-pull their bundle once. Public `hola`
apps are unaffected (bare key, byte-identical path).

### Tests
`bun run typecheck`, `bun run lint`, `bun run test` (server **432** + web **151**),
and `bun run build` all green. New server tests:
- `registry-credentials.test.ts` — `0o600` write, redacted list, resolve, dup +
  rehydrate.
- `bundles/auth-pull.test.ts` — scoped `0o600` auth file, token off argv, cache
  namespacing, allowlist extend/reject.
- `install/install-from-ref.test.ts` — draft seeded from bundle; non-compliant
  bundle rejected; strict compose rules still enforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
