### PR TITLE
feat(catalog): per-source allowRegistries for opt-in registry consent

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -81,6 +81,43 @@ The web dashboard browses a remote **catalog** of installable apps, set via
 catalog renders them. See the catalog notes in the compose
 [README](../packages/compose/README.md#app-catalog).
 
+#### Pulling bundles from a non-default registry
+
+Each version in a catalog points at an OCI package (the loose-layer
+`compose.yaml` + `manifest.json` bundle) in a registry. The server only pulls
+from a registry the operator has consented to, matching against the
+`HOLA_REGISTRY_ALLOWLIST` baseline (default `ghcr.io/try-hola/*`). This is a
+typo-squat guard, not auth — a `ghcr.io.evil.com` ref can't slip past a
+`ghcr.io/*` consent (glob-prefix anchored, not substring).
+
+For a **private** package in another namespace, register a credential (the
+credential's registry extends the allowlist automatically):
+
+```bash
+hola registry-cred add --registry ghcr.io/myorg --username <user> --token <PAT> --id myorg-ghcr
+hola install <appId> --registry-cred myorg-ghcr
+```
+
+For a **public** package in a first-party namespace (no token needed), either
+extend the baseline allowlist in the host `.env`:
+
+```bash
+HOLA_REGISTRY_ALLOWLIST=ghcr.io/try-hola/*,ghcr.io/myorg/*
+```
+
+or declare the consent per catalog source at `source add` time (the source's
+`allowRegistries` is honored on every pull sourced from it):
+
+```bash
+hola source add myorg --url https://raw.githubusercontent.com/myorg/hola-apps/main/catalog.json \
+  --allow-registry ghcr.io/myorg/*
+hola refresh    # web UI refresh button hits the same force-refresh endpoint
+hola install <appId>
+```
+
+The install-by-ref escape hatch (`hola install <ociRef>`) has no source, so it
+still needs either `--registry-cred` or the baseline allowlist to cover the ref.
+
 Through the web dashboard (or the SDK/CLI against the API), an app moves through:
 
 ```

--- a/packages/cli/src/commands/source/source.ts
+++ b/packages/cli/src/commands/source/source.ts
@@ -8,6 +8,14 @@ export interface SourceOptions {
   /** `--registry` + `--cred` register auth for a private source. */
   registry?: string;
   cred?: string;
+  /**
+   * `--allow-registry <glob>` (repeatable, comma-separated) declares the
+   * operator's consent to pull this source's bundles from a registry namespace
+   * without registering a credential — useful for *public* packages in a
+   * first-party registry (e.g. `ghcr.io/myorg/*`). Adds to the server's
+   * baseline `HOLA_REGISTRY_ALLOWLIST`.
+   */
+  allowRegistry?: string[] | string;
   json?: boolean;
 }
 
@@ -30,7 +38,7 @@ export async function runSource(
       case 'add': {
         const id = opts.id ?? positional[0];
         if (!id || !opts.url) {
-          console.error('source add requires an id and --url (and optionally --name, --registry + --cred)');
+          console.error('source add requires an id and --url (and optionally --name, --registry + --cred, --allow-registry)');
           process.exitCode = 1;
           return;
         }
@@ -40,9 +48,21 @@ export async function runSource(
           return;
         }
         const auth = opts.registry && opts.cred ? { registry: opts.registry, credentialRef: opts.cred } : undefined;
-        const record = await sdk.catalogSources.add({ id, name: opts.name ?? id, url: opts.url, auth });
+        // mri may pass repeated --allow-registry flags as an array, or comma-
+        // separated in a single flag. Flatten both into a clean glob list.
+        const allowRegistries = (Array.isArray(opts.allowRegistry) ? opts.allowRegistry : opts.allowRegistry ? [opts.allowRegistry] : [])
+          .flatMap((s) => s.split(','))
+          .map((s) => s.trim())
+          .filter(Boolean);
+        const record = await sdk.catalogSources.add({ id, name: opts.name ?? id, url: opts.url, auth, allowRegistries: allowRegistries.length > 0 ? allowRegistries : undefined });
         if (opts.json) console.log(JSON.stringify(record, null, 2));
-        else console.log(`Added catalog source '${record.id}' → ${record.url}${auth ? ` (auth: ${auth.credentialRef})` : ''}.`);
+        else {
+          const tail = [
+            auth ? `auth: ${auth.credentialRef}` : '',
+            allowRegistries.length > 0 ? `allow: ${allowRegistries.join(', ')}` : '',
+          ].filter(Boolean).join(' · ');
+          console.log(`Added catalog source '${record.id}' → ${record.url}${tail ? ` (${tail})` : ''}.`);
+        }
         return;
       }
       case 'list': {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -119,6 +119,7 @@ prog
   .describe('Manage catalog sources: add | list | rm')
   .example('source add acme --url https://raw.githubusercontent.com/acme/hola-apps/main/catalog.json')
   .example('source add acme --url <catalog.json> --registry ghcr.io --cred acme')
+  .example('source add acme --url <catalog.json> --allow-registry ghcr.io/acme/*')
   .example('source list')
   .example('source rm acme')
   .option('--id', 'Source id (alternative to the positional id)')
@@ -126,6 +127,7 @@ prog
   .option('--url', 'URL of the source catalog.json')
   .option('--registry', 'Registry host for private packages (with --cred)')
   .option('--cred', 'Stored registry credential id (with --registry)')
+  .option('--allow-registry', 'Registry glob to permit for this source (repeatable or comma-separated; e.g. ghcr.io/acme/*)')
   .option('--json', 'Print raw JSON output', false)
   .action(async (action, id, opts) => {
     const { runSource } = await load(import('./commands/source/source'));

--- a/packages/server/src/__tests__/bundles/auth-pull.test.ts
+++ b/packages/server/src/__tests__/bundles/auth-pull.test.ts
@@ -201,3 +201,55 @@ describe('RealBundleService digest-based staleness detection', () => {
     expect(readFileSync(join(base, 'app', '2.0', '.oras-digest'), 'utf8').trim()).toBe(DIGEST_A);
   });
 });
+
+describe('RealBundleService allowlist consent via extraAllowlist', () => {
+  const dirs: string[] = [];
+  afterEach(async () => {
+    await Promise.all(dirs.splice(0).map((d) => rm(d, { recursive: true, force: true })));
+  });
+
+  async function makeCache() {
+    const base = await mkdtemp(join(tmpdir(), 'hola-bundle-allow-test-'));
+    dirs.push(base);
+    return base;
+  }
+
+  test('an extraAllowlist glob unlocks an anonymous pull from a non-baseline registry', async () => {
+    const base = await makeCache();
+    const runner: CommandRunner = async () => ({ stdout: '', stderr: '' });
+    const svc = new RealBundleService(base, runner);
+
+    // Without consent: blocked (baseline allowlist is ghcr.io/try-hola/*).
+    await expect(
+      svc.ensurePulled({ appId: 'cms', version: '0.1.2', source: 'pofallon', ociRef: 'ghcr.io/pofallon/hola-get2know-cms:0.1.2' })
+    ).rejects.toThrow('REF_NOT_ALLOWED');
+
+    // With the source's allowRegistries threaded as extraAllowlist: unlocked.
+    const ok = await svc.ensurePulled({
+      appId: 'cms',
+      version: '0.1.2',
+      source: 'pofallon',
+      ociRef: 'ghcr.io/pofallon/hola-get2know-cms:0.1.2',
+      extraAllowlist: ['ghcr.io/pofallon/*'],
+    });
+    expect(ok.localPath).toBe(join(base, 'pofallon__cms', '0.1.2'));
+  });
+
+  test('a typo-squat registry is still rejected even when a broader glob is allowed', async () => {
+    const base = await makeCache();
+    const runner: CommandRunner = async () => ({ stdout: '', stderr: '' });
+    const svc = new RealBundleService(base, runner);
+
+    // matchesAllowlist is glob-prefix anchored, so ghcr.io.evil.com must NOT
+    // slip past a ghcr.io/* consent (the original typo-squat defense).
+    await expect(
+      svc.ensurePulled({
+        appId: 'evil',
+        version: '1.0',
+        source: 'pofallon',
+        ociRef: 'ghcr.io.evil.com/pofallon/evil:1.0',
+        extraAllowlist: ['ghcr.io/*'],
+      })
+    ).rejects.toThrow('REF_NOT_ALLOWED');
+  });
+});

--- a/packages/server/src/__tests__/catalog/catalog-sources.test.ts
+++ b/packages/server/src/__tests__/catalog/catalog-sources.test.ts
@@ -64,3 +64,43 @@ describe('RealCatalogSourceService', () => {
     expect(reloaded?.url).toBe(CATALOG);
   });
 });
+
+describe('RealCatalogSourceService allowRegistries (persistence + validation)', () => {
+  const dirs: string[] = [];
+  afterEach(async () => {
+    await Promise.all(dirs.splice(0).map((d) => rm(d, { recursive: true, force: true })));
+  });
+
+  test('persists allowRegistries across instances and rejects malformed globs', async () => {
+    const holaDir = await mkdtemp(join(tmpdir(), 'hola-src-allow-test-'));
+    dirs.push(holaDir);
+    const storage = new RealStorageService({ holaDir });
+    const svc = new RealCatalogSourceService(storage);
+
+    // Valid: host/* and host/prefix/* both accepted, comma-separated in a single
+    // string and as an array.
+    const rec = await svc.add({
+      id: 'pofallon',
+      name: 'Pofallon',
+      url: CATALOG,
+      allowRegistries: ['ghcr.io/pofallon/*', 'ghcr.io/acme,ghcr.io/other/*'],
+    });
+    expect(rec.allowRegistries).toEqual(['ghcr.io/pofallon/*', 'ghcr.io/acme', 'ghcr.io/other/*']);
+
+    // Persists across instances.
+    const reloaded = await new RealCatalogSourceService(storage).get('pofallon');
+    expect(reloaded?.allowRegistries).toEqual(['ghcr.io/pofallon/*', 'ghcr.io/acme', 'ghcr.io/other/*']);
+
+    // Malformed (spaces, regex metachars): rejected with a discrete error.
+    await expect(svc.add({ id: 'bad1', name: 'Bad', url: CATALOG, allowRegistries: ['ghcr io/pofallon/*'] })).rejects.toThrow('SOURCE_ALLOW_REGISTRY_INVALID');
+    await expect(svc.add({ id: 'bad2', name: 'Bad', url: CATALOG, allowRegistries: ['ghcr.io/pofallon/.+'] })).rejects.toThrow('SOURCE_ALLOW_REGISTRY_INVALID');
+  });
+
+  test('add with no allowRegistries leaves the field undefined (baseline behaviour unchanged)', async () => {
+    const holaDir = await mkdtemp(join(tmpdir(), 'hola-src-allow-test-'));
+    dirs.push(holaDir);
+    const svc = new RealCatalogSourceService(new RealStorageService({ holaDir }));
+    const rec = await svc.add({ id: 'acme', name: 'Acme', url: CATALOG });
+    expect(rec.allowRegistries).toBeUndefined();
+  });
+});

--- a/packages/server/src/services/core/bundles.ts
+++ b/packages/server/src/services/core/bundles.ts
@@ -41,6 +41,14 @@ export type EnsurePulledOpts = {
   source?: string;
   /** When set, authenticate the `oras pull` for a private registry. */
   credentials?: PullCredentials;
+  /**
+   * Additional registry glob patterns to permit for this pull (extends the
+   * server baseline `HOLA_REGISTRY_ALLOWLIST`). Used to honor a catalog
+   * source's `allowRegistries` consent — e.g. an operator-added source that
+   * declares `ghcr.io/pofallon/*` unlocks pulls from that namespace without a
+   * registered credential (which is only needed for *private* packages).
+   */
+  extraAllowlist?: string[];
 };
 
 export interface BundleService {
@@ -77,9 +85,16 @@ export class RealBundleService implements BundleService, HealthCheckable {
 
   async ensurePulled(opts: EnsurePulledOpts): Promise<BundleInfo> {
     // A registered credential's registry extends the allowlist: registering it is
-    // the operator's explicit consent to pull from that registry. Anonymous pulls
-    // to a non-baseline registry stay blocked.
-    this.enforceAllowlist(opts.ociRef, opts.credentials ? [opts.credentials.registry] : []);
+    // the operator's explicit consent to pull from that registry. A catalog
+    // source's `allowRegistries` extends it too (operator consent declared at
+    // source-add time — useful for public packages in a first-party namespace
+    // that don't need a token). Anonymous pulls to a non-baseline registry
+    // without a matching consent stay blocked.
+    const extraAllowed = [
+      ...(opts.credentials ? [opts.credentials.registry] : []),
+      ...(opts.extraAllowlist ?? []),
+    ];
+    this.enforceAllowlist(opts.ociRef, extraAllowed);
 
     // Source-qualify the cache key so two sources can't alias the same
     // appId/version. `hola` (the built-in source) keeps the bare appId key, so the

--- a/packages/server/src/services/core/catalog-sources.ts
+++ b/packages/server/src/services/core/catalog-sources.ts
@@ -20,6 +20,38 @@ import type { CatalogSourceRecord, AddCatalogSourceRequest } from '@hola/shared'
 /** Reserved source ids that a custom source may not use. */
 export const RESERVED_SOURCE_IDS = new Set(['hola', 'ref', '(ref)']);
 
+/**
+ * A registry glob pattern an operator declared for a source. Allows the same
+ * shape as the `HOLA_REGISTRY_ALLOWLIST` baseline: a host with an optional
+ * `/*` suffix. The matcher (`matchesAllowlist` in bundles.ts) globs on `*`,
+ * so reject anything weirder than `host` / `host/*` / `host/prefix/*` so an
+ * operator doesn't expect a richer pattern than the matcher honors.
+ */
+function isValidRegistryGlob(s: string): boolean {
+  // One trailing `/*` allowed, anywhere before `/*` is host/path chars only.
+  // Disallow spaces and anything that could smuggle regex metachars past glob.
+  return /^[a-zA-Z0-9._:/-]+(?:\/\*|\/[^/\s][a-zA-Z0-9._:/-]*\/\*)?$/.test(s)
+    || /^[a-zA-Z0-9._:-]+(?::\d+)?$/.test(s);
+}
+
+function normalizeAllowRegistries(input: unknown): string[] {
+  if (!input) return [];
+  const arr = Array.isArray(input) ? input : [input];
+  const out: string[] = [];
+  for (const v of arr) {
+    if (typeof v !== 'string') continue;
+    for (const part of v.split(',')) {
+      const s = part.trim();
+      if (!s) continue;
+      if (!isValidRegistryGlob(s)) {
+        throw new Error(`SOURCE_ALLOW_REGISTRY_INVALID: ${s}`);
+      }
+      out.push(s);
+    }
+  }
+  return out;
+}
+
 const STORE_PATH = 'config/catalog-sources.json';
 
 interface SourceFile {
@@ -109,6 +141,8 @@ export class RealCatalogSourceService implements CatalogSourceService {
     if (!req.url || !isHttpUrl(req.url)) throw new Error('SOURCE_URL_INVALID');
     if (req.auth && (!req.auth.registry || !req.auth.credentialRef)) throw new Error('SOURCE_AUTH_INVALID');
 
+    const allowRegistries = normalizeAllowRegistries(req.allowRegistries);
+
     const custom = await this.loadCustom();
     if (custom.some(s => s.id === id)) throw new Error('SOURCE_ID_EXISTS');
 
@@ -118,12 +152,13 @@ export class RealCatalogSourceService implements CatalogSourceService {
       type: 'index-url',
       url: req.url.trim(),
       auth: req.auth,
+      allowRegistries: allowRegistries.length > 0 ? allowRegistries : undefined,
       trust: 'custom',
       enabled: req.enabled ?? true,
     };
     custom.push(record);
     await this.saveCustom(custom);
-    this.logger.info('Catalog source added', { id, url: record.url, hasAuth: Boolean(record.auth) });
+    this.logger.info('Catalog source added', { id, url: record.url, hasAuth: Boolean(record.auth), allowRegistries: record.allowRegistries ?? [] });
     return record;
   }
 
@@ -157,9 +192,11 @@ export class MockCatalogSourceService implements CatalogSourceService {
     const id = (req.id || '').trim();
     if (RESERVED_SOURCE_IDS.has(id)) throw new Error('SOURCE_ID_RESERVED');
     if (this.custom.some(s => s.id === id)) throw new Error('SOURCE_ID_EXISTS');
+    const allowRegistries = normalizeAllowRegistries(req.allowRegistries);
     const record: CatalogSourceRecord = {
       id, name: req.name || id, type: 'index-url', url: req.url,
-      auth: req.auth, trust: 'custom', enabled: req.enabled ?? true,
+      auth: req.auth, allowRegistries: allowRegistries.length > 0 ? allowRegistries : undefined,
+      trust: 'custom', enabled: req.enabled ?? true,
     };
     this.custom.push(record);
     return record;

--- a/packages/server/src/services/core/catalog.ts
+++ b/packages/server/src/services/core/catalog.ts
@@ -438,7 +438,10 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
     // Key the cache by the RESOLVED concrete version (`v.version`) + source, so a
     // published fix reaches existing servers (a "latest" cache would go stale) and
     // two sources can't alias the same appId/version.
-    return this.pullValidateBuild({ appId, source: record.id, version: v.version, ociRef: ref, credentials });
+    // Thread the source's `allowRegistries` (operator consent declared at source-add
+    // time) through to the bundle pull so a first-party registry namespace is
+    // unlocked without registering a credential.
+    return this.pullValidateBuild({ appId, source: record.id, version: v.version, ociRef: ref, credentials, extraAllowlist: record.allowRegistries });
   }
 
   /** Find an app within a specific source's catalog (default the built-in `hola`). */
@@ -464,11 +467,11 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
    * paths. Reuses the bundle service (oras pull + allowlist + optional creds) and
    * the strict layout check, so every source is held to the same rules.
    */
-  private async pullValidateBuild(opts: { appId: string; source?: string; version: string; ociRef: string; credentials?: PullCredentials }): Promise<GetCatalogAppVersionDetailResponse> {
+  private async pullValidateBuild(opts: { appId: string; source?: string; version: string; ociRef: string; credentials?: PullCredentials; extraAllowlist?: string[] }): Promise<GetCatalogAppVersionDetailResponse> {
     // Injected in tests; otherwise lazy-imported to avoid a circular dep at load.
     const bundles = this.bundlesOverride ?? (await import('../simple-factory')).getServices().bundles;
 
-    const info = await bundles.ensurePulled({ appId: opts.appId, version: opts.version, ociRef: opts.ociRef, source: opts.source, credentials: opts.credentials });
+    const info = await bundles.ensurePulled({ appId: opts.appId, version: opts.version, ociRef: opts.ociRef, source: opts.source, credentials: opts.credentials, extraAllowlist: opts.extraAllowlist });
     const validation = await bundles.validateLayout(info.localPath);
     if (!validation.ok) {
       this.logger.warn('Bundle layout invalid', { appId: opts.appId, version: opts.version, errors: validation.errors });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -491,6 +491,15 @@ export type CatalogSourceRecord = {
   type: 'index-url';
   url: string;
   auth?: { registry: string; credentialRef: string };
+  /**
+   * Registry glob patterns this source's bundles are permitted to pull from
+   * (e.g. `ghcr.io/pofallon/*`). Adds to the server's baseline
+   * `HOLA_REGISTRY_ALLOWLIST` for any pull sourced from this catalog — the
+   * operator's explicit consent to trust a first-party registry without
+   * registering a credential (which is only needed for *private* packages).
+   * Default empty: behaviour matches the pre-existing baseline allowlist only.
+   */
+  allowRegistries?: string[];
   trust: CatalogSourceTrust;
   enabled: boolean;
 };
@@ -500,6 +509,8 @@ export type AddCatalogSourceRequest = {
   name: string;
   url: string;
   auth?: { registry: string; credentialRef: string };
+  /** Optional registry globs (e.g. `ghcr.io/pofallon/*`) — see CatalogSourceRecord. */
+  allowRegistries?: string[];
   enabled?: boolean;
 };
 

--- a/packages/web/src/pages/Settings.tsx
+++ b/packages/web/src/pages/Settings.tsx
@@ -143,6 +143,9 @@ const CatalogSourcesCard: React.FC<{ inputClass: string; labelClass: string }> =
   const [name, setName] = useState('');
   const [url, setUrl] = useState('');
   const [credentialRef, setCredentialRef] = useState('');
+  // Comma-separated registry globs (e.g. "ghcr.io/myorg/*"). Empty = baseline
+  // allowlist only; matches the server's normalizeAllowRegistries parser.
+  const [allowRegistries, setAllowRegistries] = useState('');
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
@@ -159,8 +162,18 @@ const CatalogSourcesCard: React.FC<{ inputClass: string; labelClass: string }> =
       // Pair the credential with the registry host derived from the credential record.
       const cred = creds.find(c => c.id === credentialRef);
       const auth = cred ? { registry: cred.registry, credentialRef: cred.id } : undefined;
-      await api.catalogSources.add({ id: id.trim(), name: name.trim() || id.trim(), url: url.trim(), auth });
-      setId(''); setName(''); setUrl(''); setCredentialRef(''); setAdding(false);
+      // Server accepts comma-separated globs in a single string; no client-side
+      // validation beyond non-empty trimming — the server rejects malformed
+      // globs with SOURCE_ALLOW_REGISTRY_INVALID and surfaces the message.
+      const globs = allowRegistries.split(',').map(s => s.trim()).filter(Boolean);
+      await api.catalogSources.add({
+        id: id.trim(),
+        name: name.trim() || id.trim(),
+        url: url.trim(),
+        auth,
+        allowRegistries: globs.length > 0 ? globs : undefined,
+      });
+      setId(''); setName(''); setUrl(''); setCredentialRef(''); setAllowRegistries(''); setAdding(false);
       refresh();
     } catch (e) {
       setErr(e instanceof Error ? e.message : 'Failed to add source');
@@ -195,6 +208,11 @@ const CatalogSourcesCard: React.FC<{ inputClass: string; labelClass: string }> =
               <span className="font-medium text-text-strong">{s.id}</span>
               <span className={`ml-2 text-xs px-1.5 py-0.5 rounded ${s.trust === 'verified' ? 'text-success bg-success/10' : 'text-warning bg-warning/10'}`}>{s.trust}</span>
               <div className="text-text-muted truncate">{s.url || '(built-in)'}</div>
+              {s.allowRegistries && s.allowRegistries.length > 0 && (
+                <div className="text-[12px] text-text-muted truncate">
+                  allows: {s.allowRegistries.join(', ')}
+                </div>
+              )}
             </div>
             {s.id !== 'hola' && (
               <button onClick={() => remove(s.id)} disabled={busy} className="text-text-muted hover:text-danger transition-colors disabled:opacity-50 flex-none ml-2" aria-label={`Remove ${s.id}`}>
@@ -225,6 +243,18 @@ const CatalogSourcesCard: React.FC<{ inputClass: string; labelClass: string }> =
               <option value="">None (public)</option>
               {creds.map(c => <option key={c.id} value={c.id}>{c.id} — {c.registry}</option>)}
             </select>
+          </div>
+          <div className="col-span-2">
+            <div className={labelClass}>Allowed registries (optional, comma-separated)</div>
+            <input
+              value={allowRegistries}
+              onChange={(e) => setAllowRegistries(e.target.value)}
+              placeholder="ghcr.io/myorg/*"
+              className={inputClass}
+            />
+            <p className="text-[12px] text-text-muted mt-1">
+              Registry globs this source may pull bundles from (e.g. <code>ghcr.io/myorg/*</code>); adds to the server&rsquo;s baseline allowlist. Use for <em>public</em> first-party packages — for private packages, register a credential above.
+            </p>
           </div>
           <div className="col-span-2 flex items-center gap-2">
             <button onClick={add} disabled={busy} className="bg-primary text-primary-contrast px-4 py-2 rounded-lg text-[13px] font-medium hover:bg-primary/90 transition-colors disabled:opacity-50 flex items-center gap-2">


### PR DESCRIPTION
## Problem

Self-hosters running their own catalog (`HOLA_CATALOG_URL` pointed at a `catalog.json` for first-party apps in `ghcr.io/<self>/*`) fall into a silent trap:

1. The default `HOLA_REGISTRY_ALLOWLIST` is `ghcr.io/try-hola/*` only.
2. A bundle ref like `ghcr.io/<self>/hola-<app>:<ver>` fails `enforceAllowlist` with `REF_NOT_ALLOWED` (`bundles.ts:294`).
3. That error is silently swallowed by `getDraftDefaults`'s catch (`draft.ts:875-889`), which falls back to placeholder defaults with `composeOverride: ''`.
4. `finalizeDraft` skips writing `compose-override.yml` for an empty compose (`draft.ts:786`).
5. `materializeCompose` then throws `Active release has no compose file` (`deployment.ts:1056`) — the symptom.

The prior design conflated consent with auth: the only documented way to broaden the allowlist was registering a registry credential, which forces a PAT even for **public** packages. The actual operator-consent signal for a catalog source (adding the source) had no effect on the allowlist — an artifact of the catalog-source feature (slice 2) being added after the allowlist.

## Fix

Add `allowRegistries?: string[]` to `CatalogSourceRecord` / `AddCatalogSourceRequest`. The operator declares the registry namespaces a source may pull from at `source add` time — via the web UI (Settings → Catalog Sources → Add source → "Allowed registries" field) or the CLI:

\`\`\`bash
hola source add myorg --url https://raw.githubusercontent.com/myorg/hola-apps/main/catalog.json \\
  --allow-registry ghcr.io/myorg/*
hola install <appId>
\`\`\`

Threaded through:
- \`EnsurePulledOpts.extraAllowlist\` → \`enforceAllowlist\` (alongside the credential path)
- \`catalog.ts:getVersionDetail\` reads \`record.allowRegistries\` and passes them to \`pullValidateBuild\`
- CLI \`source add --allow-registry <glob>\` (repeatable; also accepts comma-separated)
- Web UI: comma-separated input on the source-add form + "allows: …" line per row in the source list so the consent is visible
- \`RealCatalogSourceService.add\` validates each glob shape (\`host\`, \`host/*\`, \`host/prefix/*\`; rejects spaces and regex metachars) and persists
- Mock service mirrors for test parity

The typo-squat guard is preserved — \`matchesAllowlist\` is glob-prefix anchored, so \`ghcr.io.evil.com\` stays rejected even with a \`ghcr.io/*\` consent (covered by a new test).

## What's unchanged

- \`HOLA_REGISTRY_ALLOWLIST\` baseline still applies; per-source globs only add to it.
- The credential path (\`--registry-cred\`) is untouched — still the way to pull **private** packages.
- Install-by-ref (\`hola install <ociRef>\`) has no source, so it still needs \`--registry-cred\` or the baseline allowlist to cover the ref.
- \`getDraftDefaults\`'s fallback catch (\`draft.ts:875\`) is intentionally left in place — narrowing it is a separate concern; the root cause was the missing consent signal, not the catch.

## Tests

- \`auth-pull.test.ts\`: \`extraAllowlist\` glob unlocks an anonymous pull from a non-baseline registry; typo-squat registry still rejected.
- \`catalog-sources.test.ts\`: \`allowRegistries\` validation (malformed globs rejected with \`SOURCE_ALLOW_REGISTRY_INVALID\`), persistence across service instances, default-undefined preserves baseline behaviour.
- All 87 bundle/catalog/drafts server tests pass; 183 web tests pass; typecheck clean across all 7 packages; eslint clean on touched files.

The one pre-existing CLI test failure (\`install-schema.test.ts:48\`, \`TZ=UTC\`) fails on \`main\` too — unrelated to this change (verified by stash + re-run).

## Out of scope (follow-ups)

- Narrowing \`getDraftDefaults\`'s catch (\`draft.ts:875\`) so a \`REF_NOT_ALLOWED\` (or any thrown \`composeOverride\`-emptying error) bubbles up as itself rather than masquerading as a successful fall-back-to-empty-deploy implications. Separate concern with its own risk tradeoff.