### PR TITLE
chore(release): 0.7.6-rc.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/cli": {
       "name": "@hola/cli",
-      "version": "0.7.5",
+      "version": "0.7.6-rc.1",
       "bin": {
         "hola": "./bin/hola",
       },
@@ -37,11 +37,11 @@
     },
     "packages/compose": {
       "name": "@hola/compose",
-      "version": "0.7.5",
+      "version": "0.7.6-rc.1",
     },
     "packages/sdk": {
       "name": "@hola/sdk",
-      "version": "0.7.5",
+      "version": "0.7.6-rc.1",
       "dependencies": {
         "@hola/shared": "workspace:*",
       },
@@ -55,7 +55,7 @@
     },
     "packages/server": {
       "name": "@hola/server",
-      "version": "0.7.5",
+      "version": "0.7.6-rc.1",
       "dependencies": {
         "@hola/shared": "workspace:*",
         "jose": "^5.9.6",
@@ -71,7 +71,7 @@
     },
     "packages/shared": {
       "name": "@hola/shared",
-      "version": "0.7.5",
+      "version": "0.7.6-rc.1",
       "dependencies": {
         "yaml": "^2.9.0",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.7.5",
+  "version": "0.7.6-rc.1",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.7.5';
+export const CLI_VERSION = '0.7.6-rc.1';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.7.5",
+  "version": "0.7.6-rc.1",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.7.5",
+  "version": "0.7.6-rc.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.7.5",
+  "version": "0.7.6-rc.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.7.5",
+  "version": "0.7.6-rc.1",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Release bump for the **operator-consented elevated container permissions** feature (#347).

Bumps `cli` / `server` / `sdk` / `shared` / `compose` to **0.7.6-rc.1** (and `packages/cli/src/version.ts`, which defaults `hola bootstrap --ref` to `cli-v0.7.6-rc.1`).

This is a **pre-release (rc.1)** so the test build:
- pins server/web images to `0.7.6-rc.1` and **does not move `:latest`**;
- is published as a GitHub pre-release;
- lets the test host bootstrap the matching images explicitly.

Once merged, pushing the `cli-v0.7.6-rc.1` tag triggers `cli-release.yml` → multi-arch server+web images, the `hola-compose-0.7.6-rc.1.tar.gz` bundle, and the standalone `hola` CLI binaries.

Companion catalog bundle (already merged): try-hola/apps#98 — webtop 1.1.0 declares `security.elevated` + drops the broken Basic auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)