### PR TITLE
Catalog version display + refresh action; SSE fix for deployment delete

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -21,6 +21,7 @@ import {
   InstallFromRefRequest, InstallFromRefResponse,
   // Catalog sources (multi-catalog Slice 2)
   CatalogSourceRecord, AddCatalogSourceRequest, ListCatalogSourcesResponse,
+  RefreshCatalogResponse,
   // Job types
   DeleteJobsRequest, DeleteJobsResponse,
   // System types
@@ -102,7 +103,7 @@ export class HolaSdk {
     versionDetail: (appId: string, version: string, source?: string) => this.get<GetCatalogAppVersionDetailResponse>(`${API.catalog.versionDetail(appId, version)}${buildQuery({ source })}`),
     // Force an immediate re-fetch of the remote catalog (bypasses the refresh-interval
     // TTL) so newly-published app versions surface as available updates right away.
-    refresh: (force = true) => this.post<{ success: boolean; timestamp: string }>(`${API.catalog.refresh}${buildQuery({ force })}`),
+    refresh: (force = true) => this.post<RefreshCatalogResponse>(`${API.catalog.refresh}${buildQuery({ force })}`),
   };
 
   // Managed catalog sources (Homebrew-tap model). Instance-level, admin-gated.

--- a/packages/server/src/__tests__/catalog/catalog-aggregate.test.ts
+++ b/packages/server/src/__tests__/catalog/catalog-aggregate.test.ts
@@ -85,4 +85,22 @@ describe('RealCatalogService aggregation', () => {
     const globex = await catalog.getVersions('db', 'globex');
     expect(globex.items.map(v => v.version)).toEqual(['9.9.9']);
   });
+
+  test('listApps surfaces each app\'s (latest) version', async () => {
+    const { catalog } = await harness();
+    const { items } = await catalog.listApps({ page: 1, limit: 50 });
+    const byQualified = new Map(items.map(a => [`${a.source}/${a.id}`, a]));
+    expect(byQualified.get('acme/cms')!.version).toBe('1.0.0');
+    expect(byQualified.get('globex/db')!.version).toBe('9.9.9');
+  });
+
+  test('refresh reports per-source success/failure without one masking the other', async () => {
+    const { catalog } = await harness();
+    failGlobex = true;
+    const results = await catalog.refresh(true);
+    const byId = new Map(results.map(r => [r.id, r]));
+    expect(byId.get('acme')!.ok).toBe(true);
+    expect(byId.get('globex')!.ok).toBe(false);
+    expect(byId.get('globex')!.error).toBeTruthy();
+  });
 });

--- a/packages/server/src/__tests__/deployments/persistence.test.ts
+++ b/packages/server/src/__tests__/deployments/persistence.test.ts
@@ -232,6 +232,21 @@ describe('Deployment persistence (real service)', () => {
     expect((await b.routing.getRoutingMap())['gitea.local.hola']).toBeUndefined();
   });
 
+  test('deleting a deployment emits a deployment_deleted event (#331)', async () => {
+    const storage = new RealStorageService({ holaDir: dataRoot });
+    const drafts = new RealDraftService(storage, makeCatalog(), makeValidation());
+    const routing = new RealRoutingService(storage, { baseDomain: 'local.hola' });
+    const events: Array<{ type: string; data: unknown }> = [];
+    const eventBus = { emit: (e: { type: string; data: unknown }) => events.push(e), subscribe: () => ({ unsubscribe() {} }) };
+    const deployments = new RealDeploymentService(storage, makeJobs(), noDocker, drafts, routing, noLogging, new MockProvisionerService(), undefined, eventBus);
+
+    const dep = await deployments.createFromDraft({ draftId: await finalizedDraft(drafts), name: 'gitea', options: { autoStart: false } });
+    await deployments.deleteDeployment(dep.deploymentId);
+
+    const deleted = events.find(e => e.type === 'deployment_deleted');
+    expect(deleted?.data).toEqual({ deploymentId: dep.deploymentId });
+  });
+
   test('a second deployment of the same app is rejected as a host conflict', async () => {
     const { drafts, deployments } = makeSystem();
     await deployments.createFromDraft({ draftId: await finalizedDraft(drafts), name: 'gitea', options: { autoStart: false } });

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -53,6 +53,7 @@ import {
   type InstallFromRefResponse,
   type AddCatalogSourceRequest,
   type ListCatalogSourcesResponse,
+  type RefreshCatalogResponse,
 } from '@hola/shared';
 
 // Error interface for proper typing
@@ -490,8 +491,9 @@ async function route(url: URL, req: Request): Promise<Response> {
       const force = searchParams.get('force') === 'true';
       const services = getServices();
       const catalog = services.catalog;
-      await catalog.refresh(force);
-      return json({ success: true, timestamp: new Date().toISOString() });
+      const sources = await catalog.refresh(force);
+      const response: RefreshCatalogResponse = { success: true, timestamp: new Date().toISOString(), sources };
+      return json(response);
     } catch (error) {
       logger.warn('Catalog refresh failed', { error: error instanceof Error ? error.message : String(error) });
       return json({ error: { code: 'REFRESH_FAILED', message: 'Catalog refresh failed' } }, { status: 500 });

--- a/packages/server/src/services/core/catalog.ts
+++ b/packages/server/src/services/core/catalog.ts
@@ -209,7 +209,8 @@ export interface CatalogService {
    * too. `credentials` authenticate a private-registry pull.
    */
   getVersionDetailByRef(ociRef: string, credentials?: PullCredentials): Promise<GetCatalogAppVersionDetailResponse & { appId: string }>;
-  refresh(force?: boolean): Promise<void>;
+  /** Per-source outcome, so one bad source doesn't silently mask the others. */
+  refresh(force?: boolean): Promise<Array<{ id: string; name: string; ok: boolean; error?: string }>>;
 }
 
 /**
@@ -586,9 +587,16 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
     }
   }
 
-  async refresh(force = false): Promise<void> {
+  async refresh(force = false): Promise<Array<{ id: string; name: string; ok: boolean; error?: string }>> {
     const sources = await this.resolveSources();
-    await Promise.allSettled(sources.map(s => this.catalogFor(s).refresh(force)));
+    const results = await Promise.allSettled(sources.map(s => this.catalogFor(s).refresh(force)));
+    return sources.map((s, i) => {
+      const r = results[i];
+      if (r.status === 'fulfilled') return { id: s.id, name: s.name, ok: true };
+      const error = r.reason instanceof Error ? r.reason.message : String(r.reason);
+      this.logger.warn('Catalog source refresh failed', { source: s.id, error });
+      return { id: s.id, name: s.name, ok: false, error };
+    });
   }
 
   private mapApp(app: RemoteCatalog['apps'][number], source: CatalogSourceRecord): CatalogApp {
@@ -604,6 +612,7 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
       featured: !!app.featured,
       source: source.id,
       trust: source.trust as CatalogSourceTrust,
+      version: pickLatestVersion(app.versions || [])?.version,
     };
   }
 }
@@ -629,5 +638,5 @@ export class MockCatalogService implements CatalogService {
   async getVersionDetailByRef(): Promise<GetCatalogAppVersionDetailResponse & { appId: string }> {
     throw new Error('VERSION_NOT_FOUND');
   }
-  async refresh(): Promise<void> { /* no-op */ }
+  async refresh(): Promise<Array<{ id: string; name: string; ok: boolean; error?: string }>> { return []; }
 }

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -2036,6 +2036,10 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     await this.routingService.deactivateRoute(deploymentId);
     // The removed app drops out of the registry feed for remaining consumers.
     await this.reconcileAppRegistry();
+    // Deletion has no further `deployment_update` (the record is gone), so it
+    // needs its own event or the Apps/Deployments lists never learn about it
+    // short of a hard refresh.
+    this.eventBus?.emit({ type: 'deployment_deleted', data: { deploymentId } });
   }
 
   /**

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -414,6 +414,10 @@ export type CatalogApp = {
   // public catalog) and its trust level, so the UI can badge custom sources.
   source: string;
   trust: CatalogSourceTrust;
+  // Newest available version (resolved the same way "latest" resolves at
+  // install time), so the browse listing can show it without a drill-down
+  // request. Omitted if the source has no versions at all.
+  version?: string;
 };
 
 export type GetCatalogAppsRequest = PageRequest & {
@@ -501,6 +505,17 @@ export type AddCatalogSourceRequest = {
 
 export type ListCatalogSourcesResponse = {
   items: CatalogSourceRecord[];
+};
+
+/**
+ * Result of re-pulling every enabled catalog source. `sources` reports each
+ * source's outcome individually so one bad source (unreachable URL, bad JSON)
+ * doesn't silently mask the others succeeding.
+ */
+export type RefreshCatalogResponse = {
+  success: boolean;
+  timestamp: string;
+  sources: Array<{ id: string; name: string; ok: boolean; error?: string }>;
 };
 
 export type GetCatalogAppsResponse = PageResponse<CatalogApp>;
@@ -1004,7 +1019,12 @@ export type SSEDeploymentUpdateEvent = {
   };
 };
 
-export type SSEEvent = SSELogEvent | SSEJobUpdateEvent | SSESystemUpdateEvent | SSEDeploymentUpdateEvent;
+export type SSEDeploymentDeletedEvent = {
+  type: 'deployment_deleted';
+  data: { deploymentId: string };
+};
+
+export type SSEEvent = SSELogEvent | SSEJobUpdateEvent | SSESystemUpdateEvent | SSEDeploymentUpdateEvent | SSEDeploymentDeletedEvent;
 
 // Connection status for SSE
 export type SSEConnectionState = 'connecting' | 'connected' | 'disconnected' | 'error';

--- a/packages/web/src/hooks/useGlobalEvents.ts
+++ b/packages/web/src/hooks/useGlobalEvents.ts
@@ -36,11 +36,17 @@ export function useGlobalEvents(): void {
       // refresh both the deployments list and the job tracker.
       signalLive('deployments');
       signalLive('jobs');
+    } else if (event.type === 'deployment_deleted') {
+      // The record is gone — drop any cached detail page rather than patch it,
+      // and tell the Apps/Deployments lists to refetch so the tile disappears
+      // live instead of only after a hard refresh.
+      globalCache.delete(`deployment-detail-${event.data.deploymentId}`);
+      signalLive('deployments');
     }
   }, []);
 
   const sse = useSSE('/api/events', onEvent, {
-    eventTypes: ['job_update', 'deployment_update'],
+    eventTypes: ['job_update', 'deployment_update', 'deployment_deleted'],
     reconnect: true,
     reconnectDelay: 2000,
     maxReconnectDelay: 15000,

--- a/packages/web/src/pages/Catalog.tsx
+++ b/packages/web/src/pages/Catalog.tsx
@@ -18,6 +18,7 @@ import type {
 import { useCatalogAppsApi, useCatalogAppVersionsApi } from '../hooks/useCatalogApi';
 import { AppIcon } from '../components/ui/AppIcon';
 import { api } from '../utils/api-hybrid';
+import { globalCache } from '../utils/cache';
 
 const categories = ['All', 'Productivity', 'Home Automation', 'Media', 'Monitoring', 'Security', 'Database', 'Infrastructure', 'Networking'];
 
@@ -142,6 +143,9 @@ const AppDetailModal: React.FC<AppDetailModalProps> = ({ app, isOpen, onClose })
             <div>
               <h2 className="text-xl font-semibold">{app.name}</h2>
               <span className="text-sm text-text-muted bg-surface-2 px-2 py-1 rounded">{app.category}</span>
+              {app.version && (
+                <span className="ml-2 text-sm font-mono text-text-muted bg-surface-2 px-2 py-1 rounded">v{app.version}</span>
+              )}
               {app.source && app.source !== 'hola' && (
                 <span className="ml-2 text-xs text-warning bg-warning/10 px-2 py-1 rounded">{app.source} · {app.trust}</span>
               )}
@@ -267,6 +271,8 @@ export const Catalog: React.FC = () => {
   const [currentPage, setCurrentPage] = useState(parseInt(searchParams.get('page') || '1', 10));
   const [appsPerPage] = useState(12);
   const [showRefModal, setShowRefModal] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [refreshMessage, setRefreshMessage] = useState<{ text: string; failed: boolean } | null>(null);
 
   // Build API request parameters
   const apiParams = useMemo(() => {
@@ -282,8 +288,32 @@ export const Catalog: React.FC = () => {
   }, [searchTerm, selectedCategory, currentPage, appsPerPage]);
 
   // Use API hook for catalog apps
-  const { data: appsData, loading, error } = useCatalogAppsApi(apiParams);
-  
+  const { data: appsData, loading, error, refetch } = useCatalogAppsApi(apiParams);
+
+  const handleRefresh = async () => {
+    setRefreshing(true);
+    setRefreshMessage(null);
+    try {
+      const result = await api.catalog.refresh(true);
+      // The hook's own 30s cache is separate from the SDK-adapter cache the
+      // server call already invalidated — clear it too, or refetch() below
+      // would just re-serve the stale in-memory entry.
+      globalCache.deleteByPattern(/^catalog-apps-/);
+      await refetch();
+      const failed = result.sources.filter((s) => !s.ok);
+      setRefreshMessage(
+        failed.length > 0
+          ? { text: `${failed.length} of ${result.sources.length} catalog source(s) failed to refresh: ${failed.map((s) => s.name).join(', ')}`, failed: true }
+          : { text: `Refreshed ${result.sources.length} catalog source(s).`, failed: false }
+      );
+    } catch (e) {
+      setRefreshMessage({ text: e instanceof Error ? e.message : 'Catalog refresh failed', failed: true });
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+
   // Extract data from API response
   const apps = useMemo(() => appsData?.items || [], [appsData?.items]);
   const totalPages = useMemo(() => {
@@ -351,6 +381,15 @@ export const Catalog: React.FC = () => {
         </div>
         <div className="flex-1" />
         <button
+          onClick={handleRefresh}
+          disabled={refreshing}
+          title="Re-pull every configured catalog source"
+          className="h-[38px] px-3.5 flex items-center gap-2 bg-surface-1 border border-border rounded-[9px] text-[13px] font-medium text-text-muted hover:text-text-strong transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+        >
+          <RefreshCw className={`w-4 h-4 ${refreshing ? 'animate-spin' : ''}`} />
+          Refresh
+        </button>
+        <button
           onClick={() => setShowRefModal(true)}
           className="h-[38px] px-3.5 flex items-center gap-2 bg-surface-1 border border-border rounded-[9px] text-[13px] font-medium text-text-muted hover:text-text-strong transition-colors"
         >
@@ -370,6 +409,20 @@ export const Catalog: React.FC = () => {
       </div>
 
       <InstallFromRefModal isOpen={showRefModal} onClose={() => setShowRefModal(false)} />
+
+      {/* Refresh result */}
+      {refreshMessage && (
+        <div
+          className={`mb-4 rounded-card p-3 text-[13px] flex items-center gap-2 ${
+            refreshMessage.failed
+              ? 'bg-warning-weak border border-warning/20 text-warning'
+              : 'bg-success-weak border border-success/20 text-success'
+          }`}
+        >
+          <AlertCircle className="w-4 h-4 flex-none" />
+          <span>{refreshMessage.text}</span>
+        </div>
+      )}
 
       {/* Category chips */}
       <div className="flex gap-2 flex-wrap mb-5">
@@ -441,6 +494,7 @@ export const Catalog: React.FC = () => {
                       </div>
                       <div className="text-xs text-text-faint mt-px">
                         {app.category}
+                        {app.version && <span className="font-mono ml-1.5">· v{app.version}</span>}
                         {custom && <span className="ml-1.5 text-warning">· {app.source} ({app.trust})</span>}
                       </div>
                     </div>

--- a/packages/web/src/utils/sdk-adapter.ts
+++ b/packages/web/src/utils/sdk-adapter.ts
@@ -7,6 +7,7 @@ import type {
   HealthResponse, GetSummaryResponse, GetMeResponse,
   // Catalog types
   GetCatalogAppsResponse, GetCatalogAppResponse, GetCatalogAppVersionsResponse, GetCatalogAppVersionDetailResponse,
+  RefreshCatalogResponse,
   // Registry credentials + install-by-ref (multi-catalog Slice 1)
   AddRegistryCredentialRequest, ListRegistryCredentialsResponse, RegistryCredentialRecord,
   InstallFromRefRequest, InstallFromRefResponse,
@@ -324,7 +325,7 @@ export class SdkAdapter {
     // TTL) so newly-published versions surface as available updates right away.
     // A refresh can change which apps have updates, so drop the cached deployment
     // lists (they carry `updateAvailable`), catalog, and dashboard summary.
-    refresh: async (force = true): Promise<{ success: boolean; timestamp: string }> => {
+    refresh: async (force = true): Promise<RefreshCatalogResponse> => {
       const res = await this.sdk.catalog.refresh(force);
       globalCache.deleteByPattern(/^api:.*\/deployments/);
       globalCache.deleteByPattern(/^api:.*\/catalog/);


### PR DESCRIPTION
## Summary
- **#327** — the catalog browse listing and detail modal now show each app's newest available version, reusing the existing `pickLatestVersion` resolution used at install time. No drill-down request needed.
- **#328** — the catalog refresh backend (`POST /api/catalog/refresh`, already fully wired through the SDK/adapter) now has a UI trigger: a "Refresh" button on the Catalog page. `RealCatalogService.refresh()` now reports per-source success/failure (`RefreshCatalogResponse.sources[]`) instead of silently swallowing a bad source via `Promise.allSettled` — the UI surfaces a warning banner naming any source that failed.
- **#331** — deleting a deployment now emits a `deployment_deleted` SSE event (mirroring the existing `deployment_update` chokepoint pattern). The client's global event handler invalidates the cached detail entry and signals the deployments list to refetch, so the Apps/Deployments pages drop the tile live instead of only after a hard refresh.

## Test plan
- [x] `bun run typecheck` — clean across all packages
- [x] `bun run lint` — clean across all packages
- [x] `bun run test` — 525 server + 175 web tests pass, including 2 new catalog-aggregate tests (version surfaced, per-source refresh status) and 1 new deployment persistence test (`deployment_deleted` emitted with correct payload)
- [x] `bun run build` — clean across all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)