### PR TITLE
chore(release): 0.7.7

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/cli": {
       "name": "@hola/cli",
-      "version": "0.7.6",
+      "version": "0.7.7",
       "bin": {
         "hola": "./bin/hola",
       },
@@ -37,11 +37,11 @@
     },
     "packages/compose": {
       "name": "@hola/compose",
-      "version": "0.7.6",
+      "version": "0.7.7",
     },
     "packages/sdk": {
       "name": "@hola/sdk",
-      "version": "0.7.6",
+      "version": "0.7.7",
       "dependencies": {
         "@hola/shared": "workspace:*",
       },
@@ -55,7 +55,7 @@
     },
     "packages/server": {
       "name": "@hola/server",
-      "version": "0.7.6",
+      "version": "0.7.7",
       "dependencies": {
         "@hola/shared": "workspace:*",
         "jose": "^5.9.6",
@@ -71,7 +71,7 @@
     },
     "packages/shared": {
       "name": "@hola/shared",
-      "version": "0.7.6",
+      "version": "0.7.7",
       "dependencies": {
         "yaml": "^2.9.0",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.7.6';
+export const CLI_VERSION = '0.7.7';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Patch release. Bumps `cli`, `server`, `shared`, `sdk`, `compose` to **0.7.7** (plus
`packages/cli/src/version.ts` and `bun.lock`); `web` stays unversioned at `0.0.0` as
usual.

Covers the four commits since `cli-v0.7.6`:

| PR | |
|---|---|
| #364 | **fix(server): refresh the deployment's cached icon on upgrade** — the only user-facing change |
| #363 | refactor(web): remove the unrouted performance demo + its two hooks |
| #362 | refactor(web): remove the unreachable catalog app-detail modal |
| #361 | ci(release): anchor the auto-changelog at the last stable release |

### What #364 means for operators

An installed deployment caches its catalog icon at install time and nothing refreshed
it, so an app that changed its logo upstream kept the old one indefinitely. `promote`
now syncs the icon alongside the version.

This applies **going forward, on upgrade** — it does not retroactively repair records
that already cached an old icon. Those pick it up the next time they're upgraded.
(Deliberate: refreshing outside the upgrade path is a larger change and wasn't wanted
here.)

Relevant right now for `remo` (0.5.0) and `webtop` (1.1.1) in the catalog, which both
gained real logos — upgrading them on 0.7.7 will pull the new icons through.

`typecheck` · `lint` · `test` (552 server + 200 web) · `build` all green.

Tag `cli-v0.7.7` follows on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)