### PR TITLE
Collapse compose-harvested env vars under Advanced

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,49 +1,49 @@
 {
   "features": {
     "ghcr.io/devcontainers/features/aws-cli:1": {
-      "version": "1.1.4",
-      "resolved": "ghcr.io/devcontainers/features/aws-cli@sha256:1f93c8315b7a6d76982ebb2269f8b0d50413fc0f965c032edf4aee0caceb73ef",
-      "integrity": "sha256:1f93c8315b7a6d76982ebb2269f8b0d50413fc0f965c032edf4aee0caceb73ef"
+      "integrity": "sha256:3a80c965daf1f48f02466ccaf51d6f0610728f84da2be87a5295b7265d65870b",
+      "resolved": "ghcr.io/devcontainers/features/aws-cli@sha256:3a80c965daf1f48f02466ccaf51d6f0610728f84da2be87a5295b7265d65870b",
+      "version": "1.1.4"
     },
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
-      "version": "2.17.0",
-      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:25b9f05705ffba7dbe503230ac76081419306f8c8bc88e0ce78c4ecd99a0c78c",
-      "integrity": "sha256:25b9f05705ffba7dbe503230ac76081419306f8c8bc88e0ce78c4ecd99a0c78c"
+      "integrity": "sha256:1463f632a3b9d9c8fcba3fcc4dd1c00a586a3926e04f09ebc7f5323e2a9bf94e",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:1463f632a3b9d9c8fcba3fcc4dd1c00a586a3926e04f09ebc7f5323e2a9bf94e",
+      "version": "2.17.0"
     },
     "ghcr.io/devcontainers/features/github-cli:1": {
-      "version": "1.1.0",
-      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
-      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+      "integrity": "sha256:db9e34b5d71932018fd043ec4129f33cfe423bbd350063107fa5e56148efc43c",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:db9e34b5d71932018fd043ec4129f33cfe423bbd350063107fa5e56148efc43c",
+      "version": "1.1.0"
     },
     "ghcr.io/devcontainers/features/node:1": {
-      "version": "1.7.1",
-      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
-      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
+      "integrity": "sha256:fdb79b02336bfce18522defa1249d6880e0de5a185b4f25fe53d1a6bfb6f07ba",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:fdb79b02336bfce18522defa1249d6880e0de5a185b4f25fe53d1a6bfb6f07ba",
+      "version": "1.7.1"
     },
     "ghcr.io/eitsupi/devcontainer-features/jq-likes:2": {
-      "version": "2.1.1",
-      "resolved": "ghcr.io/eitsupi/devcontainer-features/jq-likes@sha256:6a8b044f9f424097ec6d212167836b26994a76a556cbcb202084be79fe8032bd",
-      "integrity": "sha256:6a8b044f9f424097ec6d212167836b26994a76a556cbcb202084be79fe8032bd"
+      "integrity": "sha256:d76db08bc7c8d1c1afbc99f9912e1009544f12f87cc39f377d59e364f3ac805c",
+      "resolved": "ghcr.io/eitsupi/devcontainer-features/jq-likes@sha256:d76db08bc7c8d1c1afbc99f9912e1009544f12f87cc39f377d59e364f3ac805c",
+      "version": "2.1.1"
     },
     "ghcr.io/get2knowio/devcontainer-features/ai-clis:2": {
-      "version": "2.0.6",
-      "resolved": "ghcr.io/get2knowio/devcontainer-features/ai-clis@sha256:c480d9b3ea88a09c969eeb7fcf7a6c74c5a4ca6b2c14ef01d7db5fc65ff4798b",
-      "integrity": "sha256:c480d9b3ea88a09c969eeb7fcf7a6c74c5a4ca6b2c14ef01d7db5fc65ff4798b"
+      "integrity": "sha256:b1bab8dbca43944a27c3ef9b6783f321d735b12eab56a3ca38da5177fbf63956",
+      "resolved": "ghcr.io/get2knowio/devcontainer-features/ai-clis@sha256:b1bab8dbca43944a27c3ef9b6783f321d735b12eab56a3ca38da5177fbf63956",
+      "version": "2.0.7"
     },
     "ghcr.io/get2knowio/devcontainer-features/github-actions-tools:2": {
-      "version": "2.0.2",
-      "resolved": "ghcr.io/get2knowio/devcontainer-features/github-actions-tools@sha256:63c152ec19fd3270976a89903ee93c4c8472be0fd3cbc6aef087257ab2630e06",
-      "integrity": "sha256:63c152ec19fd3270976a89903ee93c4c8472be0fd3cbc6aef087257ab2630e06"
+      "integrity": "sha256:2dc6e3c1f78b6c96eec6180ec3672f5fe23043d7f86bc2aab09a7a0d0a46c387",
+      "resolved": "ghcr.io/get2knowio/devcontainer-features/github-actions-tools@sha256:2dc6e3c1f78b6c96eec6180ec3672f5fe23043d7f86bc2aab09a7a0d0a46c387",
+      "version": "2.0.2"
     },
     "ghcr.io/get2knowio/devcontainer-features/modern-cli-tools:2": {
-      "version": "2.0.3",
-      "resolved": "ghcr.io/get2knowio/devcontainer-features/modern-cli-tools@sha256:d4cf41edcd17990728818792d5083fbccdf63e4fc05d2e5a867b997eafce8363",
-      "integrity": "sha256:d4cf41edcd17990728818792d5083fbccdf63e4fc05d2e5a867b997eafce8363"
+      "integrity": "sha256:d2321a76d3b40f6cdc058e370ee915c148ccfbf0c0f72baff3ae6228e23921b3",
+      "resolved": "ghcr.io/get2knowio/devcontainer-features/modern-cli-tools@sha256:d2321a76d3b40f6cdc058e370ee915c148ccfbf0c0f72baff3ae6228e23921b3",
+      "version": "2.0.4"
     },
     "ghcr.io/get2knowio/devcontainer-features/node-dev-tools:2": {
-      "version": "2.0.2",
-      "resolved": "ghcr.io/get2knowio/devcontainer-features/node-dev-tools@sha256:bcdefb033ce24be39706fc5f92a0226f799aabcbe31a9b0edf619adae434d037",
-      "integrity": "sha256:bcdefb033ce24be39706fc5f92a0226f799aabcbe31a9b0edf619adae434d037"
+      "integrity": "sha256:333ca76e3b1b7748be73615d84f320d95198ca9b37c9996fa2feb0681dc6a922",
+      "resolved": "ghcr.io/get2knowio/devcontainer-features/node-dev-tools@sha256:333ca76e3b1b7748be73615d84f320d95198ca9b37c9996fa2feb0681dc6a922",
+      "version": "2.0.2"
     }
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ hola-*.env
 .devcontainer/hola.env
 .devcontainer/.vm-state
 .devcontainer/.vm-keys/
+.devcontainer-state/
 
 # Monorepo packages
 packages/*/dist

--- a/packages/server/src/__tests__/bundles/auth-pull.test.ts
+++ b/packages/server/src/__tests__/bundles/auth-pull.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 import { mkdtemp, rm } from 'fs/promises';
-import { readFileSync, statSync } from 'fs';
+import { readFileSync, statSync, mkdirSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { RealBundleService, bundleCacheKey, type CommandRunner } from '../../services/core/bundles';
@@ -99,5 +99,105 @@ describe('RealBundleService authenticated pull', () => {
       credentials: { registry: 'registry.example.com', username: 'u', password: 'p' },
     });
     expect(ok.localPath).toBe(join(base, 'acme__app', '1.0'));
+  });
+});
+
+describe('RealBundleService digest-based staleness detection', () => {
+  const dirs: string[] = [];
+  afterEach(async () => {
+    await Promise.all(dirs.splice(0).map((d) => rm(d, { recursive: true, force: true })));
+  });
+
+  async function makeCache() {
+    const base = await mkdtemp(join(tmpdir(), 'hola-bundle-digest-test-'));
+    dirs.push(base);
+    return base;
+  }
+
+  /** Seeds a cache dir as if a prior `ensurePulled` already ran for this version. */
+  function seedCachedBundle(base: string, appId: string, version: string, digest?: string) {
+    const dest = join(base, appId, version);
+    mkdirSync(dest, { recursive: true });
+    writeFileSync(join(dest, 'compose.yaml'), 'services: {}');
+    writeFileSync(join(dest, 'manifest.json'), '{}');
+    if (digest) writeFileSync(join(dest, '.oras-digest'), digest);
+    return dest;
+  }
+
+  const DIGEST_A = 'sha256:' + 'a'.repeat(64);
+  const DIGEST_B = 'sha256:' + 'b'.repeat(64);
+
+  function runnerResolving(digest: string, pullLog: string[]): CommandRunner {
+    return async (cmd) => {
+      if (cmd.startsWith('oras resolve')) return { stdout: digest + '\n', stderr: '' };
+      if (cmd.startsWith('oras pull')) pullLog.push(cmd);
+      return { stdout: '', stderr: '' };
+    };
+  }
+
+  test('reuses the cache when the resolved digest matches the stamped marker', async () => {
+    const base = await makeCache();
+    seedCachedBundle(base, 'app', '1.0', DIGEST_A);
+    const pulls: string[] = [];
+    const svc = new RealBundleService(base, runnerResolving(DIGEST_A, pulls));
+
+    const info = await svc.ensurePulled({ appId: 'app', version: '1.0', ociRef: 'ghcr.io/try-hola/app:1.0' });
+
+    expect(pulls).toHaveLength(0); // no re-pull
+    expect(info.digest).toBe(DIGEST_A);
+  });
+
+  test('re-pulls when the registry digest no longer matches the marker (same-tag republish)', async () => {
+    const base = await makeCache();
+    const dest = seedCachedBundle(base, 'app', '1.0', DIGEST_A);
+    const pulls: string[] = [];
+    const svc = new RealBundleService(base, runnerResolving(DIGEST_B, pulls));
+
+    const info = await svc.ensurePulled({ appId: 'app', version: '1.0', ociRef: 'ghcr.io/try-hola/app:1.0' });
+
+    expect(pulls).toHaveLength(1); // stale cache triggered a fresh pull
+    expect(info.digest).toBe(DIGEST_B);
+    // The old mixed-content marker is gone/replaced after the re-pull.
+    expect(readFileSync(join(dest, '.oras-digest'), 'utf8').trim()).toBe(DIGEST_B);
+  });
+
+  test('trusts the existing cache when digest resolution fails (offline registry)', async () => {
+    const base = await makeCache();
+    seedCachedBundle(base, 'app', '1.0', DIGEST_A);
+    const pulls: string[] = [];
+    const runner: CommandRunner = async (cmd) => {
+      if (cmd.startsWith('oras resolve')) throw new Error('network unreachable');
+      if (cmd.startsWith('oras pull')) pulls.push(cmd);
+      return { stdout: '', stderr: '' };
+    };
+    const svc = new RealBundleService(base, runner);
+
+    const info = await svc.ensurePulled({ appId: 'app', version: '1.0', ociRef: 'ghcr.io/try-hola/app:1.0' });
+
+    expect(pulls).toHaveLength(0); // resolve failure must not fail or force-repull the install
+    expect(info.localPath).toBe(join(base, 'app', '1.0'));
+  });
+
+  test('trusts a pre-existing cache with no marker (bundle cached before this feature shipped)', async () => {
+    const base = await makeCache();
+    seedCachedBundle(base, 'app', '1.0'); // no .oras-digest written
+    const pulls: string[] = [];
+    const svc = new RealBundleService(base, runnerResolving(DIGEST_A, pulls));
+
+    await svc.ensurePulled({ appId: 'app', version: '1.0', ociRef: 'ghcr.io/try-hola/app:1.0' });
+
+    expect(pulls).toHaveLength(0); // no marker to compare against -> don't force a redundant re-pull
+  });
+
+  test('stamps a digest marker after a fresh (first-time) pull', async () => {
+    const base = await makeCache();
+    const pulls: string[] = [];
+    const svc = new RealBundleService(base, runnerResolving(DIGEST_A, pulls));
+
+    const info = await svc.ensurePulled({ appId: 'app', version: '2.0', ociRef: 'ghcr.io/try-hola/app:2.0' });
+
+    expect(pulls).toHaveLength(1);
+    expect(info.digest).toBe(DIGEST_A);
+    expect(readFileSync(join(base, 'app', '2.0', '.oras-digest'), 'utf8').trim()).toBe(DIGEST_A);
   });
 });

--- a/packages/server/src/__tests__/bundles/compose-parser.test.ts
+++ b/packages/server/src/__tests__/bundles/compose-parser.test.ts
@@ -56,6 +56,9 @@ services:
       expect(defaults.environment).toHaveLength(2);
       expect(defaults.environment.some(e => e.key === 'NGINX_WORKER_PROCESSES' && e.value === 'auto')).toBe(true);
       expect(defaults.environment.some(e => e.key === 'NGINX_WORKER_CONNECTIONS' && e.value === '1024')).toBe(true);
+      // Every compose-harvested row is flagged so the wizard/config UI can
+      // collapse it behind Advanced (no packager-provided label exists for it).
+      expect(defaults.environment.every(e => e.autoDetected === true)).toBe(true);
     } finally {
       // Clean up
       fs.rmSync(tempDir, { recursive: true, force: true });
@@ -97,6 +100,30 @@ services:
     expect(merged.defaultEnv.some(e => e.key === 'NODE_ENV' && e.value === 'production')).toBe(true); // From compose
     expect(merged.defaultEnv.some(e => e.key === 'PORT' && e.value === '4000')).toBe(true); // Manifest wins
     expect(merged.defaultEnv.some(e => e.key === 'DEBUG' && e.value === 'true')).toBe(true); // From manifest
+  });
+
+  test('manifest wins on key collision, dropping the compose row\'s autoDetected flag entirely', () => {
+    const composeDefaults = {
+      ports: [],
+      volumes: [],
+      environment: [
+        { key: 'PORT', value: '3000', isSecret: false, description: 'Port number', autoDetected: true },
+        { key: 'INTERNAL_DB_PASSWORD', value: 'baked-in', isSecret: true, description: 'DB password', autoDetected: true },
+      ],
+    };
+    const manifestDefaults = { ports: [], volumes: [] };
+    const manifestEnv = [{ key: 'PORT', value: '4000', isSecret: false, label: 'App Port' }];
+
+    const merged = mergeDefaults(composeDefaults, manifestDefaults, manifestEnv);
+
+    // The manifest-declared row fully replaces the compose one — no autoDetected leaks through.
+    const port = merged.defaultEnv.find(e => e.key === 'PORT');
+    expect(port).toMatchObject({ value: '4000', label: 'App Port' });
+    expect(port?.autoDetected).toBeUndefined();
+
+    // A key the manifest never mentions stays compose-derived and flagged.
+    const dbPassword = merged.defaultEnv.find(e => e.key === 'INTERNAL_DB_PASSWORD');
+    expect(dbPassword?.autoDetected).toBe(true);
   });
 
   test('should handle various compose environment formats', async () => {

--- a/packages/server/src/services/core/bundles.ts
+++ b/packages/server/src/services/core/bundles.ts
@@ -1,6 +1,6 @@
 import { exec } from 'child_process';
 import { promisify } from 'util';
-import { mkdirSync, existsSync, rmSync, statSync, mkdtempSync, writeFileSync } from 'fs';
+import { mkdirSync, existsSync, rmSync, statSync, mkdtempSync, writeFileSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { getLogger } from '../../lib/logger';
@@ -98,10 +98,26 @@ export class RealBundleService implements BundleService, HealthCheckable {
       // Touch cache entry for LRU tracking
       this.cacheManager.touch(cacheKey, opts.version);
 
-      // If already has compose.yaml and manifest.json, assume cached
-      if (existsSync(join(dest, 'compose.yaml')) && existsSync(join(dest, 'manifest.json'))) {
-        this.logger.debug('Bundle already cached', { appId: opts.appId, version: opts.version });
-        return { localPath: dest, ...this.safeStat(dest) };
+      // A cache hit by file presence alone is unsafe: a publisher can push new
+      // content under the SAME version tag (no version bump, new digest) —
+      // e.g. a hand-pushed test image, or a re-tagged `latest`/by-ref install.
+      // The on-disk path is keyed by version string, not digest, so that
+      // republish would otherwise be served stale forever. Confirm the
+      // registry's current digest still matches what we last pulled before
+      // trusting the cache; a resolve failure (offline registry, blip) falls
+      // back to trusting the existing cache rather than failing the install.
+      const filesPresent = existsSync(join(dest, 'compose.yaml')) && existsSync(join(dest, 'manifest.json'));
+      let remoteDigest: string | undefined;
+      if (filesPresent) {
+        remoteDigest = await this.resolveDigest(opts.ociRef, opts.credentials);
+        const cachedDigest = this.readDigestMarker(dest);
+        if (!remoteDigest || !cachedDigest || remoteDigest === cachedDigest) {
+          this.logger.debug('Bundle already cached', { appId: opts.appId, version: opts.version });
+          return { localPath: dest, digest: cachedDigest ?? remoteDigest, ...this.safeStat(dest) };
+        }
+        this.logger.info('Cached bundle digest is stale; re-pulling', {
+          appId: opts.appId, version: opts.version, cachedDigest, remoteDigest,
+        });
       }
 
       // Clean dest to avoid mixed content
@@ -146,10 +162,58 @@ export class RealBundleService implements BundleService, HealthCheckable {
         }
       }
 
-      return { localPath: dest, ...this.safeStat(dest) };
+      // Stamp the digest we just pulled so a FUTURE call can tell a same-tag
+      // republish apart from an untouched cache. Reuse the digest resolved
+      // above when this was a stale-cache re-pull; resolve fresh otherwise
+      // (first-ever pull for this version). Best-effort: a resolve/write
+      // failure here just means the next call re-verifies via a full pull
+      // comparison rather than trusting a marker — never fails the install.
+      const pulledDigest = remoteDigest ?? await this.resolveDigest(opts.ociRef, opts.credentials);
+      if (pulledDigest) this.writeDigestMarker(dest, pulledDigest);
+
+      return { localPath: dest, digest: pulledDigest, ...this.safeStat(dest) };
     } finally {
       this.cacheManager.markNotInUse(cacheKey, opts.version);
     }
+  }
+
+  /** Resolve the current manifest digest for an OCI ref without pulling blobs. */
+  private async resolveDigest(ociRef: string, credentials?: PullCredentials): Promise<string | undefined> {
+    let authDir: string | undefined;
+    const flags: string[] = [];
+    if (credentials) {
+      authDir = this.writeRegistryAuth(credentials);
+      flags.push(`--registry-config ${shellEscape(join(authDir, 'config.json'))}`);
+    }
+    try {
+      const { stdout } = await this.run(`oras resolve ${flags.join(' ')} ${shellEscape(ociRef)}`);
+      const digest = stdout.trim().split('\n').pop()?.trim();
+      return digest && /^sha256:[0-9a-f]{64}$/.test(digest) ? digest : undefined;
+    } catch (error) {
+      this.logger.warn('Failed to resolve remote digest; trusting existing cache if present', {
+        ref: ociRef, error: error instanceof Error ? error.message : String(error),
+      });
+      return undefined;
+    } finally {
+      if (authDir) { try { rmSync(authDir, { recursive: true, force: true }); } catch { /* best effort */ } }
+    }
+  }
+
+  private digestMarkerPath(dest: string): string {
+    return join(dest, '.oras-digest');
+  }
+
+  private readDigestMarker(dest: string): string | undefined {
+    try {
+      const digest = readFileSync(this.digestMarkerPath(dest), 'utf8').trim();
+      return digest || undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private writeDigestMarker(dest: string, digest: string): void {
+    try { writeFileSync(this.digestMarkerPath(dest), digest, { mode: 0o644 }); } catch { /* best effort */ }
   }
 
   /**

--- a/packages/server/src/services/core/compose-parser.ts
+++ b/packages/server/src/services/core/compose-parser.ts
@@ -120,6 +120,7 @@ export function parseComposeDefaults(bundlePath: string): ParsedDefaults {
                     value: value || '',
                     isSecret: isLikelySecret(key),
                     description: generateEnvDescription(key),
+                    autoDetected: true,
                   });
                 }
               }
@@ -132,6 +133,7 @@ export function parseComposeDefaults(bundlePath: string): ParsedDefaults {
                 value: String(value ?? ''),
                 isSecret: isLikelySecret(key),
                 description: generateEnvDescription(key),
+                autoDetected: true,
               });
             }
           }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -586,6 +586,15 @@ export type AppEnvVar = {
   required?: boolean;
   /** Hide behind a collapsed "Advanced" section in the install wizard. */
   advanced?: boolean;
+  /**
+   * True for a row discovered by scanning the bundle's compose.yaml
+   * `environment:` blocks rather than declared in the manifest's `defaultEnv`
+   * — internal/hardcoded config the packager never curated a label or type
+   * for (DB passwords shared between two containers, fixed ports, etc). The
+   * UI treats these like `advanced: true` (collapsed by default) since they
+   * lack packager-provided labels; never set on a manifest-declared row.
+   */
+  autoDetected?: boolean;
   placeholder?: string;
   // --- string ---
   pattern?: string;

--- a/packages/web/src/__tests__/pages/Apps.test.tsx
+++ b/packages/web/src/__tests__/pages/Apps.test.tsx
@@ -66,6 +66,18 @@ describe('Apps landing', () => {
     expect(screen.getByTitle('Bravo — view deployment')).toHaveAttribute('href', '/deployments/b-1');
   });
 
+  it('shows the manage shortcut on a non-running (e.g. failed) app too, not just running ones', async () => {
+    mockApi(
+      [{ id: 'c-1', name: 'Charlie', app: 'c', icon: '📦', status: 'error', ports: [], lastUpdated: 'now' }],
+    );
+
+    renderApps();
+
+    // Without this, the only way to reach Remove was clicking the tile itself
+    // (not obvious) or hunting through the Deployments list nav.
+    expect(await screen.findByTitle('Manage & logs')).toHaveAttribute('href', '/deployments/c-1');
+  });
+
   it('falls back to the app id when the deployment has no display name', async () => {
     mockApi(
       [{ id: 'x-1', name: '', app: 'uptime-kuma', icon: '📦', status: 'installing', ports: [], lastUpdated: 'now' }],

--- a/packages/web/src/__tests__/pages/DeploymentDetail.test.tsx
+++ b/packages/web/src/__tests__/pages/DeploymentDetail.test.tsx
@@ -132,4 +132,23 @@ describe('DeploymentDetail Configuration tab', () => {
     await waitFor(() => expect(screen.getByText(/must be between/i)).toBeInTheDocument());
     expect(deploymentsApi.update).not.toHaveBeenCalled();
   });
+
+  it('collapses autoDetected (compose-harvested, unlabeled) rows behind an Advanced toggle', async () => {
+    deploymentsApi.config.mockResolvedValueOnce({
+      appEnv: [
+        ...config.appEnv,
+        { key: 'GITEA__server__HTTP_PORT', value: '3000', isSecret: false, autoDetected: true },
+      ],
+      systemOverrides: config.systemOverrides,
+    });
+    renderDetail();
+
+    await waitFor(() => expect(screen.getByText('ADMIN_USER')).toBeInTheDocument());
+    // Hidden until the operator expands Advanced.
+    expect(screen.queryByText('GITEA__server__HTTP_PORT')).not.toBeInTheDocument();
+    expect(screen.getByText('Advanced (1)')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Advanced (1)'));
+    expect(screen.getByText('GITEA__server__HTTP_PORT')).toBeInTheDocument();
+  });
 });

--- a/packages/web/src/__tests__/pages/InstallWizard.secretWand.test.tsx
+++ b/packages/web/src/__tests__/pages/InstallWizard.secretWand.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, cleanup, within } from '@testing-library/react';
 import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import type { AppEnvVar, CreateDraftResponse, Draft } from '@hola/shared';
@@ -89,29 +89,54 @@ afterEach(() => {
   cleanup();
 });
 
-describe('InstallWizard secret wand', () => {
-  it('uses generateSecretValue with the spec recipe for a seeded secret that declares one', async () => {
-    renderWizard();
-    await waitFor(() => expect(screen.getAllByTitle('Generate a random secret')).toHaveLength(2));
+// Auto-fill (see below) reorders rows by "needs a value" — required-and-empty
+// floats to the top — so a field's wand position isn't stable across tests.
+// Look it up relative to its own labeled input instead of a flat array index.
+function wandFor(labelPattern: RegExp): HTMLElement {
+  const input = screen.getByLabelText(labelPattern);
+  const row = input.closest('.relative') as HTMLElement;
+  return within(row).getByTitle('Generate a random secret');
+}
 
-    const wands = screen.getAllByTitle('Generate a random secret');
-    // First seeded row is GEN_SECRET (has a `generate` recipe).
-    fireEvent.click(wands[0]);
+describe('InstallWizard secret wand', () => {
+  it('auto-fills a seeded secret with a `generate` recipe on draft load, no click required', async () => {
+    renderWizard();
 
     await waitFor(() => {
       const generatedInput = screen.getByLabelText(/^Generated secret/) as HTMLInputElement;
       // 4 bytes -> 8 lowercase hex chars, per the spec's generate.length: 4.
       expect(generatedInput.value).toMatch(/^[0-9a-f]{8}$/);
     });
+    // Persisted immediately (not left to the next "Next" click), same
+    // durability the manual wand-click path already gets.
+    await waitFor(() => expect(draftsApi.update).toHaveBeenCalled());
+  });
+
+  it('does not auto-fill a seeded secret with no generate recipe', async () => {
+    renderWizard();
+    await waitFor(() => expect(screen.getByLabelText(/^Generated secret/)).toBeInTheDocument());
+
+    const legacyInput = screen.getByLabelText(/^Legacy secret/) as HTMLInputElement;
+    expect(legacyInput.value).toBe('');
+  });
+
+  it('uses generateSecretValue with the spec recipe when the wand is clicked again', async () => {
+    renderWizard();
+    await waitFor(() => expect(screen.getByLabelText(/^Generated secret/)).toBeInTheDocument());
+
+    fireEvent.click(wandFor(/^Generated secret/));
+
+    await waitFor(() => {
+      const generatedInput = screen.getByLabelText(/^Generated secret/) as HTMLInputElement;
+      expect(generatedInput.value).toMatch(/^[0-9a-f]{8}$/);
+    });
   });
 
   it('falls back to the legacy 32-byte-hex value for a seeded secret with no generate recipe', async () => {
     renderWizard();
-    await waitFor(() => expect(screen.getAllByTitle('Generate a random secret')).toHaveLength(2));
+    await waitFor(() => expect(screen.getByLabelText(/^Legacy secret/)).toBeInTheDocument());
 
-    const wands = screen.getAllByTitle('Generate a random secret');
-    // Second seeded row is LEGACY_SECRET (no `generate` recipe).
-    fireEvent.click(wands[1]);
+    fireEvent.click(wandFor(/^Legacy secret/));
 
     await waitFor(() => {
       const legacyInput = screen.getByLabelText(/^Legacy secret/) as HTMLInputElement;

--- a/packages/web/src/hooks/useGlobalEvents.test.ts
+++ b/packages/web/src/hooks/useGlobalEvents.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { globalCache } from '../utils/cache';
+import type { SSEEvent } from '@hola/shared';
+
+// `useGlobalEvents` is mounted once (in AppShell) and is the ONLY thing that
+// hears every SSE event — a page that isn't currently mounted (e.g. Apps
+// while the operator is on Deployments) has no live-bus subscriber of its
+// own, so the fix must invalidate the shared `globalCache` directly rather
+// than relying on `signalLive` reaching a listener that doesn't exist yet.
+let capturedOnEvent: ((event: SSEEvent) => void) | undefined;
+vi.mock('./useSSE', () => ({
+  useSSE: (_url: string, onEvent: (event: SSEEvent) => void) => {
+    capturedOnEvent = onEvent;
+    return { isConnected: true };
+  },
+}));
+
+const { useGlobalEvents } = await import('./useGlobalEvents');
+
+describe('useGlobalEvents cache invalidation', () => {
+  beforeEach(() => {
+    globalCache.clear();
+    capturedOnEvent = undefined;
+  });
+
+  it('drops every cached deployments-list variant on deployment_deleted, not just a currently-mounted one', () => {
+    // Two different param combinations, e.g. Apps.tsx vs Deployments.tsx.
+    globalCache.set('deployments-{"page":1,"limit":100}', { data: {}, timestamp: Date.now() });
+    globalCache.set('deployments-{"status":"running"}', { data: {}, timestamp: Date.now() });
+    globalCache.set('deployment-detail-app-abc123', { data: {}, timestamp: Date.now() });
+
+    renderHook(() => useGlobalEvents());
+    expect(capturedOnEvent).toBeDefined();
+
+    capturedOnEvent!({ type: 'deployment_deleted', data: { deploymentId: 'app-abc123' } });
+
+    expect(globalCache.get('deployments-{"page":1,"limit":100}')).toBeNull();
+    expect(globalCache.get('deployments-{"status":"running"}')).toBeNull();
+    expect(globalCache.get('deployment-detail-app-abc123')).toBeNull();
+  });
+
+  it('drops every cached deployments-list variant on deployment_update too', () => {
+    globalCache.set('deployments-{"page":1,"limit":100}', { data: {}, timestamp: Date.now() });
+
+    renderHook(() => useGlobalEvents());
+    capturedOnEvent!({
+      type: 'deployment_update',
+      data: { deploymentId: 'app-abc123', status: 'running', lastUpdated: new Date(0).toISOString() },
+    });
+
+    expect(globalCache.get('deployments-{"page":1,"limit":100}')).toBeNull();
+  });
+});

--- a/packages/web/src/hooks/useGlobalEvents.ts
+++ b/packages/web/src/hooks/useGlobalEvents.ts
@@ -33,13 +33,15 @@ export function useGlobalEvents(): void {
         });
       }
       // A deployment status change usually rides alongside a lifecycle job, so
-      // refresh both the deployments list and the job tracker.
+      // refresh both the deployments list and the job tracker (`signalLive`
+      // itself drops each resource's stale `globalCache` entries first, so a
+      // page that isn't currently mounted — e.g. Apps while the operator is
+      // on Deployments — won't re-serve stale data on its next mount either).
       signalLive('deployments');
       signalLive('jobs');
     } else if (event.type === 'deployment_deleted') {
-      // The record is gone — drop any cached detail page rather than patch it,
-      // and tell the Apps/Deployments lists to refetch so the tile disappears
-      // live instead of only after a hard refresh.
+      // The record is gone — drop its cached detail page rather than patch
+      // it, then tell the deployments list to refetch live.
       globalCache.delete(`deployment-detail-${event.data.deploymentId}`);
       signalLive('deployments');
     }

--- a/packages/web/src/pages/Apps.tsx
+++ b/packages/web/src/pages/Apps.tsx
@@ -120,19 +120,23 @@ export const Apps: React.FC = () => {
                   />
                 )}
 
-                {/* Manage shortcut (running tiles only — non-running tiles already
-                    route to the detail). Sits above the stretched link. */}
-                {openable && (
-                  <Link
-                    to={`/deployments/${app.id}`}
-                    onClick={(e) => e.stopPropagation()}
-                    title="Manage & logs"
-                    aria-label={`Manage ${displayName}`}
-                    className="absolute top-2.5 right-2.5 z-[2] w-7 h-7 flex items-center justify-center rounded-[8px] text-text-faint opacity-0 group-hover:opacity-100 hover:text-primary hover:bg-primary-weak transition"
-                  >
-                    <SlidersHorizontal className="w-[15px] h-[15px]" />
-                  </Link>
-                )}
+                {/* Manage shortcut — always shown, even though a non-running
+                    tile's whole card already routes here too: without it,
+                    a failed/stopped app has no visible affordance at all for
+                    "go manage/remove this", and the card being clickable
+                    everywhere isn't obvious on its own. Sits above the
+                    stretched link (which points elsewhere for an openable
+                    tile — the external app URL — so this needs its own
+                    stopPropagation to win). */}
+                <Link
+                  to={`/deployments/${app.id}`}
+                  onClick={(e) => e.stopPropagation()}
+                  title="Manage & logs"
+                  aria-label={`Manage ${displayName}`}
+                  className="absolute top-2.5 right-2.5 z-[2] w-7 h-7 flex items-center justify-center rounded-[8px] text-text-faint opacity-0 group-hover:opacity-100 hover:text-primary hover:bg-primary-weak transition"
+                >
+                  <SlidersHorizontal className="w-[15px] h-[15px]" />
+                </Link>
                 {openable && (
                   <ExternalLink className="absolute top-2.5 left-2.5 w-4 h-4 text-text-faint opacity-0 group-hover:opacity-100 group-hover:text-primary transition" />
                 )}

--- a/packages/web/src/pages/DeploymentDetail.tsx
+++ b/packages/web/src/pages/DeploymentDetail.tsx
@@ -23,6 +23,7 @@ import {
   AlertTriangle,
   ChevronLeft,
   ChevronRight,
+  ChevronDown,
   Copy,
   ArrowUpCircle
 } from 'lucide-react';
@@ -124,6 +125,8 @@ export const DeploymentDetail: React.FC = () => {
   const [isEditing, setIsEditing] = useState(false);
   const [showSecrets, setShowSecrets] = useState<{[key: string]: boolean}>({});
   const [operationLoading, setOperationLoading] = useState<{[key: string]: boolean}>({});
+  // Collapses `advanced`/`autoDetected` env rows out of view by default (mirrors InstallWizard).
+  const [showAdvancedConfig, setShowAdvancedConfig] = useState(false);
 
   // The active release's real config (typed appEnv rows + whatever system
   // overrides the operator set at install time) — replaces the old hardcoded
@@ -540,7 +543,80 @@ export const DeploymentDetail: React.FC = () => {
           </div>
         );
 
-      case 'configuration':
+      case 'configuration': {
+        // `advanced`/`autoDetected` rows (manifest-flagged or harvested from
+        // compose.yaml with no packager-provided label) collapse behind a
+        // chevron, same split as InstallWizard step 0. A freshly-added custom
+        // row (no spec, no flags) lands in the always-visible basic bucket.
+        const indexedEnvVars = envVars.map((env, index) => ({ env, index }));
+        const basicEnvVars = indexedEnvVars.filter(({ env }) => !env.advanced && !env.autoDetected);
+        const advancedEnvVars = indexedEnvVars.filter(({ env }) => env.advanced === true || env.autoDetected === true);
+
+        const renderEditableRow = ({ env: envVar, index }: { env: AppEnvVar; index: number }) => (
+          <div key={envVar.key || index} className="flex items-start gap-2">
+            <div className="flex-1">
+              {envVar.key ? (
+                <ParamField
+                  spec={envVar}
+                  value={envVar.value}
+                  onChange={(v) => handleParamChange(index, v)}
+                  issues={issuesForKey(envVar.key)}
+                  showSecret={showSecrets[envVar.key]}
+                  onToggleSecret={() => toggleSecretVisibility(envVar.key)}
+                  onGenerateSecret={envVar.isSecret ? () => generateSecret(index) : undefined}
+                />
+              ) : (
+                // A just-added custom row has no key yet — ParamField needs
+                // one for its id/label, so show a bare key input until set.
+                <input
+                  type="text"
+                  autoFocus
+                  placeholder="VARIABLE_NAME"
+                  value={envVar.key}
+                  onChange={(e) => updateDeploymentEnvVar(index, 'key', e.target.value.toUpperCase())}
+                  className="w-full h-10 bg-surface-0 border border-border rounded-[9px] text-text-strong px-[13px] text-[13px] font-mono outline-none focus:border-primary"
+                />
+              )}
+            </div>
+            {!hasParamSpec(envVar) && !envVar.autoDetected && (
+              <button
+                type="button"
+                onClick={() => removeDeploymentEnvVar(index)}
+                className="flex-none mt-2.5 text-text-muted hover:text-danger transition-colors"
+                title="Remove custom variable"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            )}
+          </div>
+        );
+
+        const renderReadOnlyRow = ({ env: envVar }: { env: AppEnvVar; index: number }) => {
+          const showValue = envVar.isSecret && !showSecrets[envVar.key];
+          return (
+            <div
+              key={envVar.key}
+              className="flex items-center gap-[14px] px-[18px] py-[11px] border-b border-border-soft last:border-b-0"
+            >
+              <span className="font-mono text-[12.5px] text-text-muted w-[200px] flex-none break-all">
+                {envVar.label ?? envVar.key}
+              </span>
+              <span className="flex-1 font-mono text-[12.5px] break-all">
+                {showValue ? '••••••••' : (envVar.value || '(empty)')}
+              </span>
+              {envVar.isSecret && (
+                <button
+                  type="button"
+                  onClick={() => toggleSecretVisibility(envVar.key)}
+                  className="flex text-text-faint hover:text-text-strong transition-colors"
+                >
+                  {showSecrets[envVar.key] ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                </button>
+              )}
+            </div>
+          );
+        };
+
         return (
           <div className="animate-fadein flex flex-col gap-4">
             <div className="flex items-center justify-between">
@@ -611,71 +687,30 @@ export const DeploymentDetail: React.FC = () => {
 
               {isEditing ? (
                 <div className="p-[18px] space-y-3">
-                  {envVars.map((envVar, index) => (
-                    <div key={envVar.key || index} className="flex items-start gap-2">
-                      <div className="flex-1">
-                        {envVar.key ? (
-                          <ParamField
-                            spec={envVar}
-                            value={envVar.value}
-                            onChange={(v) => handleParamChange(index, v)}
-                            issues={issuesForKey(envVar.key)}
-                            showSecret={showSecrets[envVar.key]}
-                            onToggleSecret={() => toggleSecretVisibility(envVar.key)}
-                            onGenerateSecret={envVar.isSecret ? () => generateSecret(index) : undefined}
-                          />
-                        ) : (
-                          // A just-added custom row has no key yet — ParamField needs
-                          // one for its id/label, so show a bare key input until set.
-                          <input
-                            type="text"
-                            autoFocus
-                            placeholder="VARIABLE_NAME"
-                            value={envVar.key}
-                            onChange={(e) => updateDeploymentEnvVar(index, 'key', e.target.value.toUpperCase())}
-                            className="w-full h-10 bg-surface-0 border border-border rounded-[9px] text-text-strong px-[13px] text-[13px] font-mono outline-none focus:border-primary"
-                          />
-                        )}
-                      </div>
-                      {!hasParamSpec(envVar) && (
-                        <button
-                          type="button"
-                          onClick={() => removeDeploymentEnvVar(index)}
-                          className="flex-none mt-2.5 text-text-muted hover:text-danger transition-colors"
-                          title="Remove custom variable"
-                        >
-                          <X className="w-4 h-4" />
-                        </button>
-                      )}
-                    </div>
-                  ))}
+                  {basicEnvVars.map(renderEditableRow)}
                 </div>
               ) : (
-                envVars.map((envVar) => {
-                  const showValue = envVar.isSecret && !showSecrets[envVar.key];
-                  return (
-                    <div
-                      key={envVar.key}
-                      className="flex items-center gap-[14px] px-[18px] py-[11px] border-b border-border-soft last:border-b-0"
-                    >
-                      <span className="font-mono text-[12.5px] text-text-muted w-[200px] flex-none break-all">
-                        {envVar.label ?? envVar.key}
-                      </span>
-                      <span className="flex-1 font-mono text-[12.5px] break-all">
-                        {showValue ? '••••••••' : (envVar.value || '(empty)')}
-                      </span>
-                      {envVar.isSecret && (
-                        <button
-                          type="button"
-                          onClick={() => toggleSecretVisibility(envVar.key)}
-                          className="flex text-text-faint hover:text-text-strong transition-colors"
-                        >
-                          {showSecrets[envVar.key] ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
-                        </button>
-                      )}
-                    </div>
-                  );
-                })
+                basicEnvVars.map(renderReadOnlyRow)
+              )}
+
+              {advancedEnvVars.length > 0 && (
+                <div className={isEditing ? 'px-[18px] pb-[18px]' : 'border-t border-border-soft'}>
+                  <button
+                    type="button"
+                    onClick={() => setShowAdvancedConfig(v => !v)}
+                    className={`flex items-center gap-2 text-[13px] font-semibold text-text-strong ${isEditing ? 'pt-1 pb-3' : 'w-full px-[18px] py-[11px]'}`}
+                  >
+                    {showAdvancedConfig ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
+                    <span>Advanced ({advancedEnvVars.length})</span>
+                  </button>
+                  {showAdvancedConfig && (
+                    isEditing ? (
+                      <div className="space-y-3">{advancedEnvVars.map(renderEditableRow)}</div>
+                    ) : (
+                      advancedEnvVars.map(renderReadOnlyRow)
+                    )
+                  )}
+                </div>
               )}
             </div>
 
@@ -776,6 +811,7 @@ export const DeploymentDetail: React.FC = () => {
             </div>
           </div>
         );
+      }
 
       case 'history':
         return (

--- a/packages/web/src/pages/InstallWizard.tsx
+++ b/packages/web/src/pages/InstallWizard.tsx
@@ -130,6 +130,19 @@ export const InstallWizard: React.FC = () => {
           ? await createDraftHook.createDraft({ ociRef, credentialRef })
           : await createDraftHook.createDraft({ appId, source });
 
+        // Auto-fill empty secrets that carry a manifest `generate` recipe —
+        // these are machine tokens (runner registration keys, app secret
+        // keys) nobody types or remembers, same class as an internal DB
+        // password the app generates for itself. Requiring a manual wand
+        // click here bought nothing; mirrors the CLI's install.ts, which
+        // already auto-fills these non-interactively.
+        let generatedCount = 0;
+        const seededEnv = result.appEnv.map((e) => {
+          if (!(e.isSecret && e.generate && !e.value)) return e;
+          generatedCount++;
+          return { ...e, value: generateSecretValue(e.generate) };
+        });
+
         // Update state with draft data. Row order is preserved exactly as the
         // catalog declares it (env order doesn't affect deployment) — the
         // Basic section below floats required-and-empty rows to the top for
@@ -137,10 +150,17 @@ export const InstallWizard: React.FC = () => {
         // were present right now ("seeded", manifest-declared) vs. added later
         // via "Add app variable" (free-form "Custom" rows with no spec).
         setSystemEnvVars(result.systemEnv);
-        seededKeysRef.current = new Set(result.appEnv.map((e) => e.key));
-        setEnvVars(result.appEnv);
+        seededKeysRef.current = new Set(seededEnv.map((e) => e.key));
+        setEnvVars(seededEnv);
         setPorts(result.defaults.ports);
         setVolumes(result.defaults.volumes);
+
+        // Persist the generated values immediately so a refresh (or abandoning
+        // the wizard before clicking Next) doesn't lose them — same durability
+        // the manual wand-click path already gets via `updateEnvVar`.
+        if (generatedCount > 0) {
+          await api.drafts.update(result.draftId, { appEnv: seededEnv }).catch(() => {});
+        }
 
       } catch (err) {
         creatingDraftRef.current = false; // allow a retry on failure

--- a/packages/web/src/pages/InstallWizard.tsx
+++ b/packages/web/src/pages/InstallWizard.tsx
@@ -585,8 +585,11 @@ services:
         // via "Add app variable", no spec — rendered with the original grid).
         const seededKeys = seededKeysRef.current;
         const indexedEnvVars = envVars.map((env, index) => ({ env, index }));
-        const basicRows = indexedEnvVars.filter(({ env }) => seededKeys.has(env.key) && !env.advanced);
-        const advancedRows = indexedEnvVars.filter(({ env }) => seededKeys.has(env.key) && env.advanced === true);
+        // `autoDetected` rows (harvested from compose.yaml, no manifest label)
+        // fold into Advanced alongside manifest `advanced: true` rows — neither
+        // is meant to be the first thing an installer sees.
+        const basicRows = indexedEnvVars.filter(({ env }) => seededKeys.has(env.key) && !env.advanced && !env.autoDetected);
+        const advancedRows = indexedEnvVars.filter(({ env }) => seededKeys.has(env.key) && (env.advanced === true || env.autoDetected === true));
         const customRows = indexedEnvVars.filter(({ env }) => !seededKeys.has(env.key));
         // Float required-and-empty rows to the top within Basic; stable
         // (original catalog-declared order) otherwise — env order doesn't
@@ -725,7 +728,8 @@ services:
             )}
 
             {/* Advanced application variables — seeded rows with `advanced:
-                true`, collapsed by default. */}
+                true` or `autoDetected: true` (harvested from compose.yaml,
+                no manifest label), collapsed by default. */}
             {advancedRows.length > 0 && (
               <div className="mb-6">
                 <button

--- a/packages/web/src/utils/live-bus.test.ts
+++ b/packages/web/src/utils/live-bus.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { globalCache } from './cache';
+import { onLive, signalLive } from './live-bus';
+
+describe('signalLive', () => {
+  beforeEach(() => {
+    globalCache.clear();
+  });
+
+  it('drops every cached entry for the resource, not just ones a currently-mounted listener would refetch', () => {
+    // Simulates useDeploymentsApi caching two different param combinations
+    // (e.g. Apps.tsx vs Deployments.tsx) plus an unrelated jobs entry.
+    globalCache.set('deployments-{"page":1,"limit":100}', { data: {}, timestamp: Date.now() });
+    globalCache.set('deployments-{"status":"running"}', { data: {}, timestamp: Date.now() });
+    globalCache.set('jobs-{"page":1}', { data: {}, timestamp: Date.now() });
+
+    signalLive('deployments');
+
+    expect(globalCache.get('deployments-{"page":1,"limit":100}')).toBeNull();
+    expect(globalCache.get('deployments-{"status":"running"}')).toBeNull();
+    // A different resource's cache is untouched.
+    expect(globalCache.get('jobs-{"page":1}')).not.toBeNull();
+  });
+
+  it('still notifies currently-mounted listeners', () => {
+    let called = 0;
+    const unsubscribe = onLive('deployments', () => { called++; });
+    signalLive('deployments');
+    expect(called).toBe(1);
+    unsubscribe();
+  });
+});

--- a/packages/web/src/utils/live-bus.ts
+++ b/packages/web/src/utils/live-bus.ts
@@ -3,6 +3,8 @@
 // (useDeploymentsApi, useJobsApi) subscribe and refetch, so they stay live
 // without each polling. Tiny and synchronous — a UI-local pub/sub.
 
+import { globalCache } from './cache';
+
 export type LiveResource = 'deployments' | 'jobs';
 
 const listeners = new Map<LiveResource, Set<() => void>>();
@@ -20,8 +22,19 @@ export function onLive(resource: LiveResource, cb: () => void): () => void {
   };
 }
 
-/** Notify subscribers that a resource changed (a stream event arrived). */
+/**
+ * Notify subscribers that a resource changed (a stream event arrived).
+ *
+ * Also drops every cached `globalCache` entry for this resource
+ * (`useDeploymentsApi`/`useJobsApi` key their cache entries `<resource>-<params>`)
+ * — not just the currently-mounted listeners' data. `onLive` only reaches a
+ * component that happens to be mounted right now; a page that isn't (e.g.
+ * Apps while the operator is on Deployments) would otherwise still serve its
+ * stale cache entry on its next mount's unforced fetch, since nothing else
+ * ever invalidates it.
+ */
 export function signalLive(resource: LiveResource): void {
+  globalCache.deleteByPattern(new RegExp(`^${resource}-`));
   listeners.get(resource)?.forEach((cb) => {
     try {
       cb();


### PR DESCRIPTION
## Summary
Four related install/config reliability fixes, found while investigating the reported gitea env-var display issue and follow-up questions in the same conversation:

**1. Collapse compose-harvested env vars under Advanced**
`parseComposeDefaults`/`mergeDefaults` (predates typed params) harvests every key from every service's compose.yaml `environment:` block into the user-facing `defaultEnv` — not just vars the packager explicitly declared. A survey of all 14 catalog apps found this leaking 0–27 internal/hardcoded vars per app (DB passwords shared between containers, fixed ports, internal hostnames). Rather than dropping the harvest outright (a few apps reference vars via bash-default syntax like `${DB_PASSWORD:-internal_default}` a power user may legitimately want to override), every compose-harvested row is now tagged `autoDetected: true` (`AppEnvVar.autoDetected`) and folded into the same collapsed **Advanced** section the install wizard already uses for manifest `advanced: true` rows. A manifest-declared row for the same key still fully replaces the compose one, so the flag never survives onto a curated row. Extends the same Advanced collapse to `DeploymentDetail`'s Configuration tab.

**2. Auto-fill generate-recipe secrets on draft load**
The install wizard required a manual wand click before proceeding past a required secret with a manifest `generate` recipe (hex/base64/fernet) — a machine token nobody types or remembers, no different in kind from an internal DB password the app generates for itself. The CLI's `install.ts` already auto-fills these non-interactively; the web wizard now does the same at draft-creation time, persisting the value immediately. The wand remains available to regenerate.

**3. Fix cross-cutting live-bus cache staleness**
Deleting a deployment (or any status change) called `signalLive('deployments')`, but that only notifies *currently-mounted* list hooks — it never touched the underlying `globalCache`. A page that wasn't mounted at the moment of the change (e.g. Apps while the operator was on Deployments) would still serve its stale cached list on its next mount. Symptom: delete a deployment, navigate to Apps, the deleted app is still there until a hard refresh. Fixed at the source — `signalLive` now drops every `globalCache` entry matching `^<resource>-` before notifying listeners, covering both `deployments` and `jobs` (and any future `LiveResource`) instead of requiring each call site to remember it.

**4. Verify bundle cache freshness against the registry digest**
`RealBundleService.ensurePulled` decided cache reuse purely by file presence (compose.yaml/manifest.json already exist at `<cache>/<appId>/<version>`) — never checking whether the registry's content under that same version tag had actually changed. A publisher re-pushing new bits under an unbumped version tag (or a by-ref install reusing an untagged/`latest` ref) would be served the stale on-disk bundle indefinitely. `ensurePulled` now resolves the OCI ref's current manifest digest (`oras resolve`, no blob download) and compares it against a `.oras-digest` marker stamped at the last successful pull; a mismatch triggers a fresh pull, a resolve failure falls back to trusting the existing cache (never fails an install over it), and a pre-existing bundle with no marker is trusted as-is rather than forcing a fleet-wide redundant re-pull.

## Test plan
- [x] `bun run typecheck` / `lint` — clean
- [x] `bun run test` — 531 server + 182 web tests pass, including new coverage for: compose-parser `autoDetected` flagging + manifest-override precedence, DeploymentDetail's Advanced toggle, InstallWizard's auto-fill-on-load (and regeneration-on-click), `signalLive`'s cache invalidation (directly and via `useGlobalEvents`), and bundle-cache digest verification (reuse-on-match, re-pull-on-mismatch, trust-on-resolve-failure, trust-pre-existing-unmarked-cache, marker stamped after a fresh pull)
- [x] `bun run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)