### PR TITLE
fix(cli): guard bootstrap against clobbering an existing install (#351)

### DIFF
--- a/packages/cli/src/__tests__/bootstrap.test.ts
+++ b/packages/cli/src/__tests__/bootstrap.test.ts
@@ -119,6 +119,57 @@ describe('hola bootstrap', () => {
     expect(runner.calls.some((c) => c.cmd.includes('install.sh'))).toBe(false);
   });
 
+  // --- Fresh-install guard (#351) --------------------------------------------
+
+  const EXISTING_PREFLIGHT =
+    'docker=ok\ncurl=ok\ntar=ok\ncompose=ok\ndockerperm=ok\nexisting_env=present\nexisting_vol=present\n';
+
+  it('refuses to re-run against an already-bootstrapped host and points at hola update (#351)', async () => {
+    const runner = makeRunner(EXISTING_PREFLIGHT);
+    const errs: string[] = [];
+    const spy = vi.spyOn(console, 'error').mockImplementation((m?: unknown) => { errs.push(String(m)); });
+    try {
+      const res = await runBootstrap(
+        { host: 'me@vm', skipChecks: true, json: true, ref: 'cli-v0.2.0' },
+        { prompter: scriptedPrompter(answers), runner }
+      );
+      expect(res).toBeUndefined();
+      expect(process.exitCode).toBe(1);
+      // The bug is a clobbering re-run: assert we neither rewrote .env nor ran the installer.
+      expect(runner.calls.some((c) => c.cmd.includes('cat > '))).toBe(false);
+      expect(runner.calls.some((c) => c.cmd.includes('install.sh'))).toBe(false);
+      expect(errs.join('\n')).toContain('hola update --host me@vm');
+      expect(errs.join('\n')).toContain('--reinstall');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('--reinstall resets the stateful volumes before reinstalling (#351)', async () => {
+    const runner = makeRunner(EXISTING_PREFLIGHT);
+    const res = await runBootstrap(
+      { host: 'me@vm', skipChecks: true, json: true, ref: 'cli-v0.2.0', reinstall: true },
+      { prompter: scriptedPrompter(answers), runner }
+    );
+    expect(res?.steps).toContain('Reset existing install (down -v, remove Hola volumes)');
+    // The reset must precede the .env write, so regenerated secrets meet fresh volumes.
+    const resetIdx = runner.calls.findIndex((c) => c.cmd.includes('docker compose down -v'));
+    const writeIdx = runner.calls.findIndex((c) => c.cmd.includes('cat > '));
+    expect(resetIdx).toBeGreaterThanOrEqual(0);
+    expect(writeIdx).toBeGreaterThan(resetIdx);
+    expect(runner.calls.some((c) => c.cmd.includes('install.sh'))).toBe(true);
+  });
+
+  it('installs normally on a fresh host (no existing .env or volumes)', async () => {
+    const runner = makeRunner('docker=ok\ncurl=ok\ntar=ok\ncompose=ok\ndockerperm=ok\nexisting_env=absent\nexisting_vol=absent\n');
+    const res = await runBootstrap(
+      { host: 'me@vm', skipChecks: true, json: true, ref: 'cli-v0.2.0' },
+      { prompter: scriptedPrompter(answers), runner }
+    );
+    expect(res?.steps).not.toContain('Reset existing install (down -v, remove Hola volumes)');
+    expect(runner.calls.some((c) => c.cmd.includes('install.sh'))).toBe(true);
+  });
+
   it('requires --host', async () => {
     const res = await runBootstrap({ skipChecks: true, json: true }, { prompter: scriptedPrompter(answers), runner: makeRunner() });
     expect(res).toBeUndefined();

--- a/packages/cli/src/__tests__/install-schema.test.ts
+++ b/packages/cli/src/__tests__/install-schema.test.ts
@@ -44,8 +44,10 @@ describe('install schema', () => {
   it("defaults the timezone to this machine's timezone", () => {
     const tz = INSTALL_SCHEMA.find((f) => f.key === 'HOLA_DEFAULT_TZ')!;
     expect(defaultFor(tz, {})).toBe(systemTimeZone());
-    // Intl resolves a real IANA zone on any CI host, so the default is non-empty there.
-    expect(defaultFor(tz, {})).toMatch(/^[A-Za-z]+\/[A-Za-z]/);
+    // Intl resolves a real IANA zone on any host: a `Region/City` like
+    // America/New_York, or a slashless canonical zone like UTC (e.g. a
+    // container whose clock is set to UTC).
+    expect(defaultFor(tz, {})).toMatch(/^([A-Za-z]+\/[A-Za-z]|UTC)/);
   });
 
   it('gates conditional fields with requiredWhen', () => {

--- a/packages/cli/src/commands/bootstrap/bootstrap.ts
+++ b/packages/cli/src/commands/bootstrap/bootstrap.ts
@@ -20,6 +20,16 @@ export interface BootstrapOptions {
   dir?: string;
   envFile?: string;
   skipChecks?: boolean;
+  /**
+   * Wipe an existing install and reinstall from scratch. `bootstrap` is a
+   * fresh-install command and refuses a host that already has a Hola `.env` or
+   * Hola volumes (a re-run would rotate install.sh's host-generated AUTHENTIK_*
+   * secrets while the persistent volumes keep the originals, bricking SSO — #351);
+   * the config-preserving path is `hola update`. `--reinstall` is the deliberate
+   * escape hatch: it resets the stateful volumes (Postgres, Authentik, hola-data)
+   * so the freshly-generated secrets and the volumes move together.
+   */
+  reinstall?: boolean;
   dryRun?: boolean;
   json?: boolean;
 }
@@ -159,18 +169,69 @@ export async function runBootstrap(
 
     // 2) Preflight (single remote probe → key=value lines). The host pulls
     //    prebuilt images, so it needs docker + compose + curl/tar — but not git.
+    //    The probe also reports whether the host already looks bootstrapped (an
+    //    existing `.env` or leftover Hola volumes) so the guard below can refuse a
+    //    clobbering re-run — see #351.
     const probe =
       'for c in docker curl tar; do command -v "$c" >/dev/null 2>&1 && echo "$c=ok" || echo "$c=missing"; done; ' +
       'docker compose version >/dev/null 2>&1 && echo compose=ok || echo compose=missing; ' +
-      'docker ps >/dev/null 2>&1 && echo dockerperm=ok || echo dockerperm=fail';
+      'docker ps >/dev/null 2>&1 && echo dockerperm=ok || echo dockerperm=fail; ' +
+      `[ -f ${envPath} ] && echo existing_env=present || echo existing_env=absent; ` +
+      "docker volume ls -q 2>/dev/null | grep -qE '^hola(_|-)' && echo existing_vol=present || echo existing_vol=absent";
     if (opts.dryRun) {
       await ssh('Preflight host', probe);
+      // Can't probe under --dry-run, so surface the reset step only when the
+      // operator explicitly asked to reinstall (the guard would otherwise abort).
+      if (opts.reinstall) {
+        await ssh(
+          'Reset existing install (down -v, remove Hola volumes)',
+          `[ -d ${dir} ] && (cd ${dir} && docker compose down -v --remove-orphans) 2>/dev/null || true; ` +
+            "docker volume ls -q 2>/dev/null | grep -E '^hola(_|-)' | xargs -r docker volume rm -f 2>/dev/null || true",
+        );
+      }
     } else {
       const r = await ssh('Preflight host', probe);
       if (r.code !== 0) throw new BootstrapAbort(`Could not connect to ${host} (ssh exit ${r.code}).`);
       const p = parsePreflight(r.stdout);
       assertPreflight(p);
       out('  host OK (docker, compose, curl/tar, permissions)');
+
+      // 2a) Fresh-install guard (#351). `bootstrap` writes a brand-new `.env`, so
+      //     re-running it against an existing install rotates install.sh's
+      //     host-generated AUTHENTIK_* secrets while the persistent volumes keep
+      //     the originals — Authentik can no longer reach its DB and SSO bricks.
+      //     Route re-runs to `hola update` (config-preserving); `--reinstall` is
+      //     the deliberate wipe path, which resets the stateful volumes so the
+      //     regenerated secrets and the volumes move together.
+      const existing = p.existing_env === 'present' || p.existing_vol === 'present';
+      if (existing && !opts.reinstall) {
+        const where =
+          p.existing_env === 'present' ? `${envPath} exists` : 'Hola volumes are present';
+        const dirFlag = dir === DEFAULT_DIR ? '' : ` --dir ${dir}`;
+        throw new BootstrapAbort(
+          `This host already has a Hola install at ${dir} (${where}).\n` +
+            `bootstrap is for a fresh install — re-running it would rotate the SSO secrets and brick Authentik.\n\n` +
+            `To upgrade or change config (preserves your .env, data, and SSO):\n` +
+            `  hola update --host ${host}${dirFlag}\n\n` +
+            `To wipe this install and start over (DELETES all volumes and data):\n` +
+            `  hola bootstrap --host ${host}${dirFlag} --reinstall`,
+        );
+      }
+      if (existing && opts.reinstall) {
+        // Reset the stateful volumes BEFORE the new .env is written, using the
+        // OLD .env/compose still on disk so the running stack (incl. the Authentik
+        // profile) is torn down cleanly. The named-volume sweep catches anything
+        // `compose down` missed. The install dir and the ACME cert store are kept,
+        // so the reinstall reuses the existing wildcard cert (no LE rate-limit hit).
+        const reset = await ssh(
+          'Reset existing install (down -v, remove Hola volumes)',
+          `[ -d ${dir} ] && (cd ${dir} && docker compose down -v --remove-orphans) 2>/dev/null || true; ` +
+            "docker volume ls -q 2>/dev/null | grep -E '^hola(_|-)' | xargs -r docker volume rm -f 2>/dev/null || true",
+          { stream: true },
+        );
+        if (reset.code !== 0) throw new BootstrapAbort(`Resetting the existing install failed (exit ${reset.code}).`);
+        out('  existing volumes reset — reinstalling from scratch');
+      }
     }
 
     // 3) Download + extract the version-pinned compose bundle (no git, no source

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -41,6 +41,7 @@ prog
   .option('--dir', 'Install directory on the host', '/opt/hola')
   .option('--env-file', 'Use an existing .env (skip the wizard)')
   .option('--skip-checks', 'Skip live DNS/credential/catalog validation', false)
+  .option('--reinstall', 'Wipe an existing install (volumes + data) and reinstall from scratch', false)
   .option('--dry-run', 'Print the plan without connecting', false)
   .option('--json', 'Print the result as JSON', false)
   .action(async (opts) => {


### PR DESCRIPTION
## Summary

Fixes #351 — `hola bootstrap` was **not idempotent**: re-running it against an already-bootstrapped host rewrote the host `.env` wholesale, so `scripts/install.sh` regenerated its host-generated `AUTHENTIK_*` secrets (`AUTHENTIK_PG_PASS`, `AUTHENTIK_SECRET_KEY`, bootstrap creds) while the persistent volumes kept the originals. Authentik could no longer authenticate to its own Postgres → `503`s and *"Waiting for SSO provisioning…"* forever.

## Fix

`bootstrap` is now explicitly a **fresh-install** command (the config-preserving re-run path already exists as `hola update`):

- The preflight probe reports whether the host already has a Hola `.env` **or** leftover `hola-*` volumes.
- If either is present, the run **aborts** with a clear pointer to `hola update` (upgrade/config change) and to `--reinstall` (wipe & start over). No `.env` is rewritten and `install.sh` never runs — the clobber can't happen.
- **`--reinstall`** is the deliberate escape hatch: it resets the stateful volumes (`docker compose down -v` + remove `hola-*` volumes) **before** writing the new `.env`, so the freshly-generated secrets and the volumes move together. The ACME cert store is preserved (no Let's Encrypt re-issuance).

## Tests

- `refuses to re-run against an already-bootstrapped host and points at hola update` — asserts no `.env` rewrite, no `install.sh`, and the `hola update` / `--reinstall` guidance.
- `--reinstall resets the stateful volumes before reinstalling` — asserts the reset precedes the `.env` write and the installer still runs.
- `installs normally on a fresh host` — no reset step on a clean host.

Also relaxes the timezone-default test to accept a slashless canonical zone like `UTC` (it demanded `Region/City`, failing on UTC-clocked hosts despite correct behavior).

Full CLI suite: **173/173 green**; typecheck / lint / build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)