### PR TITLE
feat(web): tab-complete the timezone picker to a unique match

### DIFF
--- a/packages/web/src/__tests__/components/fields/TimezoneSelect.test.tsx
+++ b/packages/web/src/__tests__/components/fields/TimezoneSelect.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { describe, it, expect, afterEach, beforeAll, vi } from 'vitest';
+import { TimezoneSelect } from '../../../components/ui/fields/TimezoneSelect';
+
+// Deterministic zone list so the tab-complete logic is exercised regardless of
+// the test runtime's `Intl.supportedValuesOf`. Includes two zones sharing the
+// `America/N` prefix so the ambiguous case is real.
+const ZONES = ['America/New_York', 'America/Chicago', 'America/North_Dakota/New_Salem', 'Europe/London', 'UTC'];
+
+beforeAll(() => {
+  (Intl as unknown as { supportedValuesOf: (k: string) => string[] }).supportedValuesOf = (k) =>
+    (k === 'timeZone' ? ZONES : []);
+});
+
+afterEach(cleanup);
+
+function renderTz(value: string) {
+  const onChange = vi.fn();
+  render(<TimezoneSelect value={value} onChange={onChange} />);
+  return { input: screen.getByPlaceholderText('e.g. America/New_York'), onChange };
+}
+
+describe('TimezoneSelect tab-complete', () => {
+  it('completes a value that narrows to a single zone on Tab', () => {
+    const { input, onChange } = renderTz('America/New');
+    fireEvent.keyDown(input, { key: 'Tab' });
+    expect(onChange).toHaveBeenCalledWith('America/New_York');
+  });
+
+  it('does not complete an ambiguous value — lets Tab move focus', () => {
+    // `America/N` matches both New_York and North_Dakota/New_Salem.
+    const { input, onChange } = renderTz('America/N');
+    fireEvent.keyDown(input, { key: 'Tab' });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the value is already an exact zone', () => {
+    const { input, onChange } = renderTz('America/New_York');
+    fireEvent.keyDown(input, { key: 'Tab' });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('ignores Shift+Tab (reverse focus traversal)', () => {
+    const { input, onChange } = renderTz('America/New');
+    fireEvent.keyDown(input, { key: 'Tab', shiftKey: true });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('is case-insensitive', () => {
+    const { input, onChange } = renderTz('america/new');
+    fireEvent.keyDown(input, { key: 'Tab' });
+    expect(onChange).toHaveBeenCalledWith('America/New_York');
+  });
+});

--- a/packages/web/src/components/ui/fields/TimezoneSelect.tsx
+++ b/packages/web/src/components/ui/fields/TimezoneSelect.tsx
@@ -35,6 +35,30 @@ export const TimezoneSelect: React.FC<TimezoneSelectProps> = ({ id, value, onCha
   const effectivePlaceholder = placeholder ?? 'e.g. America/New_York';
   const listId = `${id ?? 'tz'}-options`;
 
+  // Tab-complete: if what's typed narrows to a SINGLE zone, Tab finishes it
+  // (e.g. "America/New" → "America/New_York") instead of just moving focus.
+  // A native `<datalist>` never auto-accepts the sole suggestion, so do it here.
+  // Prefer a unique prefix match (what Firefox's datalist shows), then fall back
+  // to a unique substring match (Chrome's behavior); if it's already an exact
+  // zone or the match is ambiguous, let Tab move focus as usual.
+  const completeOnTab = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key !== 'Tab' || e.shiftKey || e.altKey || e.ctrlKey || e.metaKey || !zones) return;
+    const v = value.trim().toLowerCase();
+    if (!v || zones.some((z) => z.toLowerCase() === v)) return;
+    const prefix = zones.filter((z) => z.toLowerCase().startsWith(v));
+    const match =
+      prefix.length === 1
+        ? prefix[0]
+        : (() => {
+            const sub = zones.filter((z) => z.toLowerCase().includes(v));
+            return sub.length === 1 ? sub[0] : null;
+          })();
+    if (match) {
+      e.preventDefault();
+      onChange(match);
+    }
+  };
+
   // The datalist depends only on the (module-cached) zone list, not on `value`,
   // so build the ~430 <option> nodes once instead of on every keystroke.
   const options = useMemo(
@@ -54,6 +78,7 @@ export const TimezoneSelect: React.FC<TimezoneSelectProps> = ({ id, value, onCha
         list={listId}
         value={value}
         onChange={(e) => onChange(e.target.value)}
+        onKeyDown={completeOnTab}
         placeholder={effectivePlaceholder}
         className={`w-full h-10 bg-surface-0 border rounded-[9px] text-text-strong px-[13px] text-[13px] font-mono outline-none focus:border-primary ${hasError ? 'border-danger/60' : 'border-border'}`}
       />


### PR DESCRIPTION
The timezone config field is a native `<input list>` + `<datalist>`. Typing `America/New` narrows the suggestions to `America/New_York`, but **Tab** just moved focus to the next field without selecting it — browsers never auto-accept the sole remaining datalist suggestion.

This adds a keydown handler so **Tab finishes a value that narrows to a single zone** (`America/New` → `America/New_York`):
- Unique **prefix** match first (what Firefox's datalist shows), then unique **substring** (Chrome's behavior).
- Ambiguous input (e.g. `America/N`), an already-exact zone, and **Shift+Tab** keep the normal focus-move behavior.
- Case-insensitive.

Scope: this is the only searchable free-text pick list; the small enums render as radios/`<select>` (type-to-jump), which don't have this issue.

Tests: 5 cases (unique-complete, ambiguous no-op, exact no-op, Shift+Tab, case-insensitive). Web suite 198 green; typecheck/lint/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)