### PR TITLE
feat(web): show installed apps as installed in the catalog

### DIFF
--- a/packages/web/src/__tests__/pages/Catalog.test.tsx
+++ b/packages/web/src/__tests__/pages/Catalog.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import { Catalog } from '../../pages/Catalog';
 import { globalCache } from '../../utils/cache';
@@ -16,15 +17,18 @@ afterEach(() => {
   global.fetch = originalFetch;
 });
 
-function mockCatalog(apps: unknown[]) {
+const page = (items: unknown[]) => ({ items, page: 1, limit: 100, total: items.length });
+
+function mockApi(apps: unknown[], deployments: unknown[] = []) {
   global.fetch = vi.fn(async (input: RequestInfo | URL) => {
     const url = String(input);
-    if (url.includes('/api/catalog/apps')) {
-      return new Response(JSON.stringify({ items: apps, page: 1, limit: 100, total: apps.length }), {
-        status: 200, headers: { 'Content-Type': 'application/json' },
-      });
-    }
-    return new Response('Not Found', { status: 404 });
+    const body = url.includes('/api/catalog/apps')
+      ? page(apps)
+      : url.includes('/api/deployments')
+        ? page(deployments)
+        : null;
+    if (!body) return new Response('Not Found', { status: 404 });
+    return new Response(JSON.stringify(body), { status: 200, headers: { 'Content-Type': 'application/json' } });
   }) as unknown as typeof fetch;
 }
 
@@ -34,14 +38,31 @@ const app = (over: Record<string, unknown> = {}) => ({
   rating: 5, downloads: 0, featured: false, source: 'hola', trust: 'official', ...over,
 });
 
+const deployment = (over: Record<string, unknown> = {}) => ({
+  id: 'webtop-ab12cd34', name: 'Ubuntu Webtop', app: 'webtop', icon: '🖥️',
+  status: 'running', ports: [], lastUpdated: 'now', ...over,
+});
+
+// Catalog now reads the deployments list (TanStack Query) to tell installed apps apart.
+const renderCatalog = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter><Catalog /></MemoryRouter>
+    </QueryClientProvider>
+  );
+};
+
 describe('Catalog', () => {
   it('renders catalog cards that link straight into the install wizard', async () => {
-    mockCatalog([app()]);
+    mockApi([app()]);
 
-    render(<MemoryRouter><Catalog /></MemoryRouter>);
+    renderCatalog();
 
     expect(await screen.findByText('Ubuntu Webtop')).toBeInTheDocument();
     expect(screen.getByText('Ubuntu desktop in your browser')).toBeInTheDocument();
+    const install = screen.getByRole('link', { name: /install/i });
+    expect(install).toHaveAttribute('href', '/catalog/webtop/install');
   });
 
   it('renders an image icon as a logo, never as literal URL text', async () => {
@@ -49,13 +70,68 @@ describe('Catalog', () => {
     // interpolates `app.icon` directly prints the raw URL for the URL-icon apps
     // that make up most of the catalog.
     const iconUrl = 'https://raw.githubusercontent.com/try-hola/apps/main/icons/webtop.svg';
-    mockCatalog([app({ icon: iconUrl })]);
+    mockApi([app({ icon: iconUrl })]);
 
-    render(<MemoryRouter><Catalog /></MemoryRouter>);
+    renderCatalog();
 
     await waitFor(() => expect(screen.getByText('Ubuntu Webtop')).toBeInTheDocument());
     expect(screen.queryByText(iconUrl)).not.toBeInTheDocument();
     const img = screen.getByAltText('Ubuntu Webtop icon') as HTMLImageElement;
     expect(img.src).toBe(iconUrl);
+  });
+
+  describe('already-installed apps', () => {
+    it('replaces Install with an Installed marker and a link to the deployment', async () => {
+      mockApi([app()], [deployment()]);
+
+      renderCatalog();
+
+      await waitFor(() => expect(screen.getByText('Installed')).toBeInTheDocument());
+      // No install affordance survives — the app is already here.
+      expect(screen.queryByRole('link', { name: /install/i })).not.toBeInTheDocument();
+      expect(screen.getByRole('link', { name: /manage/i }))
+        .toHaveAttribute('href', '/deployments/webtop-ab12cd34');
+    });
+
+    it('counts a non-running deployment as installed', async () => {
+      // The Traefik host is owned by app name regardless of status, so a stopped
+      // or errored deployment still blocks a second install server-side.
+      mockApi([app()], [deployment({ status: 'stopped' })]);
+
+      renderCatalog();
+
+      await waitFor(() => expect(screen.getByText('Installed')).toBeInTheDocument());
+      expect(screen.queryByRole('link', { name: /install/i })).not.toBeInTheDocument();
+    });
+
+    it('leaves other apps installable', async () => {
+      mockApi([app(), app({ id: 'remo', name: 'Remo', description: 'Browser terminal' })], [deployment()]);
+
+      renderCatalog();
+
+      await waitFor(() => expect(screen.getByText('Remo')).toBeInTheDocument());
+      // webtop is installed; remo is not, so exactly one Install link remains.
+      const installs = screen.getAllByRole('link', { name: /install/i });
+      expect(installs).toHaveLength(1);
+      expect(installs[0]).toHaveAttribute('href', '/catalog/remo/install');
+    });
+
+    it('still offers Install when the deployments list is unavailable', async () => {
+      // Non-fatal degradation: /api/deployments 404s, so nothing is known to be
+      // installed and the catalog behaves as it did before this feature.
+      global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes('/api/catalog/apps')) {
+          return new Response(JSON.stringify(page([app()])), { status: 200, headers: { 'Content-Type': 'application/json' } });
+        }
+        return new Response('Not Found', { status: 404 });
+      }) as unknown as typeof fetch;
+
+      renderCatalog();
+
+      await waitFor(() => expect(screen.getByText('Ubuntu Webtop')).toBeInTheDocument());
+      expect(screen.getByRole('link', { name: /install/i })).toBeInTheDocument();
+      expect(screen.queryByText('Installed')).not.toBeInTheDocument();
+    });
   });
 });

--- a/packages/web/src/pages/Catalog.tsx
+++ b/packages/web/src/pages/Catalog.tsx
@@ -9,18 +9,26 @@ import {
   AlertCircle,
   Terminal,
   X,
+  Check,
 } from 'lucide-react';
 import type {
   CatalogApp,
   GetCatalogAppsRequest,
+  GetDeploymentsRequest,
   RegistryCredentialRecord,
 } from '@hola/shared';
 import { useCatalogAppsApi } from '../hooks/useCatalogApi';
+import { useDeploymentsApi } from '../hooks/useDeploymentsApi';
 import { AppIcon } from '../components/ui/AppIcon';
 import { api } from '../utils/api-hybrid';
 import { globalCache } from '../utils/cache';
 
 const categories = ['All', 'Productivity', 'Home Automation', 'Media', 'Monitoring', 'Security', 'Database', 'Infrastructure', 'Networking'];
+
+// Installed apps are read off the deployments list so the catalog can hide the
+// install path for something that's already here. One page is plenty — a host
+// runs tens of apps, not hundreds.
+const DEPLOYMENTS_PARAMS: GetDeploymentsRequest = { page: 1, limit: 100, status: 'all' };
 
 /**
  * Modal to install a package straight from an OCI reference (the escape hatch for
@@ -127,6 +135,9 @@ export const Catalog: React.FC = () => {
 
   // Use API hook for catalog apps
   const { data: appsData, loading, error, refetch } = useCatalogAppsApi(apiParams);
+  // Failure here is non-fatal: no deployments data just means every card falls
+  // back to offering an install, which is the pre-existing behaviour.
+  const { data: deploymentsData } = useDeploymentsApi(DEPLOYMENTS_PARAMS);
 
   const handleRefresh = async () => {
     setRefreshing(true);
@@ -161,6 +172,25 @@ export const Catalog: React.FC = () => {
   
   // Calculate featured apps
   const featuredApps = useMemo(() => apps.filter(app => app.featured), [apps]);
+
+  // Map catalog app id -> the deployment already installed for it, so a card can
+  // offer "manage" instead of a second install. Every status counts, not just
+  // running: the server derives an app's Traefik host from its *app name*
+  // (routing.ts generateRule), so any existing deployment owns that host and a
+  // second install is rejected as a ConflictError regardless of whether it's up.
+  //
+  // Matching is on bare app id because DeploymentListItem carries no `source`
+  // (source lives on the detail record's metadata). An app id present in two
+  // catalog sources therefore reads as installed in both — acceptable while a
+  // second install is impossible anyway, and it goes away with multi-instance
+  // support (see the follow-up issue).
+  const installedByApp = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const d of deploymentsData?.items ?? []) {
+      if (!m.has(d.app)) m.set(d.app, d.id);
+    }
+    return m;
+  }, [deploymentsData?.items]);
 
   // Update URL params when filters change
   useEffect(() => {
@@ -300,10 +330,16 @@ export const Catalog: React.FC = () => {
             {apps.map((app: CatalogApp) => {
               const custom = app.source && app.source !== 'hola';
               const installTo = `/catalog/${app.id}/install${custom ? `?source=${app.source}` : ''}`;
+              // An installed app has no install path — the card manages the
+              // existing deployment instead. Apps that support running more than
+              // one instance would offer "Add" here; nothing does yet (see the
+              // multi-instance follow-up), so installed always means manage.
+              const installedId = installedByApp.get(app.id);
+              const goTo = installedId ? `/deployments/${installedId}` : installTo;
               return (
                 <div
                   key={`${app.source}/${app.id}`}
-                  onClick={() => navigate(installTo)}
+                  onClick={() => navigate(goTo)}
                   className="bg-surface-1 border border-border rounded-card p-[18px] flex flex-col cursor-pointer transition hover:border-primary hover:-translate-y-[2px]"
                 >
                   <div className="flex items-start gap-[13px] mb-[13px]">
@@ -337,14 +373,30 @@ export const Catalog: React.FC = () => {
                       {app.rating}
                     </span>
                     <div className="flex-1" />
-                    <Link
-                      to={installTo}
-                      onClick={(e) => e.stopPropagation()}
-                      className="h-[34px] px-[14px] flex items-center gap-[6px] bg-primary-weak text-primary rounded-lg text-[13px] font-semibold hover:bg-primary hover:text-white transition"
-                    >
-                      <Plus className="w-4 h-4" />
-                      Install
-                    </Link>
+                    {installedId ? (
+                      <>
+                        <span className="inline-flex items-center gap-1.5 text-[12px] text-text-muted font-medium">
+                          <Check className="w-3.5 h-3.5 text-success" />
+                          Installed
+                        </span>
+                        <Link
+                          to={goTo}
+                          onClick={(e) => e.stopPropagation()}
+                          className="h-[34px] px-[14px] flex items-center gap-[6px] bg-surface-2 text-text-strong border border-border rounded-lg text-[13px] font-semibold hover:border-primary transition-colors"
+                        >
+                          Manage
+                        </Link>
+                      </>
+                    ) : (
+                      <Link
+                        to={installTo}
+                        onClick={(e) => e.stopPropagation()}
+                        className="h-[34px] px-[14px] flex items-center gap-[6px] bg-primary-weak text-primary rounded-lg text-[13px] font-semibold hover:bg-primary hover:text-white transition"
+                      >
+                        <Plus className="w-4 h-4" />
+                        Install
+                      </Link>
+                    )}
                   </div>
                 </div>
               );


### PR DESCRIPTION
An app that's already installed still rendered a full Install affordance in the catalog —
a path that could only ever fail. The server derives an app's Traefik host from its **app
name**, not the deployment id (`routing.ts:98`), so `onBeforeCreate` rejects a second
deployment of the same app with a `ConflictError`. The UI was offering something the
server refuses.

## What changed

The card reads the deployments list and, for an app already present, swaps the Install
link for an **"Installed"** marker plus a **Manage** link to the deployment.

The card's own `onClick` moves with it. That mattered: the whole card was a click target
into the install wizard, so removing only the button would have left the install path one
click away and made the change cosmetic.

## Decisions worth reviewing

- **Every status counts as installed**, not just `running`. The Traefik host is owned by
  any existing deployment, so a stopped or errored one still blocks a second install.
  Showing "Install" for a stopped app would be a lie.
- **Degrades quietly.** If `/api/deployments` fails, nothing is known to be installed and
  every card offers Install — exactly the pre-existing behaviour. The catalog doesn't
  become unusable because a second endpoint is down.
- **Matching is on bare app id.** `DeploymentListItem` carries no `source` (it lives on the
  detail record's metadata), so the same app id in two catalog sources reads as installed
  in both. Harmless while a second install is impossible; noted in #366.
- **No "Add" button.** The multi-instance half of the request needs per-instance hostnames
  and a manifest flag that can't currently reach the catalog listing — filed as **#366**
  with the full analysis. The card already branches on `installedId`, so "Add" drops in as
  a third case once that lands.

## Tests

Four new cases (6 total in the file): the Installed/Manage swap, a non-running deployment
still counting as installed, other apps staying installable, and graceful degradation when
the deployments fetch fails.

Mutation-verified — forcing `installedId` to `undefined` fails 3 of them, so they're real
guards rather than tests that pass regardless.

`typecheck` · `lint` · `test` (552 server + 204 web) · `build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)