### PR TITLE
chore(release): 0.7.0

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,6 @@
+{
+  "enabledMcpjsonServers": [
+    "proxmox",
+    "vnc"
+  ]
+}

--- a/.deacon/cache/audit.jsonl
+++ b/.deacon/cache/audit.jsonl
@@ -1,0 +1,1 @@
+{"type":"container.create.begin","id":1,"timestamp":1783079889322,"name":"Node.js Agentic Development","image":"mcr.microsoft.com/devcontainers/base:ubuntu"}

--- a/.deacon/cache/features/0938a80b380d4a1b/README.md
+++ b/.deacon/cache/features/0938a80b380d4a1b/README.md
@@ -1,0 +1,54 @@
+# AI CLI Tools (ai-clis)
+
+Installs AI coding assistant CLIs and agentic development tools: Claude Code, Gemini CLI, OpenAI Codex, GitHub Copilot, OpenCode, CodeRabbit, Beads (with Dolt), and Specify CLI.
+
+## Options
+
+| Option | Description | Type | Default |
+|--------|-------------|------|---------|
+| `install` | Comma-separated list of CLIs to install (e.g. `"claudeCode,geminiCli"`). When set, only the listed CLIs are installed. When empty, all CLIs are installed. | string | `""` |
+| `omit` | Comma-separated list of CLIs to exclude (e.g. `"codex,copilot"`). When set, the listed CLIs are skipped. Applied after `install` filtering. | string | `""` |
+
+> These tools can be large — use `install` or `omit` to skip any you don't need and speed up container builds.
+
+## Usage
+
+Add this feature to your `devcontainer.json`:
+
+```jsonc
+{
+  "features": {
+    "ghcr.io/get2knowio/devcontainer-features/ai-clis:2": {}
+  }
+}
+```
+
+### Install everything except a few
+
+Use `omit` to exclude specific CLIs:
+
+```jsonc
+{
+  "features": {
+    "ghcr.io/get2knowio/devcontainer-features/ai-clis:2": {
+      "omit": "codex,copilot"
+    }
+  }
+}
+```
+
+### Install only the CLIs you want
+
+Use `install` to list exactly the CLIs you need — new CLIs added in future releases won't be installed unless you opt in:
+
+```jsonc
+{
+  "features": {
+    "ghcr.io/get2knowio/devcontainer-features/ai-clis:2": {
+      "install": "claudeCode,geminiCli"
+    }
+  }
+}
+```
+
+**Requires:** Node.js (installs after `ghcr.io/devcontainers/features/node`)

--- a/.deacon/cache/features/0938a80b380d4a1b/devcontainer-feature.json
+++ b/.deacon/cache/features/0938a80b380d4a1b/devcontainer-feature.json
@@ -1,0 +1,22 @@
+{
+  "id": "ai-clis",
+  "version": "2.0.7",
+  "name": "AI CLI Tools",
+  "documentationURL": "https://github.com/get2knowio/devcontainer-features/tree/main/src/ai-clis",
+  "description": "Installs AI coding assistant CLIs and agentic development tools: Claude Code, Gemini CLI, OpenAI Codex, GitHub Copilot, OpenCode, CodeRabbit, Beads (with Dolt), Specify CLI, QMD, and Claude Agent ACP.",
+  "options": {
+    "install": {
+      "type": "string",
+      "default": "",
+      "description": "Comma-separated list of CLIs to install (e.g. 'claudeCode,geminiCli'). When set, only the listed CLIs are installed. When empty (default), all CLIs are installed."
+    },
+    "omit": {
+      "type": "string",
+      "default": "",
+      "description": "Comma-separated list of CLIs to exclude (e.g. 'codex,copilot'). When set, the listed CLIs are skipped. Applied after 'install' filtering."
+    }
+  },
+  "installsAfter": [
+    "ghcr.io/devcontainers/features/node"
+  ]
+}

--- a/.deacon/cache/features/0938a80b380d4a1b/install.sh
+++ b/.deacon/cache/features/0938a80b380d4a1b/install.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+set -e
+
+echo "Installing AI CLI tools..."
+
+# Step 1: All tools enabled by default
+CLAUDECODE="true"
+GEMINICLI="true"
+CODEX="true"
+COPILOT="true"
+OPENCODE="true"
+CODERABBIT="true"
+BEADS="true"
+SPECIFYCLI="true"
+QMD="true"
+CLAUDEAGENTACP="true"
+
+# Step 2: If install is set, whitelist mode
+if [ -n "${INSTALL}" ]; then
+    CLAUDECODE="false"
+    GEMINICLI="false"
+    CODEX="false"
+    COPILOT="false"
+    OPENCODE="false"
+    CODERABBIT="false"
+    BEADS="false"
+    SPECIFYCLI="false"
+    QMD="false"
+    CLAUDEAGENTACP="false"
+
+    IFS=',' read -ra SELECTED <<< "${INSTALL}"
+    for item in "${SELECTED[@]}"; do
+        item="$(echo "$item" | xargs)"
+        case "$item" in
+            claudeCode)  CLAUDECODE="true" ;;
+            geminiCli)   GEMINICLI="true" ;;
+            codex)       CODEX="true" ;;
+            copilot)     COPILOT="true" ;;
+            openCode)    OPENCODE="true" ;;
+            codeRabbit)  CODERABBIT="true" ;;
+            beads)       BEADS="true" ;;
+            specifyCli)  SPECIFYCLI="true" ;;
+            qmd)             QMD="true" ;;
+            claudeAgentAcp)  CLAUDEAGENTACP="true" ;;
+            *) echo "Warning: unknown CLI '$item' in install list" ;;
+        esac
+    done
+fi
+
+# Step 3: If omit is set, blacklist filter
+if [ -n "${OMIT}" ]; then
+    IFS=',' read -ra EXCLUDED <<< "${OMIT}"
+    for item in "${EXCLUDED[@]}"; do
+        item="$(echo "$item" | xargs)"
+        case "$item" in
+            claudeCode)  CLAUDECODE="false" ;;
+            geminiCli)   GEMINICLI="false" ;;
+            codex)       CODEX="false" ;;
+            copilot)     COPILOT="false" ;;
+            openCode)    OPENCODE="false" ;;
+            codeRabbit)  CODERABBIT="false" ;;
+            beads)       BEADS="false" ;;
+            specifyCli)  SPECIFYCLI="false" ;;
+            qmd)             QMD="false" ;;
+            claudeAgentAcp)  CLAUDEAGENTACP="false" ;;
+            *) echo "Warning: unknown CLI '$item' in omit list" ;;
+        esac
+    done
+fi
+
+# Claude Code - uses its own installer (npm install -g is deprecated)
+if [ "${CLAUDECODE}" = "true" ]; then
+    echo "Installing Claude Code..."
+    su - "$_REMOTE_USER" -c 'curl -fsSL https://claude.ai/install.sh | bash' || echo "Warning: Claude Code installation failed"
+fi
+
+# Gemini CLI
+if [ "${GEMINICLI}" = "true" ]; then
+    echo "Installing Gemini CLI..."
+    npm install -g @google/gemini-cli
+fi
+
+# OpenAI Codex
+if [ "${CODEX}" = "true" ]; then
+    echo "Installing OpenAI Codex..."
+    npm install -g @openai/codex
+fi
+
+# GitHub Copilot CLI (requires Node 22+)
+if [ "${COPILOT}" = "true" ]; then
+    echo "Installing GitHub Copilot CLI..."
+    npm install -g @github/copilot
+fi
+
+# OpenCode AI
+if [ "${OPENCODE}" = "true" ]; then
+    echo "Installing OpenCode AI..."
+    curl -fsSL https://opencode.ai/install | bash
+    # Installer puts binary in $HOME/.opencode/bin — copy to a system PATH location
+    # (symlinking fails for non-root users since /root is chmod 700)
+    install -m 755 "$HOME/.opencode/bin/opencode" /usr/local/bin/opencode
+fi
+
+# CodeRabbit CLI
+if [ "${CODERABBIT}" = "true" ]; then
+    echo "Installing CodeRabbit CLI..."
+    # The upstream installer can exit non-zero even after a successful install
+    # (it prints "Installation complete" then returns exit code 2), which would
+    # abort this script under `set -e`. Tolerate the exit code and verify the
+    # binary actually landed instead.
+    curl -fsSL https://cli.coderabbit.ai/install.sh | CODERABBIT_INSTALL_DIR=/usr/local/bin sh || true
+    if [ -x /usr/local/bin/coderabbit ] || command -v coderabbit >/dev/null 2>&1; then
+        echo "CodeRabbit CLI installed."
+    else
+        echo "Warning: CodeRabbit CLI installation failed"
+    fi
+fi
+
+# Beads - coding agent memory system (depends on Dolt)
+if [ "${BEADS}" = "true" ]; then
+    echo "Installing Dolt (required by Beads)..."
+    curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | bash
+    echo "Installing Beads..."
+    npm install -g @beads/bd
+fi
+
+# Specify CLI - spec-driven development toolkit
+if [ "${SPECIFYCLI}" = "true" ]; then
+    echo "Installing Specify CLI (spec-kit) via uv..."
+    # Ensure uv is available
+    if command -v uv >/dev/null 2>&1; then
+        UV_BIN="$(command -v uv)"
+    elif [ -f "$_REMOTE_USER_HOME/.local/bin/uv" ]; then
+        UV_BIN="$_REMOTE_USER_HOME/.local/bin/uv"
+    else
+        echo "uv not found; installing via Astral script..."
+        curl -LsSf https://astral.sh/uv/install.sh | env INSTALLER_NO_MODIFY_PATH=1 sh
+        cp /root/.local/bin/uv /usr/local/bin/uv
+        cp /root/.local/bin/uvx /usr/local/bin/uvx
+        chmod 755 /usr/local/bin/uv /usr/local/bin/uvx
+        UV_BIN="/usr/local/bin/uv"
+    fi
+    # Ensure ~/.local/bin on PATH for user-installed tools
+    echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$_REMOTE_USER_HOME/.zshrc"
+    su - "$_REMOTE_USER" -c "\"$UV_BIN\" tool install specify-cli --from git+https://github.com/github/spec-kit.git" || echo "Warning: Specify CLI installation failed"
+fi
+
+# QMD - on-device search engine for markdown notes and documents
+if [ "${QMD}" = "true" ]; then
+    echo "Installing QMD..."
+    npm install -g @tobilu/qmd
+fi
+
+# Claude Agent ACP - ACP adapter for Claude Code SDK (by Zed Industries)
+if [ "${CLAUDEAGENTACP}" = "true" ]; then
+    echo "Installing Claude Agent ACP..."
+    npm install -g @zed-industries/claude-agent-acp
+fi
+
+echo "AI CLI tools installation complete."

--- a/.deacon/cache/features/0afe72bacc08b289/NOTES.md
+++ b/.deacon/cache/features/0afe72bacc08b289/NOTES.md
@@ -1,0 +1,20 @@
+## Limitations
+
+This docker-in-docker Dev Container Feature is roughly based on the [official docker-in-docker wrapper script](https://github.com/moby/moby/blob/master/hack/dind) that is part of the [Moby project](https://mobyproject.org/). With this in mind:
+* As the name implies, the Feature is expected to work when the host is running Docker (or the OSS Moby container engine it is built on). It may be possible to get running in other container engines, but it has not been tested with them.
+* The host and the container must be running on the same chip architecture. You will not be able to use it with an emulated x86 image with Docker Desktop on an Apple Silicon Mac, like in this example:
+  ```
+  FROM --platform=linux/amd64 mcr.microsoft.com/devcontainers/typescript-node:16
+  ```
+  See [Issue #219](https://github.com/devcontainers/features/issues/219) for more details.
+
+
+## OS Support
+
+This Feature should work on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager installed.
+
+Debian Trixie (13) does not include moby-cli and related system packages, so the feature cannot install with "moby": "true". To use this feature on Trixie, please set "moby": "false" or choose a different base image (for example, Ubuntu 24.04).
+
+Ubuntu 26.04 (Resolute) does not currently have moby packages available, so the feature cannot install with "moby": "true". To use this feature on Resolute, please set "moby": "false". Additionally, the kernel on Ubuntu 26.04 no longer supports legacy iptables NAT tables, so the feature automatically falls back to `iptables-nft` when `iptables-legacy` is not functional.
+
+`bash` is required to execute the `install.sh` script.

--- a/.deacon/cache/features/0afe72bacc08b289/README.md
+++ b/.deacon/cache/features/0afe72bacc08b289/README.md
@@ -1,0 +1,54 @@
+
+# Docker (Docker-in-Docker) (docker-in-docker)
+
+Create child containers *inside* a container, independent from the host's docker instance. Installs Docker extension in the container along with needed CLIs.
+
+## Example Usage
+
+```json
+"features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+}
+```
+
+## Options
+
+| Options Id | Description | Type | Default Value |
+|-----|-----|-----|-----|
+| version | Select or enter a Docker/Moby Engine version. (Availability can vary by OS version.) | string | latest |
+| moby | Install OSS Moby build instead of Docker CE | boolean | true |
+| mobyBuildxVersion | Install a specific version of moby-buildx when using Moby | string | latest |
+| dockerDashComposeVersion | Default version of Docker Compose (v1, v2 or none) | string | v2 |
+| azureDnsAutoDetection | Allow automatically setting the dockerd DNS server when the installation script detects it is running in Azure | boolean | true |
+| dockerDefaultAddressPool | Define default address pools for Docker networks. e.g. base=192.168.0.0/16,size=24 | string | - |
+| installDockerBuildx | Install Docker Buildx | boolean | true |
+| installDockerComposeSwitch | Install Compose Switch (provided docker compose is available) which is a replacement to the Compose V1 docker-compose (python) executable. It translates the command line into Compose V2 docker compose then runs the latter. | boolean | false |
+| disableIp6tables | Disable ip6tables (this option is only applicable for Docker versions 27 and greater) | boolean | false |
+
+## Customizations
+
+### VS Code Extensions
+
+- `ms-azuretools.vscode-containers`
+
+## Limitations
+
+This docker-in-docker Dev Container Feature is roughly based on the [official docker-in-docker wrapper script](https://github.com/moby/moby/blob/master/hack/dind) that is part of the [Moby project](https://mobyproject.org/). With this in mind:
+* As the name implies, the Feature is expected to work when the host is running Docker (or the OSS Moby container engine it is built on). It may be possible to get running in other container engines, but it has not been tested with them.
+* The host and the container must be running on the same chip architecture. You will not be able to use it with an emulated x86 image with Docker Desktop on an Apple Silicon Mac, like in this example:
+  ```
+  FROM --platform=linux/amd64 mcr.microsoft.com/devcontainers/typescript-node:16
+  ```
+  See [Issue #219](https://github.com/devcontainers/features/issues/219) for more details.
+
+
+## OS Support
+
+This Feature should work on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager installed.
+
+`bash` is required to execute the `install.sh` script.
+
+
+---
+
+_Note: This file was auto-generated from the [devcontainer-feature.json](https://github.com/devcontainers/features/blob/main/src/docker-in-docker/devcontainer-feature.json).  Add additional notes to a `NOTES.md`._

--- a/.deacon/cache/features/0afe72bacc08b289/devcontainer-feature.json
+++ b/.deacon/cache/features/0afe72bacc08b289/devcontainer-feature.json
@@ -1,0 +1,94 @@
+{
+  "id": "docker-in-docker",
+  "version": "2.17.0",
+  "name": "Docker (Docker-in-Docker)",
+  "documentationURL": "https://github.com/devcontainers/features/tree/main/src/docker-in-docker",
+  "description": "Create child containers *inside* a container, independent from the host's docker instance. Installs Docker extension in the container along with needed CLIs.",
+  "options": {
+    "version": {
+      "type": "string",
+      "proposals": [
+        "latest",
+        "none",
+        "20.10"
+      ],
+      "default": "latest",
+      "description": "Select or enter a Docker/Moby Engine version. (Availability can vary by OS version.)"
+    },
+    "moby": {
+      "type": "boolean",
+      "default": true,
+      "description": "Install OSS Moby build instead of Docker CE"
+    },
+    "mobyBuildxVersion": {
+      "type": "string",
+      "default": "latest",
+      "description": "Install a specific version of moby-buildx when using Moby"
+    },
+    "dockerDashComposeVersion": {
+      "type": "string",
+      "enum": [
+        "none",
+        "v1",
+        "v2"
+      ],
+      "default": "v2",
+      "description": "Default version of Docker Compose (v1, v2 or none)"
+    },
+    "azureDnsAutoDetection": {
+      "type": "boolean",
+      "default": true,
+      "description": "Allow automatically setting the dockerd DNS server when the installation script detects it is running in Azure"
+    },
+    "dockerDefaultAddressPool": {
+      "type": "string",
+      "default": "",
+      "proposals": [],
+      "description": "Define default address pools for Docker networks. e.g. base=192.168.0.0/16,size=24"
+    },
+    "installDockerBuildx": {
+      "type": "boolean",
+      "default": true,
+      "description": "Install Docker Buildx"
+    },
+    "installDockerComposeSwitch": {
+      "type": "boolean",
+      "default": false,
+      "description": "Install Compose Switch (provided docker compose is available) which is a replacement to the Compose V1 docker-compose (python) executable. It translates the command line into Compose V2 docker compose then runs the latter."
+    },
+    "disableIp6tables": {
+      "type": "boolean",
+      "default": false,
+      "description": "Disable ip6tables (this option is only applicable for Docker versions 27 and greater)"
+    }
+  },
+  "entrypoint": "/usr/local/share/docker-init.sh",
+  "privileged": true,
+  "containerEnv": {
+    "DOCKER_BUILDKIT": "1"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-azuretools.vscode-containers"
+      ],
+      "settings": {
+        "github.copilot.chat.codeGeneration.instructions": [
+          {
+            "text": "This dev container includes the Docker CLI (`docker`) pre-installed and available on the `PATH` for running and managing containers using a dedicated Docker daemon running inside the dev container."
+          }
+        ]
+      }
+    }
+  },
+  "mounts": [
+    {
+      "source": "dind-var-lib-docker-${devcontainerId}",
+      "target": "/var/lib/docker",
+      "type": "volume"
+    }
+  ],
+  "installsAfter": [
+    "ghcr.io/devcontainers/features/common-utils"
+  ]
+}

--- a/.deacon/cache/features/0afe72bacc08b289/install.sh
+++ b/.deacon/cache/features/0afe72bacc08b289/install.sh
@@ -1,0 +1,1037 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+#
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/docker-in-docker.md
+# Maintainer: The Dev Container spec maintainers
+
+
+DOCKER_VERSION="${VERSION:-"latest"}" # The Docker/Moby Engine + CLI should match in version
+USE_MOBY="${MOBY:-"true"}"
+MOBY_BUILDX_VERSION="${MOBYBUILDXVERSION:-"latest"}"
+DOCKER_DASH_COMPOSE_VERSION="${DOCKERDASHCOMPOSEVERSION:-"v2"}" #v1, v2 or none
+AZURE_DNS_AUTO_DETECTION="${AZUREDNSAUTODETECTION:-"true"}"
+DOCKER_DEFAULT_ADDRESS_POOL="${DOCKERDEFAULTADDRESSPOOL:-""}"
+USERNAME="${USERNAME:-"${_REMOTE_USER:-"automatic"}"}"
+INSTALL_DOCKER_BUILDX="${INSTALLDOCKERBUILDX:-"true"}"
+INSTALL_DOCKER_COMPOSE_SWITCH="${INSTALLDOCKERCOMPOSESWITCH:-"false"}"
+MICROSOFT_GPG_KEYS_URI="https://packages.microsoft.com/keys/microsoft.asc"
+MICROSOFT_GPG_KEYS_ROLLING_URI="https://packages.microsoft.com/keys/microsoft-rolling.asc"
+DOCKER_MOBY_ARCHIVE_VERSION_CODENAMES="trixie bookworm buster bullseye bionic focal jammy noble"
+DOCKER_LICENSED_ARCHIVE_VERSION_CODENAMES="trixie bookworm buster bullseye bionic focal hirsute impish jammy noble resolute"
+DISABLE_IP6_TABLES="${DISABLEIP6TABLES:-false}"
+
+# Default: Exit on any failure.
+set -e
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+# Setup STDERR.
+err() {
+    echo "(!) $*" >&2
+}
+
+if [ "$(id -u)" -ne 0 ]; then
+    err 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+###################
+# Helper Functions
+# See: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/shared/utils.sh
+###################
+
+# Determine the appropriate non-root user
+if [ "${USERNAME}" = "auto" ] || [ "${USERNAME}" = "automatic" ]; then
+    USERNAME=""
+    POSSIBLE_USERS=("vscode" "node" "codespace" "$(awk -v val=1000 -F ":" '$3==val{print $1}' /etc/passwd)")
+    for CURRENT_USER in "${POSSIBLE_USERS[@]}"; do
+        if id -u ${CURRENT_USER} > /dev/null 2>&1; then
+            USERNAME=${CURRENT_USER}
+            break
+        fi
+    done
+    if [ "${USERNAME}" = "" ]; then
+        USERNAME=root
+    fi
+elif [ "${USERNAME}" = "none" ] || ! id -u ${USERNAME} > /dev/null 2>&1; then
+    USERNAME=root
+fi
+
+# Package manager update function
+pkg_mgr_update() {
+    case ${ADJUSTED_ID} in
+        debian)
+            if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+                echo "Running apt-get update..."
+                apt-get update -y
+            fi
+            ;;
+        rhel)
+            if [ ${PKG_MGR_CMD} = "microdnf" ]; then
+                cache_check_dir="/var/cache/yum"
+            else
+                cache_check_dir="/var/cache/${PKG_MGR_CMD}"
+            fi
+            if [ "$(ls ${cache_check_dir}/* 2>/dev/null | wc -l)" = 0 ]; then
+                echo "Running ${PKG_MGR_CMD} makecache ..."
+                ${PKG_MGR_CMD} makecache
+            fi
+            ;;
+    esac
+}
+
+# Checks if packages are installed and installs them if not
+check_packages() {
+    case ${ADJUSTED_ID} in
+        debian)
+            if ! dpkg -s "$@" > /dev/null 2>&1; then
+                pkg_mgr_update
+                apt-get -y install --no-install-recommends "$@"
+            fi
+            ;;
+        rhel)
+            if ! rpm -q "$@" > /dev/null 2>&1; then
+                pkg_mgr_update
+                ${PKG_MGR_CMD} -y install "$@"
+            fi
+            ;;
+    esac
+}
+
+# Figure out correct version of a three part version number is not passed
+find_version_from_git_tags() {
+    local variable_name=$1
+    local requested_version=${!variable_name}
+    if [ "${requested_version}" = "none" ]; then return; fi
+    local repository=$2
+    local prefix=${3:-"tags/v"}
+    local separator=${4:-"."}
+    local last_part_optional=${5:-"false"}
+    if [ "$(echo "${requested_version}" | grep -o "." | wc -l)" != "2" ]; then
+        local escaped_separator=${separator//./\\.}
+        local last_part
+        if [ "${last_part_optional}" = "true" ]; then
+            last_part="(${escaped_separator}[0-9]+)?"
+        else
+            last_part="${escaped_separator}[0-9]+"
+        fi
+        local regex="${prefix}\\K[0-9]+${escaped_separator}[0-9]+${last_part}$"
+        local version_list="$(git ls-remote --tags ${repository} | grep -oP "${regex}" | tr -d ' ' | tr "${separator}" "." | sort -rV)"
+        if [ "${requested_version}" = "latest" ] || [ "${requested_version}" = "current" ] || [ "${requested_version}" = "lts" ]; then
+            declare -g ${variable_name}="$(echo "${version_list}" | head -n 1)"
+        else
+            set +e
+                declare -g ${variable_name}="$(echo "${version_list}" | grep -E -m 1 "^${requested_version//./\\.}([\\.\\s]|$)")"
+            set -e
+        fi
+    fi
+    if [ -z "${!variable_name}" ] || ! echo "${version_list}" | grep "^${!variable_name//./\\.}$" > /dev/null 2>&1; then
+        err "Invalid ${variable_name} value: ${requested_version}\nValid values:\n${version_list}" >&2
+        exit 1
+    fi
+    echo "${variable_name}=${!variable_name}"
+}
+
+# Use semver logic to decrement a version number then look for the closest match
+find_prev_version_from_git_tags() {
+    local variable_name=$1
+    local current_version=${!variable_name}
+    local repository=$2
+    # Normally a "v" is used before the version number, but support alternate cases
+    local prefix=${3:-"tags/v"}
+    # Some repositories use "_" instead of "." for version number part separation, support that
+    local separator=${4:-"."}
+    # Some tools release versions that omit the last digit (e.g. go)
+    local last_part_optional=${5:-"false"}
+    # Some repositories may have tags that include a suffix (e.g. actions/node-versions)
+    local version_suffix_regex=$6
+    # Try one break fix version number less if we get a failure. Use "set +e" since "set -e" can cause failures in valid scenarios.
+    set +e
+        major="$(echo "${current_version}" | grep -oE '^[0-9]+' || echo '')"
+        minor="$(echo "${current_version}" | grep -oP '^[0-9]+\.\K[0-9]+' || echo '')"
+        breakfix="$(echo "${current_version}" | grep -oP '^[0-9]+\.[0-9]+\.\K[0-9]+' 2>/dev/null || echo '')"
+
+        if [ "${minor}" = "0" ] && [ "${breakfix}" = "0" ]; then
+            ((major=major-1))
+            declare -g ${variable_name}="${major}"
+            # Look for latest version from previous major release
+            find_version_from_git_tags "${variable_name}" "${repository}" "${prefix}" "${separator}" "${last_part_optional}"
+        # Handle situations like Go's odd version pattern where "0" releases omit the last part
+        elif [ "${breakfix}" = "" ] || [ "${breakfix}" = "0" ]; then
+            ((minor=minor-1))
+            declare -g ${variable_name}="${major}.${minor}"
+            # Look for latest version from previous minor release
+            find_version_from_git_tags "${variable_name}" "${repository}" "${prefix}" "${separator}" "${last_part_optional}"
+        else
+            ((breakfix=breakfix-1))
+            if [ "${breakfix}" = "0" ] && [ "${last_part_optional}" = "true" ]; then
+                declare -g ${variable_name}="${major}.${minor}"
+            else 
+                declare -g ${variable_name}="${major}.${minor}.${breakfix}"
+            fi
+        fi
+    set -e
+}
+
+# Function to fetch the version released prior to the latest version
+get_previous_version() {
+    local url=$1
+    local repo_url=$2
+    local variable_name=$3
+    prev_version=${!variable_name}
+
+    output=$(curl -s "$repo_url");
+    if echo "$output" | jq -e 'type == "object"' > /dev/null; then
+      message=$(echo "$output" | jq -r '.message')
+      
+      if [[ $message == "API rate limit exceeded"* ]]; then
+            echo -e "\nAn attempt to find latest version using GitHub Api Failed... \nReason: ${message}"
+            echo -e "\nAttempting to find latest version using GitHub tags."
+            find_prev_version_from_git_tags prev_version "$url" "tags/v"
+            declare -g ${variable_name}="${prev_version}"
+       fi
+    elif echo "$output" | jq -e 'type == "array"' > /dev/null; then 
+        echo -e "\nAttempting to find latest version using GitHub Api."
+        version=$(echo "$output" | jq -r '.[1].tag_name')
+        declare -g ${variable_name}="${version#v}"
+    fi  
+    echo "${variable_name}=${!variable_name}"
+}
+
+get_github_api_repo_url() {
+    local url=$1
+    echo "${url/https:\/\/github.com/https:\/\/api.github.com\/repos}/releases"
+}
+
+###########################################
+# Start docker-in-docker installation
+###########################################
+
+# Ensure apt is in non-interactive to avoid prompts
+export DEBIAN_FRONTEND=noninteractive
+
+# Source /etc/os-release to get OS info
+. /etc/os-release
+
+# Determine adjusted ID and package manager
+if [ "${ID}" = "debian" ] || [ "${ID_LIKE}" = "debian" ]; then
+    ADJUSTED_ID="debian"
+    PKG_MGR_CMD="apt-get"
+    # Use dpkg for Debian-based systems
+    architecture="$(dpkg --print-architecture 2>/dev/null || uname -m)"
+elif [[ "${ID}" = "rhel" || "${ID}" = "fedora" || "${ID}" = "azurelinux" || "${ID}" = "mariner" || "${ID_LIKE}" = *"rhel"* || "${ID_LIKE}" = *"fedora"* || "${ID_LIKE}" = *"azurelinux"* || "${ID_LIKE}" = *"mariner"* ]]; then
+    ADJUSTED_ID="rhel"
+    # Determine the appropriate package manager for RHEL-based systems
+    for pkg_mgr in tdnf dnf microdnf yum; do
+        if command -v "$pkg_mgr" >/dev/null 2>&1; then
+            PKG_MGR_CMD="$pkg_mgr"
+            break
+        fi
+    done
+    
+    if [ -z "${PKG_MGR_CMD}" ]; then
+        err "Unable to find a supported package manager (tdnf, dnf, microdnf, yum)"
+        exit 1
+    fi
+    
+    architecture="$(rpm --eval '%{_arch}' 2>/dev/null || uname -m)"
+else
+    err "Linux distro ${ID} not supported."
+    exit 1
+fi
+
+# Azure Linux specific setup
+if [ "${ID}" = "azurelinux" ]; then
+    VERSION_CODENAME="azurelinux${VERSION_ID}"
+fi
+
+# Prevent attempting to install Moby on Debian trixie/resolute (packages removed)
+if [ "${USE_MOBY}" = "true" ] && [ "${ADJUSTED_ID}" = "debian" ] && ([ "${VERSION_CODENAME}" = "trixie" ] || [ "${VERSION_CODENAME}" = "resolute" ]); then
+    err "The 'moby' option is not supported on ${ID} '${VERSION_CODENAME}' because 'moby-cli' and related system packages are not available in that distribution."
+    err "To continue, either set the feature option '\"moby\": false' or use a different base image."
+    exit 1
+fi
+
+# Check if distro is supported
+if [ "${USE_MOBY}" = "true" ]; then
+    if [ "${ADJUSTED_ID}" = "debian" ]; then
+        if [[ "${DOCKER_MOBY_ARCHIVE_VERSION_CODENAMES}" != *"${VERSION_CODENAME}"* ]]; then
+            err "Unsupported distribution version '${VERSION_CODENAME}'. To resolve, either: (1) set feature option '\"moby\": false' , or (2) choose a compatible OS distribution"
+            err "Supported distributions include: ${DOCKER_MOBY_ARCHIVE_VERSION_CODENAMES}"
+            exit 1
+        fi
+        echo "(*) ${VERSION_CODENAME} is supported for Moby installation  - setting up Microsoft repository"
+    elif [ "${ADJUSTED_ID}" = "rhel" ]; then
+        if [ "${ID}" = "azurelinux" ] || [ "${ID}" = "mariner" ]; then
+            echo " (*) ${ID} ${VERSION_ID} detected - using Microsoft repositories for Moby packages"
+        else
+            echo "RHEL-based system (${ID}) detected - Moby packages may require additional configuration"
+        fi
+    fi
+else
+    if [ "${ADJUSTED_ID}" = "debian" ]; then
+        if [[ "${DOCKER_LICENSED_ARCHIVE_VERSION_CODENAMES}" != *"${VERSION_CODENAME}"* ]]; then
+            err "Unsupported distribution version '${VERSION_CODENAME}'. To resolve, please choose a compatible OS distribution"
+            err "Supported distributions include: ${DOCKER_LICENSED_ARCHIVE_VERSION_CODENAMES}"
+            exit 1
+        fi
+        echo "(*) ${VERSION_CODENAME} is supported for Docker CE installation (supported: ${DOCKER_LICENSED_ARCHIVE_VERSION_CODENAMES}) - setting up Docker repository"
+    elif [ "${ADJUSTED_ID}" = "rhel" ]; then
+        
+        echo "RHEL-based system (${ID}) detected - using Docker CE packages"
+    fi
+fi
+
+# Install base dependencies
+base_packages="curl ca-certificates pigz iptables gnupg2 wget jq"
+case ${ADJUSTED_ID} in
+    debian)
+        check_packages apt-transport-https $base_packages dirmngr
+        ;;
+    rhel)
+        check_packages $base_packages tar gawk shadow-utils policycoreutils  procps-ng systemd-libs systemd-devel
+       
+        ;;
+esac
+
+# Install git if not already present
+if ! command -v git >/dev/null 2>&1; then
+    check_packages git
+fi
+
+# Update CA certificates to ensure HTTPS connections work properly
+# This is especially important for Ubuntu 24.04 (Noble) and Debian Trixie
+# Only run for Debian-based systems (RHEL uses update-ca-trust instead)
+if [ "${ADJUSTED_ID}" = "debian" ] && command -v update-ca-certificates > /dev/null 2>&1; then
+    update-ca-certificates
+fi
+
+# Swap to legacy iptables for compatibility (Debian only)
+if [ "${ADJUSTED_ID}" = "debian" ]; then
+    # On distros where legacy iptables is no longer kernel-supported (e.g. Ubuntu 26.04 / resolute),
+    # prefer iptables-nft. Otherwise prefer legacy for backward compatibility.
+    use_nft=false
+    case "${VERSION_CODENAME}" in
+        resolute) use_nft=true ;;
+    esac
+
+    if [ "${use_nft}" = "true" ] && type iptables-nft > /dev/null 2>&1; then
+        update-alternatives --set iptables /usr/sbin/iptables-nft || true
+        update-alternatives --set ip6tables /usr/sbin/ip6tables-nft || true
+    elif type iptables-legacy > /dev/null 2>&1; then
+        update-alternatives --set iptables /usr/sbin/iptables-legacy || true
+        update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy || true
+    elif type iptables-nft > /dev/null 2>&1; then
+        update-alternatives --set iptables /usr/sbin/iptables-nft || true
+        update-alternatives --set ip6tables /usr/sbin/ip6tables-nft || true
+    fi
+fi
+
+# Set up the necessary repositories
+if [ "${USE_MOBY}" = "true" ]; then
+    # Name of open source engine/cli
+    engine_package_name="moby-engine"
+    cli_package_name="moby-cli"
+
+    case ${ADJUSTED_ID} in
+        debian)
+            # Import key safely and import Microsoft apt repo
+            {
+                curl -sSL ${MICROSOFT_GPG_KEYS_URI}
+                curl -sSL ${MICROSOFT_GPG_KEYS_ROLLING_URI}
+            } | gpg --dearmor > /usr/share/keyrings/microsoft-archive-keyring.gpg
+            echo "deb [arch=${architecture} signed-by=/usr/share/keyrings/microsoft-archive-keyring.gpg] https://packages.microsoft.com/repos/microsoft-${ID}-${VERSION_CODENAME}-prod ${VERSION_CODENAME} main" > /etc/apt/sources.list.d/microsoft.list
+            ;;
+        rhel)
+            echo "(*) ${ID} detected - checking for Moby packages..."
+        
+            # Check if moby packages are available in default repos
+            if ${PKG_MGR_CMD} list available moby-engine >/dev/null 2>&1; then
+                echo "(*) Using built-in ${ID} Moby packages"
+            else
+                case "${ID}" in
+                    azurelinux)
+                        echo "(*) Moby packages not found in Azure Linux repositories"
+                        echo "(*) For Azure Linux, Docker CE ('moby': false) is recommended"
+                        err "Moby packages are not available for Azure Linux ${VERSION_ID}."
+                        err "Recommendation: Use '\"moby\": false' to install Docker CE instead."
+                        exit 1
+                        ;;
+                    mariner)
+                        echo "(*) Adding Microsoft repository for CBL-Mariner..."
+                        # Add Microsoft repository if packages aren't available locally
+                        curl -sSL ${MICROSOFT_GPG_KEYS_URI} | gpg --dearmor > /etc/pki/rpm-gpg/microsoft.gpg
+                        cat > /etc/yum.repos.d/microsoft.repo << EOF
+[microsoft]
+name=Microsoft Repository
+baseurl=https://packages.microsoft.com/repos/microsoft-cbl-mariner-2.0-prod-base/
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/microsoft.gpg
+EOF
+                # Verify packages are available after adding repo
+                pkg_mgr_update
+                if ! ${PKG_MGR_CMD} list available moby-engine >/dev/null 2>&1; then
+                    echo "(*) Moby packages not found in Microsoft repository either"
+                    err "Moby packages are not available for CBL-Mariner ${VERSION_ID}."
+                    err "Recommendation: Use '\"moby\": false' to install Docker CE instead."
+                    exit 1
+                fi
+                ;;
+            *)
+                err "Moby packages are not available for ${ID}. Please use 'moby': false option."
+                exit 1
+                ;;
+            esac    
+        fi
+        ;;
+    esac
+else
+    # Name of licensed engine/cli
+    engine_package_name="docker-ce"
+    cli_package_name="docker-ce-cli"
+    case ${ADJUSTED_ID} in
+        debian)
+            curl -fsSL https://download.docker.com/linux/${ID}/gpg | gpg --dearmor > /usr/share/keyrings/docker-archive-keyring.gpg
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/${ID} ${VERSION_CODENAME} stable" > /etc/apt/sources.list.d/docker.list
+            ;;
+        rhel)
+            # Docker CE repository setup for RHEL-based systems
+            setup_docker_ce_repo() {
+                curl -fsSL https://download.docker.com/linux/centos/gpg > /etc/pki/rpm-gpg/docker-ce.gpg
+                cat > /etc/yum.repos.d/docker-ce.repo << EOF  
+[docker-ce-stable]
+name=Docker CE Stable
+baseurl=https://download.docker.com/linux/centos/9/\$basearch/stable
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/docker-ce.gpg
+skip_if_unavailable=1
+module_hotfixes=1
+EOF
+            }
+            install_azure_linux_deps() {
+                echo "(*) Installing device-mapper libraries for Docker CE..."
+                [ "${ID}" != "mariner" ] && ${PKG_MGR_CMD} -y install device-mapper-libs 2>/dev/null || echo "(*) Device-mapper install failed, proceeding"   
+                echo "(*) Installing additional Docker CE dependencies..."
+                ${PKG_MGR_CMD} -y install libseccomp libtool-ltdl systemd-libs libcgroup tar xz || {
+                    echo "(*) Some optional dependencies could not be installed, continuing..."
+                }
+            }
+            setup_selinux_context() {
+                if command -v getenforce >/dev/null 2>&1 && [ "$(getenforce 2>/dev/null)" != "Disabled" ]; then
+                    echo "(*) Creating minimal SELinux context for Docker compatibility..."
+                    mkdir -p /etc/selinux/targeted/contexts/files/ 2>/dev/null || true
+                    echo "/var/lib/docker(/.*)? system_u:object_r:container_file_t:s0" >> /etc/selinux/targeted/contexts/files/file_contexts.local 2>/dev/null || true
+                fi
+            }
+            
+            # Special handling for RHEL Docker CE installation
+            case "${ID}" in
+                azurelinux|mariner)
+                    echo "(*) ${ID} detected"
+                    echo "(*) Note: Moby packages work better on Azure Linux. Consider using 'moby': true"
+                    echo "(*) Setting up Docker CE repository..."
+                    
+                    setup_docker_ce_repo
+                    install_azure_linux_deps
+                    
+                    if [ "${USE_MOBY}" != "true" ]; then
+                        echo "(*) Docker CE installation for Azure Linux - skipping container-selinux"
+                        echo "(*) Note: SELinux policies will be minimal but Docker will function normally"
+                        setup_selinux_context
+                    else
+                        echo "(*) Using Moby - container-selinux not required"
+                    fi
+                    ;;
+                *)     
+                    # Standard RHEL/CentOS/Fedora approach
+                    if command -v dnf >/dev/null 2>&1; then
+                        dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+                    elif command -v yum-config-manager >/dev/null 2>&1; then
+                        yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+                    else  
+                        # Manual fallback
+                        setup_docker_ce_repo
+            fi
+            ;;
+        esac
+        ;;
+    esac    
+fi
+
+# Refresh package database
+case ${ADJUSTED_ID} in
+    debian)
+        apt-get update
+        ;;
+    rhel)
+        pkg_mgr_update
+        ;;
+esac
+
+# Soft version matching
+if [ "${DOCKER_VERSION}" = "latest" ] || [ "${DOCKER_VERSION}" = "lts" ] || [ "${DOCKER_VERSION}" = "stable" ]; then
+    # Empty, meaning grab whatever "latest" is in apt repo
+    engine_version_suffix=""
+    cli_version_suffix=""
+else
+    case ${ADJUSTED_ID} in
+        debian)
+    # Fetch a valid version from the apt-cache (eg: the Microsoft repo appends +azure, breakfix, etc...)
+    docker_version_dot_escaped="${DOCKER_VERSION//./\\.}"
+    docker_version_dot_plus_escaped="${docker_version_dot_escaped//+/\\+}"
+    # Regex needs to handle debian package version number format: https://www.systutorials.com/docs/linux/man/5-deb-version/
+    docker_version_regex="^(.+:)?${docker_version_dot_plus_escaped}([\\.\\+ ~:-]|$)"
+    set +e # Don't exit if finding version fails - will handle gracefully
+        cli_version_suffix="=$(apt-cache madison ${cli_package_name} | awk -F"|" '{print $2}' | sed -e 's/^[ \t]*//' | grep -E -m 1 "${docker_version_regex}")"
+        engine_version_suffix="=$(apt-cache madison ${engine_package_name} | awk -F"|" '{print $2}' | sed -e 's/^[ \t]*//' | grep -E -m 1 "${docker_version_regex}")"
+    set -e
+    if [ -z "${engine_version_suffix}" ] || [ "${engine_version_suffix}" = "=" ] || [ -z "${cli_version_suffix}" ] || [ "${cli_version_suffix}" = "=" ] ; then
+        err "No full or partial Docker / Moby version match found for \"${DOCKER_VERSION}\" on OS ${ID} ${VERSION_CODENAME} (${architecture}). Available versions:"
+        apt-cache madison ${cli_package_name} | awk -F"|" '{print $2}' | grep -oP '^(.+:)?\K.+'
+        exit 1
+    fi
+    ;;  
+rhel)
+     # For RHEL-based systems, use dnf/yum to find versions
+            docker_version_escaped="${DOCKER_VERSION//./\\.}"
+            set +e # Don't exit if finding version fails - will handle gracefully
+                if [ "${USE_MOBY}" = "true" ]; then
+                    available_versions=$(${PKG_MGR_CMD} list --available moby-engine 2>/dev/null | grep -v "Available Packages" | awk '{print $2}' | grep -E "^${docker_version_escaped}" | head -1)
+                else
+                    available_versions=$(${PKG_MGR_CMD} list --available docker-ce 2>/dev/null | grep -v "Available Packages" | awk '{print $2}' | grep -E "^${docker_version_escaped}" | head -1)
+                fi
+            set -e
+            if [ -n "${available_versions}" ]; then
+                engine_version_suffix="-${available_versions}"
+                cli_version_suffix="-${available_versions}"
+            else
+                echo "(*) Exact version ${DOCKER_VERSION} not found, using latest available"
+                engine_version_suffix=""
+                cli_version_suffix=""
+            fi
+            ;;
+    esac
+fi
+
+# Version matching for moby-buildx
+if [ "${USE_MOBY}" = "true" ]; then
+    if [ "${MOBY_BUILDX_VERSION}" = "latest" ]; then
+        # Empty, meaning grab whatever "latest" is in apt repo
+        buildx_version_suffix=""
+    else
+        case ${ADJUSTED_ID} in
+            debian)
+        buildx_version_dot_escaped="${MOBY_BUILDX_VERSION//./\\.}"
+        buildx_version_dot_plus_escaped="${buildx_version_dot_escaped//+/\\+}"
+        buildx_version_regex="^(.+:)?${buildx_version_dot_plus_escaped}([\\.\\+ ~:-]|$)"
+        set +e
+            buildx_version_suffix="=$(apt-cache madison moby-buildx | awk -F"|" '{print $2}' | sed -e 's/^[ \t]*//' | grep -E -m 1 "${buildx_version_regex}")"
+        set -e
+        if [ -z "${buildx_version_suffix}" ] || [ "${buildx_version_suffix}" = "=" ]; then
+            err "No full or partial moby-buildx version match found for \"${MOBY_BUILDX_VERSION}\" on OS ${ID} ${VERSION_CODENAME} (${architecture}). Available versions:"
+            apt-cache madison moby-buildx | awk -F"|" '{print $2}' | grep -oP '^(.+:)?\K.+'
+            exit 1
+        fi
+        ;;
+            rhel)
+                # For RHEL-based systems, try to find buildx version or use latest
+                buildx_version_escaped="${MOBY_BUILDX_VERSION//./\\.}"
+                set +e
+                available_buildx=$(${PKG_MGR_CMD} list --available moby-buildx 2>/dev/null | grep -v "Available Packages" | awk '{print $2}' | grep -E "^${buildx_version_escaped}" | head -1)
+                set -e
+                if [ -n "${available_buildx}" ]; then
+                    buildx_version_suffix="-${available_buildx}"
+                else
+                    echo "(*) Exact buildx version ${MOBY_BUILDX_VERSION} not found, using latest available"
+                    buildx_version_suffix=""
+                fi
+                ;;
+        esac
+        echo "buildx_version_suffix ${buildx_version_suffix}"
+    fi
+fi
+
+# Install Docker / Moby CLI if not already installed
+if type docker > /dev/null 2>&1 && type dockerd > /dev/null 2>&1; then
+    echo "Docker / Moby CLI and Engine already installed."
+else
+        case ${ADJUSTED_ID} in
+        debian)
+            if [ "${USE_MOBY}" = "true" ]; then
+                # Install engine
+                set +e # Handle error gracefully
+                    apt-get -y install --no-install-recommends moby-cli${cli_version_suffix} moby-buildx${buildx_version_suffix} moby-engine${engine_version_suffix}
+                    exit_code=$?
+                set -e    
+                
+                if [ ${exit_code} -ne 0 ]; then
+                    err "Packages for moby not available in OS ${ID} ${VERSION_CODENAME} (${architecture}). To resolve, either: (1) set feature option '\"moby\": false' , or (2) choose a compatible OS version (eg: 'ubuntu-24.04')."
+                    exit 1
+                fi
+
+                # Install compose
+                apt-get -y install --no-install-recommends moby-compose || err "Package moby-compose (Docker Compose v2) not available for OS ${ID} ${VERSION_CODENAME} (${architecture}). Skipping."
+            else
+                apt-get -y install --no-install-recommends docker-ce-cli${cli_version_suffix} docker-ce${engine_version_suffix}
+                # Install compose
+                apt-mark hold docker-ce docker-ce-cli
+                apt-get -y install --no-install-recommends docker-compose-plugin || echo "(*) Package docker-compose-plugin (Docker Compose v2) not available for OS ${ID} ${VERSION_CODENAME} (${architecture}). Skipping."
+            fi
+            ;;
+        rhel)
+            if [ "${USE_MOBY}" = "true" ]; then
+                set +e # Handle error gracefully
+                    ${PKG_MGR_CMD} -y install moby-cli${cli_version_suffix} moby-engine${engine_version_suffix}
+                    exit_code=$?
+                set -e
+                
+                if [ ${exit_code} -ne 0 ]; then
+                    err "Packages for moby not available in OS ${ID} ${VERSION_CODENAME} (${architecture}). To resolve, either: (1) set feature option '\"moby\": false' , or (2) choose a compatible OS version."
+                    exit 1
+                fi
+
+                # Install compose
+                if [ "${DOCKER_DASH_COMPOSE_VERSION}" != "none" ]; then
+                    ${PKG_MGR_CMD} -y install moby-compose || echo "(*) Package moby-compose not available for ${ID} ${VERSION_CODENAME} (${architecture}). Skipping."
+                fi
+            else
+                               # Special handling for Azure Linux Docker CE installation
+                if [ "${ID}" = "azurelinux" ] || [ "${ID}" = "mariner" ]; then
+                    echo "(*) Installing Docker CE on Azure Linux (bypassing container-selinux dependency)..."
+                    
+                    # Use rpm with --force and --nodeps for Azure Linux
+                    set +e  # Don't exit on error for this section
+                    ${PKG_MGR_CMD} -y install docker-ce${cli_version_suffix} docker-ce-cli${engine_version_suffix} containerd.io
+                    install_result=$?
+                    set -e
+                    
+                    if [ $install_result -ne 0 ]; then
+                        echo "(*) Standard installation failed, trying manual installation..."
+                        
+                        echo "(*) Standard installation failed, trying manual installation..."
+                        
+                        # Create directory for downloading packages
+                        mkdir -p /tmp/docker-ce-install
+                        
+                        # Download packages manually using curl since tdnf doesn't support download
+                        echo "(*) Downloading Docker CE packages manually..."
+                        
+                        # Get the repository baseurl
+                        repo_baseurl="https://download.docker.com/linux/centos/9/x86_64/stable"
+                        
+                        # Download packages directly
+                        cd /tmp/docker-ce-install
+                        
+                        # Get package names with versions
+                        if [ -n "${cli_version_suffix}" ]; then
+                            docker_ce_version="${cli_version_suffix#-}"
+                            docker_cli_version="${engine_version_suffix#-}"
+                        else
+                            # Get latest version from repository
+                            docker_ce_version="latest"
+                        fi
+                        
+                        echo "(*) Attempting to download Docker CE packages from repository..."
+                        
+                        # Try to download latest packages if specific version fails
+                        if ! curl -fsSL "${repo_baseurl}/Packages/docker-ce-${docker_ce_version}.el9.x86_64.rpm" -o docker-ce.rpm 2>/dev/null; then
+                            # Fallback: try to get latest available version
+                            echo "(*) Specific version not found, trying latest..."
+                            latest_docker=$(curl -s "${repo_baseurl}/Packages/" | grep -o 'docker-ce-[0-9][^"]*\.el9\.x86_64\.rpm' | head -1)
+                            latest_cli=$(curl -s "${repo_baseurl}/Packages/" | grep -o 'docker-ce-cli-[0-9][^"]*\.el9\.x86_64\.rpm' | head -1)
+                            latest_containerd=$(curl -s "${repo_baseurl}/Packages/" | grep -o 'containerd\.io-[0-9][^"]*\.el9\.x86_64\.rpm' | head -1)
+                            
+                            if [ -n "${latest_docker}" ]; then
+                                curl -fsSL "${repo_baseurl}/Packages/${latest_docker}" -o docker-ce.rpm
+                                curl -fsSL "${repo_baseurl}/Packages/${latest_cli}" -o docker-ce-cli.rpm
+                                curl -fsSL "${repo_baseurl}/Packages/${latest_containerd}" -o containerd.io.rpm
+                            else
+                                echo "(*) ERROR: Could not find Docker CE packages in repository"
+                                echo "(*) Please check repository configuration or use 'moby': true"
+                                exit 1
+                            fi
+                        fi
+                        # Install systemd libraries required by Docker CE
+                        echo "(*) Installing systemd libraries required by Docker CE..."
+                        ${PKG_MGR_CMD} -y install systemd-libs || ${PKG_MGR_CMD} -y install systemd-devel || {
+                            echo "(*) WARNING: Could not install systemd libraries"
+                            echo "(*) Docker may fail to start without these"
+                        }
+                         
+                        # Install with rpm --force --nodeps
+                        echo "(*) Installing Docker CE packages with dependency override..."
+                        rpm -Uvh --force --nodeps *.rpm
+                        
+                        # Cleanup
+                        cd /
+                        rm -rf /tmp/docker-ce-install
+                        
+                        echo "(*) Docker CE installation completed with dependency bypass"
+                        echo "(*) Note: Some SELinux functionality may be limited without container-selinux"
+                    fi
+                else
+                    # Standard installation for other RHEL-based systems
+                    ${PKG_MGR_CMD} -y install docker-ce${cli_version_suffix} docker-ce-cli${engine_version_suffix} containerd.io
+                fi
+                # Install compose
+                if [ "${DOCKER_DASH_COMPOSE_VERSION}" != "none" ]; then
+                    ${PKG_MGR_CMD} -y install docker-compose-plugin || echo "(*) Package docker-compose-plugin not available for ${ID} ${VERSION_CODENAME} (${architecture}). Skipping."
+                fi
+            fi
+            ;;
+    esac
+fi
+
+echo "Finished installing docker / moby!"
+
+docker_home="/usr/libexec/docker"
+cli_plugins_dir="${docker_home}/cli-plugins"
+
+# fallback for docker-compose
+fallback_compose(){
+    local url=$1
+    local repo_url=$(get_github_api_repo_url "$url")
+    echo -e "\n(!) Failed to fetch the latest artifacts for docker-compose v${compose_version}..."
+    get_previous_version "${url}" "${repo_url}" compose_version
+    echo -e "\nAttempting to install v${compose_version}"
+    curl -fsSL "https://github.com/docker/compose/releases/download/v${compose_version}/docker-compose-linux-${target_compose_arch}" -o ${docker_compose_path}
+}
+
+# If 'docker-compose' command is to be included
+if [ "${DOCKER_DASH_COMPOSE_VERSION}" != "none" ]; then
+    case "${architecture}" in
+    amd64|x86_64) target_compose_arch=x86_64 ;;
+    arm64|aarch64) target_compose_arch=aarch64 ;;
+    *)
+        echo "(!) Docker in docker does not support machine architecture '$architecture'. Please use an x86-64 or ARM64 machine."
+        exit 1
+    esac
+
+    docker_compose_path="/usr/local/bin/docker-compose"
+    if [ "${DOCKER_DASH_COMPOSE_VERSION}" = "v1" ]; then
+        err "The final Compose V1 release, version 1.29.2, was May 10, 2021. These packages haven't received any security updates since then. Use at your own risk."
+        INSTALL_DOCKER_COMPOSE_SWITCH="false"
+
+        if [ "${target_compose_arch}" = "x86_64" ]; then
+            echo "(*) Installing docker compose v1..."
+            curl -fsSL "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64" -o ${docker_compose_path}
+            chmod +x ${docker_compose_path}
+
+            # Download the SHA256 checksum
+            DOCKER_COMPOSE_SHA256="$(curl -sSL "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64.sha256" | awk '{print $1}')"
+            echo "${DOCKER_COMPOSE_SHA256}  ${docker_compose_path}" > docker-compose.sha256sum
+            sha256sum -c docker-compose.sha256sum --ignore-missing
+        elif [ "${VERSION_CODENAME}" = "bookworm" ]; then
+            err "Docker compose v1 is unavailable for 'bookworm' on Arm64. Kindly switch to use v2"
+            exit 1
+        else
+            # Use pip to get a version that runs on this architecture
+            check_packages python3-minimal python3-pip libffi-dev python3-venv
+            echo "(*) Installing docker compose v1 via pip..."
+            export PYTHONUSERBASE=/usr/local
+            pip3 install --disable-pip-version-check --no-cache-dir --user "Cython<3.0" pyyaml wheel docker-compose --no-build-isolation
+        fi
+    else
+        compose_version=${DOCKER_DASH_COMPOSE_VERSION#v}
+        docker_compose_url="https://github.com/docker/compose"
+        find_version_from_git_tags compose_version "$docker_compose_url" "tags/v"
+        echo "(*) Installing docker-compose ${compose_version}..."
+        curl -fsSL "https://github.com/docker/compose/releases/download/v${compose_version}/docker-compose-linux-${target_compose_arch}" -o ${docker_compose_path} || {
+                 echo -e "\n(!) Failed to fetch the latest artifacts for docker-compose v${compose_version}..." 
+                 fallback_compose "$docker_compose_url"
+        }
+
+        chmod +x ${docker_compose_path}
+
+        # Download the SHA256 checksum
+        DOCKER_COMPOSE_SHA256="$(curl -sSL "https://github.com/docker/compose/releases/download/v${compose_version}/docker-compose-linux-${target_compose_arch}.sha256" | awk '{print $1}')"
+        echo "${DOCKER_COMPOSE_SHA256}  ${docker_compose_path}" > docker-compose.sha256sum
+        sha256sum -c docker-compose.sha256sum --ignore-missing
+
+        mkdir -p ${cli_plugins_dir}
+        cp ${docker_compose_path} ${cli_plugins_dir}
+    fi
+fi
+
+# fallback method for compose-switch
+fallback_compose-switch() {
+    local url=$1
+    local repo_url=$(get_github_api_repo_url "$url")
+    echo -e "\n(!) Failed to fetch the latest artifacts for compose-switch v${compose_switch_version}..."
+    get_previous_version "$url" "$repo_url" compose_switch_version
+    echo -e "\nAttempting to install v${compose_switch_version}"
+    curl -fsSL "https://github.com/docker/compose-switch/releases/download/v${compose_switch_version}/docker-compose-linux-${target_switch_arch}" -o /usr/local/bin/compose-switch
+}
+# Install docker-compose switch if not already installed - https://github.com/docker/compose-switch#manual-installation
+if [ "${INSTALL_DOCKER_COMPOSE_SWITCH}" = "true" ] && ! type compose-switch > /dev/null 2>&1; then
+    if type docker-compose > /dev/null 2>&1; then
+        echo "(*) Installing compose-switch..."
+        current_compose_path="$(command -v docker-compose)"
+        target_compose_path="$(dirname "${current_compose_path}")/docker-compose-v1"
+        compose_switch_version="latest"
+        compose_switch_url="https://github.com/docker/compose-switch"
+        # Try to get latest version, fallback to known stable version if GitHub API fails
+        set +e
+        find_version_from_git_tags compose_switch_version "$compose_switch_url"
+        if [ $? -ne 0 ] || [ -z "${compose_switch_version}" ] || [ "${compose_switch_version}" = "latest" ]; then
+            echo "(*) GitHub API rate limited or failed, using fallback method"
+            fallback_compose-switch "$compose_switch_url"
+        fi
+        set -e
+        
+        # Map architecture for compose-switch downloads
+        case "${architecture}" in
+            amd64|x86_64) target_switch_arch=amd64 ;;
+            arm64|aarch64) target_switch_arch=arm64 ;;
+            *) target_switch_arch=${architecture} ;;
+        esac
+        curl -fsSL "https://github.com/docker/compose-switch/releases/download/v${compose_switch_version}/docker-compose-linux-${target_switch_arch}" -o /usr/local/bin/compose-switch || fallback_compose-switch "$compose_switch_url"
+        chmod +x /usr/local/bin/compose-switch
+        # TODO: Verify checksum once available: https://github.com/docker/compose-switch/issues/11
+        # Setup v1 CLI as alternative in addition to compose-switch (which maps to v2)
+        mv "${current_compose_path}" "${target_compose_path}"
+        update-alternatives --install ${docker_compose_path} docker-compose /usr/local/bin/compose-switch 99
+        update-alternatives --install ${docker_compose_path} docker-compose "${target_compose_path}" 1
+    else
+        err "Skipping installation of compose-switch as docker compose is unavailable..."
+    fi
+fi
+
+# If init file already exists, exit
+if [ -f "/usr/local/share/docker-init.sh" ]; then
+    echo "/usr/local/share/docker-init.sh already exists, so exiting."
+    # Clean up
+    rm -rf /var/lib/apt/lists/*
+    exit 0
+fi
+echo "docker-init doesn't exist, adding..."
+
+if ! cat /etc/group | grep -e "^docker:" > /dev/null 2>&1; then
+        groupadd -r docker
+fi
+
+usermod -aG docker ${USERNAME}
+
+# fallback for docker/buildx
+fallback_buildx() {
+    local url=$1
+    local repo_url=$(get_github_api_repo_url "$url")
+    echo -e "\n(!) Failed to fetch the latest artifacts for docker buildx v${buildx_version}..."
+    get_previous_version "$url" "$repo_url" buildx_version
+    buildx_file_name="buildx-v${buildx_version}.linux-${target_buildx_arch}"
+    echo -e "\nAttempting to install v${buildx_version}"
+    wget https://github.com/docker/buildx/releases/download/v${buildx_version}/${buildx_file_name}
+}
+ 
+if [ "${INSTALL_DOCKER_BUILDX}" = "true" ]; then
+    buildx_version="latest"
+    docker_buildx_url="https://github.com/docker/buildx"
+    find_version_from_git_tags buildx_version "$docker_buildx_url" "refs/tags/v"
+    echo "(*) Installing buildx ${buildx_version}..."
+
+      # Map architecture for buildx downloads
+    case "${architecture}" in
+        amd64|x86_64) target_buildx_arch=amd64 ;;
+        arm64|aarch64) target_buildx_arch=arm64 ;;
+        *) target_buildx_arch=${architecture} ;;
+    esac
+
+    buildx_file_name="buildx-v${buildx_version}.linux-${target_buildx_arch}"
+
+    cd /tmp
+    wget https://github.com/docker/buildx/releases/download/v${buildx_version}/${buildx_file_name} || fallback_buildx "$docker_buildx_url"
+    
+    docker_home="/usr/libexec/docker"
+    cli_plugins_dir="${docker_home}/cli-plugins"
+
+    mkdir -p ${cli_plugins_dir}
+    mv ${buildx_file_name} ${cli_plugins_dir}/docker-buildx
+    chmod +x ${cli_plugins_dir}/docker-buildx
+
+    chown -R "${USERNAME}:docker" "${docker_home}"
+    chmod -R g+r+w "${docker_home}"
+    find "${docker_home}" -type d -print0 | xargs -n 1 -0 chmod g+s
+fi
+
+DOCKER_DEFAULT_IP6_TABLES=""
+if [ "$DISABLE_IP6_TABLES" == true ]; then
+    requested_version=""
+    # checking whether the version requested either is in semver format or just a number denoting the major version
+    # and, extracting the major version number out of the two scenarios
+    semver_regex="^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$"
+    if echo "$DOCKER_VERSION" | grep -Eq $semver_regex; then
+        requested_version=$(echo $DOCKER_VERSION | cut -d. -f1)
+    elif echo "$DOCKER_VERSION" | grep -Eq "^[1-9][0-9]*$"; then
+        requested_version=$DOCKER_VERSION
+    fi
+    if [ "$DOCKER_VERSION" = "latest" ] || [[ -n "$requested_version" && "$requested_version" -ge 27 ]] ; then
+        DOCKER_DEFAULT_IP6_TABLES="--ip6tables=false"
+        echo "(!) As requested, passing '${DOCKER_DEFAULT_IP6_TABLES}'"
+    fi
+fi
+
+if [ ! -d /usr/local/share ]; then
+    mkdir -p /usr/local/share
+fi
+
+tee /usr/local/share/docker-init.sh > /dev/null \
+<< EOF
+#!/bin/sh
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+set -e
+
+AZURE_DNS_AUTO_DETECTION=${AZURE_DNS_AUTO_DETECTION}
+DOCKER_DEFAULT_ADDRESS_POOL=${DOCKER_DEFAULT_ADDRESS_POOL}
+DOCKER_DEFAULT_IP6_TABLES=${DOCKER_DEFAULT_IP6_TABLES}
+EOF
+
+tee -a /usr/local/share/docker-init.sh > /dev/null \
+<< 'EOF'
+dockerd_start="AZURE_DNS_AUTO_DETECTION=${AZURE_DNS_AUTO_DETECTION} DOCKER_DEFAULT_ADDRESS_POOL=${DOCKER_DEFAULT_ADDRESS_POOL} DOCKER_DEFAULT_IP6_TABLES=${DOCKER_DEFAULT_IP6_TABLES} $(cat << 'INNEREOF'
+    # explicitly remove dockerd and containerd PID file to ensure that it can start properly if it was stopped uncleanly
+    find /run /var/run -iname 'docker*.pid' -delete || :
+    find /run /var/run -iname 'container*.pid' -delete || :
+
+    # -- Start: dind wrapper script --
+    # Maintained: https://github.com/moby/moby/blob/master/hack/dind
+
+    export container=docker
+
+    if [ -d /sys/kernel/security ] && ! mountpoint -q /sys/kernel/security; then
+        mount -t securityfs none /sys/kernel/security || {
+            echo >&2 'Could not mount /sys/kernel/security.'
+            echo >&2 'AppArmor detection and --privileged mode might break.'
+        }
+    fi
+
+    # Mount /tmp (conditionally)
+    if ! mountpoint -q /tmp; then
+        mount -t tmpfs none /tmp
+    fi
+
+    set_cgroup_nesting()
+    {
+        # cgroup v2: enable nesting
+        if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
+            # move the processes from the root group to the /init group,
+            # otherwise writing subtree_control fails with EBUSY.
+            # An error during moving non-existent process (i.e., "cat") is ignored.
+            mkdir -p /sys/fs/cgroup/init
+            xargs -rn1 < /sys/fs/cgroup/cgroup.procs > /sys/fs/cgroup/init/cgroup.procs || :
+            # enable controllers
+            sed -e 's/ / +/g' -e 's/^/+/' < /sys/fs/cgroup/cgroup.controllers \
+                > /sys/fs/cgroup/cgroup.subtree_control
+        fi
+    }
+
+    # Set cgroup nesting, retrying if necessary
+    retry_cgroup_nesting=0
+
+    until [ "${retry_cgroup_nesting}" -eq "5" ];
+    do
+        set +e
+            set_cgroup_nesting
+
+            if [ $? -ne 0 ]; then
+                echo "(*) cgroup v2: Failed to enable nesting, retrying..."
+            else
+                break
+            fi
+
+            retry_cgroup_nesting=`expr $retry_cgroup_nesting + 1`
+        set -e
+    done
+
+    # -- End: dind wrapper script --
+
+    # Handle DNS
+    set +e
+        cat /etc/resolv.conf | grep -i 'internal.cloudapp.net' > /dev/null 2>&1
+        if [ $? -eq 0 ] && [ "${AZURE_DNS_AUTO_DETECTION}" = "true" ]
+        then
+            echo "Setting dockerd Azure DNS."
+            CUSTOMDNS="--dns 168.63.129.16"
+        else
+            echo "Not setting dockerd DNS manually."
+            CUSTOMDNS=""
+        fi
+    set -e
+
+    if [ -z "$DOCKER_DEFAULT_ADDRESS_POOL" ]
+    then
+        DEFAULT_ADDRESS_POOL=""
+    else
+        DEFAULT_ADDRESS_POOL="--default-address-pool $DOCKER_DEFAULT_ADDRESS_POOL"
+    fi
+
+    # Start docker/moby engine
+    ( dockerd $CUSTOMDNS $DEFAULT_ADDRESS_POOL $DOCKER_DEFAULT_IP6_TABLES > /tmp/dockerd.log 2>&1 ) &
+INNEREOF
+)"
+
+sudo_if() {
+    COMMAND="$*"
+
+    if [ "$(id -u)" -ne 0 ]; then
+        sudo $COMMAND
+    else
+        $COMMAND
+    fi
+}
+
+retry_docker_start_count=0
+docker_ok="false"
+
+until [ "${docker_ok}" = "true"  ] || [ "${retry_docker_start_count}" -eq "5" ];
+do
+    # Start using sudo if not invoked as root
+    if [ "$(id -u)" -ne 0 ]; then
+        sudo /bin/sh -c "${dockerd_start}"
+    else
+        eval "${dockerd_start}"
+    fi
+
+    retry_count=0
+    until [ "${docker_ok}" = "true"  ] || [ "${retry_count}" -eq "5" ];
+    do
+        sleep 1s
+        set +e
+            docker info > /dev/null 2>&1 && docker_ok="true"
+        set -e
+
+        retry_count=`expr $retry_count + 1`
+    done
+
+    if [ "${docker_ok}" != "true" ] && [ "${retry_docker_start_count}" != "4" ]; then
+        echo "(*) Failed to start docker, retrying..."
+        set +e
+            sudo_if pkill dockerd
+            sudo_if pkill containerd
+        set -e
+    fi
+
+    retry_docker_start_count=`expr $retry_docker_start_count + 1`
+done
+
+# Execute whatever commands were passed in (if any). This allows us
+# to set this script to ENTRYPOINT while still executing the default CMD.
+exec "$@"
+EOF
+
+chmod +x /usr/local/share/docker-init.sh
+chown ${USERNAME}:root /usr/local/share/docker-init.sh
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+echo 'docker-in-docker-debian script has completed!'

--- a/.deacon/cache/features/12320c7892eee517/README.md
+++ b/.deacon/cache/features/12320c7892eee517/README.md
@@ -1,0 +1,36 @@
+# GitHub Actions Tools (github-actions-tools)
+
+Installs tools for local GitHub Actions development: act (local runner) and actionlint (workflow linter).
+
+## Options
+
+| Option | Description | Type | Default |
+|--------|-------------|------|---------|
+| `install` | Comma-separated list of tools to install (e.g. `"act"`). When set, only the listed tools are installed. When empty, all tools are installed. | string | `""` |
+| `omit` | Comma-separated list of tools to exclude (e.g. `"actionlint"`). When set, the listed tools are skipped. Applied after `install` filtering. | string | `""` |
+| `actVersion` | Version of act to install | string | `0.2.84` |
+| `actionlintVersion` | Version of actionlint to install | string | `1.7.10` |
+
+## Usage
+
+Add this feature to your `devcontainer.json`:
+
+```jsonc
+{
+  "features": {
+    "ghcr.io/get2knowio/devcontainer-features/github-actions-tools:2": {}
+  }
+}
+```
+
+### Install only actionlint
+
+```jsonc
+{
+  "features": {
+    "ghcr.io/get2knowio/devcontainer-features/github-actions-tools:2": {
+      "install": "actionlint"
+    }
+  }
+}
+```

--- a/.deacon/cache/features/12320c7892eee517/devcontainer-feature.json
+++ b/.deacon/cache/features/12320c7892eee517/devcontainer-feature.json
@@ -1,0 +1,29 @@
+{
+  "id": "github-actions-tools",
+  "version": "2.0.2",
+  "name": "GitHub Actions Tools",
+  "documentationURL": "https://github.com/get2knowio/devcontainer-features/tree/main/src/github-actions-tools",
+  "description": "Installs tools for local GitHub Actions development: act (local runner) and actionlint (workflow linter).",
+  "options": {
+    "install": {
+      "type": "string",
+      "default": "",
+      "description": "Comma-separated list of tools to install (e.g. 'act'). When set, only the listed tools are installed. When empty (default), all tools are installed."
+    },
+    "omit": {
+      "type": "string",
+      "default": "",
+      "description": "Comma-separated list of tools to exclude (e.g. 'actionlint'). When set, the listed tools are skipped. Applied after 'install' filtering."
+    },
+    "actVersion": {
+      "type": "string",
+      "default": "latest",
+      "description": "Version of act to install, or 'latest'"
+    },
+    "actionlintVersion": {
+      "type": "string",
+      "default": "latest",
+      "description": "Version of actionlint to install, or 'latest'"
+    }
+  }
+}

--- a/.deacon/cache/features/12320c7892eee517/install.sh
+++ b/.deacon/cache/features/12320c7892eee517/install.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+set -e
+
+echo "Installing GitHub Actions tools..."
+
+ARCH=$(dpkg --print-architecture)
+
+resolve_latest_version() {
+    local repo="$1"
+    local tag
+    tag=$(curl -sI "https://github.com/${repo}/releases/latest" \
+          | grep -i "^location:" | sed 's/.*\///' | tr -d '\r\n')
+    echo "${tag#v}"
+}
+
+# Step 1: All tools enabled by default
+ACT="true"
+ACTIONLINT="true"
+
+# Step 2: If install is set, whitelist mode
+if [ -n "${INSTALL}" ]; then
+    ACT="false"
+    ACTIONLINT="false"
+
+    IFS=',' read -ra SELECTED <<< "${INSTALL}"
+    for item in "${SELECTED[@]}"; do
+        item="$(echo "$item" | xargs)"
+        case "$item" in
+            act)        ACT="true" ;;
+            actionlint) ACTIONLINT="true" ;;
+            *) echo "Warning: unknown tool '$item' in install list" ;;
+        esac
+    done
+fi
+
+# Step 3: If omit is set, blacklist filter
+if [ -n "${OMIT}" ]; then
+    IFS=',' read -ra EXCLUDED <<< "${OMIT}"
+    for item in "${EXCLUDED[@]}"; do
+        item="$(echo "$item" | xargs)"
+        case "$item" in
+            act)        ACT="false" ;;
+            actionlint) ACTIONLINT="false" ;;
+            *) echo "Warning: unknown tool '$item' in omit list" ;;
+        esac
+    done
+fi
+
+# act - run GitHub Actions locally
+if [ "${ACT}" = "true" ]; then
+    if [ "${ACTVERSION}" = "latest" ]; then
+        ACTVERSION=$(resolve_latest_version "nektos/act")
+        echo "Resolved act latest -> ${ACTVERSION}"
+    fi
+    echo "Installing act ${ACTVERSION}..."
+    case "$ARCH" in
+        amd64) ACT_ARCH="x86_64" ;;
+        arm64) ACT_ARCH="arm64" ;;
+        *) echo "Unsupported architecture for act: $ARCH" && exit 1 ;;
+    esac
+    ACT_URL="https://github.com/nektos/act/releases/download/v${ACTVERSION}/act_Linux_${ACT_ARCH}.tar.gz"
+    curl -fsSL "$ACT_URL" | tar -xz -C /usr/local/bin act
+    chmod +x /usr/local/bin/act
+fi
+
+# actionlint - GitHub Actions workflow linter
+if [ "${ACTIONLINT}" = "true" ]; then
+    if [ "${ACTIONLINTVERSION}" = "latest" ]; then
+        ACTIONLINTVERSION=$(resolve_latest_version "rhysd/actionlint")
+        echo "Resolved actionlint latest -> ${ACTIONLINTVERSION}"
+    fi
+    echo "Installing actionlint ${ACTIONLINTVERSION}..."
+    case "$ARCH" in
+        amd64) ACTIONLINT_ARCH="amd64" ;;
+        arm64) ACTIONLINT_ARCH="arm64" ;;
+        *) echo "Unsupported architecture for actionlint: $ARCH" && exit 1 ;;
+    esac
+    ACTIONLINT_URL="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINTVERSION}/actionlint_${ACTIONLINTVERSION}_linux_${ACTIONLINT_ARCH}.tar.gz"
+    curl -fsSL "$ACTIONLINT_URL" | tar -xz -C /usr/local/bin actionlint
+    chmod +x /usr/local/bin/actionlint
+fi
+
+echo "GitHub Actions tools installation complete."

--- a/.deacon/cache/features/268b0d3baa8e5b25/NOTES.md
+++ b/.deacon/cache/features/268b0d3baa8e5b25/NOTES.md
@@ -1,0 +1,7 @@
+Available versions of the AWS CLI can be found here: https://github.com/aws/aws-cli/blob/v2/CHANGELOG.rst.
+
+## OS Support
+
+This Feature should work on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager installed.
+
+`bash` is required to execute the `install.sh` script.

--- a/.deacon/cache/features/268b0d3baa8e5b25/README.md
+++ b/.deacon/cache/features/268b0d3baa8e5b25/README.md
@@ -1,0 +1,37 @@
+
+# AWS CLI (aws-cli)
+
+Installs the AWS CLI along with needed dependencies. Useful for base Dockerfiles that often are missing required install dependencies like gpg.
+
+## Example Usage
+
+```json
+"features": {
+    "ghcr.io/devcontainers/features/aws-cli:1": {}
+}
+```
+
+## Options
+
+| Options Id | Description | Type | Default Value |
+|-----|-----|-----|-----|
+| version | Select or enter an AWS CLI version. | string | latest |
+
+## Customizations
+
+### VS Code Extensions
+
+- `AmazonWebServices.aws-toolkit-vscode`
+
+Available versions of the AWS CLI can be found here: https://github.com/aws/aws-cli/blob/v2/CHANGELOG.rst.
+
+## OS Support
+
+This Feature should work on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager installed.
+
+`bash` is required to execute the `install.sh` script.
+
+
+---
+
+_Note: This file was auto-generated from the [devcontainer-feature.json](https://github.com/devcontainers/features/blob/main/src/aws-cli/devcontainer-feature.json).  Add additional notes to a `NOTES.md`._

--- a/.deacon/cache/features/268b0d3baa8e5b25/devcontainer-feature.json
+++ b/.deacon/cache/features/268b0d3baa8e5b25/devcontainer-feature.json
@@ -1,0 +1,39 @@
+{
+    "id": "aws-cli",
+    "version": "1.1.4",
+    "name": "AWS CLI",
+    "documentationURL": "https://github.com/devcontainers/features/tree/main/src/aws-cli",
+    "description": "Installs the AWS CLI along with needed dependencies. Useful for base Dockerfiles that often are missing required install dependencies like gpg.",
+    "options": {
+        "version": {
+            "type": "string",
+            "proposals": [
+                "latest"
+            ],
+            "default": "latest",
+            "description": "Select or enter an AWS CLI version."
+        },
+        "verbose": {
+            "type": "boolean",
+            "default": true,
+            "description": "Suppress verbose output."
+        }
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "AmazonWebServices.aws-toolkit-vscode"
+            ],
+            "settings": {
+                "github.copilot.chat.codeGeneration.instructions": [
+                    {
+                        "text": "This dev container includes the AWS CLI along with needed dependencies pre-installed and available on the `PATH`, along with the AWS Toolkit extensions for AWS development."
+                    }
+                ]
+            }
+        }
+    },
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/common-utils"
+    ]
+}

--- a/.deacon/cache/features/268b0d3baa8e5b25/install.sh
+++ b/.deacon/cache/features/268b0d3baa8e5b25/install.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+#
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/awscli.md
+# Maintainer: The VS Code and Codespaces Teams
+
+set -e
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+VERSION=${VERSION:-"latest"}
+VERBOSE=${VERBOSE:-"true"}
+
+AWSCLI_GPG_KEY=FB5DB77FD5C118B80511ADA8A6310ACC4672475C
+AWSCLI_GPG_KEY_MATERIAL="-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mQINBF2Cr7UBEADJZHcgusOJl7ENSyumXh85z0TRV0xJorM2B/JL0kHOyigQluUG
+ZMLhENaG0bYatdrKP+3H91lvK050pXwnO/R7fB/FSTouki4ciIx5OuLlnJZIxSzx
+PqGl0mkxImLNbGWoi6Lto0LYxqHN2iQtzlwTVmq9733zd3XfcXrZ3+LblHAgEt5G
+TfNxEKJ8soPLyWmwDH6HWCnjZ/aIQRBTIQ05uVeEoYxSh6wOai7ss/KveoSNBbYz
+gbdzoqI2Y8cgH2nbfgp3DSasaLZEdCSsIsK1u05CinE7k2qZ7KgKAUIcT/cR/grk
+C6VwsnDU0OUCideXcQ8WeHutqvgZH1JgKDbznoIzeQHJD238GEu+eKhRHcz8/jeG
+94zkcgJOz3KbZGYMiTh277Fvj9zzvZsbMBCedV1BTg3TqgvdX4bdkhf5cH+7NtWO
+lrFj6UwAsGukBTAOxC0l/dnSmZhJ7Z1KmEWilro/gOrjtOxqRQutlIqG22TaqoPG
+fYVN+en3Zwbt97kcgZDwqbuykNt64oZWc4XKCa3mprEGC3IbJTBFqglXmZ7l9ywG
+EEUJYOlb2XrSuPWml39beWdKM8kzr1OjnlOm6+lpTRCBfo0wa9F8YZRhHPAkwKkX
+XDeOGpWRj4ohOx0d2GWkyV5xyN14p2tQOCdOODmz80yUTgRpPVQUtOEhXQARAQAB
+tCFBV1MgQ0xJIFRlYW0gPGF3cy1jbGlAYW1hem9uLmNvbT6JAlQEEwEIAD4WIQT7
+Xbd/1cEYuAURraimMQrMRnJHXAUCXYKvtQIbAwUJB4TOAAULCQgHAgYVCgkICwIE
+FgIDAQIeAQIXgAAKCRCmMQrMRnJHXJIXEAChLUIkg80uPUkGjE3jejvQSA1aWuAM
+yzy6fdpdlRUz6M6nmsUhOExjVIvibEJpzK5mhuSZ4lb0vJ2ZUPgCv4zs2nBd7BGJ
+MxKiWgBReGvTdqZ0SzyYH4PYCJSE732x/Fw9hfnh1dMTXNcrQXzwOmmFNNegG0Ox
+au+VnpcR5Kz3smiTrIwZbRudo1ijhCYPQ7t5CMp9kjC6bObvy1hSIg2xNbMAN/Do
+ikebAl36uA6Y/Uczjj3GxZW4ZWeFirMidKbtqvUz2y0UFszobjiBSqZZHCreC34B
+hw9bFNpuWC/0SrXgohdsc6vK50pDGdV5kM2qo9tMQ/izsAwTh/d/GzZv8H4lV9eO
+tEis+EpR497PaxKKh9tJf0N6Q1YLRHof5xePZtOIlS3gfvsH5hXA3HJ9yIxb8T0H
+QYmVr3aIUes20i6meI3fuV36VFupwfrTKaL7VXnsrK2fq5cRvyJLNzXucg0WAjPF
+RrAGLzY7nP1xeg1a0aeP+pdsqjqlPJom8OCWc1+6DWbg0jsC74WoesAqgBItODMB
+rsal1y/q+bPzpsnWjzHV8+1/EtZmSc8ZUGSJOPkfC7hObnfkl18h+1QtKTjZme4d
+H17gsBJr+opwJw/Zio2LMjQBOqlm3K1A4zFTh7wBC7He6KPQea1p2XAMgtvATtNe
+YLZATHZKTJyiqA==
+=vYOk
+-----END PGP PUBLIC KEY BLOCK-----"
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+apt_get_update()
+{
+    if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+        echo "Running apt-get update..."
+        apt-get update -y
+    fi
+}
+
+# Checks if packages are installed and installs them if not
+check_packages() {
+    if ! dpkg -s "$@" > /dev/null 2>&1; then
+        apt_get_update
+        apt-get -y install --no-install-recommends "$@"
+    fi
+}
+
+export DEBIAN_FRONTEND=noninteractive
+
+check_packages curl ca-certificates gpg dirmngr unzip bash-completion less
+
+verify_aws_cli_gpg_signature() {
+    local filePath=$1
+    local sigFilePath=$2
+    local awsGpgKeyring=aws-cli-public-key.gpg
+
+    echo "${AWSCLI_GPG_KEY_MATERIAL}" | gpg --dearmor > "./${awsGpgKeyring}"
+    gpg --batch --quiet --no-default-keyring --keyring "./${awsGpgKeyring}" --verify "${sigFilePath}" "${filePath}"
+    local status=$?
+
+    rm "./${awsGpgKeyring}"
+
+    return ${status}
+}
+
+install() {
+    local scriptZipFile=awscli.zip
+    local scriptSigFile=awscli.sig
+
+    # See Linux install docs at https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
+    if [ "${VERSION}" != "latest" ]; then
+        local versionStr=-${VERSION}
+    fi
+    architecture=$(dpkg --print-architecture)
+    case "${architecture}" in
+        amd64) architectureStr=x86_64 ;;
+        arm64) architectureStr=aarch64 ;;
+        *)
+            echo "AWS CLI does not support machine architecture '$architecture'. Please use an x86-64 or ARM64 machine."
+            exit 1
+    esac
+    local scriptUrl=https://awscli.amazonaws.com/awscli-exe-linux-${architectureStr}${versionStr}.zip
+    curl "${scriptUrl}" -o "${scriptZipFile}"
+    curl "${scriptUrl}.sig" -o "${scriptSigFile}"
+
+    verify_aws_cli_gpg_signature "$scriptZipFile" "$scriptSigFile"
+    if (( $? > 0 )); then
+        echo "Could not verify GPG signature of AWS CLI install script. Make sure you provided a valid version."
+        exit 1
+    fi
+
+    if [ "${VERBOSE}" = "false" ]; then
+        unzip -q "${scriptZipFile}"
+    else
+        unzip "${scriptZipFile}"
+    fi
+    
+    ./aws/install
+
+    # AWS bash completion
+    mkdir -p /etc/bash_completion.d
+    cp ./scripts/vendor/aws_bash_completer /etc/bash_completion.d/aws
+
+    # AWS zsh completion
+    mkdir -p /usr/local/share/zsh/site-functions/
+    cp ./scripts/vendor/aws_zsh_completer.sh /usr/local/share/zsh/site-functions/_aws
+    sed -i '1s/^/#compdef aws\n/' /usr/local/share/zsh/site-functions/_aws
+
+    rm -rf ./aws
+}
+
+echo "(*) Installing AWS CLI..."
+
+install
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+echo "Done!"

--- a/.deacon/cache/features/268b0d3baa8e5b25/scripts/fetch-latest-completer-scripts.sh
+++ b/.deacon/cache/features/268b0d3baa8e5b25/scripts/fetch-latest-completer-scripts.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+#
+# Docs: https://github.com/devcontainers/features/tree/main/src/aws-cli
+# Maintainer: The Dev Container spec maintainers
+#
+# Run this script to replace aws_bash_completer and aws_zsh_completer.sh with the latest and greatest available version
+# 
+COMPLETER_SCRIPTS=$(dirname "${BASH_SOURCE[0]}")
+BASH_COMPLETER_SCRIPT="$COMPLETER_SCRIPTS/vendor/aws_bash_completer"
+ZSH_COMPLETER_SCRIPT="$COMPLETER_SCRIPTS/vendor/aws_zsh_completer.sh"
+
+wget https://raw.githubusercontent.com/aws/aws-cli/v2/bin/aws_bash_completer -O "$BASH_COMPLETER_SCRIPT"
+chmod +x "$BASH_COMPLETER_SCRIPT"
+
+wget https://raw.githubusercontent.com/aws/aws-cli/v2/bin/aws_zsh_completer.sh -O "$ZSH_COMPLETER_SCRIPT"
+chmod +x "$ZSH_COMPLETER_SCRIPT"

--- a/.deacon/cache/features/268b0d3baa8e5b25/scripts/vendor/README.md
+++ b/.deacon/cache/features/268b0d3baa8e5b25/scripts/vendor/README.md
@@ -1,0 +1,12 @@
+### **IMPORTANT NOTE**
+
+Scripts in this directory are sourced externally and not maintained by the Dev Container spec maintainers. Do not make changes directly as they might be overwritten at any moment.
+
+## aws_bash_completer
+
+`aws_bash_completer` is a copy of <https://raw.githubusercontent.com/aws/aws-cli/v2/bin/aws_bash_completer>.
+
+## aws_zsh_completer.sh
+
+`aws_zsh_completer.sh` is a copy of <https://raw.githubusercontent.com/aws/aws-cli/v2/bin/aws_zsh_completer.sh>.
+

--- a/.deacon/cache/features/268b0d3baa8e5b25/scripts/vendor/aws_bash_completer
+++ b/.deacon/cache/features/268b0d3baa8e5b25/scripts/vendor/aws_bash_completer
@@ -1,0 +1,6 @@
+# Typically that would be added under one of the following paths:
+# - /etc/bash_completion.d
+# - /usr/local/etc/bash_completion.d
+# - /usr/share/bash-completion/completions
+
+complete -C aws_completer aws

--- a/.deacon/cache/features/268b0d3baa8e5b25/scripts/vendor/aws_zsh_completer.sh
+++ b/.deacon/cache/features/268b0d3baa8e5b25/scripts/vendor/aws_zsh_completer.sh
@@ -1,0 +1,60 @@
+# Source this file to activate auto completion for zsh using the bash
+# compatibility helper.  Make sure to run `compinit` before, which should be
+# given usually.
+#
+# % source /path/to/zsh_complete.sh
+#
+# Typically that would be called somewhere in your .zshrc.
+#
+# Note, the overwrite of _bash_complete() is to export COMP_LINE and COMP_POINT
+# That is only required for zsh <= edab1d3dbe61da7efe5f1ac0e40444b2ec9b9570
+#
+# https://github.com/zsh-users/zsh/commit/edab1d3dbe61da7efe5f1ac0e40444b2ec9b9570
+#
+# zsh releases prior to that version do not export the required env variables!
+
+autoload -Uz bashcompinit
+bashcompinit -i
+
+_bash_complete() {
+  local ret=1
+  local -a suf matches
+  local -x COMP_POINT COMP_CWORD
+  local -a COMP_WORDS COMPREPLY BASH_VERSINFO
+  local -x COMP_LINE="$words"
+  local -A savejobstates savejobtexts
+
+  (( COMP_POINT = 1 + ${#${(j. .)words[1,CURRENT]}} + $#QIPREFIX + $#IPREFIX + $#PREFIX ))
+  (( COMP_CWORD = CURRENT - 1))
+  COMP_WORDS=( $words )
+  BASH_VERSINFO=( 2 05b 0 1 release )
+
+  savejobstates=( ${(kv)jobstates} )
+  savejobtexts=( ${(kv)jobtexts} )
+
+  [[ ${argv[${argv[(I)nospace]:-0}-1]} = -o ]] && suf=( -S '' )
+
+  matches=( ${(f)"$(compgen $@ -- ${words[CURRENT]})"} )
+
+  if [[ -n $matches ]]; then
+    if [[ ${argv[${argv[(I)filenames]:-0}-1]} = -o ]]; then
+      compset -P '*/' && matches=( ${matches##*/} )
+      compset -S '/*' && matches=( ${matches%%/*} )
+      compadd -Q -f "${suf[@]}" -a matches && ret=0
+    else
+      compadd -Q "${suf[@]}" -a matches && ret=0
+    fi
+  fi
+
+  if (( ret )); then
+    if [[ ${argv[${argv[(I)default]:-0}-1]} = -o ]]; then
+      _default "${suf[@]}" && ret=0
+    elif [[ ${argv[${argv[(I)dirnames]:-0}-1]} = -o ]]; then
+      _directories "${suf[@]}" && ret=0
+    fi
+  fi
+
+  return ret
+}
+
+complete -C aws_completer aws

--- a/.deacon/cache/features/9dc38e0e7a3dc7d2/README.md
+++ b/.deacon/cache/features/9dc38e0e7a3dc7d2/README.md
@@ -1,0 +1,53 @@
+# Modern CLI Tools (modern-cli-tools)
+
+Installs modern CLI replacements and TUI tools: bat, ripgrep, fd, fzf, eza, zoxide, neovim, tmux, lazygit, ast-grep, jujutsu, zellij, and starship.
+
+## Options
+
+| Option | Description | Type | Default |
+|--------|-------------|------|---------|
+| `install` | Comma-separated list of tools to install (e.g. `"bat,ripgrep,fzf"`). When set, only the listed tools are installed. When empty, all tools are installed. | string | `""` |
+| `omit` | Comma-separated list of tools to exclude (e.g. `"neovim,tmux"`). When set, the listed tools are skipped. Applied after `install` filtering. | string | `""` |
+| `jujutsuVersion` | Version of jujutsu to install | string | `0.38.0` |
+| `ezaVersion` | Version of eza to install | string | `latest` |
+| `lazygitVersion` | Version of lazygit to install | string | `0.59.0` |
+| `astGrepVersion` | Version of ast-grep to install | string | `0.40.5` |
+| `zellijVersion` | Version of zellij to install | string | `0.43.1` |
+| `starshipVersion` | Version of starship to install | string | `latest` |
+
+## Usage
+
+Add this feature to your `devcontainer.json`:
+
+```jsonc
+{
+  "features": {
+    "ghcr.io/get2knowio/devcontainer-features/modern-cli-tools:2": {}
+  }
+}
+```
+
+### Install only specific tools
+
+```jsonc
+{
+  "features": {
+    "ghcr.io/get2knowio/devcontainer-features/modern-cli-tools:2": {
+      "install": "bat,ripgrep,fd,fzf,eza,lazygit"
+    }
+  }
+}
+```
+
+### Exclude zellij and pin lazygit version
+
+```jsonc
+{
+  "features": {
+    "ghcr.io/get2knowio/devcontainer-features/modern-cli-tools:2": {
+      "omit": "zellij",
+      "lazygitVersion": "0.58.0"
+    }
+  }
+}
+```

--- a/.deacon/cache/features/9dc38e0e7a3dc7d2/devcontainer-feature.json
+++ b/.deacon/cache/features/9dc38e0e7a3dc7d2/devcontainer-feature.json
@@ -1,0 +1,49 @@
+{
+  "id": "modern-cli-tools",
+  "version": "2.0.4",
+  "name": "Modern CLI Tools",
+  "documentationURL": "https://github.com/get2knowio/devcontainer-features/tree/main/src/modern-cli-tools",
+  "description": "Installs modern CLI replacements and TUI tools: bat, ripgrep, fd, fzf, eza, zoxide, neovim, tmux, lazygit, ast-grep, jujutsu, zellij, and starship.",
+  "options": {
+    "install": {
+      "type": "string",
+      "default": "",
+      "description": "Comma-separated list of tools to install (e.g. 'bat,ripgrep,fzf'). When set, only the listed tools are installed. When empty (default), all tools are installed."
+    },
+    "omit": {
+      "type": "string",
+      "default": "",
+      "description": "Comma-separated list of tools to exclude (e.g. 'neovim,tmux'). When set, the listed tools are skipped. Applied after 'install' filtering."
+    },
+    "jujutsuVersion": {
+      "type": "string",
+      "default": "latest",
+      "description": "Version of jujutsu to install, or 'latest'"
+    },
+    "ezaVersion": {
+      "type": "string",
+      "default": "latest",
+      "description": "Version of eza to install, or 'latest'"
+    },
+    "lazygitVersion": {
+      "type": "string",
+      "default": "latest",
+      "description": "Version of lazygit to install, or 'latest'"
+    },
+    "astGrepVersion": {
+      "type": "string",
+      "default": "latest",
+      "description": "Version of ast-grep to install, or 'latest'"
+    },
+    "zellijVersion": {
+      "type": "string",
+      "default": "latest",
+      "description": "Version of zellij to install, or 'latest'"
+    },
+    "starshipVersion": {
+      "type": "string",
+      "default": "latest",
+      "description": "Version of starship to install, or 'latest'"
+    }
+  }
+}

--- a/.deacon/cache/features/9dc38e0e7a3dc7d2/install.sh
+++ b/.deacon/cache/features/9dc38e0e7a3dc7d2/install.sh
@@ -1,0 +1,255 @@
+#!/bin/bash
+set -e
+
+echo "Installing modern CLI tools..."
+
+ARCH=$(dpkg --print-architecture)
+
+resolve_latest_version() {
+    local repo="$1"
+    local tag
+    tag=$(curl -sI "https://github.com/${repo}/releases/latest" \
+          | grep -i "^location:" | sed 's/.*\///' | tr -d '\r\n')
+    echo "${tag#v}"
+}
+
+# Step 1: All tools enabled by default
+BAT="true"
+RIPGREP="true"
+FD="true"
+FZF="true"
+EZA="true"
+ZOXIDE="true"
+NEOVIM="true"
+TMUX="true"
+LAZYGIT="true"
+ASTGREP="true"
+JUJUTSU="true"
+ZELLIJ="true"
+STARSHIP="true"
+
+# Step 2: If install is set, whitelist mode
+if [ -n "${INSTALL}" ]; then
+    BAT="false"
+    RIPGREP="false"
+    FD="false"
+    FZF="false"
+    EZA="false"
+    ZOXIDE="false"
+    NEOVIM="false"
+    TMUX="false"
+    LAZYGIT="false"
+    ASTGREP="false"
+    JUJUTSU="false"
+    ZELLIJ="false"
+    STARSHIP="false"
+
+    IFS=',' read -ra SELECTED <<< "${INSTALL}"
+    for item in "${SELECTED[@]}"; do
+        item="$(echo "$item" | xargs)"
+        case "$item" in
+            bat)      BAT="true" ;;
+            ripgrep)  RIPGREP="true" ;;
+            fd)       FD="true" ;;
+            fzf)      FZF="true" ;;
+            eza)      EZA="true" ;;
+            zoxide)   ZOXIDE="true" ;;
+            neovim)   NEOVIM="true" ;;
+            tmux)     TMUX="true" ;;
+            lazygit)  LAZYGIT="true" ;;
+            astGrep)  ASTGREP="true" ;;
+            jujutsu)  JUJUTSU="true" ;;
+            zellij)   ZELLIJ="true" ;;
+            starship) STARSHIP="true" ;;
+            *) echo "Warning: unknown tool '$item' in install list" ;;
+        esac
+    done
+fi
+
+# Step 3: If omit is set, blacklist filter
+if [ -n "${OMIT}" ]; then
+    IFS=',' read -ra EXCLUDED <<< "${OMIT}"
+    for item in "${EXCLUDED[@]}"; do
+        item="$(echo "$item" | xargs)"
+        case "$item" in
+            bat)      BAT="false" ;;
+            ripgrep)  RIPGREP="false" ;;
+            fd)       FD="false" ;;
+            fzf)      FZF="false" ;;
+            eza)      EZA="false" ;;
+            zoxide)   ZOXIDE="false" ;;
+            neovim)   NEOVIM="false" ;;
+            tmux)     TMUX="false" ;;
+            lazygit)  LAZYGIT="false" ;;
+            astGrep)  ASTGREP="false" ;;
+            jujutsu)  JUJUTSU="false" ;;
+            zellij)   ZELLIJ="false" ;;
+            starship) STARSHIP="false" ;;
+            *) echo "Warning: unknown tool '$item' in omit list" ;;
+        esac
+    done
+fi
+
+# --- APT-based tools ---
+APT_PACKAGES=""
+if [ "${BAT}" = "true" ]; then APT_PACKAGES="$APT_PACKAGES bat"; fi
+if [ "${RIPGREP}" = "true" ]; then APT_PACKAGES="$APT_PACKAGES ripgrep"; fi
+if [ "${FD}" = "true" ]; then APT_PACKAGES="$APT_PACKAGES fd-find"; fi
+if [ "${FZF}" = "true" ]; then APT_PACKAGES="$APT_PACKAGES fzf"; fi
+if [ "${NEOVIM}" = "true" ]; then APT_PACKAGES="$APT_PACKAGES neovim"; fi
+if [ "${TMUX}" = "true" ]; then APT_PACKAGES="$APT_PACKAGES tmux"; fi
+
+if [ -n "$APT_PACKAGES" ]; then
+    apt-get update -y
+    apt-get install -y --no-install-recommends $APT_PACKAGES
+    apt-get clean
+    rm -rf /var/lib/apt/lists/*
+fi
+
+# Create symlinks for apt tools
+if [ "${BAT}" = "true" ] && [ -f /usr/bin/batcat ]; then
+    ln -sf /usr/bin/batcat /usr/bin/bat
+fi
+if [ "${FD}" = "true" ] && [ -f /usr/bin/fdfind ]; then
+    ln -sf /usr/bin/fdfind /usr/bin/fd
+fi
+
+# --- GitHub release tools ---
+
+# eza
+if [ "${EZA}" = "true" ]; then
+    echo "Installing eza..."
+    case "$ARCH" in
+        amd64) EZA_ARCH="x86_64" ;;
+        arm64) EZA_ARCH="aarch64" ;;
+        *) echo "Unsupported architecture for eza: $ARCH" && exit 1 ;;
+    esac
+    if [ "${EZAVERSION}" = "latest" ]; then
+        EZA_TAR_URL="https://github.com/eza-community/eza/releases/latest/download/eza_${EZA_ARCH}-unknown-linux-gnu.tar.gz"
+    else
+        EZA_TAR_URL="https://github.com/eza-community/eza/releases/download/v${EZAVERSION}/eza_${EZA_ARCH}-unknown-linux-gnu.tar.gz"
+    fi
+    curl -fsSL "$EZA_TAR_URL" | tar -xzf - -C /usr/local/bin/
+fi
+
+# zoxide
+if [ "${ZOXIDE}" = "true" ]; then
+    echo "Installing zoxide..."
+    curl -sSfL https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh | sh -s -- --bin-dir /usr/local/bin
+fi
+
+# lazygit
+if [ "${LAZYGIT}" = "true" ]; then
+    if [ "${LAZYGITVERSION}" = "latest" ]; then
+        LAZYGITVERSION=$(resolve_latest_version "jesseduffield/lazygit")
+        echo "Resolved lazygit latest -> ${LAZYGITVERSION}"
+    fi
+    echo "Installing lazygit ${LAZYGITVERSION}..."
+    case "$ARCH" in
+        amd64) LG_ARCH="x86_64" ;;
+        arm64) LG_ARCH="arm64" ;;
+        *) echo "Unsupported architecture for lazygit: $ARCH" && exit 1 ;;
+    esac
+    LG_URL="https://github.com/jesseduffield/lazygit/releases/download/v${LAZYGITVERSION}/lazygit_${LAZYGITVERSION}_Linux_${LG_ARCH}.tar.gz"
+    curl -fsSL "$LG_URL" -o /tmp/lazygit.tgz
+    tar -xzf /tmp/lazygit.tgz -C /tmp lazygit
+    install /tmp/lazygit /usr/local/bin/lazygit
+    rm -f /tmp/lazygit.tgz /tmp/lazygit
+fi
+
+# ast-grep
+if [ "${ASTGREP}" = "true" ]; then
+    if [ "${ASTGREPVERSION}" = "latest" ]; then
+        ASTGREPVERSION=$(resolve_latest_version "ast-grep/ast-grep")
+        echo "Resolved ast-grep latest -> ${ASTGREPVERSION}"
+    fi
+    echo "Installing ast-grep ${ASTGREPVERSION}..."
+    case "$ARCH" in
+        amd64) SG_ARCH="x86_64" ;;
+        arm64) SG_ARCH="aarch64" ;;
+        *) echo "Unsupported architecture for ast-grep: $ARCH" && exit 1 ;;
+    esac
+    AST_GREP_URL="https://github.com/ast-grep/ast-grep/releases/download/${ASTGREPVERSION}/app-${SG_ARCH}-unknown-linux-gnu.zip"
+    curl -fsSL "$AST_GREP_URL" -o /tmp/ast-grep.zip
+    unzip -q /tmp/ast-grep.zip -d /tmp/ast-grep
+    install /tmp/ast-grep/sg /usr/local/bin/sg
+    install /tmp/ast-grep/ast-grep /usr/local/bin/ast-grep 2>/dev/null || cp /tmp/ast-grep/sg /usr/local/bin/ast-grep
+    rm -rf /tmp/ast-grep.zip /tmp/ast-grep
+fi
+
+# jujutsu (jj) - next-gen Git-compatible VCS
+if [ "${JUJUTSU}" = "true" ]; then
+    if [ "${JUJUTSUVERSION}" = "latest" ]; then
+        JUJUTSUVERSION=$(resolve_latest_version "jj-vcs/jj")
+        echo "Resolved jujutsu latest -> ${JUJUTSUVERSION}"
+    fi
+    echo "Installing jujutsu ${JUJUTSUVERSION}..."
+    case "$ARCH" in
+        amd64) JJ_ARCH="x86_64" ;;
+        arm64) JJ_ARCH="aarch64" ;;
+        *) echo "Unsupported architecture for jujutsu: $ARCH" && exit 1 ;;
+    esac
+    JJ_URL="https://github.com/jj-vcs/jj/releases/download/v${JUJUTSUVERSION}/jj-v${JUJUTSUVERSION}-${JJ_ARCH}-unknown-linux-musl.tar.gz"
+    curl -fsSL "$JJ_URL" -o /tmp/jj.tgz
+    # The jj tarball has a top-level "./" entry; extracting it straight into
+    # /tmp would apply that entry's 0755 mode to /tmp itself, stripping the
+    # 1777 sticky bit and breaking apt's _apt sandbox for anything installed
+    # afterward. Extract into a dedicated throwaway dir instead.
+    mkdir -p /tmp/jj-extract
+    tar -xzf /tmp/jj.tgz -C /tmp/jj-extract
+    install /tmp/jj-extract/jj /usr/local/bin/jj
+    rm -rf /tmp/jj.tgz /tmp/jj-extract
+fi
+
+# zellij
+if [ "${ZELLIJ}" = "true" ]; then
+    if [ "${ZELLIJVERSION}" = "latest" ]; then
+        ZELLIJVERSION=$(resolve_latest_version "zellij-org/zellij")
+        echo "Resolved zellij latest -> ${ZELLIJVERSION}"
+    fi
+    echo "Installing zellij ${ZELLIJVERSION}..."
+    case "$ARCH" in
+        amd64) ZELLIJ_ARCH="x86_64" ;;
+        arm64) ZELLIJ_ARCH="aarch64" ;;
+        *) echo "Unsupported architecture for zellij: $ARCH" && exit 1 ;;
+    esac
+    ZELLIJ_URL="https://github.com/zellij-org/zellij/releases/download/v${ZELLIJVERSION}/zellij-${ZELLIJ_ARCH}-unknown-linux-musl.tar.gz"
+    curl -fsSL "$ZELLIJ_URL" -o /tmp/zellij.tgz
+    tar -xzf /tmp/zellij.tgz -C /usr/local/bin zellij
+    rm -f /tmp/zellij.tgz
+fi
+
+# starship
+if [ "${STARSHIP}" = "true" ]; then
+    if [ "${STARSHIPVERSION}" = "latest" ]; then
+        STARSHIPVERSION=$(resolve_latest_version "starship/starship")
+        echo "Resolved starship latest -> ${STARSHIPVERSION}"
+    fi
+    echo "Installing starship ${STARSHIPVERSION}..."
+    case "$ARCH" in
+        amd64) STARSHIP_ARCH="x86_64-unknown-linux-gnu" ;;
+        arm64) STARSHIP_ARCH="aarch64-unknown-linux-musl" ;;  # no gnu build published for arm64
+        *) echo "Unsupported architecture for starship: $ARCH" && exit 1 ;;
+    esac
+    STARSHIP_URL="https://github.com/starship/starship/releases/download/v${STARSHIPVERSION}/starship-${STARSHIP_ARCH}.tar.gz"
+    curl -fsSL "$STARSHIP_URL" | tar -xzf - -C /usr/local/bin starship
+fi
+
+# --- Shell configuration ---
+ZSHRC="$_REMOTE_USER_HOME/.zshrc"
+
+if [ "${EZA}" = "true" ]; then
+    echo 'alias ls="eza --icons"' >> "$ZSHRC"
+    echo 'alias ll="eza -l --icons"' >> "$ZSHRC"
+    echo 'alias la="eza -la --icons"' >> "$ZSHRC"
+fi
+
+if [ "${ZOXIDE}" = "true" ]; then
+    echo 'eval "$(zoxide init zsh)"' >> "$ZSHRC"
+fi
+
+if [ "${STARSHIP}" = "true" ]; then
+    echo 'eval "$(starship init zsh)"' >> "$ZSHRC"
+fi
+
+echo "Modern CLI tools installation complete."

--- a/.deacon/cache/features/a6202c39d2d762d2/NOTES.md
+++ b/.deacon/cache/features/a6202c39d2d762d2/NOTES.md
@@ -1,0 +1,9 @@
+## OS Support
+
+This Feature should work on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager installed.
+
+`bash` is required to execute the `install.sh` script.
+
+## Extensions
+
+If you set the `extensions` option, the feature will run `gh extension install` for each entry (comma-separated). Extensions are installed for the most appropriate non-root user (based on `USERNAME` / `_REMOTE_USER`), with a fallback to `root`.

--- a/.deacon/cache/features/a6202c39d2d762d2/README.md
+++ b/.deacon/cache/features/a6202c39d2d762d2/README.md
@@ -1,0 +1,29 @@
+# GitHub CLI (github-cli)
+
+Installs the GitHub CLI. Auto-detects latest version and installs needed dependencies.
+
+## Example Usage
+
+```json
+"features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+}
+```
+
+## Options
+
+| Options Id                       | Description                                                                                         | Type    | Default Value |
+| -------------------------------- | --------------------------------------------------------------------------------------------------- | ------- | ------------- |
+| version                          | Select version of the GitHub CLI, if not latest.                                                    | string  | latest        |
+| installDirectlyFromGitHubRelease | -                                                                                                   | boolean | true          |
+| extensions                       | Comma-separated list of GitHub CLI extensions to install (e.g. 'dlvhdr/gh-dash,github/gh-copilot'). | string  |               |
+
+## OS Support
+
+This Feature should work on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager installed.
+
+`bash` is required to execute the `install.sh` script.
+
+---
+
+_Note: This file was auto-generated from the [devcontainer-feature.json](https://github.com/devcontainers/features/blob/main/src/github-cli/devcontainer-feature.json). Add additional notes to a `NOTES.md`._

--- a/.deacon/cache/features/a6202c39d2d762d2/devcontainer-feature.json
+++ b/.deacon/cache/features/a6202c39d2d762d2/devcontainer-feature.json
@@ -1,0 +1,42 @@
+{
+    "id": "github-cli",
+    "version": "1.1.0",
+    "name": "GitHub CLI",
+    "documentationURL": "https://github.com/devcontainers/features/tree/main/src/github-cli",
+    "description": "Installs the GitHub CLI. Auto-detects latest version and installs needed dependencies.",
+    "options": {
+        "version": {
+            "type": "string",
+            "proposals": [
+                "latest",
+                "none"
+            ],
+            "default": "latest",
+            "description": "Select version of the GitHub CLI, if not latest."
+        },
+        "installDirectlyFromGitHubRelease": {
+            "type": "boolean",
+            "default": true
+        },
+        "extensions": {
+            "type": "string",
+            "default": "",
+            "description": "Comma-separated list of GitHub CLI extensions to install (e.g. 'dlvhdr/gh-dash,github/gh-copilot')."
+        }
+    },
+    "customizations": {
+        "vscode": {
+            "settings": {
+                "github.copilot.chat.codeGeneration.instructions": [
+                    {
+                        "text": "This dev container includes the GitHub CLI (`gh`), which is pre-installed and available on the `PATH`. IMPORTANT: `gh api -f` does not support object values, use multiple `-f` flags with hierarchical keys and string values instead. When using GitHub actions `actions/upload-artifact` or `actions/download-artifact` use v4 or later."
+                    }
+                ]
+            }
+        }
+    },
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/common-utils",
+        "ghcr.io/devcontainers/features/git"
+    ]
+}

--- a/.deacon/cache/features/a6202c39d2d762d2/install.sh
+++ b/.deacon/cache/features/a6202c39d2d762d2/install.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+#
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/github.md
+# Maintainer: The VS Code and Codespaces Teams
+
+CLI_VERSION=${VERSION:-"latest"}
+INSTALL_DIRECTLY_FROM_GITHUB_RELEASE=${INSTALLDIRECTLYFROMGITHUBRELEASE:-"true"}
+EXTENSIONS=${EXTENSIONS:-""}
+
+GITHUB_CLI_ARCHIVE_GPG_KEY=23F3D4EA75716059
+
+set -e
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Get the list of GPG key servers that are reachable
+get_gpg_key_servers() {
+    declare -A keyservers_curl_map=(
+        ["hkp://keyserver.ubuntu.com"]="http://keyserver.ubuntu.com:11371"
+        ["hkp://keyserver.ubuntu.com:80"]="http://keyserver.ubuntu.com"
+        ["hkps://keys.openpgp.org"]="https://keys.openpgp.org"
+        ["hkp://keyserver.pgp.com"]="http://keyserver.pgp.com:11371"
+    )
+
+    local curl_args=""
+    local keyserver_reachable=false  # Flag to indicate if any keyserver is reachable
+
+    if [ ! -z "${KEYSERVER_PROXY}" ]; then
+        curl_args="--proxy ${KEYSERVER_PROXY}"
+    fi
+
+    for keyserver in "${!keyservers_curl_map[@]}"; do
+        local keyserver_curl_url="${keyservers_curl_map[${keyserver}]}"
+        if curl -s ${curl_args} --max-time 5 ${keyserver_curl_url} > /dev/null; then
+            echo "keyserver ${keyserver}"
+            keyserver_reachable=true
+        else
+            echo "(*) Keyserver ${keyserver} is not reachable." >&2
+        fi
+    done
+
+    if ! $keyserver_reachable; then
+        echo "(!) No keyserver is reachable." >&2
+        exit 1
+    fi
+}
+
+# Import the specified key in a variable name passed in as 
+receive_gpg_keys() {
+    local keys=${!1}
+    local keyring_args=""
+    if [ ! -z "$2" ]; then
+        keyring_args="--no-default-keyring --keyring $2"
+    fi
+
+    # Install curl
+    if ! type curl > /dev/null 2>&1; then
+        check_packages curl
+    fi
+
+    # Use a temporary location for gpg keys to avoid polluting image
+    export GNUPGHOME="/tmp/tmp-gnupg"
+    mkdir -p ${GNUPGHOME}
+    chmod 700 ${GNUPGHOME}
+    echo -e "disable-ipv6\n$(get_gpg_key_servers)" > ${GNUPGHOME}/dirmngr.conf
+    # GPG key download sometimes fails for some reason and retrying fixes it.
+    local retry_count=0
+    local gpg_ok="false"
+    set +e
+    until [ "${gpg_ok}" = "true" ] || [ "${retry_count}" -eq "5" ]; 
+    do
+        echo "(*) Downloading GPG key..."
+        ( echo "${keys}" | xargs -n 1 gpg -q ${keyring_args} --recv-keys) 2>&1 && gpg_ok="true"
+        if [ "${gpg_ok}" != "true" ]; then
+            echo "(*) Failed getting key, retrying in 10s..."
+            (( retry_count++ ))
+            sleep 10s
+        fi
+    done
+    set -e
+    if [ "${gpg_ok}" = "false" ]; then
+        echo "(!) Failed to get gpg key."
+        exit 1
+    fi
+}
+
+apt_get_update()
+{
+    if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+        echo "Running apt-get update..."
+        apt-get update -y
+    fi
+}
+
+# Checks if packages are installed and installs them if not
+check_packages() {
+    if ! dpkg -s "$@" > /dev/null 2>&1; then
+        apt_get_update
+        apt-get -y install --no-install-recommends "$@"
+    fi
+}
+
+# Figure out correct version of a three part version number is not passed
+find_version_from_git_tags() {
+    local variable_name=$1
+    local requested_version=${!variable_name}
+    if [ "${requested_version}" = "none" ]; then return; fi
+    local repository=$2
+    local prefix=${3:-"tags/v"}
+    local separator=${4:-"."}
+    local last_part_optional=${5:-"false"}    
+    if [ "$(echo "${requested_version}" | grep -o "." | wc -l)" != "2" ]; then
+        local escaped_separator=${separator//./\\.}
+        local last_part
+        if [ "${last_part_optional}" = "true" ]; then
+            last_part="(${escaped_separator}[0-9]+)?"
+        else
+            last_part="${escaped_separator}[0-9]+"
+        fi
+        local regex="${prefix}\\K[0-9]+${escaped_separator}[0-9]+${last_part}$"
+        local version_list="$(git ls-remote --tags ${repository} | grep -oP "${regex}" | tr -d ' ' | tr "${separator}" "." | sort -rV)"
+        if [ "${requested_version}" = "latest" ] || [ "${requested_version}" = "current" ] || [ "${requested_version}" = "lts" ]; then
+            declare -g ${variable_name}="$(echo "${version_list}" | head -n 1)"
+        else
+            set +e
+            declare -g ${variable_name}="$(echo "${version_list}" | grep -E -m 1 "^${requested_version//./\\.}([\\.\\s]|$)")"
+            set -e
+        fi
+    fi
+    if [ -z "${!variable_name}" ] || ! echo "${version_list}" | grep "^${!variable_name//./\\.}$" > /dev/null 2>&1; then
+        echo -e "Invalid ${variable_name} value: ${requested_version}\nValid values:\n${version_list}" >&2
+        exit 1
+    fi
+    echo "${variable_name}=${!variable_name}"
+}
+
+# Use semver logic to decrement a version number then look for the closest match
+find_prev_version_from_git_tags() {
+    local variable_name=$1
+    local current_version=${!variable_name}
+    local repository=$2
+    # Normally a "v" is used before the version number, but support alternate cases
+    local prefix=${3:-"tags/v"}
+    # Some repositories use "_" instead of "." for version number part separation, support that
+    local separator=${4:-"."}
+    # Some tools release versions that omit the last digit (e.g. go)
+    local last_part_optional=${5:-"false"}
+    # Some repositories may have tags that include a suffix (e.g. actions/node-versions)
+    local version_suffix_regex=$6
+    # Try one break fix version number less if we get a failure. Use "set +e" since "set -e" can cause failures in valid scenarios.
+    set +e
+        major="$(echo "${current_version}" | grep -oE '^[0-9]+' || echo '')"
+        minor="$(echo "${current_version}" | grep -oP '^[0-9]+\.\K[0-9]+' || echo '')"
+        breakfix="$(echo "${current_version}" | grep -oP '^[0-9]+\.[0-9]+\.\K[0-9]+' 2>/dev/null || echo '')"
+
+        if [ "${minor}" = "0" ] && [ "${breakfix}" = "0" ]; then
+            ((major=major-1))
+            declare -g ${variable_name}="${major}"
+            # Look for latest version from previous major release
+            find_version_from_git_tags "${variable_name}" "${repository}" "${prefix}" "${separator}" "${last_part_optional}"
+        # Handle situations like Go's odd version pattern where "0" releases omit the last part
+        elif [ "${breakfix}" = "" ] || [ "${breakfix}" = "0" ]; then
+            ((minor=minor-1))
+            declare -g ${variable_name}="${major}.${minor}"
+            # Look for latest version from previous minor release
+            find_version_from_git_tags "${variable_name}" "${repository}" "${prefix}" "${separator}" "${last_part_optional}"
+        else
+            ((breakfix=breakfix-1))
+            if [ "${breakfix}" = "0" ] && [ "${last_part_optional}" = "true" ]; then
+                declare -g ${variable_name}="${major}.${minor}"
+            else 
+                declare -g ${variable_name}="${major}.${minor}.${breakfix}"
+            fi
+        fi
+    set -e
+}
+
+# Fall back on direct download if no apt package exists
+# Fetches .deb file to be installed with dpkg
+install_deb_using_github() {
+    check_packages wget
+    arch=$(dpkg --print-architecture)
+
+    find_version_from_git_tags CLI_VERSION https://github.com/cli/cli
+    cli_filename="gh_${CLI_VERSION}_linux_${arch}.deb"
+
+    mkdir -p /tmp/ghcli
+    pushd /tmp/ghcli
+    wget -q --show-progress --progress=dot:giga https://github.com/cli/cli/releases/download/v${CLI_VERSION}/${cli_filename}
+    exit_code=$?
+    set -e
+    if [ "$exit_code" != "0" ]; then
+        # Handle situation where git tags are ahead of what was is available to actually download
+        echo "(!) github-cli version ${CLI_VERSION} failed to download. Attempting to fall back one version to retry..."
+        find_prev_version_from_git_tags CLI_VERSION https://github.com/cli/cli
+        wget -q --show-progress --progress=dot:giga https://github.com/cli/cli/releases/download/v${CLI_VERSION}/${cli_filename}
+    fi
+
+    dpkg -i /tmp/ghcli/${cli_filename}
+    popd
+    rm -rf /tmp/ghcli
+}
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Install curl, apt-transport-https, curl, gpg, or dirmngr, git if missing
+check_packages curl ca-certificates apt-transport-https dirmngr gnupg2
+if ! type git > /dev/null 2>&1; then
+    check_packages git
+fi
+
+# Soft version matching
+if [ "${CLI_VERSION}" != "latest" ] && [ "${CLI_VERSION}" != "lts" ] && [ "${CLI_VERSION}" != "stable" ]; then
+    find_version_from_git_tags CLI_VERSION "https://github.com/cli/cli"
+    version_suffix="=${CLI_VERSION}"
+else
+    version_suffix=""
+fi
+
+# Install the GitHub CLI
+echo "Downloading github CLI..."
+
+if [ "${INSTALL_DIRECTLY_FROM_GITHUB_RELEASE}" = "true" ]; then
+    install_deb_using_github
+else
+   # Import key safely (new method rather than deprecated apt-key approach) and install
+    . /etc/os-release
+    receive_gpg_keys GITHUB_CLI_ARCHIVE_GPG_KEY /usr/share/keyrings/githubcli-archive-keyring.gpg
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list
+    apt-get update
+    apt-get -y install "gh${version_suffix}"
+    rm -rf "/tmp/gh/gnupg"
+    echo "Done!"
+fi
+
+# Install requested GitHub CLI extensions (if any)
+if [ -n "${EXTENSIONS}" ]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    EXTENSIONS_SCRIPT="${SCRIPT_DIR}/scripts/install-extensions.sh"
+
+    # Determine the appropriate non-root user (mirrors other features' "automatic" behavior)
+    USERNAME="${USERNAME:-"${_REMOTE_USER:-"automatic"}"}"
+    if [ "${USERNAME}" = "auto" ] || [ "${USERNAME}" = "automatic" ]; then
+        USERNAME=""
+        POSSIBLE_USERS=("vscode" "node" "codespace" "$(awk -v val=1000 -F ":" '$3==val{print $1}' /etc/passwd)")
+        for CURRENT_USER in "${POSSIBLE_USERS[@]}"; do
+            if [ -n "${CURRENT_USER}" ] && id -u "${CURRENT_USER}" > /dev/null 2>&1; then
+                USERNAME="${CURRENT_USER}"
+                break
+            fi
+        done
+        if [ -z "${USERNAME}" ]; then
+            USERNAME=root
+        fi
+    elif [ "${USERNAME}" = "none" ] || ! id -u "${USERNAME}" > /dev/null 2>&1; then
+        USERNAME=root
+    fi
+
+    if [ "${USERNAME}" = "root" ]; then
+        EXTENSIONS="${EXTENSIONS}" bash "${EXTENSIONS_SCRIPT}"
+    else
+        EXTENSIONS_ESCAPED="$(printf '%q' "${EXTENSIONS}")"
+        USERNAME_ESCAPED="$(printf '%q' "${USERNAME}")"
+        su - "${USERNAME}" -c "EXTENSIONS=${EXTENSIONS_ESCAPED} USERNAME=${USERNAME_ESCAPED} INSTALL_EXTENSIONS=true bash '${EXTENSIONS_SCRIPT}'"
+        INSTALL_EXTENSIONS=false bash "${EXTENSIONS_SCRIPT}"
+    fi
+fi
+
+# Clean up
+rm -rf /var/lib/apt/lists/*

--- a/.deacon/cache/features/a6202c39d2d762d2/scripts/install-extensions.sh
+++ b/.deacon/cache/features/a6202c39d2d762d2/scripts/install-extensions.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+set -e
+
+EXTENSIONS=${EXTENSIONS:-""}
+INSTALL_EXTENSIONS=${INSTALL_EXTENSIONS:-"true"}
+
+trim() {
+    local value="$1"
+    value="${value#${value%%[![:space:]]*}}"
+    value="${value%${value##*[![:space:]]}}"
+    echo "${value}"
+}
+
+install_extension() {
+    local extension="$1"
+    local extensions_root
+    local repo_name
+
+    extensions_root="${XDG_DATA_HOME:-"${HOME}/.local/share"}/gh/extensions"
+    repo_name="${extension##*/}"
+
+    mkdir -p "${extensions_root}"
+    if [ ! -d "${extensions_root}/${repo_name}" ]; then
+        git clone --depth 1 "https://github.com/${extension}.git" "${extensions_root}/${repo_name}"
+    fi
+}
+
+ensure_gh_extension_list_wrapper() {
+    if [ "$(id -u)" -ne 0 ]; then
+        return
+    fi
+
+    if gh extension list >/dev/null 2>&1; then
+        return
+    fi
+
+    cat > /usr/local/bin/gh <<'EOF'
+#!/usr/bin/env bash
+set -e
+
+REAL_GH=/usr/bin/gh
+
+if [ "$#" -ge 2 ]; then
+    cmd="$1"
+    sub="$2"
+    if { [ "$cmd" = "extension" ] || [ "$cmd" = "extensions" ] || [ "$cmd" = "ext" ]; } && { [ "$sub" = "list" ] || [ "$sub" = "ls" ]; }; then
+        extensions_root="${XDG_DATA_HOME:-"$HOME/.local/share"}/gh/extensions"
+        if [ -d "$extensions_root" ]; then
+            shopt -s nullglob
+            for d in "$extensions_root"/*; do
+                [ -d "$d" ] || continue
+                url=""
+                if command -v git >/dev/null 2>&1 && [ -d "$d/.git" ]; then
+                    url="$(git -C "$d" config --get remote.origin.url 2>/dev/null || true)"
+                fi
+                if [ -n "$url" ]; then
+                    url="${url%.git}"
+                    url="${url#https://github.com/}"
+                    url="${url#http://github.com/}"
+                    url="${url#ssh://git@github.com/}"
+                    url="${url#git@github.com:}"
+                    echo "$url"
+                fi
+            done
+        fi
+        exit 0
+    fi
+fi
+
+exec "$REAL_GH" "$@"
+EOF
+    chmod +x /usr/local/bin/gh
+}
+
+if [ "${INSTALL_EXTENSIONS}" = "true" ]; then
+    if [ -z "${EXTENSIONS}" ]; then
+        exit 0
+    fi
+
+    echo "Installing GitHub CLI extensions: ${EXTENSIONS}"
+    IFS=',' read -r -a extension_list <<< "${EXTENSIONS}"
+    for extension in "${extension_list[@]}"; do
+        extension="$(trim "${extension}")"
+        if [ -z "${extension}" ]; then
+            continue
+        fi
+
+        install_extension "${extension}"
+    done
+fi
+
+ensure_gh_extension_list_wrapper

--- a/.deacon/cache/features/cc0182a5316616c7/NOTES.md
+++ b/.deacon/cache/features/cc0182a5316616c7/NOTES.md
@@ -1,0 +1,27 @@
+## Using nvm from postCreateCommand or another lifecycle command
+
+Certain operations like `postCreateCommand` run non-interactive, non-login shells. Unfortunately, `nvm` is really particular that it needs to be "sourced" before it is used, which can only happen automatically with interactive and/or login shells. Fortunately, this is easy to work around:
+
+Just can source the `nvm` startup script before using it:
+
+```json
+"postCreateCommand": ". ${NVM_DIR}/nvm.sh && nvm install --lts"
+```
+
+Note that typically the default shell in these cases is `sh` not `bash`, so use `. ${NVM_DIR}/nvm.sh` instead of `source ${NVM_DIR}/nvm.sh`.
+
+Alternatively, you can start up an interactive shell which will in turn source `nvm`:
+
+```json
+"postCreateCommand": "bash -i -c 'nvm install --lts'"
+```
+
+
+
+## OS Support
+
+Debian/Ubuntu, RedHat Enterprise Linux, Fedora, Alma, and Rocky Linux distributions with the `apt`, `yum`, `dnf`, or `microdnf` package manager installed.
+
+**Note**:  RedHat 7 Family (RedHat, CentOS, etc.) must use Node versions less than 18 due to its system libraries and long-term support (LTS) policies.
+
+`bash` is required to execute the `install.sh` script.

--- a/.deacon/cache/features/cc0182a5316616c7/README.md
+++ b/.deacon/cache/features/cc0182a5316616c7/README.md
@@ -1,0 +1,62 @@
+
+# Node.js (via nvm), yarn and pnpm (node)
+
+Installs Node.js, nvm, yarn, pnpm, and needed dependencies.
+
+## Example Usage
+
+```json
+"features": {
+    "ghcr.io/devcontainers/features/node:1": {}
+}
+```
+
+## Options
+
+| Options Id | Description | Type | Default Value |
+|-----|-----|-----|-----|
+| version | Select or enter a Node.js version to install | string | lts |
+| nodeGypDependencies | Install dependencies to compile native node modules (node-gyp)? | boolean | true |
+| nvmInstallPath | The path where NVM will be installed. | string | /usr/local/share/nvm |
+| pnpmVersion | Select or enter the PNPM version to install | string | latest |
+| nvmVersion | Version of NVM to install. | string | latest |
+| installYarnUsingApt | On Debian and Ubuntu systems, you have the option to install Yarn globally via APT. If you choose not to use this option, Yarn will be set up using Corepack instead. This choice is specific to Debian and Ubuntu; for other Linux distributions, Yarn is always installed using Corepack, with a fallback to installation via NPM if an error occurs. | boolean | false |
+
+## Customizations
+
+### VS Code Extensions
+
+- `dbaeumer.vscode-eslint`
+
+## Using nvm from postCreateCommand or another lifecycle command
+
+Certain operations like `postCreateCommand` run non-interactive, non-login shells. Unfortunately, `nvm` is really particular that it needs to be "sourced" before it is used, which can only happen automatically with interactive and/or login shells. Fortunately, this is easy to work around:
+
+Just can source the `nvm` startup script before using it:
+
+```json
+"postCreateCommand": ". ${NVM_DIR}/nvm.sh && nvm install --lts"
+```
+
+Note that typically the default shell in these cases is `sh` not `bash`, so use `. ${NVM_DIR}/nvm.sh` instead of `source ${NVM_DIR}/nvm.sh`.
+
+Alternatively, you can start up an interactive shell which will in turn source `nvm`:
+
+```json
+"postCreateCommand": "bash -i -c 'nvm install --lts'"
+```
+
+
+
+## OS Support
+
+Debian/Ubuntu, RedHat Enterprise Linux, Fedora, Alma, and Rocky Linux distributions with the `apt`, `yum`, `dnf`, or `microdnf` package manager installed.
+
+**Note**:  RedHat 7 Family (RedHat, CentOS, etc.) must use Node versions less than 18 due to its system libraries and long-term support (LTS) policies.
+
+`bash` is required to execute the `install.sh` script.
+
+
+---
+
+_Note: This file was auto-generated from the [devcontainer-feature.json](https://github.com/devcontainers/features/blob/main/src/node/devcontainer-feature.json).  Add additional notes to a `NOTES.md`._

--- a/.deacon/cache/features/cc0182a5316616c7/devcontainer-feature.json
+++ b/.deacon/cache/features/cc0182a5316616c7/devcontainer-feature.json
@@ -1,0 +1,81 @@
+{
+    "id": "node",
+    "version": "1.7.1",
+    "name": "Node.js (via nvm), yarn and pnpm.",
+    "documentationURL": "https://github.com/devcontainers/features/tree/main/src/node",
+    "description": "Installs Node.js, nvm, yarn, pnpm, and needed dependencies.",
+    "options": {
+        "version": {
+            "type": "string",
+            "proposals": [
+                "lts",
+                "latest",
+                "none",
+                "22",
+                "20"
+            ],
+            "default": "lts",
+            "description": "Select or enter a Node.js version to install"
+        },
+        "nodeGypDependencies": {
+            "type": "boolean",
+            "default": true,
+            "description": "Install dependencies to compile native node modules (node-gyp)?"
+        },
+        "nvmInstallPath": {
+            "type": "string",
+            "default": "/usr/local/share/nvm",
+            "description": "The path where NVM will be installed."
+        },
+        "pnpmVersion": {
+            "type": "string",
+            "proposals": [
+                "latest",
+                "8.8.0",
+                "8.0.0",
+                "7.30.0",
+                "6.14.8",
+                "5.18.10",
+                "none"
+            ],
+            "default": "latest",
+            "description": "Select or enter the PNPM version to install"
+        },
+        "nvmVersion": {
+            "type": "string",
+            "proposals": [
+                "latest",
+                "0.39"
+            ],
+            "default": "latest",
+            "description": "Version of NVM to install."
+        },
+        "installYarnUsingApt": {
+            "type": "boolean",
+            "default": false,
+            "description": "On Debian and Ubuntu systems, you have the option to install Yarn globally via APT. If you choose not to use this option, Yarn will be set up using Corepack instead. This choice is specific to Debian and Ubuntu; for other Linux distributions, Yarn is always installed using Corepack, with a fallback to installation via NPM if an error occurs."
+        }
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "dbaeumer.vscode-eslint"
+            ],
+            "settings": {
+                "github.copilot.chat.codeGeneration.instructions": [
+                    {
+                        "text": "This dev container includes `node`, `npm` and `eslint` pre-installed and available on the `PATH` for Node.js and JavaScript development."
+                    }
+                ]
+            }
+        }
+    },
+    "containerEnv": {
+        "NVM_DIR": "/usr/local/share/nvm",
+        "NVM_SYMLINK_CURRENT": "true",
+        "PATH": "/usr/local/share/nvm/current/bin:${PATH}"
+    },
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/common-utils"
+    ]
+}

--- a/.deacon/cache/features/cc0182a5316616c7/install.sh
+++ b/.deacon/cache/features/cc0182a5316616c7/install.sh
@@ -1,0 +1,442 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://github.com/devcontainers/features/blob/main/LICENSE for license information.
+#-------------------------------------------------------------------------------------------------------------------------
+#
+# Docs: https://github.com/devcontainers/features/tree/main/src/node
+# Maintainer: The Dev Container spec maintainers
+
+export NODE_VERSION="${VERSION:-"lts"}"
+export PNPM_VERSION="${PNPMVERSION:-"latest"}"
+export NVM_VERSION="${NVMVERSION:-"latest"}"
+export NVM_DIR="${NVMINSTALLPATH:-"/usr/local/share/nvm"}"
+INSTALL_TOOLS_FOR_NODE_GYP="${NODEGYPDEPENDENCIES:-true}"
+export INSTALL_YARN_USING_APT="${INSTALLYARNUSINGAPT:-false}"  # only concerns Debian-based systems
+
+# Comma-separated list of node versions to be installed (with nvm)
+# alongside NODE_VERSION, but not set as default.
+ADDITIONAL_VERSIONS="${ADDITIONALVERSIONS:-""}"
+
+USERNAME="${USERNAME:-"${_REMOTE_USER:-"automatic"}"}"
+UPDATE_RC="${UPDATE_RC:-"true"}"
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Bring in ID, ID_LIKE, VERSION_ID, VERSION_CODENAME
+. /etc/os-release
+# Get an adjusted ID independent of distro variants
+MAJOR_VERSION_ID=$(echo ${VERSION_ID} | cut -d . -f 1)
+if [ "${ID}" = "debian" ] || [ "${ID_LIKE}" = "debian" ]; then
+    ADJUSTED_ID="debian"
+elif [[ "${ID}" = "rhel" || "${ID}" = "fedora" || "${ID}" = "mariner" || "${ID_LIKE}" = *"rhel"* || "${ID_LIKE}" = *"fedora"* || "${ID_LIKE}" = *"mariner"* ]]; then
+    ADJUSTED_ID="rhel"
+    if [[ "${ID}" = "rhel" ]] || [[ "${ID}" = *"alma"* ]] || [[ "${ID}" = *"rocky"* ]]; then
+        VERSION_CODENAME="rhel${MAJOR_VERSION_ID}"
+    else
+        VERSION_CODENAME="${ID}${MAJOR_VERSION_ID}"
+    fi
+else
+    echo "Linux distro ${ID} not supported."
+    exit 1
+fi
+
+if [ "${ADJUSTED_ID}" = "rhel" ] && [ "${VERSION_CODENAME-}" = "centos7" ]; then
+    # As of 1 July 2024, mirrorlist.centos.org no longer exists.
+    # Update the repo files to reference vault.centos.org.
+    sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+    sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+    sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+fi
+
+# Setup INSTALL_CMD & PKG_MGR_CMD
+if type apt-get > /dev/null 2>&1; then
+    PKG_MGR_CMD=apt-get
+    INSTALL_CMD="${PKG_MGR_CMD} -y install --no-install-recommends"
+elif type microdnf > /dev/null 2>&1; then
+    PKG_MGR_CMD=microdnf
+    INSTALL_CMD="${PKG_MGR_CMD} -y install --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0"
+elif type dnf > /dev/null 2>&1; then
+    PKG_MGR_CMD=dnf
+    INSTALL_CMD="${PKG_MGR_CMD} -y install"
+else
+    PKG_MGR_CMD=yum
+    INSTALL_CMD="${PKG_MGR_CMD} -y install"
+fi
+
+# Clean up
+clean_up() {
+    case ${ADJUSTED_ID} in
+        debian)
+            rm -rf /var/lib/apt/lists/*
+            ;;
+        rhel)
+            rm -rf /var/cache/dnf/* /var/cache/yum/*
+            rm -f /etc/yum.repos.d/yarn.repo
+            ;;
+    esac
+}
+clean_up
+
+# Ensure that login shells get the correct path if the user updated the PATH using ENV.
+rm -f /etc/profile.d/00-restore-env.sh
+echo "export PATH=${PATH//$(sh -lc 'echo $PATH')/\$PATH}" > /etc/profile.d/00-restore-env.sh
+chmod +x /etc/profile.d/00-restore-env.sh
+
+updaterc() {
+    local _bashrc
+    local _zshrc
+    if [ "${UPDATE_RC}" = "true" ]; then
+        case $ADJUSTED_ID in
+            debian)
+                _bashrc=/etc/bash.bashrc
+                _zshrc=/etc/zsh/zshrc
+                ;;
+            rhel)
+                _bashrc=/etc/bashrc
+                _zshrc=/etc/zshrc
+            ;;
+        esac
+        echo "Updating ${_bashrc} and ${_zshrc}..."
+        if [[ "$(cat ${_bashrc})" != *"$1"* ]]; then
+            echo -e "$1" >> "${_bashrc}"
+        fi
+        if [ -f "${_zshrc}" ] && [[ "$(cat ${_zshrc})" != *"$1"* ]]; then
+            echo -e "$1" >> "${_zshrc}"
+        fi
+    fi
+}
+
+pkg_mgr_update() {
+    case $ADJUSTED_ID in
+        debian)
+            if [ "$(find /var/lib/apt/lists/* 2>/dev/null | wc -l)" = "0" ]; then
+                echo "Running apt-get update..."
+                ${PKG_MGR_CMD} update -y
+            fi
+            ;;
+        rhel)
+            if [ ${PKG_MGR_CMD} = "microdnf" ]; then
+                if [ "$(ls /var/cache/yum/* 2>/dev/null | wc -l)" = 0 ]; then
+                    echo "Running ${PKG_MGR_CMD} makecache ..."
+                    ${PKG_MGR_CMD} makecache
+                fi
+            else
+                if [ "$(ls /var/cache/${PKG_MGR_CMD}/* 2>/dev/null | wc -l)" = 0 ]; then
+                    echo "Running ${PKG_MGR_CMD} check-update ..."
+                    set +e
+                        stderr_messages=$(${PKG_MGR_CMD} -q check-update 2>&1)
+                        rc=$?
+                        # centos 7 sometimes returns a status of 100 when it apears to work.
+                        if [ $rc != 0 ] && [ $rc != 100 ]; then
+                            echo "(Error) ${PKG_MGR_CMD} check-update produced the following error message(s):"
+                            echo "${stderr_messages}"
+                            exit 1
+                        fi
+                    set -e
+                fi
+            fi
+            ;;
+    esac
+}
+
+# Checks if packages are installed and installs them if not
+check_packages() {
+    case ${ADJUSTED_ID} in
+        debian)
+            if ! dpkg -s "$@" > /dev/null 2>&1; then
+                pkg_mgr_update
+                ${INSTALL_CMD} "$@"
+            fi
+            ;;
+        rhel)
+            if ! rpm -q "$@" > /dev/null 2>&1; then
+                pkg_mgr_update
+                ${INSTALL_CMD} "$@"
+            fi
+            ;;
+    esac
+}
+
+# Figure out correct version of a three part version number is not passed
+find_version_from_git_tags() {
+    local variable_name=$1
+    local requested_version=${!variable_name}
+    if [ "${requested_version}" = "none" ]; then return; fi
+    local repository=$2
+    local prefix=${3:-"tags/v"}
+    local separator=${4:-"."}
+    local last_part_optional=${5:-"false"}
+    if [ "$(echo "${requested_version}" | grep -o "." | wc -l)" != "2" ]; then
+        local escaped_separator=${separator//./\\.}
+        local last_part
+        if [ "${last_part_optional}" = "true" ]; then
+            last_part="(${escaped_separator}[0-9]+)?"
+        else
+            last_part="${escaped_separator}[0-9]+"
+        fi
+        local regex="${prefix}\\K[0-9]+${escaped_separator}[0-9]+${last_part}$"
+        local version_list="$(git ls-remote --tags ${repository} | grep -oP "${regex}" | tr -d ' ' | tr "${separator}" "." | sort -rV)"
+        if [ "${requested_version}" = "latest" ] || [ "${requested_version}" = "current" ] || [ "${requested_version}" = "lts" ]; then
+            declare -g ${variable_name}="$(echo "${version_list}" | head -n 1)"
+        else
+            set +e
+            declare -g ${variable_name}="$(echo "${version_list}" | grep -E -m 1 "^${requested_version//./\\.}([\\.\\s]|$)")"
+            set -e
+        fi
+    fi
+    if [ -z "${!variable_name}" ] || ! echo "${version_list}" | grep "^${!variable_name//./\\.}$" > /dev/null 2>&1; then
+        echo -e "Invalid ${variable_name} value: ${requested_version}\nValid values:\n${version_list}" >&2
+        exit 1
+    fi
+    echo "${variable_name}=${!variable_name}"
+}
+
+install_yarn() {
+    if [ "${ADJUSTED_ID}" = "debian" ] && [ "${INSTALL_YARN_USING_APT}" = "true" ]; then
+        # for backward compatiblity with existing devcontainer features, install yarn
+        # via apt-get on Debian systems
+        if ! type yarn >/dev/null 2>&1; then
+            # Import key safely (new method rather than deprecated apt-key approach) and install
+            mkdir -p /etc/apt/keyrings
+            curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor --yes -o /etc/apt/keyrings/yarn-archive-keyring.gpg
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/yarn-archive-keyring.gpg] https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list
+            apt-get update
+            apt-get -y install --no-install-recommends yarn
+        else
+            echo "Yarn is already installed."
+        fi
+    else
+        local _ver=${1:-node}
+        # on non-debian systems or if user opted not to use APT, prefer corepack
+        # Fallback to npm based installation of yarn.
+        # But try to leverage corepack if possible
+        # From https://yarnpkg.com:
+        # The preferred way to manage Yarn is by-project and through Corepack, a tool
+        # shipped by default with Node.js. Modern releases of Yarn aren't meant to be
+        # installed globally, or from npm.
+        if ! bash -c ". '${NVM_DIR}/nvm.sh' && nvm use ${_ver} && type yarn >/dev/null 2>&1"; then
+            if bash -c ". '${NVM_DIR}/nvm.sh' && nvm use ${_ver} && type corepack >/dev/null 2>&1"; then
+                su ${USERNAME} -c "umask 0002 && . '${NVM_DIR}/nvm.sh' && nvm use ${_ver} && corepack enable"
+            fi
+            if ! bash -c ". '${NVM_DIR}/nvm.sh' && nvm use ${_ver} && type yarn >/dev/null 2>&1"; then
+                # Yum/DNF want to install nodejs dependencies, we'll use NPM to install yarn
+                su ${USERNAME} -c "umask 0002 && . '${NVM_DIR}/nvm.sh' && nvm use ${_ver} && npm install --global yarn"
+            fi
+        else
+            echo "Yarn already installed."
+        fi
+    fi
+}
+
+# Mariner does not have awk installed by default, this can cause
+# problems is username is auto* and later when we try to install
+# node via npm.
+if ! type awk >/dev/null 2>&1; then
+    check_packages awk
+fi
+
+# Determine the appropriate non-root user
+if [ "${USERNAME}" = "auto" ] || [ "${USERNAME}" = "automatic" ]; then
+    USERNAME=""
+    POSSIBLE_USERS=("vscode" "node" "codespace" "$(awk -v val=1000 -F ":" '$3==val{print $1}' /etc/passwd)")
+    for CURRENT_USER in "${POSSIBLE_USERS[@]}"; do
+        if id -u ${CURRENT_USER} > /dev/null 2>&1; then
+            USERNAME=${CURRENT_USER}
+            break
+        fi
+    done
+    if [ "${USERNAME}" = "" ]; then
+        USERNAME=root
+    fi
+elif [ "${USERNAME}" = "none" ] || ! id -u ${USERNAME} > /dev/null 2>&1; then
+    USERNAME=root
+fi
+
+# Ensure apt is in non-interactive to avoid prompts
+export DEBIAN_FRONTEND=noninteractive
+
+if ( [ -n "${VERSION_CODENAME}" ] && [[ "bionic" = *"${VERSION_CODENAME}"* ]] ) || [[ "rhel7" = *"${ADJUSTED_ID}${MAJOR_VERSION_ID}"* ]]; then
+    node_major_version=$(echo "${NODE_VERSION}" | cut -d . -f 1)
+    if [[ "${node_major_version}" -ge 18 ]] || [[ "${NODE_VERSION}" = "lts" ]] || [[ "${NODE_VERSION}" = "latest" ]]; then
+        echo "(!) Unsupported distribution version '${VERSION_CODENAME}' for Node >= 18. Details: https://github.com/nodejs/node/issues/42351#issuecomment-1068424442"
+        exit 1
+    fi
+fi
+
+# Install dependencies
+case ${ADJUSTED_ID} in
+    debian)
+        check_packages apt-transport-https curl ca-certificates tar gnupg2 dirmngr
+        ;;
+    rhel)
+        check_packages ca-certificates tar gnupg2 which findutils util-linux tar
+        # minimal RHEL installs may not include curl, or includes curl-minimal instead.
+        # Install curl if the "curl" command is not present.
+        if ! type curl > /dev/null 2>&1; then
+            check_packages curl
+        fi
+        ;;
+esac
+
+if ! type git > /dev/null 2>&1; then
+    check_packages git
+fi
+
+# Adjust node version if required
+if [ "${NODE_VERSION}" = "none" ]; then
+    export NODE_VERSION=
+elif [ "${NODE_VERSION}" = "lts" ]; then
+    export NODE_VERSION="lts/*"
+elif [ "${NODE_VERSION}" = "latest" ]; then
+    export NODE_VERSION="node"
+fi
+
+find_version_from_git_tags NVM_VERSION "https://github.com/nvm-sh/nvm"
+
+# Install snipppet that we will run as the user
+nvm_install_snippet="$(cat << EOF
+set -e
+umask 0002
+# Do not update profile - we'll do this manually
+export PROFILE=/dev/null
+curl -so- "https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh" | bash ||  {
+    PREV_NVM_VERSION=$(curl -s https://api.github.com/repos/nvm-sh/nvm/releases/latest | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+    curl -so- "https://raw.githubusercontent.com/nvm-sh/nvm/\${PREV_NVM_VERSION}/install.sh" | bash
+    NVM_VERSION="\${PREV_NVM_VERSION}"
+}
+[ -s "${NVM_DIR}/nvm.sh" ] && source "${NVM_DIR}/nvm.sh"
+if [ "${NODE_VERSION}" != "" ]; then
+    nvm alias default "${NODE_VERSION}"
+fi
+EOF
+)"
+
+# Snippet that should be added into rc / profiles
+nvm_rc_snippet="$(cat << EOF
+export NVM_DIR="${NVM_DIR}"
+[ -s "\$NVM_DIR/nvm.sh" ] && . "\$NVM_DIR/nvm.sh"
+[ -s "\$NVM_DIR/bash_completion" ] && . "\$NVM_DIR/bash_completion"
+EOF
+)"
+
+# Create a symlink to the installed version for use in Dockerfile PATH statements
+export NVM_SYMLINK_CURRENT=true
+
+# Create nvm group to the user's UID or GID to change while still allowing access to nvm
+if ! cat /etc/group | grep -e "^nvm:" > /dev/null 2>&1; then
+    groupadd -r nvm
+fi
+usermod -a -G nvm ${USERNAME}
+
+# Install nvm (which also installs NODE_VERSION), otherwise
+# use nvm to install the specified node version. Always use
+# umask 0002 so both the owner so that everything is u+rw,g+rw
+umask 0002
+if [ ! -d "${NVM_DIR}" ]; then
+    # Create nvm dir, and set sticky bit
+    mkdir -p "${NVM_DIR}"
+    chown "${USERNAME}:nvm" "${NVM_DIR}"
+    chmod g+rws "${NVM_DIR}"
+    su ${USERNAME} -c "${nvm_install_snippet}" 2>&1
+    # Update rc files
+    if [ "${UPDATE_RC}" = "true" ]; then
+        updaterc "${nvm_rc_snippet}"
+    fi
+else
+    echo "NVM already installed."
+    if [ "${NODE_VERSION}" != "" ]; then
+        su ${USERNAME} -c "umask 0002 && . '$NVM_DIR/nvm.sh' && nvm install '${NODE_VERSION}' && nvm alias default '${NODE_VERSION}'"
+    fi
+fi
+
+# Possibly install yarn (puts yarn in per-Node install on RHEL, uses system yarn on Debian)
+if [ -n "${NODE_VERSION}" ] && [ "${NODE_VERSION}" != "none" ]; then
+    install_yarn
+fi
+
+# Additional node versions to be installed but not be set as
+# default we can assume the nvm is the group owner of the nvm
+# directory and the sticky bit on directories so any installed
+# files will have will have the correct ownership (nvm)
+if [ ! -z "${ADDITIONAL_VERSIONS}" ]; then
+    OLDIFS=$IFS
+    IFS=","
+        read -a additional_versions <<< "$ADDITIONAL_VERSIONS"
+        for ver in "${additional_versions[@]}"; do
+            su ${USERNAME} -c "umask 0002 && . '$NVM_DIR/nvm.sh' && nvm install '${ver}'"
+            # possibly install yarn (puts yarn in per-Node install on RHEL, uses system yarn on Debian)
+            install_yarn "${ver}"
+        done
+
+        # Ensure $NODE_VERSION is on the $PATH
+        if [ "${NODE_VERSION}" != "" ]; then
+                su ${USERNAME} -c "umask 0002 && . '$NVM_DIR/nvm.sh' && nvm use default"
+        fi
+    IFS=$OLDIFS
+fi
+
+# Install pnpm
+if [ ! -z "${PNPM_VERSION}" ] && [ "${PNPM_VERSION}" = "none" ]; then
+    echo "Ignoring installation of PNPM"
+else
+    if bash -c ". '${NVM_DIR}/nvm.sh' && type npm >/dev/null 2>&1"; then
+        (
+            . "${NVM_DIR}/nvm.sh"
+            [ ! -z "$http_proxy" ] && npm set proxy="$http_proxy"
+            [ ! -z "$https_proxy" ] && npm set https-proxy="$https_proxy"
+            [ ! -z "$no_proxy" ] && npm set noproxy="$no_proxy"
+            npm install -g pnpm@$PNPM_VERSION --force
+        )
+    else
+        echo "Skip installing pnpm because npm is missing"
+    fi
+fi
+
+# If enabled, verify "python3", "make", "gcc", "g++" commands are available so node-gyp works - https://github.com/nodejs/node-gyp
+if [ "${INSTALL_TOOLS_FOR_NODE_GYP}" = "true" ]; then
+    echo "Verifying node-gyp OS requirements..."
+    to_install=""
+    if ! type make > /dev/null 2>&1; then
+        to_install="${to_install} make"
+    fi
+    if ! type gcc > /dev/null 2>&1; then
+        to_install="${to_install} gcc"
+    fi
+    if ! type g++ > /dev/null 2>&1; then
+        if [ ${ADJUSTED_ID} = "debian" ]; then
+            to_install="${to_install} g++"
+        elif [ ${ADJUSTED_ID} = "rhel" ]; then
+            to_install="${to_install} gcc-c++"
+        fi
+    fi
+    if ! type python3 > /dev/null 2>&1; then
+        if [ ${ADJUSTED_ID} = "debian" ]; then
+            to_install="${to_install} python3-minimal"
+        elif [ ${ADJUSTED_ID} = "rhel" ]; then
+            to_install="${to_install} python3"
+        fi
+    fi
+    if [ ! -z "${to_install}" ]; then
+        pkg_mgr_update
+        check_packages ${to_install}
+    fi
+fi
+
+
+# Clean up
+su ${USERNAME} -c "umask 0002 && . '$NVM_DIR/nvm.sh' && nvm clear-cache"
+clean_up
+
+# Ensure privs are correct for installed node versions. Unfortunately the
+# way nvm installs node versions pulls privs from the tar which does not
+# have group write set. We need this when the gid/uid is updated.
+mkdir -p "${NVM_DIR}/versions"
+chmod -R g+rw "${NVM_DIR}/versions"
+
+echo "Done!"

--- a/.deacon/cache/features/cf02cbe11d14ed55/README.md
+++ b/.deacon/cache/features/cf02cbe11d14ed55/README.md
@@ -1,0 +1,36 @@
+# Node.js Development Tools (node-dev-tools)
+
+Installs TypeScript toolchain, bundlers, linters, file watchers, and Bun runtime for Node.js development.
+
+## Options
+
+| Option | Description | Type | Default |
+|--------|-------------|------|---------|
+| `install` | Comma-separated list of tool groups to install (e.g. `"typescript,bun"`). When set, only the listed groups are installed. When empty, all groups are installed. | string | `""` |
+| `omit` | Comma-separated list of tool groups to exclude (e.g. `"bun"`). When set, the listed groups are skipped. Applied after `install` filtering. | string | `""` |
+
+## Usage
+
+Add this feature to your `devcontainer.json`:
+
+```jsonc
+{
+  "features": {
+    "ghcr.io/get2knowio/devcontainer-features/node-dev-tools:2": {}
+  }
+}
+```
+
+### TypeScript and Bun only
+
+```jsonc
+{
+  "features": {
+    "ghcr.io/get2knowio/devcontainer-features/node-dev-tools:2": {
+      "install": "typescript,bun"
+    }
+  }
+}
+```
+
+**Requires:** Node.js (installs after `ghcr.io/devcontainers/features/node`)

--- a/.deacon/cache/features/cf02cbe11d14ed55/devcontainer-feature.json
+++ b/.deacon/cache/features/cf02cbe11d14ed55/devcontainer-feature.json
@@ -1,0 +1,22 @@
+{
+  "id": "node-dev-tools",
+  "version": "2.0.2",
+  "name": "Node.js Development Tools",
+  "documentationURL": "https://github.com/get2knowio/devcontainer-features/tree/main/src/node-dev-tools",
+  "description": "Installs TypeScript toolchain, bundlers, linters, file watchers, and Bun runtime for Node.js development.",
+  "options": {
+    "install": {
+      "type": "string",
+      "default": "",
+      "description": "Comma-separated list of tool groups to install (e.g. 'typescript,bun'). When set, only the listed groups are installed. When empty (default), all groups are installed."
+    },
+    "omit": {
+      "type": "string",
+      "default": "",
+      "description": "Comma-separated list of tool groups to exclude (e.g. 'bun'). When set, the listed groups are skipped. Applied after 'install' filtering."
+    }
+  },
+  "installsAfter": [
+    "ghcr.io/devcontainers/features/node"
+  ]
+}

--- a/.deacon/cache/features/cf02cbe11d14ed55/install.sh
+++ b/.deacon/cache/features/cf02cbe11d14ed55/install.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+set -e
+
+echo "Installing Node.js development tools..."
+
+# Step 1: All tools enabled by default
+TYPESCRIPT="true"
+BUNDLERS="true"
+LINTERS="true"
+WATCHERS="true"
+BUN="true"
+
+# Step 2: If install is set, whitelist mode
+if [ -n "${INSTALL}" ]; then
+    TYPESCRIPT="false"
+    BUNDLERS="false"
+    LINTERS="false"
+    WATCHERS="false"
+    BUN="false"
+
+    IFS=',' read -ra SELECTED <<< "${INSTALL}"
+    for item in "${SELECTED[@]}"; do
+        item="$(echo "$item" | xargs)"
+        case "$item" in
+            typescript) TYPESCRIPT="true" ;;
+            bundlers)   BUNDLERS="true" ;;
+            linters)    LINTERS="true" ;;
+            watchers)   WATCHERS="true" ;;
+            bun)        BUN="true" ;;
+            *) echo "Warning: unknown tool group '$item' in install list" ;;
+        esac
+    done
+fi
+
+# Step 3: If omit is set, blacklist filter
+if [ -n "${OMIT}" ]; then
+    IFS=',' read -ra EXCLUDED <<< "${OMIT}"
+    for item in "${EXCLUDED[@]}"; do
+        item="$(echo "$item" | xargs)"
+        case "$item" in
+            typescript) TYPESCRIPT="false" ;;
+            bundlers)   BUNDLERS="false" ;;
+            linters)    LINTERS="false" ;;
+            watchers)   WATCHERS="false" ;;
+            bun)        BUN="false" ;;
+            *) echo "Warning: unknown tool group '$item' in omit list" ;;
+        esac
+    done
+fi
+
+# TypeScript toolchain
+if [ "${TYPESCRIPT}" = "true" ]; then
+    echo "Installing TypeScript toolchain..."
+    npm install -g typescript ts-node tsx @types/node
+fi
+
+# Bundlers
+if [ "${BUNDLERS}" = "true" ]; then
+    echo "Installing bundlers..."
+    npm install -g vite esbuild
+fi
+
+# Linters and formatters
+if [ "${LINTERS}" = "true" ]; then
+    echo "Installing linters and formatters..."
+    npm install -g prettier eslint @biomejs/biome
+fi
+
+# File watchers
+if [ "${WATCHERS}" = "true" ]; then
+    echo "Installing file watchers..."
+    npm install -g nodemon tsc-watch concurrently
+fi
+
+# Bun runtime
+if [ "${BUN}" = "true" ]; then
+    echo "Installing Bun..."
+    su - "$_REMOTE_USER" -c 'curl -fsSL https://bun.sh/install | bash'
+    # Create system-wide symlinks
+    ln -sf "$_REMOTE_USER_HOME/.bun/bin/bun" /usr/local/bin/bun
+    ln -sf "$_REMOTE_USER_HOME/.bun/bin/bunx" /usr/local/bin/bunx
+fi
+
+# --- Shell configuration ---
+ZSHRC="$_REMOTE_USER_HOME/.zshrc"
+
+cat >> "$ZSHRC" << 'ALIASES'
+# TypeScript development aliases
+alias tsc="npx tsc"
+alias tsx="npx tsx"
+alias tsw="npx tsc-watch"
+alias dev="npm run dev"
+alias build="npm run build"
+alias test="npm test"
+alias lint="npm run lint"
+alias format="npm run format"
+# Add npm completion if available
+if command -v npm >/dev/null 2>&1; then eval "$(npm completion zsh)"; fi
+ALIASES
+
+if [ "${BUN}" = "true" ]; then
+    echo 'export PATH="$HOME/.bun/bin:$PATH"' >> "$ZSHRC"
+fi
+
+echo "Node.js development tools installation complete."

--- a/.deacon/cache/features/d80072df042fc8c0/NOTES.md
+++ b/.deacon/cache/features/d80072df042fc8c0/NOTES.md
@@ -1,0 +1,49 @@
+<!-- markdownlint-disable MD041 -->
+
+## Supported platforms
+
+`linux/amd64` and `linux/arm64` platforms `debian` and `ubuntu`.
+
+## Available versions
+
+The versions of jq, yq, gojq, xq and jaq can be specified by version number or `"none"` or `"latest"` as follows.
+
+Note that for the `linux/arm64` platform, **the `jqVersion` option only supports jq version 1.7rc1 or later**.
+
+```json
+"features": {
+    "ghcr.io/eitsupi/devcontainer-features/jq-likes:1": {
+        "jqVersion": "none",
+        "yqVersion": "4",
+        "gojqVersion": "latest",
+        "xqVersion": "latest"
+    }
+}
+```
+
+To install RC versions of jq, another option `"allowJqRcVersion"` must be set to `true`.
+
+```json
+"features": {
+    "ghcr.io/eitsupi/devcontainer-features/jq-likes:1": {
+        "jqVersion": "1.7rc1",
+        "allowJqRcVersion": true
+    }
+}
+```
+
+If `"jqVersion": "os-provided"` is specified, jq will be installed via the package manager.
+
+## Release notes
+
+### 2.0.0
+
+- Change the default value of `jqVersion` from `"os-provided"` to `"latest"`.
+
+## References
+
+- jq: <https://jqlang.github.io/jq>
+- yq: <https://mikefarah.gitbook.io/yq>
+- gojq: <https://github.com/itchyny/gojq>
+- xq: <https://github.com/MiSawa/xq>
+- jaq: <https://github.com/01mf02/jaq>

--- a/.deacon/cache/features/d80072df042fc8c0/README.md
+++ b/.deacon/cache/features/d80072df042fc8c0/README.md
@@ -1,0 +1,78 @@
+
+# jq, yq, gojq, xq, jaq (jq-likes)
+
+Installs jq and jq like command line tools (yq, gojq, xq, jaq).
+
+## Example Usage
+
+```json
+"features": {
+    "ghcr.io/eitsupi/devcontainer-features/jq-likes:2": {}
+}
+```
+
+## Options
+
+| Options Id | Description | Type | Default Value |
+|-----|-----|-----|-----|
+| jqVersion | Select version of jq. | string | latest |
+| yqVersion | Select version of yq. | string | none |
+| gojqVersion | Select version of gojq. | string | none |
+| xqVersion | Select version of xq. | string | none |
+| jaqVersion | Select version of jaq. | string | none |
+| allowJqRcVersion | Allow jq pre-release RC version to be installed. | boolean | false |
+
+<!-- markdownlint-disable MD041 -->
+
+## Supported platforms
+
+`linux/amd64` and `linux/arm64` platforms `debian` and `ubuntu`.
+
+## Available versions
+
+The versions of jq, yq, gojq, xq and jaq can be specified by version number or `"none"` or `"latest"` as follows.
+
+Note that for the `linux/arm64` platform, **the `jqVersion` option only supports jq version 1.7rc1 or later**.
+
+```json
+"features": {
+    "ghcr.io/eitsupi/devcontainer-features/jq-likes:1": {
+        "jqVersion": "none",
+        "yqVersion": "4",
+        "gojqVersion": "latest",
+        "xqVersion": "latest"
+    }
+}
+```
+
+To install RC versions of jq, another option `"allowJqRcVersion"` must be set to `true`.
+
+```json
+"features": {
+    "ghcr.io/eitsupi/devcontainer-features/jq-likes:1": {
+        "jqVersion": "1.7rc1",
+        "allowJqRcVersion": true
+    }
+}
+```
+
+If `"jqVersion": "os-provided"` is specified, jq will be installed via the package manager.
+
+## Release notes
+
+### 2.0.0
+
+- Change the default value of `jqVersion` from `"os-provided"` to `"latest"`.
+
+## References
+
+- jq: <https://jqlang.github.io/jq>
+- yq: <https://mikefarah.gitbook.io/yq>
+- gojq: <https://github.com/itchyny/gojq>
+- xq: <https://github.com/MiSawa/xq>
+- jaq: <https://github.com/01mf02/jaq>
+
+
+---
+
+_Note: This file was auto-generated from the [devcontainer-feature.json](https://github.com/eitsupi/devcontainer-features/blob/main/src/jq-likes/devcontainer-feature.json).  Add additional notes to a `NOTES.md`._

--- a/.deacon/cache/features/d80072df042fc8c0/devcontainer-feature.json
+++ b/.deacon/cache/features/d80072df042fc8c0/devcontainer-feature.json
@@ -1,0 +1,68 @@
+{
+	"name": "jq, yq, gojq, xq, jaq",
+	"id": "jq-likes",
+	"version": "2.1.1",
+	"description": "Installs jq and jq like command line tools (yq, gojq, xq, jaq).",
+	"documentationURL": "https://github.com/eitsupi/devcontainer-features/tree/main/src/jq-likes",
+	"options": {
+		"jqVersion": {
+			"type": "string",
+			"proposals": [
+				"latest",
+				"os-provided",
+				"1",
+				"none"
+			],
+			"default": "latest",
+			"description": "Select version of jq."
+		},
+		"yqVersion": {
+			"type": "string",
+			"proposals": [
+				"latest",
+				"4",
+				"none"
+			],
+			"default": "none",
+			"description": "Select version of yq."
+		},
+		"gojqVersion": {
+			"type": "string",
+			"proposals": [
+				"latest",
+				"none"
+			],
+			"default": "none",
+			"description": "Select version of gojq."
+		},
+		"xqVersion": {
+			"type": "string",
+			"proposals": [
+				"latest",
+				"none"
+			],
+			"default": "none",
+			"description": "Select version of xq."
+		},
+		"jaqVersion": {
+			"type": "string",
+			"proposals": [
+				"latest",
+				"1",
+				"none"
+			],
+			"default": "none",
+			"description": "Select version of jaq."
+		},
+		"allowJqRcVersion": {
+			"type": "boolean",
+			"default": false,
+			"description": "Allow jq pre-release RC version to be installed."
+		}
+	},
+	"installsAfter": [
+		"ghcr.io/devcontainers/features/common-utils",
+		"ghcr.io/devcontainers/features/powershell",
+		"ghcr.io/meaningful-ooo/devcontainer-features/fish"
+	]
+}

--- a/.deacon/cache/features/d80072df042fc8c0/install.sh
+++ b/.deacon/cache/features/d80072df042fc8c0/install.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+
+JQ_VERSION=${JQVERSION:-"latest"}
+YQ_VERSION=${YQVERSION:-"none"}
+GOJQ_VERSION=${GOJQVERSION:-"none"}
+XQ_VERSION=${XQVERSION:-"none"}
+JAQ_VERSION=${JAQVERSION:-"none"}
+
+ALLOW_JQ_RC=${ALLOWJQRCVERSION:-"false"}
+
+USERNAME=${USERNAME:-${_REMOTE_USER:-"automatic"}}
+
+set -e
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+architecture="$(dpkg --print-architecture)"
+if [ "${architecture}" != "amd64" ] && [ "${architecture}" != "arm64" ]; then
+    echo "(!) Architecture $architecture unsupported"
+    exit 1
+fi
+
+# Determine the appropriate non-root user
+if [ "${USERNAME}" = "auto" ] || [ "${USERNAME}" = "automatic" ]; then
+    USERNAME=""
+    POSSIBLE_USERS=("vscode" "node" "codespace" "$(awk -v val=1000 -F ":" '$3==val{print $1}' /etc/passwd)")
+    for CURRENT_USER in "${POSSIBLE_USERS[@]}"; do
+        if id -u "${CURRENT_USER}" >/dev/null 2>&1; then
+            USERNAME=${CURRENT_USER}
+            break
+        fi
+    done
+    if [ "${USERNAME}" = "" ]; then
+        USERNAME=root
+    fi
+elif [ "${USERNAME}" = "none" ] || ! id -u ${USERNAME} >/dev/null 2>&1; then
+    USERNAME=root
+fi
+
+apt_get_update() {
+    if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+        echo "Running apt-get update..."
+        apt-get update -y
+    fi
+}
+
+# Checks if packages are installed and installs them if not
+check_packages() {
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
+        apt_get_update
+        apt-get -y install --no-install-recommends "$@"
+    fi
+}
+
+check_git() {
+    if [ ! -x "$(command -v git)" ]; then
+        check_packages git
+    fi
+}
+
+find_version_from_git_tags() {
+    local variable_name=$1
+    local requested_version=${!variable_name}
+    if [ "${requested_version}" = "none" ]; then return; fi
+    local repository=$2
+    local prefix=${3:-"tags/v"}
+    local separator=${4:-"."}
+    local last_part_optional=${5:-"false"}
+    local suffix=${6:-""}
+    if [ "$(echo "${requested_version}" | grep -o "." | wc -l)" != "2" ]; then
+        local escaped_separator=${separator//./\\.}
+        local last_part
+        if [ "${last_part_optional}" = "true" ]; then
+            last_part="(${escaped_separator}[0-9]+)*?"
+        else
+            last_part="${escaped_separator}[0-9]+"
+        fi
+        local regex="${prefix}\\K[0-9]+${escaped_separator}[0-9]+${last_part}${suffix}$"
+        local version_list
+        check_git
+        check_packages ca-certificates
+        version_list="$(git ls-remote --tags "${repository}" | grep -oP "${regex}" | tr -d ' ' | tr "${separator}" "." | sed "s/\([a-zA-Z]\+\)/-\1-/g" | sort -t - -k 1,1Vr -k 2,2 -k 3,3nr | sed "s/-//g")"
+        if [ "${requested_version}" = "latest" ] || [ "${requested_version}" = "current" ] || [ "${requested_version}" = "lts" ]; then
+            declare -g "${variable_name}"="$(echo "${version_list}" | head -n 1)"
+        else
+            set +e
+            declare -g "${variable_name}"="$(echo "${version_list}" | grep -E -m 1 "^${requested_version//./\\.}([\\.\\s]|$)")"
+            set -e
+        fi
+    fi
+    if [ -z "${!variable_name}" ] || ! echo "${version_list}" | grep "^${!variable_name//./\\.}$" >/dev/null 2>&1; then
+        echo -e "Invalid ${variable_name} value: ${requested_version}\nValid values:\n${version_list}" >&2
+        exit 1
+    fi
+    echo "${variable_name}=${!variable_name}"
+}
+
+setup_yq_completions() {
+    local username=$1
+    local for_bash=${2:-"true"}
+    local for_zsh=${3:-"true"}
+    local for_fish=${4:-"true"}
+    local for_pwsh=${5:-"true"}
+    # bash
+    if [ "${for_bash}" = "true" ] && [ -d /etc/bash_completion.d/ ]; then
+        if yq shell-completion bash >/dev/null 2>&1; then
+            echo "Installing bash completion..."
+            yq shell-completion bash >/etc/bash_completion.d/yq
+        fi
+    fi
+
+    # zsh
+    if [ "${for_zsh}" = "true" ] && [ -d /usr/local/share/zsh/site-functions/ ]; then
+        if yq shell-completion zsh >/dev/null 2>&1; then
+            echo "Installing zsh completion..."
+            yq shell-completion zsh >/usr/local/share/zsh/site-functions/_yq
+            chown -R "${username}:${username}" /usr/local/share/zsh/site-functions/_yq
+        fi
+    fi
+
+    # fish
+    local fish_config_dir="/home/${username}/.config/fish"
+    if [ "${username}" = "root" ]; then
+        fish_config_dir="/root/.config/fish"
+    fi
+    if [ "${for_fish}" = "true" ] && [ -d "${fish_config_dir}" ]; then
+        if yq shell-completion fish >/dev/null 2>&1; then
+            echo "Installing fish completion..."
+            yq shell-completion fish >"${fish_config_dir}/completions/yq.fish"
+            chown -R "${username}:${username}" "${fish_config_dir}"
+        fi
+    fi
+
+    # pwsh
+    local pwsh_script_dir="/home/${username}/.local/share/powershell/Scripts"
+    local pwsh_profile_dir="/home/${username}/.config/powershell"
+    if [ "${username}" = "root" ]; then
+        pwsh_script_dir="/root/.local/share/powershell/Scripts"
+        pwsh_profile_dir="/root/.config/powershell"
+    fi
+    local pwsh_profile_file="${pwsh_profile_dir}/Microsoft.PowerShell_profile.ps1"
+    if [ "${for_pwsh}" = "true" ] && [ -x "$(command -v pwsh)" ]; then
+        if yq shell-completion powershell >/dev/null 2>&1; then
+            echo "Installing pwsh completion..."
+            mkdir -p "${pwsh_script_dir}"
+            mkdir -p "${pwsh_profile_dir}"
+            yq shell-completion powershell >"${pwsh_script_dir}/yq.ps1"
+            echo "Invoke-Expression -Command ${pwsh_script_dir}/yq.ps1" >>"${pwsh_profile_file}"
+            chown -R "${username}:${username}" "${pwsh_script_dir}"
+            chown -R "${username}:${username}" "${pwsh_profile_dir}"
+        fi
+    fi
+}
+
+setup_gojq_completions() {
+    local username=$1
+    local completions_dir=$2
+    local for_zsh=${3:-"true"}
+
+    # zsh
+    local zsh_comp_file="${completions_dir}/_gojq"
+    if [ "${for_zsh}" = "true" ] && [ -f "${zsh_comp_file}" ] && [ -d /usr/local/share/zsh/site-functions/ ] ; then
+        echo "Installing zsh completion..."
+        mv "${zsh_comp_file}" /usr/local/share/zsh/site-functions/_gojq
+        chown -R "${username}:${username}" /usr/local/share/zsh/site-functions/_gojq
+    fi
+}
+
+download_old_jq() {
+    local version
+    local output_file
+    local architecture
+
+    version=$1
+    output_file=$2
+    architecture="$(dpkg --print-architecture)"
+
+    if [ "${architecture}" = "arm64" ]; then
+        echo "(!) Architecture $architecture unsupported for jq ${version}"
+        exit 1
+    fi
+
+    curl -fsL "https://github.com/jqlang/jq/releases/download/jq-${version}/jq-linux64" -o "${output_file}"
+}
+
+export DEBIAN_FRONTEND=noninteractive
+
+if [ "${JQ_VERSION}" = "os-provided" ]; then
+    echo "Installing jq via OS package manager..."
+    check_packages jq
+    JQ_VERSION="none"
+else
+    if [ "${ALLOW_JQ_RC}" = "true" ]; then
+        jq_version_suffix="(rc[0-9]+)?"
+    else
+        jq_version_suffix=""
+    fi
+    # Soft version matching
+    find_version_from_git_tags JQ_VERSION "https://github.com/jqlang/jq" "tags/jq-" "." "true" "${jq_version_suffix}"
+fi
+
+# Soft version matching
+find_version_from_git_tags YQ_VERSION "https://github.com/mikefarah/yq"
+find_version_from_git_tags GOJQ_VERSION "https://github.com/itchyny/gojq"
+find_version_from_git_tags XQ_VERSION "https://github.com/MiSawa/xq"
+find_version_from_git_tags JAQ_VERSION "https://github.com/01mf02/jaq"
+
+if [ "${JQ_VERSION}" != "none" ]; then
+    check_packages curl ca-certificates
+    echo "Downloading jq ${JQ_VERSION}..."
+    mkdir /tmp/jq
+    curl -fsL "https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-linux-${architecture}" -o /tmp/jq/jq ||
+        download_old_jq "${JQ_VERSION}" /tmp/jq/jq
+    mv /tmp/jq/jq /usr/local/bin/jq
+    chmod +x /usr/local/bin/jq
+    rm -rf /tmp/jq
+fi
+
+if [ "${YQ_VERSION}" != "none" ]; then
+    check_packages curl ca-certificates
+    echo "Downloading yq ${YQ_VERSION}..."
+    mkdir /tmp/yq
+    curl -fsL "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_${architecture}.tar.gz" | tar xz -C /tmp/yq
+    mv "/tmp/yq/yq_linux_${architecture}" /usr/local/bin/yq
+    pushd /tmp/yq
+    ./install-man-page.sh
+    popd
+    rm -rf /tmp/yq
+    setup_yq_completions "${USERNAME}"
+fi
+
+if [ "${GOJQ_VERSION}" != "none" ]; then
+    check_packages curl ca-certificates
+    echo "Downloading gojq ${GOJQ_VERSION}..."
+    mkdir /tmp/gojq
+    curl -fsL "https://github.com/itchyny/gojq/releases/download/v${GOJQ_VERSION}/gojq_v${GOJQ_VERSION}_linux_${architecture}.tar.gz" | tar xz -C /tmp/gojq
+    mv "/tmp/gojq/gojq_v${GOJQ_VERSION}_linux_${architecture}/gojq" /usr/local/bin/gojq
+    setup_gojq_completions "${USERNAME}" "/tmp/gojq/gojq_v${GOJQ_VERSION}_linux_${architecture}"
+    rm -rf /tmp/gojq
+fi
+
+if [ "${XQ_VERSION}" != "none" ]; then
+    check_packages curl ca-certificates
+    echo "Downloading xq ${XQ_VERSION}..."
+    mkdir /tmp/xq
+    curl -fsL "https://github.com/MiSawa/xq/releases/download/v${XQ_VERSION}/xq-v${XQ_VERSION}-$(uname -m)-unknown-linux-musl.tar.gz" | tar xz -C /tmp/xq
+    mv "/tmp/xq/xq-v${XQ_VERSION}-$(uname -m)-unknown-linux-musl/xq" /usr/local/bin/xq
+    rm -rf /tmp/xq
+fi
+
+if [ "${JAQ_VERSION}" != "none" ]; then
+    check_packages curl ca-certificates
+    echo "Downloading jaq ${JAQ_VERSION}..."
+    curl -fsL "https://github.com/01mf02/jaq/releases/download/v${JAQ_VERSION}/jaq-$(uname -m)-unknown-linux-musl" -o /usr/local/bin/jaq ||
+        curl -fsL "https://github.com/01mf02/jaq/releases/download/v${JAQ_VERSION}/jaq-$(uname -m)-unknown-linux-gnu" -o /usr/local/bin/jaq ||
+        curl -fsL "https://github.com/01mf02/jaq/releases/download/v${JAQ_VERSION}/jaq-v${JAQ_VERSION}-$(uname -m)-unknown-linux-musl" -o /usr/local/bin/jaq ||
+        curl -fsL "https://github.com/01mf02/jaq/releases/download/v${JAQ_VERSION}/jaq-v${JAQ_VERSION}-$(uname -m)-unknown-linux-gnu" -o /usr/local/bin/jaq
+    chmod +x /usr/local/bin/jaq
+fi
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+echo "Done!"

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/cli": {
       "name": "@hola/cli",
-      "version": "0.6.39",
+      "version": "0.7.0",
       "bin": {
         "hola": "./bin/hola",
       },
@@ -37,11 +37,11 @@
     },
     "packages/compose": {
       "name": "@hola/compose",
-      "version": "0.6.39",
+      "version": "0.7.0",
     },
     "packages/sdk": {
       "name": "@hola/sdk",
-      "version": "0.6.39",
+      "version": "0.7.0",
       "dependencies": {
         "@hola/shared": "workspace:*",
       },
@@ -55,7 +55,7 @@
     },
     "packages/server": {
       "name": "@hola/server",
-      "version": "0.6.39",
+      "version": "0.7.0",
       "dependencies": {
         "@hola/shared": "workspace:*",
         "jose": "^5.9.6",
@@ -71,7 +71,7 @@
     },
     "packages/shared": {
       "name": "@hola/shared",
-      "version": "0.6.39",
+      "version": "0.7.0",
       "dependencies": {
         "yaml": "^2.9.0",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.6.39",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.6.39';
+export const CLI_VERSION = '0.7.0';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.6.39",
+  "version": "0.7.0",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.6.39",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.6.39",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.6.39",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Bump published packages **0.6.39 → 0.7.0** for the multi-catalog release.

Ships in 0.7.0:
- **#323** — install from OCI reference + private-registry credentials (slice 1)
- **#324** — custom catalog sources / Homebrew-tap model (slice 2)

Minor bump (vs the usual patch) to signal the new user-facing capability. Synced across `@hola/{cli,compose,sdk,server,shared}` + `cli/src/version.ts` + `bun.lock`; `web` stays `0.0.0`.

After merge, tagging `cli-v0.7.0` triggers `cli-release.yml` (multi-arch GHCR images, CLI binaries, compose bundle, GitHub Release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)