### PR TITLE
fix(server): refresh the deployment's cached icon on upgrade

### DIFF
--- a/packages/server/src/__tests__/deployments/promote-refreshes-icon.test.ts
+++ b/packages/server/src/__tests__/deployments/promote-refreshes-icon.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Promote refreshes the deployment's cached catalog icon.
+ *
+ * `icon` is persisted onto the deployment record at install (createFromDraft) so
+ * the launcher can render a tile without a live catalog lookup. Nothing refreshed
+ * it afterwards, so an app whose catalog package changed its logo kept the icon it
+ * had on install day forever — even across upgrades. promote() resolves the new
+ * manifest anyway, so it now syncs the icon alongside the version.
+ *
+ * `name` is deliberately excluded: a caller-supplied name wins at install and the
+ * record can't tell one from a manifest-derived default, so refreshing it would
+ * clobber an operator's rename. That exclusion is asserted here too.
+ */
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { RealDeploymentService } from '../../services/core/deployment';
+import { MockProvisionerService } from '../../services/core/provisioner';
+import { RealDraftService } from '../../services/core/draft';
+import { RealStorageService } from '../../services/core/storage';
+import { RealRoutingService } from '../../services/core/routing';
+import type { DockerService } from '../../services/core/docker';
+
+type CatalogArg = ConstructorParameters<typeof RealDraftService>[1];
+type ValidationArg = ConstructorParameters<typeof RealDraftService>[2];
+type JobArg = ConstructorParameters<typeof RealDeploymentService>[1];
+
+const EMOJI_ICON = '🖥️';
+const LOGO_ICON = 'https://raw.githubusercontent.com/try-hola/apps/main/icons/remo.svg';
+
+/** Catalog whose icon can change between installs, as a real one does when a package ships a logo. */
+function makeCatalog(icon: { current: string }): CatalogArg {
+  return {
+    getApp: async (appId: string) => ({ id: appId, name: 'Remo', icon: icon.current }),
+    getVersionDetail: async () => ({
+      defaultEnv: [],
+      defaults: { ports: [{ container: 8080, protocol: 'tcp' as const }], volumes: [] },
+    }),
+  } as unknown as CatalogArg;
+}
+
+function makeValidation(): ValidationArg {
+  return {
+    validateDraft: async () => ({ ok: true, errors: [], warnings: [] }),
+    preflightCheck: async () => ({ ok: true, checks: [] }),
+  } as unknown as ValidationArg;
+}
+
+function makeJobs(): JobArg {
+  const jobs: Array<{ id: string; type: string; status: string; startedAt: string; deploymentId?: string }> = [];
+  return {
+    createJob: async (p: { type: string; deploymentId?: string }) => {
+      const job = { id: crypto.randomUUID(), type: p.type, status: 'queued', startedAt: new Date().toISOString(), deploymentId: p.deploymentId };
+      jobs.push(job);
+      return job;
+    },
+    listJobs: async () => jobs,
+    cancelJob: async () => {},
+    getJob: async () => null,
+    onJobUpdate: () => ({ unsubscribe() {} }),
+    setExecutor: () => {},
+    healthCheck: async () => ({ healthy: true, lastCheck: new Date() }),
+  } as unknown as JobArg;
+}
+
+const noDocker = {} as unknown as DockerService;
+type LoggingArg = ConstructorParameters<typeof RealDeploymentService>[5];
+const noLogging = {
+  log: async () => {},
+  onLog: () => ({ unsubscribe() {} }),
+  logJob: async () => {},
+  logDeployment: async () => {},
+  healthCheck: async () => ({ healthy: true, lastCheck: new Date() }),
+} as unknown as LoggingArg;
+
+describe('promote refreshes the cached catalog icon', () => {
+  let dataRoot: string;
+  const icon = { current: EMOJI_ICON };
+
+  beforeEach(async () => {
+    dataRoot = await mkdtemp(join(tmpdir(), 'hola-promote-icon-'));
+    icon.current = EMOJI_ICON;
+  });
+  afterEach(async () => {
+    await rm(dataRoot, { recursive: true, force: true });
+  });
+
+  function makeSystem() {
+    const storage = new RealStorageService({ holaDir: dataRoot });
+    const drafts = new RealDraftService(storage, makeCatalog(icon), makeValidation());
+    const routing = new RealRoutingService(storage, { baseDomain: 'local.hola' });
+    const deployments = new RealDeploymentService(storage, makeJobs(), noDocker, drafts, routing, noLogging, new MockProvisionerService());
+    return { drafts, deployments };
+  }
+
+  async function finalizedDraft(drafts: RealDraftService, version: string): Promise<string> {
+    const { draftId } = await drafts.createDraft({ appId: 'remo', version });
+    await drafts.updateDraft(draftId, { composeOverride: 'services:\n  remo-web:\n    image: remo-web:' + version + '\n' });
+    await drafts.finalizeDraft(draftId);
+    return draftId;
+  }
+
+  test('picks up a new catalog logo on upgrade, and bumps the version with it', async () => {
+    const { deployments, drafts } = makeSystem();
+
+    const dep = await deployments.createFromDraft({
+      draftId: await finalizedDraft(drafts, '0.4.6'), name: 'remo', options: { autoStart: false },
+    });
+    expect((await deployments.getDeployment(dep.deploymentId)).icon).toBe(EMOJI_ICON);
+
+    // The catalog package swaps its emoji for a real logo and cuts a new version.
+    icon.current = LOGO_ICON;
+    await deployments.promote(dep.deploymentId, {
+      draftId: await finalizedDraft(drafts, '0.5.0'), options: { autoStart: false },
+    });
+
+    const after = await deployments.getDeployment(dep.deploymentId);
+    expect(after.icon).toBe(LOGO_ICON);
+    expect(after.version).toBe('0.5.0');
+  });
+
+  test('leaves an operator-chosen deployment name alone', async () => {
+    const { deployments, drafts } = makeSystem();
+
+    const dep = await deployments.createFromDraft({
+      draftId: await finalizedDraft(drafts, '0.4.6'), name: 'my-terminal', options: { autoStart: false },
+    });
+
+    icon.current = LOGO_ICON;
+    await deployments.promote(dep.deploymentId, {
+      draftId: await finalizedDraft(drafts, '0.5.0'), options: { autoStart: false },
+    });
+
+    const after = await deployments.getDeployment(dep.deploymentId);
+    expect(after.name).toBe('my-terminal'); // not overwritten by the manifest's "Remo"
+    expect(after.icon).toBe(LOGO_ICON); // …but the icon still refreshes
+  });
+
+  test('an unchanged icon survives a promote (no spurious rewrite)', async () => {
+    const { deployments, drafts } = makeSystem();
+
+    const dep = await deployments.createFromDraft({
+      draftId: await finalizedDraft(drafts, '0.4.6'), name: 'remo', options: { autoStart: false },
+    });
+    await deployments.promote(dep.deploymentId, {
+      draftId: await finalizedDraft(drafts, '0.5.0'), options: { autoStart: false },
+    });
+
+    const after = await deployments.getDeployment(dep.deploymentId);
+    expect(after.icon).toBe(EMOJI_ICON);
+    expect(after.version).toBe('0.5.0');
+  });
+});

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -676,14 +676,33 @@ abstract class InMemoryDeploymentService implements DeploymentService {
     // Atomically switch the active release to the new one.
     await this.promoteRelease(deploymentId, releaseId);
 
-    // Sync the deployment's displayed version to the promoted release. promoteRelease
-    // only moves the release pointers (it's shared with rollback and the Release type
-    // carries no version); without this the record (and the UI's "update available")
-    // would still report the pre-upgrade version after a successful promote.
-    if (version) {
+    // Sync the deployment's catalog-derived display fields to the promoted release.
+    // promoteRelease only moves the release pointers (it's shared with rollback and
+    // the Release type carries no version); without this the record (and the UI's
+    // "update available") would still report the pre-upgrade version after a
+    // successful promote.
+    //
+    // The icon rides along for the same reason: it's persisted at install
+    // (createFromDraft) purely as a cache so the launcher needn't hit the catalog,
+    // so an app whose package changes its logo would otherwise show the icon it had
+    // on install day forever. We've just resolved the new manifest, so it's free.
+    //
+    // `name` is deliberately NOT refreshed — a caller-supplied name wins at install
+    // and the record can't distinguish one from a manifest-derived default, so
+    // rewriting it here would clobber an operator's rename.
+    const promotedIcon = artifacts?.manifest.icon;
+    if (version || promotedIcon) {
       const promoted = this.requireDeployment(deploymentId);
-      if (promoted.version !== version) {
+      let changed = false;
+      if (version && promoted.version !== version) {
         promoted.version = version;
+        changed = true;
+      }
+      if (promotedIcon && promoted.icon !== promotedIcon) {
+        promoted.icon = promotedIcon;
+        changed = true;
+      }
+      if (changed) {
         this.deployments.set(deploymentId, promoted);
         await this.persistDeployment(promoted);
       }


### PR DESCRIPTION
## The bug

`icon` is persisted onto the deployment record at install so the launcher can render
a tile without a live catalog lookup:

```ts
// deployment.ts:575 — createFromDraft
icon: artifacts?.manifest.icon || '📦',
```

Nothing ever refreshed it. `promote` — the upgrade path — synced `version` onto the
record but not `icon`, so **an app whose catalog package changed its logo kept the
icon it had on install day forever**, upgrade or no upgrade. Only the Catalog page
showed the new one, because it reads catalog data live.

Surfaced by shipping logos for the `remo` and `webtop` packages (try-hola/apps #111,
#112): every already-installed deployment would have gone on showing `🖥️` no matter
what.

## The fix

Sync the icon in the block that already syncs the version. `promote` resolves the new
manifest anyway for the skip-guard, so the current icon is already in hand — this
costs nothing extra.

**`name` is deliberately excluded.** A caller-supplied name wins at install
(`request.name || manifest.displayName || app`) and the record can't tell one from a
manifest-derived default, so refreshing it would clobber an operator's rename. There's
a test asserting that exclusion.

## Tests

Three cases in `promote-refreshes-icon.test.ts` — icon refreshes on upgrade alongside
the version, an operator-chosen name survives, and an unchanged icon doesn't churn.

Verified they fail without the fix, with exactly the reported symptom:

```
expect(after.icon).toBe(LOGO_ICON)
Expected: "https://raw.githubusercontent.com/try-hola/apps/main/icons/remo.svg"
Received: "🖥️"
```

`typecheck` · `lint` · `test` (552 server + 200 web) · `build` all green.

## Note for operators

This fixes the icon going *forward*, on the next upgrade. It doesn't retroactively
repair records that already cached an old icon — those pick it up when they next
upgrade. Separately, catalog changes take up to 24h to be noticed at all
(`HOLA_CATALOG_REFRESH_INTERVAL_MS`, default 86400000); "Check for updates" on the
Deployments page forces a refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)