### PR TITLE
chore(release): 0.7.5

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/cli": {
       "name": "@hola/cli",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "bin": {
         "hola": "./bin/hola",
       },
@@ -37,11 +37,11 @@
     },
     "packages/compose": {
       "name": "@hola/compose",
-      "version": "0.7.3",
+      "version": "0.7.5",
     },
     "packages/sdk": {
       "name": "@hola/sdk",
-      "version": "0.7.3",
+      "version": "0.7.5",
       "dependencies": {
         "@hola/shared": "workspace:*",
       },
@@ -55,7 +55,7 @@
     },
     "packages/server": {
       "name": "@hola/server",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "dependencies": {
         "@hola/shared": "workspace:*",
         "jose": "^5.9.6",
@@ -71,7 +71,7 @@
     },
     "packages/shared": {
       "name": "@hola/shared",
-      "version": "0.7.3",
+      "version": "0.7.5",
       "dependencies": {
         "yaml": "^2.9.0",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.7.4';
+export const CLI_VERSION = '0.7.5';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.7.3",
+  "version": "0.7.5",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.7.3",
+  "version": "0.7.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.7.3",
+  "version": "0.7.5",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Bump all published packages to **0.7.5**.

Ships the web state-freshness rework (#343): reactive server state via TanStack Query with the global `/api/events` SSE stream wired into the `QueryClient`, fixing cross-view staleness that previously required a browser refresh.

Also re-syncs `shared`/`sdk`/`compose` (were 0.7.3) up to the common version alongside `server`/`cli` (were 0.7.4). `web` stays `0.0.0` (unversioned) by convention.

After merge, tag `cli-v0.7.5` to trigger `cli-release.yml` (multi-arch server+web images → GHCR, compose tarball, and standalone `hola` CLI binaries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)