### PR TITLE
feat: operator-consented elevated container permissions (manifest security.elevated)

### DIFF
--- a/packages/server/src/__tests__/provisioner/manifest-security.test.ts
+++ b/packages/server/src/__tests__/provisioner/manifest-security.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Unit tests for coerceManifestSecurity / requestsPrivilegeEscalation.
+ *
+ * The catalog drops unknown manifest fields, so the `security` block is coerced
+ * defensively: well-formed elevated-permission entries pass through, malformed
+ * ones are dropped (a manifest can't invent a privilege or request one without a
+ * reason), and a block with nothing valid degrades to undefined (fully hardened).
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { coerceManifestSecurity, requestsPrivilegeEscalation } from '../../services/core/manifest-security';
+
+describe('coerceManifestSecurity', () => {
+  test('returns undefined for missing/non-object/empty input', () => {
+    expect(coerceManifestSecurity(undefined)).toBeUndefined();
+    expect(coerceManifestSecurity(null)).toBeUndefined();
+    expect(coerceManifestSecurity('allow-privilege-escalation')).toBeUndefined();
+    expect(coerceManifestSecurity([])).toBeUndefined();
+    expect(coerceManifestSecurity({})).toBeUndefined();
+    expect(coerceManifestSecurity({ elevated: [] })).toBeUndefined();
+  });
+
+  test('coerces a well-formed privilege-escalation request', () => {
+    const out = coerceManifestSecurity({
+      elevated: [{ type: 'allow-privilege-escalation', reason: 'Desktop needs sudo.' }],
+    });
+    expect(out).toEqual({ elevated: [{ type: 'allow-privilege-escalation', reason: 'Desktop needs sudo.' }] });
+  });
+
+  test('trims the reason and drops entries missing a reason', () => {
+    expect(
+      coerceManifestSecurity({ elevated: [{ type: 'allow-privilege-escalation', reason: '  needs sudo  ' }] })
+    ).toEqual({ elevated: [{ type: 'allow-privilege-escalation', reason: 'needs sudo' }] });
+
+    // reason absent / blank -> entry dropped -> whole block undefined.
+    expect(coerceManifestSecurity({ elevated: [{ type: 'allow-privilege-escalation' }] })).toBeUndefined();
+    expect(
+      coerceManifestSecurity({ elevated: [{ type: 'allow-privilege-escalation', reason: '   ' }] })
+    ).toBeUndefined();
+  });
+
+  test('drops unknown permission types (forward-compat: no invented privileges)', () => {
+    expect(
+      coerceManifestSecurity({ elevated: [{ type: 'allow-everything', reason: 'nope' }] })
+    ).toBeUndefined();
+    // known + unknown -> only the known one survives.
+    expect(
+      coerceManifestSecurity({
+        elevated: [
+          { type: 'privileged-mode', reason: 'no' },
+          { type: 'allow-privilege-escalation', reason: 'yes' },
+        ],
+      })
+    ).toEqual({ elevated: [{ type: 'allow-privilege-escalation', reason: 'yes' }] });
+  });
+
+  test('de-duplicates repeated types (first wins)', () => {
+    expect(
+      coerceManifestSecurity({
+        elevated: [
+          { type: 'allow-privilege-escalation', reason: 'first' },
+          { type: 'allow-privilege-escalation', reason: 'second' },
+        ],
+      })
+    ).toEqual({ elevated: [{ type: 'allow-privilege-escalation', reason: 'first' }] });
+  });
+});
+
+describe('requestsPrivilegeEscalation', () => {
+  test('true only when the escalation grant is present', () => {
+    expect(requestsPrivilegeEscalation(undefined)).toBe(false);
+    expect(requestsPrivilegeEscalation({ elevated: [] })).toBe(false);
+    expect(
+      requestsPrivilegeEscalation({ elevated: [{ type: 'allow-privilege-escalation', reason: 'x' }] })
+    ).toBe(true);
+  });
+});

--- a/packages/server/src/__tests__/routing/compose-defaults.test.ts
+++ b/packages/server/src/__tests__/routing/compose-defaults.test.ts
@@ -101,4 +101,50 @@ describe('applyPlatformDefaults', () => {
     const input = 'networks:\n  hola:\n    external: true\n';
     expect(applyPlatformDefaults(input, ON)).toBe(input);
   });
+
+  describe('privilege escalation opt-out', () => {
+    const withEscalation = (yaml: string, services: string[], opts: ComposeDefaultsConfig = ON) =>
+      parse(applyPlatformDefaults(yaml, opts, { allowPrivilegeEscalationServices: services }));
+
+    test('granted service does NOT get no-new-privileges (so sudo works)', () => {
+      const doc = withEscalation('services:\n  webtop:\n    image: webtop:1\n', ['webtop']);
+      // no security_opt key at all (Docker default no_new_privs unset).
+      expect(doc.services.webtop.security_opt).toBeUndefined();
+      // other platform defaults still apply.
+      expect(doc.services.webtop.restart).toBe('unless-stopped');
+    });
+
+    test('grant strips an app-declared no-new-privileges:true, keeps other opts', () => {
+      const input = [
+        'services:',
+        '  webtop:',
+        '    image: webtop:1',
+        '    security_opt:',
+        '      - no-new-privileges:true',
+        '      - seccomp:unconfined',
+        '',
+      ].join('\n');
+      const doc = withEscalation(input, ['webtop']);
+      expect(doc.services.webtop.security_opt).toEqual(['seccomp:unconfined']);
+    });
+
+    test('escalation is scoped to the named service; siblings stay hardened', () => {
+      const input = 'services:\n  webtop:\n    image: webtop:1\n  db:\n    image: postgres:16\n';
+      const doc = withEscalation(input, ['webtop']);
+      expect(doc.services.webtop.security_opt).toBeUndefined();
+      expect(doc.services.db.security_opt).toEqual(['no-new-privileges:true']);
+    });
+
+    test('escalation applies even when the install-wide config is a no-op', () => {
+      const off: ComposeDefaultsConfig = { restartPolicy: '', logMaxSize: '', logMaxFile: '3', noNewPrivileges: false };
+      const input = 'services:\n  webtop:\n    image: webtop:1\n    security_opt:\n      - no-new-privileges:true\n';
+      const doc = parse(applyPlatformDefaults(input, off, { allowPrivilegeEscalationServices: ['webtop'] }));
+      expect(doc.services.webtop.security_opt).toBeUndefined();
+    });
+
+    test('no escalation list -> hardening applied as usual', () => {
+      const doc = withEscalation('services:\n  webtop:\n    image: webtop:1\n', []);
+      expect(doc.services.webtop.security_opt).toEqual(['no-new-privileges:true']);
+    });
+  });
 });

--- a/packages/server/src/services/core/catalog.ts
+++ b/packages/server/src/services/core/catalog.ts
@@ -24,6 +24,7 @@ import type {
 import type { CatalogSourceService } from './catalog-sources';
 import type { RegistryCredentialService } from './registry-credentials';
 import { coerceManifestAuth } from './manifest-auth';
+import { coerceManifestSecurity } from './manifest-security';
 import { coerceConsumes } from './app-registry';
 import { coerceManifestUpgrade } from './manifest-upgrade';
 import { coerceManifestBackup } from './manifest-backup';
@@ -500,6 +501,7 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
         };
         auth?: unknown;
         consumes?: unknown;
+        security?: unknown;
         upgrade?: unknown;
         backup?: unknown;
         ingress?: { service?: unknown; port?: unknown };
@@ -565,6 +567,11 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
       // so new capability names need no server change (ADR 0002).
       const consumes = coerceConsumes(manifest.consumes);
 
+      // Elevated container permissions the app requests (e.g. sudo needs
+      // privilege escalation). Coerced narrowly like `auth`; the wizard surfaces
+      // each for consent and the deploy lifecycle relaxes the matching hardening.
+      const security = coerceManifestSecurity(manifest.security);
+
       // Upgrade-safety metadata (#284 Phase 0): drives the server-side skip-guard
       // on promote and the dashboard's pre-upgrade warning. Coerced narrowly like
       // `auth`, so unknown fields don't survive into the deploy lifecycle.
@@ -583,7 +590,7 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
           ? manifest.ingress.service.trim()
           : undefined;
 
-      return { ...merged, version, composeOverride, auth, consumes, upgrade, backup, ingressService } satisfies GetCatalogAppVersionDetailResponse;
+      return { ...merged, version, composeOverride, auth, consumes, security, upgrade, backup, ingressService } satisfies GetCatalogAppVersionDetailResponse;
     } catch (error) {
       this.logger.warn('Failed to read or parse bundle manifest', { version, error: error instanceof Error ? error.message : String(error) });
       throw new Error('MANIFEST_UNAVAILABLE', { cause: error });

--- a/packages/server/src/services/core/compose-defaults.ts
+++ b/packages/server/src/services/core/compose-defaults.ts
@@ -31,7 +31,7 @@ function isNoop(opts: ComposeDefaultsConfig): boolean {
   );
 }
 
-function applyToService(service: ComposeService, opts: ComposeDefaultsConfig): void {
+function applyToService(service: ComposeService, opts: ComposeDefaultsConfig, allowPrivilegeEscalation: boolean): void {
   // restart — fill-if-absent (app wins).
   if (opts.restartPolicy && service.restart === undefined) {
     service.restart = opts.restartPolicy;
@@ -45,8 +45,23 @@ function applyToService(service: ComposeService, opts: ComposeDefaultsConfig): v
     };
   }
 
-  // security_opt — additive policy: ensure no-new-privileges, preserve app entries.
-  if (opts.noNewPrivileges) {
+  // security_opt — additive hardening: ensure no-new-privileges, preserve app
+  // entries. EXCEPT when the app has been granted privilege escalation for this
+  // service (an operator-consented manifest request, e.g. a browser desktop that
+  // needs `sudo`): then we must NOT set no-new-privileges — and must strip any
+  // no-new-privileges:true the app itself declared — or the `no_new_privs` kernel
+  // flag would still block setuid escalation and defeat the grant.
+  if (allowPrivilegeEscalation) {
+    if (Array.isArray(service.security_opt)) {
+      const kept = (service.security_opt as unknown[]).filter(
+        (e): e is string => typeof e === 'string' && e !== NO_NEW_PRIVILEGES
+      );
+      // Drop the key entirely when nothing else remains, so we don't emit an
+      // empty `security_opt: []` (Docker default is no_new_privs unset → sudo works).
+      if (kept.length) service.security_opt = kept;
+      else delete service.security_opt;
+    }
+  } else if (opts.noNewPrivileges) {
     const existing = Array.isArray(service.security_opt)
       ? (service.security_opt as unknown[]).filter((e): e is string => typeof e === 'string')
       : [];
@@ -69,15 +84,37 @@ function applyToService(service: ComposeService, opts: ComposeDefaultsConfig): v
   if (opts.cpus && service.cpus === undefined) service.cpus = opts.cpus;
 }
 
+/** Per-deploy overrides that can't come from install-wide config. */
+export interface PlatformDefaultsRuntime {
+  /**
+   * Compose service names the app has been granted privilege escalation for
+   * (operator-consented `security.elevated` manifest request). These services
+   * skip the `no-new-privileges` hardening so setuid escalation (`sudo`) works.
+   * Empty/omitted → every service is hardened as usual.
+   */
+  allowPrivilegeEscalationServices?: string[];
+}
+
 /**
  * Return the compose YAML with platform defaults applied to every service.
  * Returns the input unchanged when nothing would change or when the document
  * has no services. Parse-failure tolerant: callers may rely on this not throwing
  * on already-validated compose, but a parse error propagates (mirrors the
  * sibling helpers).
+ *
+ * `runtime.allowPrivilegeEscalationServices` names services the operator has
+ * consented to run without `no-new-privileges` (see AppSecurityConfig). Because
+ * that opt-out must be honored even when the install-wide config is otherwise a
+ * no-op, its presence forces the parse/rewrite path.
  */
-export function applyPlatformDefaults(composeYaml: string, opts: ComposeDefaultsConfig): string {
-  if (isNoop(opts)) return composeYaml;
+export function applyPlatformDefaults(
+  composeYaml: string,
+  opts: ComposeDefaultsConfig,
+  runtime: PlatformDefaultsRuntime = {}
+): string {
+  const escalate = new Set(runtime.allowPrivilegeEscalationServices ?? []);
+  // A no-op config with no escalation to apply changes nothing — skip the rewrite.
+  if (isNoop(opts) && escalate.size === 0) return composeYaml;
 
   const doc = (parse(composeYaml) ?? {}) as ComposeDoc;
   const services = doc.services;
@@ -85,8 +122,8 @@ export function applyPlatformDefaults(composeYaml: string, opts: ComposeDefaults
     return composeYaml;
   }
 
-  for (const service of Object.values(services)) {
-    if (service && typeof service === 'object') applyToService(service, opts);
+  for (const [name, service] of Object.entries(services)) {
+    if (service && typeof service === 'object') applyToService(service, opts, escalate.has(name));
   }
 
   return stringify(doc);

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -35,9 +35,11 @@ import type {
   ProvisionedAuthRef,
   GetLogsResponse,
   LogEntry,
-  GetDeploymentConfigResponse
+  GetDeploymentConfigResponse,
+  AppSecurityConfig
 } from '@hola/shared';
 import { checkUpgradePath, isNewerVersion } from '@hola/shared';
+import { requestsPrivilegeEscalation } from './manifest-security';
 import { validateParams } from '@hola/shared/param-validate';
 
 import { getLogger } from '../../lib/logger';
@@ -1132,7 +1134,12 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     // Apply install-wide operational defaults (restart, log rotation,
     // no-new-privileges hardening, optional TZ/limits) to every service. The app
     // wins for fill-if-absent fields; hardening is additive. See compose-defaults.
-    content = applyPlatformDefaults(content, composeDefaultsConfig);
+    // An app that declared (and the operator consented to) privilege escalation
+    // gets no-new-privileges dropped on its ingress service so `sudo` works — the
+    // grant is scoped to the ingress service, leaving any sidecars hardened.
+    const security = await this.readActiveSecurity(deployment);
+    const allowPrivilegeEscalationServices = requestsPrivilegeEscalation(security) ? [ingressService] : [];
+    content = applyPlatformDefaults(content, composeDefaultsConfig, { allowPrivilegeEscalationServices });
 
     // Grant a trusted app (e.g. a backup tool) read-only access to ALL apps'
     // data when its manifest declares `consumes: apps-data`. Identity-mapped so
@@ -1216,6 +1223,20 @@ export class RealDeploymentService extends InMemoryDeploymentService {
       return manifest.consumes ?? [];
     } catch {
       return [];
+    }
+  }
+
+  /** Elevated container permissions the active release's manifest declares. */
+  private async readActiveSecurity(deployment: EnhancedDeploymentDetail): Promise<AppSecurityConfig | undefined> {
+    const releaseId = deployment.currentReleaseId;
+    if (!releaseId) return undefined;
+    const manifestPath = `deployments/${deployment.id}/releases/${releaseId}/manifest.json`;
+    if (!(await this.storageService.fileExists(manifestPath))) return undefined;
+    try {
+      const manifest = JSON.parse(await this.storageService.readFileAsString(manifestPath)) as FinalizedManifest;
+      return manifest.security;
+    } catch {
+      return undefined;
     }
   }
 

--- a/packages/server/src/services/core/draft.ts
+++ b/packages/server/src/services/core/draft.ts
@@ -21,6 +21,7 @@ import type {
   AppEnvVar,
   DraftDefaults,
   AppAuthConfig,
+  AppSecurityConfig,
   AppUpgradeMeta,
   AppBackupConfig
 } from '@hola/shared';
@@ -73,6 +74,10 @@ export interface FinalizedManifest {
   // Cross-app capabilities consumed (e.g. `app-registry`); carried so the
   // deploy lifecycle can publish the right feeds without re-reading the bundle.
   consumes?: string[];
+  // Elevated container permissions the app requested (e.g. privilege escalation
+  // for sudo); carried so the deploy lifecycle can relax the matching hardening
+  // without re-reading the bundle.
+  security?: AppSecurityConfig;
   // The compose service to route to / inject auth env into; carried so
   // materializeCompose targets the right service for multi-service apps.
   ingressService?: string;
@@ -421,6 +426,7 @@ export class RealDraftService implements DraftService {
         composeOverride,
         auth: defaults.auth,
         consumes: defaults.consumes,
+        security: defaults.security,
         ingressService: defaults.ingressService,
         upgrade: defaults.upgrade,
         backup: defaults.backup,
@@ -457,6 +463,9 @@ export class RealDraftService implements DraftService {
         systemEnv: [],
         appEnv,
         defaults: defaults.defaults,
+        // Surface any elevated permissions the app requested so the wizard can
+        // prompt for consent before install.
+        security: defaults.security,
       };
 
       this.logger.info('Draft created successfully', { draftId, appId: request.appId });
@@ -509,6 +518,7 @@ export class RealDraftService implements DraftService {
         composeOverride,
         auth: detail.auth,
         consumes: detail.consumes,
+        security: detail.security,
         ingressService: detail.ingressService,
         upgrade: detail.upgrade,
         backup: detail.backup,
@@ -537,6 +547,7 @@ export class RealDraftService implements DraftService {
         systemEnv: [],
         appEnv,
         defaults: detail.defaults,
+        security: detail.security,
       };
     } catch (error) {
       this.logger.error('Failed to create draft from ref', error as Error, { draftId, ociRef });
@@ -770,6 +781,7 @@ export class RealDraftService implements DraftService {
         composeOverride: draft.composeOverride ?? '',
         auth: draft.auth,
         consumes: draft.consumes,
+        security: draft.security,
         ingressService: draft.ingressService,
         upgrade: draft.upgrade,
         backup: draft.backup,
@@ -856,7 +868,7 @@ export class RealDraftService implements DraftService {
     };
   }
 
-  async getDraftDefaults(appId: string, version?: string, source?: string): Promise<{ env: AppEnvVar[]; defaults: DraftDefaults; composeOverride: string; auth?: AppAuthConfig; consumes?: string[]; ingressService?: string; upgrade?: AppUpgradeMeta; backup?: AppBackupConfig; resolvedVersion?: string }> {
+  async getDraftDefaults(appId: string, version?: string, source?: string): Promise<{ env: AppEnvVar[]; defaults: DraftDefaults; composeOverride: string; auth?: AppAuthConfig; consumes?: string[]; security?: AppSecurityConfig; ingressService?: string; upgrade?: AppUpgradeMeta; backup?: AppBackupConfig; resolvedVersion?: string }> {
     try {
       const versionDetail = await this.catalogService.getVersionDetail(appId, version || 'latest', source);
       return {
@@ -865,6 +877,7 @@ export class RealDraftService implements DraftService {
         composeOverride: versionDetail.composeOverride ?? '',
         auth: versionDetail.auth,
         consumes: versionDetail.consumes,
+        security: versionDetail.security,
         ingressService: versionDetail.ingressService,
         upgrade: versionDetail.upgrade,
         backup: versionDetail.backup,

--- a/packages/server/src/services/core/manifest-security.ts
+++ b/packages/server/src/services/core/manifest-security.ts
@@ -1,0 +1,59 @@
+// Defensive coercion for a catalog bundle manifest's optional `security` block
+// into a typed AppSecurityConfig. Mirrors the narrow-shape coercion used for
+// `auth`/`consumes` in catalog.ts: anything malformed degrades to `undefined`
+// (treated as "no elevated permissions requested") rather than throwing, so a
+// sloppy manifest never breaks catalog browsing — it just doesn't get the grant.
+
+import type { AppSecurityConfig, ElevatedPermission, ElevatedPermissionType } from '@hola/shared';
+
+// The elevated-permission types the server understands. An unknown `type` is
+// dropped (not granted): a manifest can't invent a privilege the platform hasn't
+// implemented, and forward-compat means a newer bundle on an older server simply
+// doesn't get the not-yet-supported grant rather than failing to install.
+const ELEVATED_TYPES: readonly ElevatedPermissionType[] = ['allow-privilege-escalation'];
+
+function asRecord(v: unknown): Record<string, unknown> | undefined {
+  return v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : undefined;
+}
+
+function asString(v: unknown): string | undefined {
+  return typeof v === 'string' && v.trim().length > 0 ? v.trim() : undefined;
+}
+
+function coerceElevated(v: unknown): ElevatedPermission | undefined {
+  const rec = asRecord(v);
+  if (!rec) return undefined;
+  const type = asString(rec.type) as ElevatedPermissionType | undefined;
+  if (!type || !ELEVATED_TYPES.includes(type)) return undefined;
+  // A reason is mandatory — it's what the operator reads before consenting. Drop
+  // an entry that doesn't justify itself rather than surface a bare checkbox.
+  const reason = asString(rec.reason);
+  if (!reason) return undefined;
+  return { type, reason };
+}
+
+/**
+ * Coerce the optional manifest `security` block. Returns undefined when absent,
+ * malformed, or when it declares no valid elevated permission — so the common
+ * (fully-hardened) case carries no security object at all. Duplicate types are
+ * de-duplicated (first wins) so a manifest can't stack the same grant twice.
+ */
+export function coerceManifestSecurity(raw: unknown): AppSecurityConfig | undefined {
+  const rec = asRecord(raw);
+  if (!rec) return undefined;
+  const list = Array.isArray(rec.elevated) ? rec.elevated : [];
+  const seen = new Set<ElevatedPermissionType>();
+  const elevated: ElevatedPermission[] = [];
+  for (const entry of list) {
+    const coerced = coerceElevated(entry);
+    if (!coerced || seen.has(coerced.type)) continue;
+    seen.add(coerced.type);
+    elevated.push(coerced);
+  }
+  return elevated.length ? { elevated } : undefined;
+}
+
+/** True when the app requests the privilege-escalation grant (drop no-new-privileges). */
+export function requestsPrivilegeEscalation(security: AppSecurityConfig | undefined): boolean {
+  return !!security?.elevated.some((e) => e.type === 'allow-privilege-escalation');
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -669,6 +669,11 @@ export type GetCatalogAppVersionDetailResponse = {
   // (e.g. pg_dump before a file-level capture). Optional: most apps (and SQLite)
   // are fine with crash-consistent file snapshots and omit it.
   backup?: AppBackupConfig;
+  // Elevated container permissions the app requests (e.g. a browser desktop that
+  // needs `sudo`). Each entry is surfaced for explicit operator consent in the
+  // install wizard and relaxes the corresponding platform hardening at deploy
+  // time. Optional: apps that don't declare it run fully hardened.
+  security?: AppSecurityConfig;
 };
 
 // ------------------------------------------------------
@@ -773,6 +778,35 @@ export type AppAuthConfig = {
   fallback?: 'forward-auth';
 };
 
+// Elevated container permissions an app may request in its bundle manifest.
+// These relax the platform's default container hardening for a specific,
+// declared reason, so the install wizard can surface each one for explicit
+// operator consent before install. Kept as a discriminated list (not a single
+// boolean) so each grant is named, individually explained, and individually
+// acknowledged — and so it can grow (e.g. Linux capabilities) without redesign.
+//
+// - `allow-privilege-escalation`: drop the `no-new-privileges:true` hardening on
+//   the app's ingress service so setuid escalation (i.e. `sudo`) works inside the
+//   container. Needed by browser-desktop apps (e.g. webtop) whose whole purpose is
+//   an interactive shell with admin access. This is the ONLY type today; the
+//   underlying `no_new_privs` flag is a single kernel boolean and is not further
+//   subdivisible (granular grants would be Linux capabilities — a future type).
+export type ElevatedPermissionType = 'allow-privilege-escalation';
+
+export type ElevatedPermission = {
+  type: ElevatedPermissionType;
+  // Human-readable justification shown next to the consent checkbox. Required —
+  // an app must say WHY it needs the grant so the operator can make an informed
+  // decision. Coercion drops any entry missing a non-empty reason.
+  reason: string;
+};
+
+export type AppSecurityConfig = {
+  // Elevated permissions the app requests. Every entry becomes a red, must-check
+  // consent row in the install wizard; the server grants ONLY what's declared.
+  elevated: ElevatedPermission[];
+};
+
 // Opaque handle to the auth artifacts provisioned for a deployment, persisted on
 // its metadata so they can be reused (idempotent re-deploy) and torn down on delete.
 // Keyed on deploymentId (stable across releases), never releaseId.
@@ -815,6 +849,11 @@ export type Draft = {
   // Cross-app capabilities consumed (e.g. `app-registry`), seeded from the bundle
   // manifest and carried through finalize (ADR 0002).
   consumes?: string[];
+  // Elevated container permissions the app requests, seeded from the bundle
+  // manifest and carried through finalize (read-only; not user-editable). The
+  // install wizard surfaces each for consent; the deploy lifecycle relaxes the
+  // matching hardening.
+  security?: AppSecurityConfig;
   // The compose service to route to / inject auth env into, for multi-service
   // apps whose ingress service isn't named after the app id. Seeded from the
   // bundle manifest and carried through finalize (read-only; not user-editable).
@@ -850,6 +889,10 @@ export type CreateDraftResponse = {
   systemEnv: AppEnvVar[];
   appEnv: AppEnvVar[];
   defaults: DraftDefaults;
+  // Elevated container permissions the app requests (seeded from the bundle
+  // manifest), so the install wizard can surface each for explicit operator
+  // consent. Absent when the app requests none (the fully-hardened default).
+  security?: AppSecurityConfig;
 };
 
 export type GetDraftResponse = Draft;

--- a/packages/web/src/pages/InstallWizard.tsx
+++ b/packages/web/src/pages/InstallWizard.tsx
@@ -9,6 +9,7 @@ import type {
   DraftDefaults,
   PatchDraftRequest,
   ValidationIssue,
+  AppSecurityConfig,
 } from '@hola/shared';
 import { validateParams, generateSecretValue, isEffectivelyRequired } from '@hola/shared/param-validate';
 import { useCreateDraft, useDraftApi } from '../hooks/useDraftApi';
@@ -18,13 +19,34 @@ import { useDraftFinalization } from '../hooks/useDraftFinalization';
 import { api } from '../utils/api-hybrid';
 
 const steps = [
-  { id: 'env', name: 'Environment Variables', description: 'Configure application settings' },
+  { id: 'env', name: 'Configuration', description: 'Configure application settings and permissions' },
   { id: 'compose', name: 'Compose Override', description: 'Upload custom Docker Compose configuration' },
   { id: 'files', name: 'Additional Files', description: 'Upload configuration files and certificates' },
   { id: 'advanced', name: 'Advanced Options', description: 'Configure ports, volumes, and other settings' },
   { id: 'validate', name: 'Validate & Preflight', description: 'Check configuration and system compatibility' },
   { id: 'summary', name: 'Summary & Confirm', description: 'Review and confirm installation' },
 ];
+
+// Human-readable label + risk note for each elevated-permission type the wizard
+// surfaces for consent. Kept exhaustive so a new type added to the shared union
+// forces a decision here (TS narrows the default to `never`).
+function elevatedPermissionLabel(type: AppSecurityConfig['elevated'][number]['type']): string {
+  switch (type) {
+    case 'allow-privilege-escalation':
+      return 'Allow privilege escalation (sudo / root)';
+    default:
+      return type;
+  }
+}
+
+function elevatedPermissionRisk(type: AppSecurityConfig['elevated'][number]['type']): string {
+  switch (type) {
+    case 'allow-privilege-escalation':
+      return 'Risk: processes in this container can escalate to root (no-new-privileges is disabled for it).';
+    default:
+      return 'Relaxes this container’s security hardening.';
+  }
+}
 
 export const InstallWizard: React.FC = () => {
   const { appId } = useParams();
@@ -89,6 +111,11 @@ export const InstallWizard: React.FC = () => {
   const [uploadedFiles, setUploadedFiles] = useState<string[]>([]);
   const [ports, setPorts] = useState<DraftDefaults['ports']>([]);
   const [volumes, setVolumes] = useState<DraftDefaults['volumes']>([]);
+  // Elevated container permissions the app requests (from its manifest) and the
+  // operator's per-permission acknowledgements. Install is gated until every
+  // requested permission is explicitly acknowledged (see canProceed, case 0).
+  const [security, setSecurity] = useState<AppSecurityConfig | undefined>();
+  const [ackedPermissions, setAckedPermissions] = useState<Set<string>>(new Set());
   const [showSecrets, setShowSecrets] = useState<{[key: string]: boolean}>({});
   const [composeOverride, setComposeOverride] = useState('');
   const [editMode, setEditMode] = useState(false);
@@ -154,6 +181,7 @@ export const InstallWizard: React.FC = () => {
         setEnvVars(seededEnv);
         setPorts(result.defaults.ports);
         setVolumes(result.defaults.volumes);
+        setSecurity(result.security);
 
         // Persist the generated values immediately so a refresh (or abandoning
         // the wizard before clicking Next) doesn't lose them — same durability
@@ -249,7 +277,11 @@ export const InstallWizard: React.FC = () => {
         // mirroring what the server would reject at validate/preflight time
         // anyway. Server validation remains authoritative and unchanged.
         const noBlockingIssues = !paramIssues.some(i => i.severity === 'error');
-        return !isLoading && requiredOk && noBlockingIssues;
+        // Elevated permissions (if any) must each be explicitly acknowledged
+        // before install can proceed — informed consent for relaxing container
+        // hardening (see the elevated-permissions block below).
+        const permissionsAcked = (security?.elevated ?? []).every(p => ackedPermissions.has(p.type));
+        return !isLoading && requiredOk && noBlockingIssues && permissionsAcked;
       }
       case 4: // Validate & Preflight
         // Allow proceeding if not loading, and either checks haven't run yet OR both have passed
@@ -621,10 +653,54 @@ services:
 
         return (
           <div>
-            <div className="text-base font-semibold mb-1">Environment variables</div>
+            <div className="text-base font-semibold mb-1">Configuration</div>
             <p className="text-[13.5px] text-text-muted mb-5">
               Defaults are pre-filled from the catalog. Override system defaults only when needed. Secrets are masked — reveal to check.
             </p>
+
+            {/* Elevated permissions — the app's manifest requests relaxations of
+                the platform's default container hardening. Each must be explicitly
+                acknowledged (informed consent) before install can proceed. */}
+            {(security?.elevated ?? []).length > 0 && (
+              <div className="mb-6 border border-danger/50 bg-danger-weak rounded-[10px] p-[14px]">
+                <div className="flex items-center gap-2 mb-2">
+                  <AlertTriangle className="w-4 h-4 text-danger" />
+                  <h4 className="text-[13.5px] font-semibold text-danger">This app requests elevated permissions</h4>
+                </div>
+                <p className="text-[12.5px] text-text-muted mb-3">
+                  Granting these relaxes container security for this app. Review each and confirm to continue.
+                </p>
+                <div className="space-y-2">
+                  {security!.elevated.map((perm) => (
+                    <label
+                      key={perm.type}
+                      className="flex items-start gap-3 p-[12px] border border-danger/40 rounded-[8px] bg-surface-1 cursor-pointer"
+                    >
+                      <input
+                        type="checkbox"
+                        className="mt-[3px] accent-danger"
+                        checked={ackedPermissions.has(perm.type)}
+                        onChange={(e) => {
+                          setAckedPermissions((prev) => {
+                            const next = new Set(prev);
+                            if (e.target.checked) next.add(perm.type);
+                            else next.delete(perm.type);
+                            return next;
+                          });
+                        }}
+                      />
+                      <span>
+                        <span className="block text-[13px] font-semibold text-text-strong">
+                          {elevatedPermissionLabel(perm.type)}
+                        </span>
+                        <span className="block text-[12.5px] text-text-muted mt-[2px]">{perm.reason}</span>
+                        <span className="block text-[12px] text-danger mt-[3px]">{elevatedPermissionRisk(perm.type)}</span>
+                      </span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+            )}
 
             {/* System Environment Variables — only shown when the operator has
                 defined platform-wide vars (none by default). */}


### PR DESCRIPTION
## Why

Hola force-appends `no-new-privileges:true` to **every** service of **every** app as a hardening default, with no per-app override. That's the right default, but it's fundamentally incompatible with an app class that needs privilege escalation — a browser desktop (webtop) ships passwordless `sudo`, yet the `no_new_privs` kernel flag blocks setuid escalation, so `sudo` dies with *"the 'no new privileges' flag is set."* There was no way for an app to opt out, and flipping the install-wide `HOLA_DEFAULT_NO_NEW_PRIVILEGES` would weaken **all** apps.

## What

A manifest-declared, **operator-consented** capability for a specific, named relaxation of container hardening.

```json
"security": {
  "elevated": [
    { "type": "allow-privilege-escalation",
      "reason": "The Ubuntu desktop needs sudo for apt & admin tasks." }
  ]
}
```

- **Granular, not a blanket toggle.** A discriminated list where each entry is named, individually explained, and individually acknowledged — so consenting to "allow sudo" never silently also grants something else. Extends cleanly to Linux capabilities later without redesign. (The one type today, `allow-privilege-escalation`, maps to the `no_new_privs` boolean, which is itself not subdivisible — granular grants would be capabilities, a future type.)
- **Scoped.** Escalation drops `no-new-privileges` for the app's **ingress service only**; sidecars stay hardened.
- **Least privilege.** The server grants *only* what the manifest declares; unknown types are dropped (a manifest can't invent a privilege).
- **Informed consent.** The install wizard's first step (renamed **"Configuration"**) shows a red, must-acknowledge row per requested permission — with the app's reason and a risk note — and gates install until each is checked.

## How it's wired (mirrors the existing `auth`/`consumes` capability path)

- **shared** — `ElevatedPermission` / `AppSecurityConfig`; `security?` on the catalog version detail, `CreateDraftResponse`, and `Draft`.
- **server** — `coerceManifestSecurity` (defensive: drops unknown types, requires a `reason`, de-dupes) wired into catalog manifest parsing → carried through draft finalize into `FinalizedManifest` → `readActiveSecurity` in the deploy lifecycle feeds `applyPlatformDefaults`, which now **skips and strips** `no-new-privileges` for escalation-granted services.
- **web** — `InstallWizard` step renamed to "Configuration"; red per-permission consent block; `canProceed` gates on acknowledgement.

## Tests

- `compose-defaults` escalation: granted service loses `no-new-privileges`, an app-declared `no-new-privileges:true` is stripped, the opt-out applies even when the install-wide config is a no-op, and sibling services stay hardened.
- `manifest-security` coercion: unknown types dropped, missing/blank reason dropped, de-dup, `requestsPrivilegeEscalation`.
- Full `typecheck` + `lint` + `build` green. (Two pre-existing `snapshot.test.ts` failures are unrelated — they fail identically on a clean `main`.)

## Companion

Bundle change declaring the grant + the manifest schema addition: **try-hola/apps#98** (webtop). Forward-compatible both ways — an old server ignores the `security` block; a new server hardens apps that don't declare it exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)