### PR TITLE
fix(cli): don't crash on `hola logs` when the SDK returns undefined

### DIFF
--- a/packages/cli/src/__tests__/deployment-logs.test.ts
+++ b/packages/cli/src/__tests__/deployment-logs.test.ts
@@ -23,6 +23,15 @@ describe('deployment logs', () => {
     expect(logs.join('\n')).toContain('hello');
   });
 
+  it('does not crash when the SDK returns undefined (non-JSON / empty 204 response)', async () => {
+    const sdk = {
+      deployments: { logs: vi.fn(async () => undefined as unknown as undefined) },
+    };
+    await runDeploymentLogs('dep1', {}, { sdk: sdk as unknown as HolaSdk });
+    expect(process.exitCode).toBe(0);
+    expect(logs.join('\n')).toContain('No logs.');
+  });
+
   it('streams over SSE with --follow and prints message frames', async () => {
     const sdk = { deployments: { logs: vi.fn() } };
     const stream: typeof streamSSE = vi.fn(async (_url, _opts, onEvent) => {

--- a/packages/cli/src/commands/deployments/deployments.ts
+++ b/packages/cli/src/commands/deployments/deployments.ts
@@ -63,11 +63,21 @@ export async function runDeploymentLogs(
   }
   const sdk = injected?.sdk ?? new HolaSdk();
   try {
-    const res = (await sdk.deployments.logs(deploymentId)) as {
-      entries?: Array<{ timestamp?: string; message?: string }>;
-    };
+    const res = (await sdk.deployments.logs(deploymentId)) as
+      | { entries?: Array<{ timestamp?: string; message?: string }> }
+      | undefined
+      | null;
     if (opts.json) {
-      console.log(JSON.stringify(res, null, 2));
+      console.log(JSON.stringify(res ?? {}, null, 2));
+      return;
+    }
+    // SDK's parseJson returns undefined when the server responded 2xx with a
+    // non-JSON body (e.g. an upstream proxy returned a cached empty 204, or the
+    // server returned no body). Rather than crash evaluating `res.entries`,
+    // fall back to "No logs." — same UX as an empty but well-formed response.
+    if (!res || typeof res !== 'object') {
+      console.log('No logs.');
+      await maybeNotifyUpdate(sdk, opts);
       return;
     }
     const entries = res.entries ?? [];


### PR DESCRIPTION
## Problem

`hola logs <deployment>` crashes with:

```
Failed: undefined is not an object (evaluating 'res.entries')
```

`runDeploymentLogs` cast the SDK result as `{ entries?: ... }` and read `res.entries` directly. The SDK's `parseJson` returns `undefined` whenever the server responds 2xx with a non-JSON body (e.g. an upstream proxy serving a cached empty 204, or a deployment whose logs endpoint yields no body), which made `res.entries` throw — masking the real state behind the generic `Failed:` banner and blocking diagnosis of the underlying install issue.

## Fix

Treat a missing/non-object response the same as an empty-but-well-formed one (`No logs.`) so the operator can move on; the underlying transport issue is separately surfacable via `--json` or the web UI logs stream.

Adds a regression test for the undefined-response case. Existing tests pass; typecheck clean.