### PR TITLE
docs(readme): document the --prerelease install option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ platform from the latest release; builds from source with Bun if none is publish
 curl -fsSL https://raw.githubusercontent.com/try-hola/hola/main/cli-install.sh | sh
 ```
 
+To install the latest **pre-release** (e.g. an `-rc.N` build) instead of the latest
+stable release, add `--prerelease`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/try-hola/hola/main/cli-install.sh | sh -s -- --prerelease
+```
+
+(Or pin an exact tag with `HOLA_VERSION=cli-v0.7.6-rc.2 sh`.)
+
 Then set up a server with `hola bootstrap --host user@your-vm`, or point the CLI at an
 existing one (`HOLA_API_URL` + `HOLA_TOKEN`). See
 [Install (production)](#install-production-single-host) and
@@ -149,6 +158,7 @@ Bun if no release is published yet):
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/try-hola/hola/main/cli-install.sh | sh
+# add `-s -- --prerelease` to install the latest pre-release instead of stable
 export HOLA_API_URL=https://<HOLA_DOMAIN>     # the web origin (proxies /api to the server)
 export HOLA_TOKEN=<admin-api-key>             # printed by the server installer
 hola --help

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -14,6 +14,14 @@ Install the standalone `hola` binary (downloads a prebuilt release binary, or bu
 curl -fsSL https://raw.githubusercontent.com/try-hola/hola/main/cli-install.sh | sh
 ```
 
+To install the latest **pre-release** (e.g. an `-rc.N` build) instead of the latest stable release, pass `--prerelease`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/try-hola/hola/main/cli-install.sh | sh -s -- --prerelease
+```
+
+Other selectors: `HOLA_VERSION=cli-v0.7.6-rc.2` pins an exact tag (overrides `--prerelease`); `HOLA_PRERELEASE=true` is equivalent to the flag.
+
 Then point it at your server:
 ```bash
 export HOLA_API_URL=https://<your-hola-domain>   # web origin; proxies /api to the server


### PR DESCRIPTION
Documents the new `--prerelease` install flag (added in #354) in the READMEs, mirroring how [get2knowio/deacon](https://github.com/get2knowio/deacon) documents its pre-release install.

Updated:
- **README.md** — "Install the CLI" gets a `--prerelease` one-liner (+ a note on pinning an exact tag with `HOLA_VERSION`); "CLI on another machine" gets an inline comment.
- **packages/cli/README.md** — same `--prerelease` snippet plus the `HOLA_VERSION` / `HOLA_PRERELEASE` selectors.

```bash
curl -fsSL https://raw.githubusercontent.com/try-hola/hola/main/cli-install.sh | sh -s -- --prerelease
```

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)