### PR TITLE
chore(release): 0.7.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/cli": {
       "name": "@hola/cli",
-      "version": "0.7.1",
+      "version": "0.7.3",
       "bin": {
         "hola": "./bin/hola",
       },
@@ -37,11 +37,11 @@
     },
     "packages/compose": {
       "name": "@hola/compose",
-      "version": "0.7.1",
+      "version": "0.7.3",
     },
     "packages/sdk": {
       "name": "@hola/sdk",
-      "version": "0.7.1",
+      "version": "0.7.3",
       "dependencies": {
         "@hola/shared": "workspace:*",
       },
@@ -55,7 +55,7 @@
     },
     "packages/server": {
       "name": "@hola/server",
-      "version": "0.7.1",
+      "version": "0.7.3",
       "dependencies": {
         "@hola/shared": "workspace:*",
         "jose": "^5.9.6",
@@ -71,7 +71,7 @@
     },
     "packages/shared": {
       "name": "@hola/shared",
-      "version": "0.7.1",
+      "version": "0.7.3",
       "dependencies": {
         "yaml": "^2.9.0",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.7.2';
+export const CLI_VERSION = '0.7.3';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Bump published packages 0.7.2 → 0.7.3 for the per-source catalog `allowRegistries` opt-in registry consent (#337), so self-hosters running their own catalog don't fall into the silent "Active release has no compose file" trap when their bundle sits in a first-party registry namespace outside the baseline `HOLA_REGISTRY_ALLOWLIST`.

After this merges, I'll push the `cli-v0.7.3` tag which triggers `.github/workflows/cli-release.yml` to build the multi-arch server/web images + standalone CLI binaries + compose bundle and publish the GitHub Release.