### PR TITLE
chore(release): 0.7.6-rc.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/cli": {
       "name": "@hola/cli",
-      "version": "0.7.6-rc.2",
+      "version": "0.7.6-rc.3",
       "bin": {
         "hola": "./bin/hola",
       },
@@ -37,11 +37,11 @@
     },
     "packages/compose": {
       "name": "@hola/compose",
-      "version": "0.7.6-rc.2",
+      "version": "0.7.6-rc.3",
     },
     "packages/sdk": {
       "name": "@hola/sdk",
-      "version": "0.7.6-rc.2",
+      "version": "0.7.6-rc.3",
       "dependencies": {
         "@hola/shared": "workspace:*",
       },
@@ -55,7 +55,7 @@
     },
     "packages/server": {
       "name": "@hola/server",
-      "version": "0.7.6-rc.2",
+      "version": "0.7.6-rc.3",
       "dependencies": {
         "@hola/shared": "workspace:*",
         "jose": "^5.9.6",
@@ -71,7 +71,7 @@
     },
     "packages/shared": {
       "name": "@hola/shared",
-      "version": "0.7.6-rc.2",
+      "version": "0.7.6-rc.3",
       "dependencies": {
         "yaml": "^2.9.0",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.7.6-rc.2",
+  "version": "0.7.6-rc.3",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.7.6-rc.2';
+export const CLI_VERSION = '0.7.6-rc.3';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.7.6-rc.2",
+  "version": "0.7.6-rc.3",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.7.6-rc.2",
+  "version": "0.7.6-rc.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.7.6-rc.2",
+  "version": "0.7.6-rc.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.7.6-rc.2",
+  "version": "0.7.6-rc.3",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Release **0.7.6-rc.3**.

Bumps the published packages (cli, compose, sdk, server, shared) + `packages/cli/src/version.ts` and the lockfile from `0.7.6-rc.2`.

### Included since 0.7.6-rc.2
- feat(server): forward-auth path exemptions — `auth.forwardAuth.bypassPaths` lets a manifest exempt specific URL prefixes from Authentik forward-auth, so a non-browser client can reach an app API path the app guards with its own token (#356, #357).

Tag `cli-v0.7.6-rc.3` after merge to build the prerelease artifacts (server/web images + CLI binaries + compose bundle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)