### PR TITLE
feat(catalog): custom catalog sources (multi-catalog slice 2)

### DIFF
--- a/packages/cli/src/commands/catalog/catalog.ts
+++ b/packages/cli/src/commands/catalog/catalog.ts
@@ -5,6 +5,7 @@ import { maybeNotifyUpdate } from '../../lib/update-notice';
 
 export interface CatalogOptions {
   category?: string;
+  source?: string;
   limit?: number | string;
   json?: boolean;
 }
@@ -21,6 +22,7 @@ export async function runCatalog(
     const res = (await sdk.catalog.apps({
       q: query,
       category: opts.category,
+      source: opts.source,
       page: 1,
       limit: Number.isFinite(limit) ? limit : 100,
     })) as GetCatalogAppsResponse;
@@ -38,9 +40,11 @@ export async function runCatalog(
 
     const idWidth = Math.max(3, ...res.items.map(a => a.id.length));
     for (const app of res.items) {
-      console.log(`${(app.icon || '📦')} ${app.id.padEnd(idWidth)}  ${app.description}`);
+      // Badge apps from a non-default source so their origin/trust is visible.
+      const badge = app.source && app.source !== 'hola' ? `  [${app.source}·${app.trust}]` : '';
+      console.log(`${(app.icon || '📦')} ${app.id.padEnd(idWidth)}  ${app.description}${badge}`);
     }
-    console.log(`\n${res.total} app(s). Install with: hola install <id>`);
+    console.log(`\n${res.total} app(s). Install with: hola install <id> [--source <source>]`);
     await maybeNotifyUpdate(sdk, opts);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/packages/cli/src/commands/install/install.ts
+++ b/packages/cli/src/commands/install/install.ts
@@ -14,6 +14,8 @@ export interface InstallOptions {
   strict?: boolean;
   /** From `--registry-cred`: stored credential id for a private OCI ref install. */
   registryCred?: string;
+  /** From `--source`: catalog source id to install from (default: hola). */
+  source?: string;
 }
 
 /**
@@ -89,8 +91,9 @@ export async function runInstall(
       out(`Creating draft from OCI reference ${rawAppId}${opts.registryCred ? ` (credential: ${opts.registryCred})` : ''}`);
       draftId = (await sdk.installFromRef({ ociRef: rawAppId, credentialRef: opts.registryCred })).draftId;
     } else {
-      out(`Creating draft for ${appId}@${version} (from catalog)`);
-      draftId = ((await sdk.drafts.create({ appId, version })) as CreateDraftResponse).draftId;
+      const from = opts.source && opts.source !== 'hola' ? ` (source: ${opts.source})` : '';
+      out(`Creating draft for ${appId}@${version} (from catalog${from})`);
+      draftId = ((await sdk.drafts.create({ appId, version, source: opts.source })) as CreateDraftResponse).draftId;
     }
 
     // Apply env overrides onto the catalog-seeded appEnv (merge by key).

--- a/packages/cli/src/commands/source/source.ts
+++ b/packages/cli/src/commands/source/source.ts
@@ -1,0 +1,75 @@
+import { HolaSdk } from '@hola/sdk';
+import type { CatalogSourceRecord } from '@hola/shared';
+
+export interface SourceOptions {
+  id?: string;
+  name?: string;
+  url?: string;
+  /** `--registry` + `--cred` register auth for a private source. */
+  registry?: string;
+  cred?: string;
+  json?: boolean;
+}
+
+/**
+ * Manage catalog sources (`add | list | rm`) — the Homebrew-tap model. A source
+ * is a catalog.json (same schema as the public catalog) hosted elsewhere,
+ * optionally with a stored registry credential for private packages. The built-in
+ * `hola` source is always present and can't be removed.
+ */
+export async function runSource(
+  action: string,
+  opts: SourceOptions,
+  injected?: { sdk?: HolaSdk; args?: string[] }
+): Promise<void> {
+  const sdk = injected?.sdk ?? new HolaSdk();
+  const positional = injected?.args ?? [];
+
+  try {
+    switch (action) {
+      case 'add': {
+        const id = opts.id ?? positional[0];
+        if (!id || !opts.url) {
+          console.error('source add requires an id and --url (and optionally --name, --registry + --cred)');
+          process.exitCode = 1;
+          return;
+        }
+        if ((opts.registry && !opts.cred) || (!opts.registry && opts.cred)) {
+          console.error('source add: --registry and --cred must be provided together');
+          process.exitCode = 1;
+          return;
+        }
+        const auth = opts.registry && opts.cred ? { registry: opts.registry, credentialRef: opts.cred } : undefined;
+        const record = await sdk.catalogSources.add({ id, name: opts.name ?? id, url: opts.url, auth });
+        if (opts.json) console.log(JSON.stringify(record, null, 2));
+        else console.log(`Added catalog source '${record.id}' → ${record.url}${auth ? ` (auth: ${auth.credentialRef})` : ''}.`);
+        return;
+      }
+      case 'list': {
+        const { items } = await sdk.catalogSources.list();
+        if (opts.json) { console.log(JSON.stringify(items, null, 2)); return; }
+        const idWidth = Math.max(2, ...items.map((s: CatalogSourceRecord) => s.id.length));
+        for (const s of items) {
+          const flags = [s.trust, s.enabled ? 'enabled' : 'disabled'].join(', ');
+          console.log(`${s.id.padEnd(idWidth)}  ${s.url || '(no url)'}  [${flags}]`);
+        }
+        return;
+      }
+      case 'rm':
+      case 'remove': {
+        const id = opts.id ?? positional[0];
+        if (!id) { console.error('source rm requires a source id'); process.exitCode = 1; return; }
+        await sdk.catalogSources.remove(id);
+        console.log(`Removed catalog source '${id}'.`);
+        return;
+      }
+      default:
+        console.error(`Unknown action '${action}'. Use: add | list | rm`);
+        process.exitCode = 1;
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`source ${action} failed: ${msg}`);
+    process.exitCode = 1;
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -105,11 +105,31 @@ prog
   .command('catalog [query]')
   .describe('Browse the app catalog (optionally filter by query)')
   .option('--category', 'Filter by category')
+  .option('--source', 'Only list apps from this catalog source id')
   .option('--limit', 'Max apps to list', 100)
   .option('--json', 'Print raw JSON output', false)
   .action(async (query, opts) => {
     const { runCatalog } = await load(import('./commands/catalog/catalog'));
     await runCatalog(query, camelKeys(opts));
+  });
+
+// source — manage catalog sources (the Homebrew-tap model)
+prog
+  .command('source <action> [id]')
+  .describe('Manage catalog sources: add | list | rm')
+  .example('source add acme --url https://raw.githubusercontent.com/acme/hola-apps/main/catalog.json')
+  .example('source add acme --url <catalog.json> --registry ghcr.io --cred acme')
+  .example('source list')
+  .example('source rm acme')
+  .option('--id', 'Source id (alternative to the positional id)')
+  .option('--name', 'Human-readable source name')
+  .option('--url', 'URL of the source catalog.json')
+  .option('--registry', 'Registry host for private packages (with --cred)')
+  .option('--cred', 'Stored registry credential id (with --registry)')
+  .option('--json', 'Print raw JSON output', false)
+  .action(async (action, id, opts) => {
+    const { runSource } = await load(import('./commands/source/source'));
+    await runSource(action, camelKeys(opts), { args: id ? [id] : [] });
   });
 
 // install — install a catalog app by id (draft from catalog → finalize → deploy)
@@ -124,6 +144,7 @@ prog
   .option('--app-version', 'App version to install (or use <appId>@<version>)', 'latest')
   .option('--name', 'Deployment name (default: the app id)')
   .option('--set', 'Override an env var, KEY=VALUE (repeatable)')
+  .option('--source', 'Catalog source id to install from (default: hola)')
   .option('--registry-cred', 'Stored registry credential id for a private OCI reference install')
   .option('--strict', 'Fail on validation warnings', false)
   .option('--no-stream', 'Do not watch the deployment job', false)

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -18,6 +18,8 @@ import {
   // Registry credentials + install-by-ref (multi-catalog Slice 1)
   RegistryCredentialRecord, AddRegistryCredentialRequest, ListRegistryCredentialsResponse,
   InstallFromRefRequest, InstallFromRefResponse,
+  // Catalog sources (multi-catalog Slice 2)
+  CatalogSourceRecord, AddCatalogSourceRequest, ListCatalogSourcesResponse,
   // Job types
   DeleteJobsRequest, DeleteJobsResponse,
   // System types
@@ -93,12 +95,20 @@ export class HolaSdk {
 
   catalog = {
     apps: (qs?: GetCatalogAppsRequest) => this.get<GetCatalogAppsResponse>(`${API.catalog.apps}${buildQuery(qs as Record<string, string | number | boolean | undefined>)}`),
-    app: (appId: string) => this.get<GetCatalogAppResponse>(API.catalog.appById(appId)),
-    versions: (appId: string) => this.get<GetCatalogAppVersionsResponse>(API.catalog.versions(appId)),
-    versionDetail: (appId: string, version: string) => this.get<GetCatalogAppVersionDetailResponse>(API.catalog.versionDetail(appId, version)),
+    // `source` selects which catalog source the app comes from (default `hola`).
+    app: (appId: string, source?: string) => this.get<GetCatalogAppResponse>(`${API.catalog.appById(appId)}${buildQuery({ source })}`),
+    versions: (appId: string, source?: string) => this.get<GetCatalogAppVersionsResponse>(`${API.catalog.versions(appId)}${buildQuery({ source })}`),
+    versionDetail: (appId: string, version: string, source?: string) => this.get<GetCatalogAppVersionDetailResponse>(`${API.catalog.versionDetail(appId, version)}${buildQuery({ source })}`),
     // Force an immediate re-fetch of the remote catalog (bypasses the refresh-interval
     // TTL) so newly-published app versions surface as available updates right away.
     refresh: (force = true) => this.post<{ success: boolean; timestamp: string }>(`${API.catalog.refresh}${buildQuery({ force })}`),
+  };
+
+  // Managed catalog sources (Homebrew-tap model). Instance-level, admin-gated.
+  catalogSources = {
+    list: () => this.get<ListCatalogSourcesResponse>(API.catalogSources.base),
+    add: (data: AddCatalogSourceRequest) => this.post<CatalogSourceRecord>(API.catalogSources.base, data),
+    remove: (id: string) => this.delete<{ success: boolean }>(API.catalogSources.byId(id)),
   };
 
   // Registry credentials for private OCI pulls. The token is write-only: `add`

--- a/packages/server/src/__tests__/catalog/catalog-aggregate.test.ts
+++ b/packages/server/src/__tests__/catalog/catalog-aggregate.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { RealCatalogService } from '../../services/core/catalog';
+import { MockCatalogSourceService } from '../../services/core/catalog-sources';
+
+const URLS: Record<string, unknown> = {
+  'https://acme.test/catalog.json': {
+    apps: [
+      { id: 'cms', name: 'Acme CMS', category: 'apps', versions: [{ version: '1.0.0', refs: { oci: 'ghcr.io/acme/cms:1.0.0' } }] },
+      { id: 'db', name: 'Acme DB', category: 'database', versions: [{ version: '2.0.0' }] },
+    ],
+  },
+  'https://globex.test/catalog.json': {
+    apps: [
+      // Same appId as an acme app → collision that must NOT drop either.
+      { id: 'db', name: 'Globex DB', category: 'database', versions: [{ version: '9.9.9' }] },
+    ],
+  },
+};
+
+const okResponse = (body: unknown) => ({
+  ok: true,
+  status: 200,
+  headers: { get: () => null },
+  json: async () => body,
+});
+
+describe('RealCatalogService aggregation', () => {
+  const realFetch = globalThis.fetch;
+  let failGlobex = false;
+
+  beforeEach(() => {
+    failGlobex = false;
+    // Stub network: serve each source's catalog.json by URL.
+    globalThis.fetch = (async (input: unknown) => {
+      const url = String(input);
+      if (url.includes('globex') && failGlobex) throw new Error('boom');
+      const body = URLS[url];
+      if (!body) throw new Error(`unexpected url ${url}`);
+      return okResponse(body);
+    }) as unknown as typeof fetch;
+  });
+  afterEach(() => { globalThis.fetch = realFetch; });
+
+  async function harness() {
+    const sources = new MockCatalogSourceService();
+    await sources.add({ id: 'acme', name: 'Acme', url: 'https://acme.test/catalog.json' });
+    await sources.add({ id: 'globex', name: 'Globex', url: 'https://globex.test/catalog.json' });
+    // hola has no URL in the test env, so it is inert and doesn't interfere.
+    const catalog = new RealCatalogService(undefined, sources, undefined);
+    return { catalog };
+  }
+
+  test('merges apps across sources, badges each with source + trust', async () => {
+    const { catalog } = await harness();
+    const { items } = await catalog.listApps({ page: 1, limit: 50 });
+
+    const byQualified = new Map(items.map(a => [`${a.source}/${a.id}`, a]));
+    expect(byQualified.has('acme/cms')).toBe(true);
+    expect(byQualified.get('acme/cms')!.trust).toBe('custom');
+    // The colliding `db` id survives once per source (namespaced), not deduped away.
+    expect(byQualified.has('acme/db')).toBe(true);
+    expect(byQualified.has('globex/db')).toBe(true);
+    expect(byQualified.get('globex/db')!.name).toBe('Globex DB');
+  });
+
+  test('a single source filter returns only that source', async () => {
+    const { catalog } = await harness();
+    const { items } = await catalog.listApps({ page: 1, limit: 50, source: 'globex' });
+    expect(items.map(a => `${a.source}/${a.id}`)).toEqual(['globex/db']);
+  });
+
+  test('is fail-soft: a broken source does not sink the listing', async () => {
+    const { catalog } = await harness();
+    failGlobex = true;
+    const { items } = await catalog.listApps({ page: 1, limit: 50 });
+    // Acme still lists; globex is skipped.
+    expect(items.some(a => a.source === 'acme')).toBe(true);
+    expect(items.some(a => a.source === 'globex')).toBe(false);
+  });
+
+  test('getVersions routes to the right source', async () => {
+    const { catalog } = await harness();
+    const acme = await catalog.getVersions('db', 'acme');
+    expect(acme.items.map(v => v.version)).toEqual(['2.0.0']);
+    const globex = await catalog.getVersions('db', 'globex');
+    expect(globex.items.map(v => v.version)).toEqual(['9.9.9']);
+  });
+});

--- a/packages/server/src/__tests__/catalog/catalog-sources.test.ts
+++ b/packages/server/src/__tests__/catalog/catalog-sources.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { RealStorageService } from '../../services/core/storage';
+import { RealCatalogSourceService } from '../../services/core/catalog-sources';
+
+const CATALOG = 'https://raw.githubusercontent.com/acme/hola-apps/main/catalog.json';
+
+describe('RealCatalogSourceService', () => {
+  const dirs: string[] = [];
+  afterEach(async () => {
+    await Promise.all(dirs.splice(0).map((d) => rm(d, { recursive: true, force: true })));
+  });
+
+  async function makeService() {
+    const holaDir = await mkdtemp(join(tmpdir(), 'hola-src-test-'));
+    dirs.push(holaDir);
+    return new RealCatalogSourceService(new RealStorageService({ holaDir }));
+  }
+
+  test('always includes the built-in hola source (verified), even with nothing stored', async () => {
+    const svc = await makeService();
+    const list = await svc.list();
+    expect(list[0]).toMatchObject({ id: 'hola', trust: 'verified', enabled: true });
+    expect(list.length).toBe(1);
+  });
+
+  test('add persists a custom source, list surfaces it after hola, remove deletes it', async () => {
+    const svc = await makeService();
+    const rec = await svc.add({ id: 'acme', name: 'Acme', url: CATALOG });
+    expect(rec).toMatchObject({ id: 'acme', trust: 'custom', enabled: true, url: CATALOG });
+
+    const list = await svc.list();
+    expect(list.map(s => s.id)).toEqual(['hola', 'acme']);
+
+    await svc.remove('acme');
+    expect((await svc.list()).map(s => s.id)).toEqual(['hola']);
+    await expect(svc.remove('acme')).rejects.toThrow('SOURCE_NOT_FOUND');
+  });
+
+  test('rejects reserved ids, duplicates, invalid ids and non-http urls', async () => {
+    const svc = await makeService();
+    await expect(svc.add({ id: 'hola', name: 'x', url: CATALOG })).rejects.toThrow('SOURCE_ID_RESERVED');
+    await expect(svc.add({ id: '(ref)', name: 'x', url: CATALOG })).rejects.toThrow('SOURCE_ID_RESERVED');
+    await expect(svc.add({ id: 'Bad Id', name: 'x', url: CATALOG })).rejects.toThrow('SOURCE_ID_INVALID');
+    await expect(svc.add({ id: 'acme', name: 'x', url: 'not-a-url' })).rejects.toThrow('SOURCE_URL_INVALID');
+
+    await svc.add({ id: 'acme', name: 'Acme', url: CATALOG });
+    await expect(svc.add({ id: 'acme', name: 'Acme2', url: CATALOG })).rejects.toThrow('SOURCE_ID_EXISTS');
+  });
+
+  test('the built-in hola source cannot be removed', async () => {
+    const svc = await makeService();
+    await expect(svc.remove('hola')).rejects.toThrow('SOURCE_ID_RESERVED');
+  });
+
+  test('custom sources persist across service instances', async () => {
+    const holaDir = await mkdtemp(join(tmpdir(), 'hola-src-test-'));
+    dirs.push(holaDir);
+    const storage = new RealStorageService({ holaDir });
+    await new RealCatalogSourceService(storage).add({ id: 'acme', name: 'Acme', url: CATALOG });
+    const reloaded = await new RealCatalogSourceService(storage).get('acme');
+    expect(reloaded?.url).toBe(CATALOG);
+  });
+});

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -50,6 +50,8 @@ import {
   type ListRegistryCredentialsResponse,
   type InstallFromRefRequest,
   type InstallFromRefResponse,
+  type AddCatalogSourceRequest,
+  type ListCatalogSourcesResponse,
 } from '@hola/shared';
 
 // Error interface for proper typing
@@ -423,10 +425,11 @@ async function route(url: URL, req: Request): Promise<Response> {
     const limit = Number(searchParams.get('limit')) || 12;
     const query = searchParams.get('query') || undefined;
     const category = searchParams.get('category') || undefined;
+    const source = searchParams.get('source') || undefined;
     try {
       const services = getServices();
       const catalog = services.catalog;
-      const payload = await catalog.listApps({ page, limit, q: query, category });
+      const payload = await catalog.listApps({ page, limit, q: query, category, source });
       return json(payload);
     } catch (error) {
       // No bundled fallback — the only catalog is the remote one (HOLA_CATALOG_URL).
@@ -439,10 +442,11 @@ async function route(url: URL, req: Request): Promise<Response> {
   const catalogAppMatch = pathname.match(/^\/api\/catalog\/apps\/([^/]+)$/);
   if (catalogAppMatch && req.method === 'GET') {
     const appId = decodeURIComponent(catalogAppMatch[1]);
+    const source = searchParams.get('source') || undefined;
     try {
       const services = getServices();
       const catalog = services.catalog;
-      const payload = await catalog.getApp(appId);
+      const payload = await catalog.getApp(appId, source);
       return json(payload);
     } catch {
       return notFound();
@@ -452,10 +456,11 @@ async function route(url: URL, req: Request): Promise<Response> {
   const catalogVersionsMatch = pathname.match(/^\/api\/catalog\/apps\/([^/]+)\/versions$/);
   if (catalogVersionsMatch && req.method === 'GET') {
     const appId = decodeURIComponent(catalogVersionsMatch[1]);
+    const source = searchParams.get('source') || undefined;
     try {
       const services = getServices();
       const catalog = services.catalog;
-      const payload = await catalog.getVersions(appId);
+      const payload = await catalog.getVersions(appId, source);
       return json(payload);
     } catch {
       return notFound();
@@ -466,10 +471,11 @@ async function route(url: URL, req: Request): Promise<Response> {
   if (catalogVersionDetailMatch && req.method === 'GET') {
     const appId = decodeURIComponent(catalogVersionDetailMatch[1]);
     const version = decodeURIComponent(catalogVersionDetailMatch[2]);
+    const source = searchParams.get('source') || undefined;
     try {
       const services = getServices();
       const catalog = services.catalog;
-      const payload = await catalog.getVersionDetail(appId, version);
+      const payload = await catalog.getVersionDetail(appId, version, source);
       return json(payload);
     } catch (error) {
       logger.warn('Catalog version detail failed', { appId, version, error: error instanceof Error ? error.message : String(error) });
@@ -531,6 +537,51 @@ async function route(url: URL, req: Request): Promise<Response> {
       if (message === 'CREDENTIAL_NOT_FOUND') return notFound();
       logger.error('Failed to remove registry credential', error as Error);
       return json({ error: { code: 'CREDENTIAL_REMOVE_FAILED', message: 'Failed to remove registry credential' } }, { status: 500 });
+    }
+  }
+
+  // ===== CATALOG SOURCE ROUTES =====
+  // Managed list of catalog.json sources (Homebrew-tap model). Instance-level,
+  // admin-gated. The built-in `hola` source is synthesized (not stored) and can't
+  // be removed.
+  if (pathname === API.catalogSources.base && req.method === 'GET') {
+    try {
+      const items = await getServices().catalogSources.list();
+      return json({ items } satisfies ListCatalogSourcesResponse);
+    } catch (error) {
+      logger.error('Failed to list catalog sources', error as Error);
+      return json({ error: { code: 'SOURCE_LIST_FAILED', message: 'Failed to list catalog sources' } }, { status: 500 });
+    }
+  }
+
+  if (pathname === API.catalogSources.base && req.method === 'POST') {
+    try {
+      const body = (await req.json().catch(() => ({}))) as Partial<AddCatalogSourceRequest>;
+      if (!body.id || !body.url) {
+        return json({ error: { code: 'MISSING_FIELDS', message: 'id and url are required' } }, { status: 400 });
+      }
+      const record = await getServices().catalogSources.add(body as AddCatalogSourceRequest);
+      return json(record, { status: 201 });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const status = message === 'SOURCE_ID_EXISTS' ? 409 : 400;
+      logger.warn('Failed to add catalog source', { error: message });
+      return json({ error: { code: 'SOURCE_ADD_FAILED', message } }, { status });
+    }
+  }
+
+  const sourceMatch = pathname.match(/^\/api\/catalog-sources\/([^/]+)$/);
+  if (sourceMatch && req.method === 'DELETE') {
+    const id = decodeURIComponent(sourceMatch[1]);
+    try {
+      await getServices().catalogSources.remove(id);
+      return json({ success: true });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (message === 'SOURCE_NOT_FOUND') return notFound();
+      const status = message === 'SOURCE_ID_RESERVED' ? 400 : 500;
+      logger.warn('Failed to remove catalog source', { error: message });
+      return json({ error: { code: 'SOURCE_REMOVE_FAILED', message } }, { status });
     }
   }
 

--- a/packages/server/src/services/core/catalog-sources.ts
+++ b/packages/server/src/services/core/catalog-sources.ts
@@ -1,0 +1,173 @@
+/**
+ * Catalog Source Service — Slice 2 (multi-catalog)
+ *
+ * Manages the list of catalog sources (the Homebrew-tap / `helm repo add` model).
+ * A source is just a catalog.json (the SAME schema as the public catalog) hosted
+ * elsewhere, optionally with a stored credential for private package pulls.
+ * Instance-level and admin-gated — Hola has no per-user tenancy.
+ *
+ * The built-in `hola` source is NOT persisted: it's synthesized at read time from
+ * `catalogConfig.catalogUrl` so the env var stays authoritative and can't go
+ * stale. Only user-added custom sources live in config/catalog-sources.json.
+ */
+
+import { getLogger } from '../../lib/logger';
+import { catalogConfig } from '../../config/catalog';
+import type { HealthCheckable, ServiceHealth } from './types';
+import type { StorageService } from './storage';
+import type { CatalogSourceRecord, AddCatalogSourceRequest } from '@hola/shared';
+
+/** Reserved source ids that a custom source may not use. */
+export const RESERVED_SOURCE_IDS = new Set(['hola', 'ref', '(ref)']);
+
+const STORE_PATH = 'config/catalog-sources.json';
+
+interface SourceFile {
+  sources: CatalogSourceRecord[];
+}
+
+export interface CatalogSourceService extends HealthCheckable {
+  /** All sources: the synthesized built-in `hola` source first, then custom ones. */
+  list(): Promise<CatalogSourceRecord[]>;
+  /** Only the enabled sources (what the catalog aggregator fans out over). */
+  listEnabled(): Promise<CatalogSourceRecord[]>;
+  add(req: AddCatalogSourceRequest): Promise<CatalogSourceRecord>;
+  remove(id: string): Promise<void>;
+  /** A single source by id (built-in or custom), or undefined. */
+  get(id: string): Promise<CatalogSourceRecord | undefined>;
+}
+
+/** The built-in public catalog, synthesized from the env-configured URL. */
+export function builtinHolaSource(): CatalogSourceRecord {
+  return {
+    id: 'hola',
+    name: 'Hola (public catalog)',
+    type: 'index-url',
+    url: catalogConfig.catalogUrl ?? '',
+    trust: 'verified',
+    enabled: true,
+  };
+}
+
+function isHttpUrl(url: string): boolean {
+  try {
+    const u = new URL(url);
+    return u.protocol === 'https:' || u.protocol === 'http:';
+  } catch {
+    return false;
+  }
+}
+
+export class RealCatalogSourceService implements CatalogSourceService {
+  private logger = getLogger().child({ service: 'CatalogSourceService' });
+
+  constructor(private storage: StorageService) {}
+
+  async healthCheck(): Promise<ServiceHealth> {
+    try {
+      await this.loadCustom();
+      return { healthy: true, lastCheck: new Date() };
+    } catch (error) {
+      return { healthy: false, lastCheck: new Date(), error: error instanceof Error ? error.message : String(error) };
+    }
+  }
+
+  private async loadCustom(): Promise<CatalogSourceRecord[]> {
+    if (!(await this.storage.fileExists(STORE_PATH))) return [];
+    try {
+      const parsed = JSON.parse(await this.storage.readFileAsString(STORE_PATH)) as SourceFile;
+      return Array.isArray(parsed?.sources) ? parsed.sources : [];
+    } catch (error) {
+      this.logger.warn('Failed to read catalog sources; treating as empty', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return [];
+    }
+  }
+
+  private async saveCustom(sources: CatalogSourceRecord[]): Promise<void> {
+    await this.storage.writeFile(STORE_PATH, JSON.stringify({ sources } satisfies SourceFile, null, 2));
+  }
+
+  async list(): Promise<CatalogSourceRecord[]> {
+    return [builtinHolaSource(), ...(await this.loadCustom())];
+  }
+
+  async listEnabled(): Promise<CatalogSourceRecord[]> {
+    return (await this.list()).filter(s => s.enabled && s.url);
+  }
+
+  async get(id: string): Promise<CatalogSourceRecord | undefined> {
+    return (await this.list()).find(s => s.id === id);
+  }
+
+  async add(req: AddCatalogSourceRequest): Promise<CatalogSourceRecord> {
+    const id = (req.id || '').trim();
+    if (!id) throw new Error('SOURCE_ID_REQUIRED');
+    if (RESERVED_SOURCE_IDS.has(id)) throw new Error('SOURCE_ID_RESERVED');
+    if (!/^[a-z0-9][a-z0-9-]*$/.test(id)) throw new Error('SOURCE_ID_INVALID');
+    if (!req.url || !isHttpUrl(req.url)) throw new Error('SOURCE_URL_INVALID');
+    if (req.auth && (!req.auth.registry || !req.auth.credentialRef)) throw new Error('SOURCE_AUTH_INVALID');
+
+    const custom = await this.loadCustom();
+    if (custom.some(s => s.id === id)) throw new Error('SOURCE_ID_EXISTS');
+
+    const record: CatalogSourceRecord = {
+      id,
+      name: (req.name || '').trim() || id,
+      type: 'index-url',
+      url: req.url.trim(),
+      auth: req.auth,
+      trust: 'custom',
+      enabled: req.enabled ?? true,
+    };
+    custom.push(record);
+    await this.saveCustom(custom);
+    this.logger.info('Catalog source added', { id, url: record.url, hasAuth: Boolean(record.auth) });
+    return record;
+  }
+
+  async remove(id: string): Promise<void> {
+    if (RESERVED_SOURCE_IDS.has(id)) throw new Error('SOURCE_ID_RESERVED');
+    const custom = await this.loadCustom();
+    const next = custom.filter(s => s.id !== id);
+    if (next.length === custom.length) throw new Error('SOURCE_NOT_FOUND');
+    await this.saveCustom(next);
+    this.logger.info('Catalog source removed', { id });
+  }
+}
+
+/** In-memory source store for tests/dev. Always includes the built-in `hola`. */
+export class MockCatalogSourceService implements CatalogSourceService {
+  private custom: CatalogSourceRecord[] = [];
+
+  async healthCheck(): Promise<ServiceHealth> {
+    return { healthy: true, lastCheck: new Date() };
+  }
+  async list(): Promise<CatalogSourceRecord[]> {
+    return [builtinHolaSource(), ...this.custom];
+  }
+  async listEnabled(): Promise<CatalogSourceRecord[]> {
+    return (await this.list()).filter(s => s.enabled && s.url);
+  }
+  async get(id: string): Promise<CatalogSourceRecord | undefined> {
+    return (await this.list()).find(s => s.id === id);
+  }
+  async add(req: AddCatalogSourceRequest): Promise<CatalogSourceRecord> {
+    const id = (req.id || '').trim();
+    if (RESERVED_SOURCE_IDS.has(id)) throw new Error('SOURCE_ID_RESERVED');
+    if (this.custom.some(s => s.id === id)) throw new Error('SOURCE_ID_EXISTS');
+    const record: CatalogSourceRecord = {
+      id, name: req.name || id, type: 'index-url', url: req.url,
+      auth: req.auth, trust: 'custom', enabled: req.enabled ?? true,
+    };
+    this.custom.push(record);
+    return record;
+  }
+  async remove(id: string): Promise<void> {
+    if (RESERVED_SOURCE_IDS.has(id)) throw new Error('SOURCE_ID_RESERVED');
+    const next = this.custom.filter(s => s.id !== id);
+    if (next.length === this.custom.length) throw new Error('SOURCE_NOT_FOUND');
+    this.custom = next;
+  }
+}

--- a/packages/server/src/services/core/catalog.ts
+++ b/packages/server/src/services/core/catalog.ts
@@ -13,7 +13,11 @@ import type {
   GetCatalogAppVersionDetailResponse,
   CatalogApp,
   CatalogAppVersion,
+  CatalogSourceRecord,
+  CatalogSourceTrust,
 } from '@hola/shared';
+import type { CatalogSourceService } from './catalog-sources';
+import type { RegistryCredentialService } from './registry-credentials';
 import { coerceManifestAuth } from './manifest-auth';
 import { coerceConsumes } from './app-registry';
 import { coerceManifestUpgrade } from './manifest-upgrade';
@@ -95,9 +99,9 @@ export function parseOciRef(ref: string): { appId: string; version: string } {
 
 export interface CatalogService {
   listApps(req: GetCatalogAppsRequest): Promise<GetCatalogAppsResponse>;
-  getApp(appId: string): Promise<GetCatalogAppResponse>;
-  getVersions(appId: string): Promise<GetCatalogAppVersionsResponse>;
-  getVersionDetail(appId: string, version: string): Promise<GetCatalogAppVersionDetailResponse>;
+  getApp(appId: string, source?: string): Promise<GetCatalogAppResponse>;
+  getVersions(appId: string, source?: string): Promise<GetCatalogAppVersionsResponse>;
+  getVersionDetail(appId: string, version: string, source?: string): Promise<GetCatalogAppVersionDetailResponse>;
   /**
    * Resolve a version detail directly from an OCI package reference, bypassing
    * the catalog index (Slice 1 install-by-ref). Pulls + validates + coerces the
@@ -108,35 +112,176 @@ export interface CatalogService {
   refresh(force?: boolean): Promise<void>;
 }
 
-export class RealCatalogService implements CatalogService, HealthCheckable {
-  private logger = getLogger().child({ service: 'RealCatalogService' });
+/**
+ * One catalog.json source: encapsulates the HTTP fetch with ETag/Last-Modified
+ * conditional requests, a timeout with stale-cache fallback, and concurrent-fetch
+ * de-duplication. The aggregator holds one of these per enabled source.
+ */
+export class SourceCatalog {
+  private logger = getLogger().child({ service: 'SourceCatalog' });
   private cache: { data: RemoteCatalog | null; ts: number; etag?: string; lastModified?: string } = { data: null, ts: 0 };
   private inflight?: Promise<void>;
 
-  /** Optional injected bundle service (tests). Production resolves it lazily from
-   *  the service factory to avoid a circular import at module load. */
-  constructor(private bundlesOverride?: BundleService) {}
+  constructor(readonly url: string) {}
+
+  async ensureLoaded(): Promise<RemoteCatalog> {
+    const now = Date.now();
+    if (this.cache.data && now - this.cache.ts < catalogConfig.refreshIntervalMs) return this.cache.data;
+    await this.load();
+    if (!this.cache.data) throw new Error('CATALOG_UNAVAILABLE');
+    return this.cache.data;
+  }
+
+  async refresh(force = false): Promise<void> {
+    const now = Date.now();
+    if (!force && now - this.cache.ts < catalogConfig.refreshIntervalMs) return;
+    await this.load();
+  }
+
+  private async load(): Promise<void> {
+    if (this.inflight) { await this.inflight; return; }
+
+    if (!this.url) {
+      this.cache = { data: { apps: [] }, ts: Date.now() };
+      return;
+    }
+
+    this.inflight = (async () => {
+      this.logger.info('Fetching catalog source', { url: this.url });
+      const headers: Record<string, string> = {};
+      if (this.cache.etag) headers['If-None-Match'] = this.cache.etag;
+      if (this.cache.lastModified) headers['If-Modified-Since'] = this.cache.lastModified;
+
+      const controller = new AbortController();
+      const tid = setTimeout(() => controller.abort(), catalogConfig.fetchTimeoutMs || 3000);
+      try {
+        const res = await fetch(this.url, { headers, signal: controller.signal });
+        if (res.status === 304 && this.cache.data) {
+          this.cache.ts = Date.now();
+          return;
+        }
+        if (!res.ok) throw new Error(`Catalog fetch failed: ${res.status}`);
+        const data = (await res.json()) as RemoteCatalog;
+        this.cache = {
+          data,
+          ts: Date.now(),
+          etag: res.headers.get('etag') || undefined,
+          lastModified: res.headers.get('last-modified') || undefined,
+        };
+      } catch (error) {
+        if (error instanceof Error && (error.name === 'AbortError' || error.message.includes('aborted'))) {
+          this.logger.warn('Catalog fetch aborted (timeout)', { url: this.url, timeoutMs: catalogConfig.fetchTimeoutMs });
+          if (this.cache.data) { this.cache.ts = Date.now(); return; }
+        }
+        if (!this.cache.data) throw error instanceof Error ? error : new Error(String(error));
+        this.logger.warn('Catalog fetch failed; retaining prior cache', { url: this.url, error: error instanceof Error ? error.message : String(error) });
+        this.cache.ts = Date.now();
+      } finally {
+        clearTimeout(tid);
+      }
+    })();
+
+    try {
+      await this.inflight;
+    } finally {
+      this.inflight = undefined;
+    }
+  }
+}
+
+/**
+ * Display/collision key for an app across sources: bare for the built-in `hola`
+ * source, `<sourceId>/<appId>` otherwise, so a private app can't collide with a
+ * public one. NOTE: this is NOT the wire id — `CatalogApp.id` stays bare and the
+ * source travels in a separate `source` field.
+ */
+export function qualifiedId(source: string, appId: string): string {
+  return source === 'hola' ? appId : `${source}/${appId}`;
+}
+
+export class RealCatalogService implements CatalogService, HealthCheckable {
+  private logger = getLogger().child({ service: 'RealCatalogService' });
+  /** Per-source fetchers, keyed by `${id}::${url}` so a URL change re-fetches. */
+  private catalogs = new Map<string, SourceCatalog>();
+
+  /**
+   * All optional so existing constructions/tests keep working; production resolves
+   * bundles/sources/credentials lazily from the service factory to avoid a circular
+   * import at module load.
+   */
+  constructor(
+    private bundlesOverride?: BundleService,
+    private sourcesOverride?: CatalogSourceService,
+    private credentialsOverride?: RegistryCredentialService,
+  ) {}
+
+  private async sourcesService(): Promise<CatalogSourceService> {
+    return this.sourcesOverride ?? (await import('../simple-factory')).getServices().catalogSources;
+  }
+
+  private async credentialsService(): Promise<RegistryCredentialService> {
+    return this.credentialsOverride ?? (await import('../simple-factory')).getServices().registryCredentials;
+  }
+
+  /** Reuse (or create) the fetcher for a source, re-creating it if the URL changed. */
+  private catalogFor(source: CatalogSourceRecord): SourceCatalog {
+    const key = `${source.id}::${source.url}`;
+    let sc = this.catalogs.get(key);
+    if (!sc) {
+      // Drop any stale entry for this id under a different URL.
+      for (const k of this.catalogs.keys()) if (k.startsWith(`${source.id}::`)) this.catalogs.delete(k);
+      sc = new SourceCatalog(source.url);
+      this.catalogs.set(key, sc);
+    }
+    return sc;
+  }
+
+  /** The sources to serve: a single one when `source` is given (else all enabled). */
+  private async resolveSources(source?: string): Promise<CatalogSourceRecord[]> {
+    const svc = await this.sourcesService();
+    if (source) {
+      const rec = await svc.get(source);
+      return rec ? [rec] : [];
+    }
+    return svc.listEnabled();
+  }
 
   async healthCheck(): Promise<ServiceHealth> {
-    try {
-      // If a catalog URL is configured, attempt a HEAD/GET
-      if (catalogConfig.catalogUrl) {
-        await this.ensureLoaded();
-      }
-      return { healthy: true, lastCheck: new Date() };
-    } catch (error) {
-      return { healthy: false, lastCheck: new Date(), error: error instanceof Error ? error.message : String(error) };
-    }
+    // Fetch failures are fail-soft in listApps, so health is about the service
+    // being wired, not every source being reachable.
+    return { healthy: true, lastCheck: new Date() };
   }
 
   async listApps(req: GetCatalogAppsRequest): Promise<GetCatalogAppsResponse> {
-    const data = await this.ensureLoaded();
     const page = req.page ?? 1;
     const limit = req.limit ?? 12;
     const q = (req.q || req.query || '').toLowerCase();
     const category = req.category?.toLowerCase();
 
-    let items = data.apps.map(this.mapApp);
+    const sources = await this.resolveSources(req.source);
+    // Fan out; a slow/broken source must not sink the whole listing.
+    const results = await Promise.allSettled(
+      sources.map(async (s) => {
+        const data = await this.catalogFor(s).ensureLoaded();
+        return data.apps.map(a => this.mapApp(a, s));
+      })
+    );
+
+    // Merge + dedupe by the source-qualified id (an app can appear once per source).
+    const seen = new Set<string>();
+    let items: CatalogApp[] = [];
+    for (const r of results) {
+      if (r.status !== 'fulfilled') {
+        this.logger.warn('A catalog source failed to load; skipping', { error: r.reason instanceof Error ? r.reason.message : String(r.reason) });
+        continue;
+      }
+      for (const app of r.value) {
+        const key = qualifiedId(app.source, app.id);
+        if (seen.has(key)) continue;
+        seen.add(key);
+        items.push(app);
+      }
+    }
 
     if (q) {
       items = items.filter(a =>
@@ -151,33 +296,24 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
 
     const total = items.length;
     const start = (page - 1) * limit;
-    const slice = items.slice(start, start + limit);
-
-    return { items: slice, page, limit, total };
+    return { items: items.slice(start, start + limit), page, limit, total };
   }
 
-  async getApp(appId: string): Promise<GetCatalogAppResponse> {
-    const data = await this.ensureLoaded();
-    const app = data.apps.find(a => a.id === appId);
-    if (!app) throw new Error('APP_NOT_FOUND');
-    const mapped = this.mapApp(app);
+  async getApp(appId: string, source = 'hola'): Promise<GetCatalogAppResponse> {
+    const { app, record } = await this.locateApp(appId, source);
+    const mapped = this.mapApp(app, record);
     const versions = (app.versions || []).map(v => v.version);
     return { ...mapped, versions };
   }
 
-  async getVersions(appId: string): Promise<GetCatalogAppVersionsResponse> {
-    const data = await this.ensureLoaded();
-    const app = data.apps.find(a => a.id === appId);
-    if (!app) throw new Error('APP_NOT_FOUND');
+  async getVersions(appId: string, source = 'hola'): Promise<GetCatalogAppVersionsResponse> {
+    const { app } = await this.locateApp(appId, source);
     const items: CatalogAppVersion[] = (app.versions || []).map(v => ({ version: v.version, createdAt: v.createdAt || new Date().toISOString() }));
     return { items, total: items.length };
   }
 
-  async getVersionDetail(appId: string, version: string, credentials?: PullCredentials, source?: string): Promise<GetCatalogAppVersionDetailResponse> {
-    // Locate app/version with OCI ref
-    const data = await this.ensureLoaded();
-    const app = data.apps.find(a => a.id === appId);
-    if (!app) throw new Error('APP_NOT_FOUND');
+  async getVersionDetail(appId: string, version: string, source = 'hola'): Promise<GetCatalogAppVersionDetailResponse> {
+    const { app, record } = await this.locateApp(appId, source);
     const versions = app.versions || [];
     // Resolve the meta-version "latest" (and an unspecified version) to the
     // newest concrete release. Catalog entries pin real versions (e.g. 1.2.1),
@@ -191,14 +327,27 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
     const ref = v.refs?.oci;
     if (!ref) throw new Error('NO_OCI_REF');
 
-    // Pull and validate bundle. Key the cache by the RESOLVED concrete version
-    // (`v.version`), NOT the meta-version `version` ("latest"). ensurePulled skips
-    // the OCI pull when a cached bundle's compose.yaml+manifest.json already exist,
-    // so caching under `<app>/latest` means a server that installed an app before a
-    // fix was published keeps serving that stale `latest` bundle forever — the new
-    // concrete version never gets pulled. Keying by the concrete version makes every
-    // new release a cache miss, so published fixes actually reach existing servers.
-    return this.pullValidateBuild({ appId, source, version: v.version, ociRef: ref, credentials });
+    // Resolve the source's stored credential (if any) for a private package pull.
+    let credentials: PullCredentials | undefined;
+    if (record.auth?.credentialRef) {
+      credentials = await (await this.credentialsService()).resolve(record.auth.credentialRef);
+      if (!credentials) throw new Error(`CREDENTIAL_NOT_FOUND: ${record.auth.credentialRef}`);
+    }
+
+    // Key the cache by the RESOLVED concrete version (`v.version`) + source, so a
+    // published fix reaches existing servers (a "latest" cache would go stale) and
+    // two sources can't alias the same appId/version.
+    return this.pullValidateBuild({ appId, source: record.id, version: v.version, ociRef: ref, credentials });
+  }
+
+  /** Find an app within a specific source's catalog (default the built-in `hola`). */
+  private async locateApp(appId: string, source: string): Promise<{ app: RemoteCatalog['apps'][number]; record: CatalogSourceRecord }> {
+    const record = await (await this.sourcesService()).get(source);
+    if (!record) throw new Error('APP_NOT_FOUND');
+    const data = await this.catalogFor(record).ensureLoaded();
+    const app = data.apps.find(a => a.id === appId);
+    if (!app) throw new Error('APP_NOT_FOUND');
+    return { app, record };
   }
 
   async getVersionDetailByRef(ociRef: string, credentials?: PullCredentials): Promise<GetCatalogAppVersionDetailResponse & { appId: string }> {
@@ -341,87 +490,11 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
   }
 
   async refresh(force = false): Promise<void> {
-    const now = Date.now();
-    if (!force && now - this.cache.ts < catalogConfig.refreshIntervalMs) return;
-    await this.loadRemoteCatalog();
+    const sources = await this.resolveSources();
+    await Promise.allSettled(sources.map(s => this.catalogFor(s).refresh(force)));
   }
 
-  // Helpers
-  private async ensureLoaded(): Promise<RemoteCatalog> {
-    const now = Date.now();
-    if (this.cache.data && (now - this.cache.ts < catalogConfig.refreshIntervalMs)) {
-      return this.cache.data;
-    }
-    await this.loadRemoteCatalog();
-    if (!this.cache.data) throw new Error('CATALOG_UNAVAILABLE');
-    return this.cache.data;
-  }
-
-  private async loadRemoteCatalog(): Promise<void> {
-    // De-duplicate concurrent fetches
-    if (this.inflight) {
-      await this.inflight;
-      return;
-    }
-
-    if (!catalogConfig.catalogUrl) {
-      // Without a URL, treat as healthy but empty; callers will fallback if needed
-      this.logger.info('No catalog URL configured; real catalog is inert');
-      this.cache = { data: { apps: [] }, ts: Date.now() };
-      return;
-    }
-
-    this.inflight = (async () => {
-      this.logger.info('Fetching remote catalog', { url: catalogConfig.catalogUrl });
-      const headers: Record<string, string> = {};
-      if (this.cache.etag) headers['If-None-Match'] = this.cache.etag;
-      if (this.cache.lastModified) headers['If-Modified-Since'] = this.cache.lastModified;
-
-      const controller = new AbortController();
-      const tid = setTimeout(() => controller.abort(), catalogConfig.fetchTimeoutMs || 3000);
-      try {
-        const res = await fetch(catalogConfig.catalogUrl!, { headers, signal: controller.signal });
-        if (res.status === 304 && this.cache.data) {
-          this.logger.debug('Catalog not modified');
-          this.cache.ts = Date.now();
-          return;
-        }
-        if (!res.ok) throw new Error(`Catalog fetch failed: ${res.status}`);
-        const data = (await res.json()) as RemoteCatalog;
-        this.cache = {
-          data,
-            ts: Date.now(),
-            etag: res.headers.get('etag') || undefined,
-            lastModified: res.headers.get('last-modified') || undefined,
-        };
-      } catch (error) {
-        if ((error instanceof Error && error.name === 'AbortError') || (error instanceof Error && error.message.includes('aborted'))) {
-          this.logger.warn('Catalog fetch aborted (timeout)', { timeoutMs: catalogConfig.fetchTimeoutMs });
-          // If we have existing cache, treat as not modified
-          if (this.cache.data) {
-            this.cache.ts = Date.now();
-            return;
-          }
-        }
-        // Re-throw for outer callers when no cache exists
-        if (!this.cache.data) {
-          throw error instanceof Error ? error : new Error(String(error));
-        }
-        this.logger.warn('Catalog fetch failed; retaining prior cache', { error: error instanceof Error ? error.message : String(error) });
-        this.cache.ts = Date.now();
-      } finally {
-        clearTimeout(tid);
-      }
-    })();
-
-    try {
-      await this.inflight;
-    } finally {
-      this.inflight = undefined;
-    }
-  }
-
-  private mapApp(app: RemoteCatalog['apps'][number]): CatalogApp {
+  private mapApp(app: RemoteCatalog['apps'][number], source: CatalogSourceRecord): CatalogApp {
     return {
       id: app.id,
       name: app.name,
@@ -432,6 +505,8 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
       downloads: app.downloads ?? 0,
       tags: app.tags || [],
       featured: !!app.featured,
+      source: source.id,
+      trust: source.trust as CatalogSourceTrust,
     };
   }
 }

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -568,6 +568,9 @@ abstract class InMemoryDeploymentService implements DeploymentService {
           // Captured from the authenticated principal at create time (the deploy
           // job runs async without a request context). Feeds `${HOLA_USER_EMAIL}`.
           ...(request.installedBy ? { installedBy: request.installedBy } : {}),
+          // The catalog source (default `hola`), carried through the finalized
+          // manifest, so update detection checks the right source.
+          ...(artifacts?.manifest.source ? { source: artifacts.manifest.source } : {}),
         },
       };
       this.deployments.set(deploymentId, deployment);
@@ -706,7 +709,7 @@ abstract class InMemoryDeploymentService implements DeploymentService {
    * in-memory/mock service has no catalog); RealDeploymentService overrides it.
    */
   protected async enrichUpdateInfo(
-    items: Array<{ app: string; version?: string; latestVersion?: string; updateAvailable?: boolean }>,
+    items: Array<{ id?: string; app: string; version?: string; latestVersion?: string; updateAvailable?: boolean }>,
   ): Promise<void> {
     void items;
   }
@@ -1423,23 +1426,32 @@ export class RealDeploymentService extends InMemoryDeploymentService {
    * fields unset rather than failing the list/detail request.
    */
   protected override async enrichUpdateInfo(
-    items: Array<{ app: string; version?: string; latestVersion?: string; updateAvailable?: boolean }>,
+    items: Array<{ id?: string; app: string; version?: string; latestVersion?: string; updateAvailable?: boolean }>,
   ): Promise<void> {
     if (!this.catalogService || items.length === 0) return;
-    const latestByApp = new Map<string, string | undefined>();
-    for (const app of new Set(items.map((i) => i.app))) {
+    // The source an item was installed from (default `hola`), so update detection
+    // queries the right catalog. Keyed per (source, app) since two sources could
+    // publish the same appId. `(ref)` installs have no index to check → skipped.
+    const sourceOf = (item: { id?: string; app: string }) =>
+      (item.id ? this.deployments.get(item.id)?.metadata?.source : undefined) ?? 'hola';
+    const latestByKey = new Map<string, string | undefined>();
+    for (const item of items) {
+      const source = sourceOf(item);
+      const key = `${source}::${item.app}`;
+      if (latestByKey.has(key)) continue;
+      if (source === '(ref)') { latestByKey.set(key, undefined); continue; }
       try {
-        const { items: versions } = await this.catalogService.getVersions(app);
+        const { items: versions } = await this.catalogService.getVersions(item.app, source);
         const newest = versions
           .map((v) => v.version)
           .reduce<string | undefined>((best, v) => (!best || isNewerVersion(v, best) ? v : best), undefined);
-        latestByApp.set(app, newest);
+        latestByKey.set(key, newest);
       } catch {
-        latestByApp.set(app, undefined); // app not in catalog / catalog down — skip
+        latestByKey.set(key, undefined); // app not in catalog / catalog down — skip
       }
     }
     for (const item of items) {
-      const latest = latestByApp.get(item.app);
+      const latest = latestByKey.get(`${sourceOf(item)}::${item.app}`);
       if (!latest) continue;
       item.latestVersion = latest;
       // Only flag an update when the installed version is a concrete, comparable

--- a/packages/server/src/services/core/draft.ts
+++ b/packages/server/src/services/core/draft.ts
@@ -334,11 +334,11 @@ export class RealDraftService implements DraftService {
     this.logger.info('Creating draft', { draftId, appId: request.appId, version: request.version, source });
 
     try {
-      // Get app info from catalog
-      const app = await this.catalogService.getApp(request.appId);
+      // Get app info from catalog (from the requested source, default `hola`)
+      const app = await this.catalogService.getApp(request.appId, source);
 
       // Get default environment and configuration
-      const defaults = await this.getDraftDefaults(request.appId, request.version);
+      const defaults = await this.getDraftDefaults(request.appId, request.version, source);
 
       // Seed the draft's compose from the catalog bundle so it can be deployed
       // without the user pasting compose. Guard it through the same parse check
@@ -781,9 +781,9 @@ export class RealDraftService implements DraftService {
     };
   }
 
-  async getDraftDefaults(appId: string, version?: string): Promise<{ env: AppEnvVar[]; defaults: DraftDefaults; composeOverride: string; auth?: AppAuthConfig; consumes?: string[]; ingressService?: string; upgrade?: AppUpgradeMeta; backup?: AppBackupConfig; resolvedVersion?: string }> {
+  async getDraftDefaults(appId: string, version?: string, source?: string): Promise<{ env: AppEnvVar[]; defaults: DraftDefaults; composeOverride: string; auth?: AppAuthConfig; consumes?: string[]; ingressService?: string; upgrade?: AppUpgradeMeta; backup?: AppBackupConfig; resolvedVersion?: string }> {
     try {
-      const versionDetail = await this.catalogService.getVersionDetail(appId, version || 'latest');
+      const versionDetail = await this.catalogService.getVersionDetail(appId, version || 'latest', source);
       return {
         env: versionDetail.defaultEnv,
         defaults: versionDetail.defaults,

--- a/packages/server/src/services/simple-factory.ts
+++ b/packages/server/src/services/simple-factory.ts
@@ -23,6 +23,7 @@ import { InProcessEventBus, type EventBus } from './core/event-bus';
 import { RealCatalogService, MockCatalogService, type CatalogService } from './core/catalog';
 import { RealBundleService, MockBundleService, type BundleService } from './core/bundles';
 import { RealRegistryCredentialService, MockRegistryCredentialService, type RegistryCredentialService } from './core/registry-credentials';
+import { RealCatalogSourceService, MockCatalogSourceService, type CatalogSourceService } from './core/catalog-sources';
 import { RealDraftService, MockDraftService, type DraftService } from './core/draft';
 import { RealValidationService, MockValidationService, type ValidationService } from './core/validation';
 import { RealRoutingService, MockRoutingService, type RoutingService } from './core/routing';
@@ -48,6 +49,7 @@ export interface Services {
   catalog: CatalogService;
   bundles: BundleService;
   registryCredentials: RegistryCredentialService;
+  catalogSources: CatalogSourceService;
   drafts: DraftService;
   validation: ValidationService;
   routing: RoutingService;
@@ -91,6 +93,7 @@ export function createServices(env: ServiceEnvironment): Services {
       catalog: new MockCatalogService(),
       bundles: new MockBundleService(),
       registryCredentials: new MockRegistryCredentialService(),
+      catalogSources: new MockCatalogSourceService(),
       drafts: new MockDraftService(),
       validation: new MockValidationService(),
       routing: new MockRoutingService(),
@@ -148,6 +151,7 @@ export function createServices(env: ServiceEnvironment): Services {
       catalog,
       bundles: new RealBundleService(storage.resolveHolaPath('cache', 'bundles')),
       registryCredentials,
+      catalogSources: new RealCatalogSourceService(storage),
       drafts,
       validation,
       routing,
@@ -217,6 +221,7 @@ export function createServices(env: ServiceEnvironment): Services {
     catalog,
     bundles: new RealBundleService(storage.resolveHolaPath('cache', 'bundles')),
     registryCredentials,
+    catalogSources: new RealCatalogSourceService(storage),
     drafts,
     validation,
     routing,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -32,6 +32,13 @@ export const API = {
   // and the shared primitive every catalog install builds on).
   installFromRef: '/api/install-from-ref',
 
+  // Managed list of catalog sources (Homebrew-tap model). Instance-level,
+  // admin-gated. The built-in public catalog is the seeded `hola` source.
+  catalogSources: {
+    base: '/api/catalog-sources',
+    byId: (id: string) => `/api/catalog-sources/${id}`,
+  },
+
   drafts: {
     create: '/api/drafts',
     byId: (draftId: string) => `/api/drafts/${draftId}`,
@@ -388,6 +395,8 @@ export type GetSummaryResponse = {
 // ------------------------------------------------------
 // Catalog
 // ------------------------------------------------------
+export type CatalogSourceTrust = 'verified' | 'custom';
+
 export type CatalogApp = {
   id: string;
   name: string;
@@ -398,6 +407,10 @@ export type CatalogApp = {
   downloads: string | number;
   tags: string[];
   featured: boolean;
+  // Which catalog source this app comes from (defaults to `hola`, the built-in
+  // public catalog) and its trust level, so the UI can badge custom sources.
+  source: string;
+  trust: CatalogSourceTrust;
 };
 
 export type GetCatalogAppsRequest = PageRequest & {
@@ -452,6 +465,39 @@ export type InstallFromRefRequest = {
 
 export type InstallFromRefResponse = {
   draftId: string;
+};
+
+// ------------------------------------------------------
+// Catalog sources (managed list of catalog.json indexes)
+// ------------------------------------------------------
+
+/**
+ * A registered catalog source. `type: 'index-url'` points at a catalog.json (the
+ * SAME schema as the public catalog, hosted elsewhere). `auth` names a stored
+ * registry credential used to pull the source's private packages. `trust` badges
+ * the source in the UI; the built-in `hola` source is `verified`, user-added
+ * sources are `custom`.
+ */
+export type CatalogSourceRecord = {
+  id: string;
+  name: string;
+  type: 'index-url';
+  url: string;
+  auth?: { registry: string; credentialRef: string };
+  trust: CatalogSourceTrust;
+  enabled: boolean;
+};
+
+export type AddCatalogSourceRequest = {
+  id: string;
+  name: string;
+  url: string;
+  auth?: { registry: string; credentialRef: string };
+  enabled?: boolean;
+};
+
+export type ListCatalogSourcesResponse = {
+  items: CatalogSourceRecord[];
 };
 
 export type GetCatalogAppsResponse = PageResponse<CatalogApp>;
@@ -1192,6 +1238,9 @@ export type EnhancedDeploymentDetail = DeploymentDetail & {
     // context). `email` seeds the `${HOLA_USER_EMAIL}` compose token. Only present
     // for OIDC-authenticated dashboard users; absent for admin-key / CLI installs.
     installedBy?: { email?: string; name?: string };
+    // The catalog source this app was installed from (defaults to `hola`). Used to
+    // check the right source for available updates. `(ref)` for install-by-ref.
+    source?: string;
     // Auth artifacts provisioned for this deployment (if any), so they can be
     // reused on re-deploy and torn down on delete. Keyed on deploymentId.
     // `middleware` is set for forward-auth apps so the route can be re-emitted

--- a/packages/web/src/pages/Catalog.tsx
+++ b/packages/web/src/pages/Catalog.tsx
@@ -142,6 +142,9 @@ const AppDetailModal: React.FC<AppDetailModalProps> = ({ app, isOpen, onClose })
             <div>
               <h2 className="text-xl font-semibold">{app.name}</h2>
               <span className="text-sm text-text-muted bg-surface-2 px-2 py-1 rounded">{app.category}</span>
+              {app.source && app.source !== 'hola' && (
+                <span className="ml-2 text-xs text-warning bg-warning/10 px-2 py-1 rounded">{app.source} · {app.trust}</span>
+              )}
             </div>
           </div>
           <button
@@ -239,7 +242,10 @@ const AppDetailModal: React.FC<AppDetailModalProps> = ({ app, isOpen, onClose })
           </button>
           <div className="flex space-x-3">
             <Link
-              to={`/catalog/${app.id}/install${selectedVersion ? `?version=${selectedVersion}` : ''}`}
+              to={`/catalog/${app.id}/install?${new URLSearchParams({
+                ...(selectedVersion ? { version: selectedVersion } : {}),
+                ...(app.source && app.source !== 'hola' ? { source: app.source } : {}),
+              }).toString()}`}
               className="bg-primary text-primary-contrast px-6 py-2 rounded-lg font-medium hover:bg-primary/90 transition-colors"
               onClick={onClose}
             >
@@ -416,10 +422,11 @@ export const Catalog: React.FC = () => {
         <>
           <div className="grid gap-4 grid-cols-[repeat(auto-fill,minmax(300px,1fr))]">
             {apps.map((app: CatalogApp) => {
-              const installTo = `/catalog/${app.id}/install`;
+              const custom = app.source && app.source !== 'hola';
+              const installTo = `/catalog/${app.id}/install${custom ? `?source=${app.source}` : ''}`;
               return (
                 <div
-                  key={app.id}
+                  key={`${app.source}/${app.id}`}
                   onClick={() => navigate(installTo)}
                   className="bg-surface-1 border border-border rounded-card p-[18px] flex flex-col cursor-pointer transition hover:border-primary hover:-translate-y-[2px]"
                 >
@@ -432,7 +439,10 @@ export const Catalog: React.FC = () => {
                           <Star className="w-3.5 h-3.5 text-warning fill-current flex-none" />
                         )}
                       </div>
-                      <div className="text-xs text-text-faint mt-px">{app.category}</div>
+                      <div className="text-xs text-text-faint mt-px">
+                        {app.category}
+                        {custom && <span className="ml-1.5 text-warning">· {app.source} ({app.trust})</span>}
+                      </div>
                     </div>
                     <span className="font-mono text-[11px] text-text-faint flex items-center gap-1 flex-none">
                       <Download className="w-3 h-3" />

--- a/packages/web/src/pages/InstallWizard.tsx
+++ b/packages/web/src/pages/InstallWizard.tsx
@@ -33,6 +33,8 @@ export const InstallWizard: React.FC = () => {
   // a catalog index entry.
   const ociRef = searchParams.get('ref') || undefined;
   const credentialRef = searchParams.get('cred') || undefined;
+  // Catalog source the app comes from (Slice 2); defaults to the built-in `hola`.
+  const source = searchParams.get('source') || undefined;
   const [currentStep, setCurrentStep] = useState(0);
   
   // Draft API hooks
@@ -108,7 +110,7 @@ export const InstallWizard: React.FC = () => {
       try {
         const result = ociRef
           ? await createDraftHook.createDraft({ ociRef, credentialRef })
-          : await createDraftHook.createDraft({ appId });
+          : await createDraftHook.createDraft({ appId, source });
 
         // Update state with draft data. Float required-but-empty secrets to the
         // top so the operator sees what they must fill first (env order doesn't
@@ -132,7 +134,7 @@ export const InstallWizard: React.FC = () => {
     };
 
     initializeDraft();
-  }, [appId, ociRef, credentialRef, createDraftHook]); // Include the whole hook object
+  }, [appId, ociRef, credentialRef, source, createDraftHook]); // Include the whole hook object
 
   // Update draft data helper function
   const updateDraftData = React.useCallback(async (updates: PatchDraftRequest) => {

--- a/packages/web/src/pages/Settings.tsx
+++ b/packages/web/src/pages/Settings.tsx
@@ -15,7 +15,8 @@ import {
 import type {
   SystemEnvVar,
   GetBackupSettingsResponse,
-  RegistryCredentialRecord
+  RegistryCredentialRecord,
+  CatalogSourceRecord
 } from '@hola/shared';
 import { useSettingsApi } from '../hooks/useSettingsApi';
 import { useBackupSettingsApi } from '../hooks/useSettingsApi';
@@ -122,6 +123,119 @@ const RegistryCredentialsCard: React.FC<{ inputClass: string; labelClass: string
       ) : (
         <button onClick={() => setAdding(true)} className="flex items-center gap-2 text-[13px] font-medium text-primary hover:opacity-80 transition-opacity">
           <Plus className="w-4 h-4" /> Add credential
+        </button>
+      )}
+    </div>
+  );
+};
+
+/**
+ * Manage catalog sources (the Homebrew-tap model). A source is a catalog.json —
+ * the SAME schema as the public catalog — hosted elsewhere, optionally with a
+ * stored registry credential for private packages. The built-in `hola` source is
+ * always present (verified) and can't be removed.
+ */
+const CatalogSourcesCard: React.FC<{ inputClass: string; labelClass: string }> = ({ inputClass, labelClass }) => {
+  const [items, setItems] = useState<CatalogSourceRecord[]>([]);
+  const [creds, setCreds] = useState<RegistryCredentialRecord[]>([]);
+  const [adding, setAdding] = useState(false);
+  const [id, setId] = useState('');
+  const [name, setName] = useState('');
+  const [url, setUrl] = useState('');
+  const [credentialRef, setCredentialRef] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const refresh = React.useCallback(() => {
+    api.catalogSources.list().then(r => setItems(r.items)).catch(() => setItems([]));
+    api.registryCredentials.list().then(r => setCreds(r.items)).catch(() => setCreds([]));
+  }, []);
+  React.useEffect(() => { refresh(); }, [refresh]);
+
+  const add = async () => {
+    if (!id.trim() || !url.trim()) { setErr('id and url are required.'); return; }
+    setBusy(true); setErr(null);
+    try {
+      // Pair the credential with the registry host derived from the credential record.
+      const cred = creds.find(c => c.id === credentialRef);
+      const auth = cred ? { registry: cred.registry, credentialRef: cred.id } : undefined;
+      await api.catalogSources.add({ id: id.trim(), name: name.trim() || id.trim(), url: url.trim(), auth });
+      setId(''); setName(''); setUrl(''); setCredentialRef(''); setAdding(false);
+      refresh();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Failed to add source');
+    } finally { setBusy(false); }
+  };
+
+  const remove = async (sourceId: string) => {
+    setBusy(true); setErr(null);
+    try { await api.catalogSources.remove(sourceId); refresh(); }
+    catch (e) { setErr(e instanceof Error ? e.message : 'Failed to remove source'); }
+    finally { setBusy(false); }
+  };
+
+  return (
+    <div className="bg-surface-1 border border-border rounded-card p-5">
+      <div className="font-semibold text-[15px] mb-1">Catalog Sources</div>
+      <p className="text-[13px] text-text-muted mb-3.5">
+        Add your own app catalogs (the same <code>catalog.json</code> schema, hosted anywhere). Apps from custom sources are badged in the catalog.
+      </p>
+
+      {err && (
+        <div className="bg-danger-weak border border-danger/20 text-danger rounded-card p-3 text-[13px] mb-3 flex items-center gap-2">
+          <AlertTriangle className="w-4 h-4 flex-none" />
+          <span>{err}</span>
+        </div>
+      )}
+
+      <div className="flex flex-col gap-2 mb-3">
+        {items.map(s => (
+          <div key={s.id} className="flex items-center justify-between bg-surface-0 border border-border rounded-lg px-3 py-2">
+            <div className="text-[13px] min-w-0">
+              <span className="font-medium text-text-strong">{s.id}</span>
+              <span className={`ml-2 text-xs px-1.5 py-0.5 rounded ${s.trust === 'verified' ? 'text-success bg-success/10' : 'text-warning bg-warning/10'}`}>{s.trust}</span>
+              <div className="text-text-muted truncate">{s.url || '(built-in)'}</div>
+            </div>
+            {s.id !== 'hola' && (
+              <button onClick={() => remove(s.id)} disabled={busy} className="text-text-muted hover:text-danger transition-colors disabled:opacity-50 flex-none ml-2" aria-label={`Remove ${s.id}`}>
+                <X className="w-4 h-4" />
+              </button>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {adding ? (
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <div className={labelClass}>Source id</div>
+            <input value={id} onChange={(e) => setId(e.target.value)} placeholder="acme" className={inputClass} />
+          </div>
+          <div>
+            <div className={labelClass}>Name (optional)</div>
+            <input value={name} onChange={(e) => setName(e.target.value)} placeholder="Acme apps" className={inputClass} />
+          </div>
+          <div className="col-span-2">
+            <div className={labelClass}>Catalog URL</div>
+            <input value={url} onChange={(e) => setUrl(e.target.value)} placeholder="https://raw.githubusercontent.com/acme/hola-apps/main/catalog.json" className={inputClass} />
+          </div>
+          <div className="col-span-2">
+            <div className={labelClass}>Registry credential (for private packages)</div>
+            <select value={credentialRef} onChange={(e) => setCredentialRef(e.target.value)} className={inputClass}>
+              <option value="">None (public)</option>
+              {creds.map(c => <option key={c.id} value={c.id}>{c.id} — {c.registry}</option>)}
+            </select>
+          </div>
+          <div className="col-span-2 flex items-center gap-2">
+            <button onClick={add} disabled={busy} className="bg-primary text-primary-contrast px-4 py-2 rounded-lg text-[13px] font-medium hover:bg-primary/90 transition-colors disabled:opacity-50 flex items-center gap-2">
+              <Save className="w-4 h-4" /> Add source
+            </button>
+            <button onClick={() => { setAdding(false); setErr(null); }} className="px-4 py-2 rounded-lg text-[13px] text-text-muted hover:text-text-strong transition-colors">Cancel</button>
+          </div>
+        </div>
+      ) : (
+        <button onClick={() => setAdding(true)} className="flex items-center gap-2 text-[13px] font-medium text-primary hover:opacity-80 transition-opacity">
+          <Plus className="w-4 h-4" /> Add source
         </button>
       )}
     </div>
@@ -656,6 +770,9 @@ export const Settings: React.FC = () => {
 
         {/* Registry credentials for private OCI pulls (multi-catalog) */}
         <RegistryCredentialsCard inputClass={inputClass} labelClass={labelClass} />
+
+        {/* Catalog sources (Homebrew-tap model, multi-catalog) */}
+        <CatalogSourcesCard inputClass={inputClass} labelClass={labelClass} />
 
         {/* Identity management notice */}
         <div className="bg-surface-1 border border-border rounded-card p-5 flex items-start gap-3">

--- a/packages/web/src/utils/api-hybrid.ts
+++ b/packages/web/src/utils/api-hybrid.ts
@@ -54,6 +54,8 @@ export const api = {
   // Registry credentials + install-by-ref (multi-catalog Slice 1) — SDK-only.
   registryCredentials: sdkAdapter.registryCredentials,
   installFromRef: sdkAdapter.installFromRef,
+  // Catalog sources (multi-catalog Slice 2) — SDK-only.
+  catalogSources: sdkAdapter.catalogSources,
 
   // Deployment endpoints - not migrated yet
   deployments: USE_SDK_FOR.deployments

--- a/packages/web/src/utils/sdk-adapter.ts
+++ b/packages/web/src/utils/sdk-adapter.ts
@@ -10,6 +10,8 @@ import type {
   // Registry credentials + install-by-ref (multi-catalog Slice 1)
   AddRegistryCredentialRequest, ListRegistryCredentialsResponse, RegistryCredentialRecord,
   InstallFromRefRequest, InstallFromRefResponse,
+  // Catalog sources (multi-catalog Slice 2)
+  AddCatalogSourceRequest, ListCatalogSourcesResponse, CatalogSourceRecord,
   // Draft types  
   CreateDraftRequest, CreateDraftResponse, GetDraftResponse, 
   PatchDraftRequest, PatchDraftResponse, ValidateDraftResponse, FinalizeDraftResponse,
@@ -297,24 +299,24 @@ export class SdkAdapter {
 
   // Catalog with smart caching
   catalog = {
-    apps: (params?: { query?: string; category?: string; page?: number; limit?: number }): Promise<GetCatalogAppsResponse> => {
+    apps: (params?: { query?: string; category?: string; source?: string; page?: number; limit?: number }): Promise<GetCatalogAppsResponse> => {
       const query = this.buildQuery(params || {});
       const path = `/api/catalog/apps${query}`;
       return this.getWithCache(path, () => this.sdk.get<GetCatalogAppsResponse>(path));
     },
-    
-    appById: (appId: string): Promise<GetCatalogAppResponse> => {
-      const path = `/api/catalog/apps/${appId}`;
+
+    appById: (appId: string, source?: string): Promise<GetCatalogAppResponse> => {
+      const path = `/api/catalog/apps/${appId}${this.buildQuery({ source })}`;
       return this.getWithCache(path, () => this.sdk.get<GetCatalogAppResponse>(path));
     },
-    
-    versions: (appId: string): Promise<GetCatalogAppVersionsResponse> => {
-      const path = `/api/catalog/apps/${appId}/versions`;
+
+    versions: (appId: string, source?: string): Promise<GetCatalogAppVersionsResponse> => {
+      const path = `/api/catalog/apps/${appId}/versions${this.buildQuery({ source })}`;
       return this.getWithCache(path, () => this.sdk.get<GetCatalogAppVersionsResponse>(path));
     },
-    
-    versionDetail: (appId: string, version: string): Promise<GetCatalogAppVersionDetailResponse> => {
-      const path = `/api/catalog/apps/${appId}/versions/${encodeURIComponent(version)}`;
+
+    versionDetail: (appId: string, version: string, source?: string): Promise<GetCatalogAppVersionDetailResponse> => {
+      const path = `/api/catalog/apps/${appId}/versions/${encodeURIComponent(version)}${this.buildQuery({ source })}`;
       return this.getWithCache(path, () => this.sdk.get<GetCatalogAppVersionDetailResponse>(path));
     },
 
@@ -351,6 +353,25 @@ export class SdkAdapter {
   // Install a package straight from an OCI reference (escape hatch for one-offs).
   installFromRef = (data: InstallFromRefRequest): Promise<InstallFromRefResponse> =>
     this.enhancedRequest('POST', '/api/install-from-ref', () => this.sdk.installFromRef(data), data, false);
+
+  // Managed catalog sources (Homebrew-tap model). Mutations drop the cached list
+  // and the catalog listing so newly-added sources' apps surface.
+  catalogSources = {
+    list: (): Promise<ListCatalogSourcesResponse> =>
+      this.getWithCache('/api/catalog-sources', () => this.sdk.catalogSources.list()),
+    add: async (data: AddCatalogSourceRequest): Promise<CatalogSourceRecord> => {
+      const res = await this.sdk.catalogSources.add(data);
+      globalCache.deleteByPattern(/^api:.*\/catalog-sources/);
+      globalCache.deleteByPattern(/^api:.*\/catalog/);
+      return res;
+    },
+    remove: async (id: string): Promise<{ success: boolean }> => {
+      const res = await this.sdk.catalogSources.remove(id);
+      globalCache.deleteByPattern(/^api:.*\/catalog-sources/);
+      globalCache.deleteByPattern(/^api:.*\/catalog/);
+      return res;
+    },
+  };
 
   // Drafts (Install Wizard) with cache invalidation
   drafts = {


### PR DESCRIPTION
## Multi-catalog — Slice 2: custom catalog sources

Second of two stacked PRs, logically stacked on **#323 (Slice 1)**.

> ⚠️ **Merge order & review**: **Merge #323 first.** This PR temporarily targets
> `main` so CI runs on it (the repo's workflows only trigger on PRs targeting
> `main`), which means its diff currently also shows #323's commit. Review **only
> the `feat(catalog): custom catalog sources` commit** here. Once #323 squash-merges,
> I'll `git rebase --onto main …` this branch so the diff collapses to just the
> slice-2 commit. **Do not merge this before #323.**

Generalizes the single hardcoded catalog into a managed **list** of sources (the
Homebrew-tap / `helm repo add` model), building on the Slice-1 pull primitive. Users
add their own `catalog.json` — the **same schema** hosted elsewhere — and its apps
merge into the catalog, namespaced and trust-badged. The public catalog is unchanged
and still works with zero config.

### What's new
- **`CatalogSourceService`** (Real/Mock): add/list/remove, persisted to
  `config/catalog-sources.json`. The built-in `hola` source is **synthesized** from
  `HOLA_CATALOG_URL` (not stored, so the env stays authoritative) and can't be
  removed; reserved ids, invalid ids, and non-http URLs are rejected.
- **`RealCatalogService` is now an aggregator**: the per-source
  fetch/cache/etag/timeout logic is extracted into a reusable `SourceCatalog`;
  `listApps` fans out over enabled sources with `Promise.allSettled` (a broken
  source is skipped, not fatal), merges + dedupes by a source-qualified id, and
  badges each app with `source` + `trust`. `getApp`/`getVersions`/`getVersionDetail`
  take an optional `source` (default `hola`) and resolve the source's stored
  credential for private package pulls.
- **`appId` stays bare** + a separate `source` field travels alongside (default
  `hola`), so routes and persisted deployment records need no migration.
  `<sourceId>/<appId>` is only a display/collision key, never the wire id.
- **Update detection per source**: deployments persist their install source
  (`metadata.source`); update-available/rollback derive from the right source's
  index. `(ref)` installs have no index and are skipped (no false positives).
- **Surfaces**: `/api/catalog-sources` CRUD + `?source=` on the catalog GET routes;
  SDK `catalogSources` + `source` params; CLI `hola source add|list|rm`, `--source`
  on `catalog`/`install`, and source badges; web source/trust badges on catalog
  cards, a Settings → Catalog Sources panel, and `source` threaded through the
  install wizard.

### Tests
`bun run typecheck`, `bun run lint`, `bun run test` (server **432** + web **151**),
and `bun run build` all green. New server tests:
- `catalog/catalog-sources.test.ts` — `hola` seeded/undeletable, add/list/remove,
  reserved/dup/invalid rejected, rehydrate.
- `catalog/catalog-aggregate.test.ts` — merge + namespacing + collision,
  single-source filter, fail-soft, per-source version routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
