### PR TITLE
fix(server): surface blocked/failed bundle pulls instead of swallowing them

### DIFF
--- a/packages/server/src/__tests__/catalog/catalog-sources.test.ts
+++ b/packages/server/src/__tests__/catalog/catalog-sources.test.ts
@@ -103,4 +103,79 @@ describe('RealCatalogSourceService allowRegistries (persistence + validation)', 
     const rec = await svc.add({ id: 'acme', name: 'Acme', url: CATALOG });
     expect(rec.allowRegistries).toBeUndefined();
   });
+
+  describe('update', () => {
+    test('adds allowRegistries to an existing source without delete-and-re-add', async () => {
+      // The motivating case: a source was added without allowRegistries, its
+      // pulls fail REF_NOT_ALLOWED, and the fix must not require recreating it.
+      const holaDir = await mkdtemp(join(tmpdir(), 'hola-src-update-'));
+      dirs.push(holaDir);
+      const storage = new RealStorageService({ holaDir });
+      const svc = new RealCatalogSourceService(storage);
+      await svc.add({ id: 'pofallon', name: 'Pofallon', url: CATALOG });
+
+      const updated = await svc.update('pofallon', { allowRegistries: ['ghcr.io/pofallon/*'] });
+      expect(updated.allowRegistries).toEqual(['ghcr.io/pofallon/*']);
+
+      // Untouched fields survive, and it persists across instances.
+      expect(updated).toMatchObject({ id: 'pofallon', name: 'Pofallon', url: CATALOG, trust: 'custom', enabled: true });
+      expect((await new RealCatalogSourceService(storage).get('pofallon'))?.allowRegistries).toEqual(['ghcr.io/pofallon/*']);
+    });
+
+    test('patches only the supplied fields, and clears with empty array / null', async () => {
+      const holaDir = await mkdtemp(join(tmpdir(), 'hola-src-update2-'));
+      dirs.push(holaDir);
+      const svc = new RealCatalogSourceService(new RealStorageService({ holaDir }));
+      await svc.add({
+        id: 'acme', name: 'Acme', url: CATALOG,
+        allowRegistries: ['ghcr.io/acme/*'], auth: { registry: 'ghcr.io', credentialRef: 'acme-bot' },
+      });
+
+      const renamed = await svc.update('acme', { name: 'Acme Corp' });
+      expect(renamed.name).toBe('Acme Corp');
+      expect(renamed.url).toBe(CATALOG); // untouched
+      expect(renamed.allowRegistries).toEqual(['ghcr.io/acme/*']); // untouched
+      expect(renamed.auth).toEqual({ registry: 'ghcr.io', credentialRef: 'acme-bot' }); // untouched
+
+      expect((await svc.update('acme', { allowRegistries: [] })).allowRegistries).toBeUndefined();
+      expect((await svc.update('acme', { auth: null })).auth).toBeUndefined();
+      expect((await svc.update('acme', { enabled: false })).enabled).toBe(false);
+    });
+
+    test('applies the same validation as add, and refuses unknown/reserved ids', async () => {
+      const holaDir = await mkdtemp(join(tmpdir(), 'hola-src-update3-'));
+      dirs.push(holaDir);
+      const svc = new RealCatalogSourceService(new RealStorageService({ holaDir }));
+      await svc.add({ id: 'acme', name: 'Acme', url: CATALOG });
+
+      // A patch must not be able to write a record `add` would have rejected.
+      await expect(svc.update('acme', { url: 'ftp://nope' })).rejects.toThrow('SOURCE_URL_INVALID');
+      await expect(svc.update('acme', { allowRegistries: ['ghcr io/x/*'] })).rejects.toThrow('SOURCE_ALLOW_REGISTRY_INVALID');
+      await expect(svc.update('acme', { auth: { registry: 'ghcr.io', credentialRef: '' } })).rejects.toThrow('SOURCE_AUTH_INVALID');
+
+      await expect(svc.update('nope', { name: 'x' })).rejects.toThrow('SOURCE_NOT_FOUND');
+      // The built-in source is synthesized from env — there's nothing to patch.
+      await expect(svc.update('hola', { name: 'x' })).rejects.toThrow('SOURCE_ID_RESERVED');
+    });
+  });
+
+  test('a corrupt source store fails loudly instead of silently wiping every source', async () => {
+    // loadCustom used to return [] on a parse failure. add()/update() are
+    // read-modify-write over that result, so the next write would have persisted
+    // an empty list — destroying every configured source on a transient read error.
+    const holaDir = await mkdtemp(join(tmpdir(), 'hola-src-corrupt-'));
+    dirs.push(holaDir);
+    const storage = new RealStorageService({ holaDir });
+    const svc = new RealCatalogSourceService(storage);
+    await svc.add({ id: 'acme', name: 'Acme', url: CATALOG });
+
+    await storage.writeFile('config/catalog-sources.json', '{ this is not json');
+
+    await expect(svc.list()).rejects.toThrow(/unreadable or corrupt/);
+    await expect(svc.add({ id: 'other', name: 'Other', url: CATALOG })).rejects.toThrow(/unreadable or corrupt/);
+    expect((await svc.healthCheck()).healthy).toBe(false);
+
+    // Critically, the bad add did NOT overwrite the store with an empty list.
+    expect(await storage.readFileAsString('config/catalog-sources.json')).toBe('{ this is not json');
+  });
 });

--- a/packages/server/src/__tests__/drafts/bundle-failure-surfaces.test.ts
+++ b/packages/server/src/__tests__/drafts/bundle-failure-surfaces.test.ts
@@ -1,0 +1,109 @@
+/**
+ * A blocked/failed bundle pull must fail draft creation with the REAL reason.
+ *
+ * Regression for the reported bug: adding a custom catalog source without
+ * `allowRegistries` and installing from it produced a draft anyway. The
+ * REF_NOT_ALLOWED thrown by the allowlist was swallowed by getDraftDefaults'
+ * blanket catch, which substituted placeholder defaults (APP_PORT=8080, ports
+ * 8080:80, no defaultEnv, empty composeOverride). That bogus draft finalized,
+ * a release was cut with no compose, and the operator's first sign of trouble
+ * was the deploy job failing with "Active release has no compose file" —
+ * nine seconds after the real cause had been logged as a WARN.
+ *
+ * The rule: only "this app has no bundle" (BundleUnavailableError) may fall
+ * back. Every hard failure (blocked registry, denied/unreachable pull, bad
+ * credential, malformed bundle) propagates.
+ */
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { RealDraftService } from '../../services/core/draft';
+import { RealStorageService } from '../../services/core/storage';
+import { BundleError, BundleUnavailableError } from '../../middleware/error-mapping';
+
+type CatalogArg = ConstructorParameters<typeof RealDraftService>[1];
+type ValidationArg = ConstructorParameters<typeof RealDraftService>[2];
+
+const APP = { id: 'get2know-cms', name: 'get2know CMS', icon: '📝' };
+
+/** Catalog whose getVersionDetail fails the way the reported install did. */
+function makeCatalog(failure: unknown): CatalogArg {
+  return {
+    getApp: async () => APP,
+    getVersionDetail: async () => { throw failure; },
+  } as unknown as CatalogArg;
+}
+
+function makeValidation(): ValidationArg {
+  return {
+    validateDraft: async () => ({ ok: true, errors: [], warnings: [] }),
+    preflightCheck: async () => ({ ok: true, checks: [] }),
+  } as unknown as ValidationArg;
+}
+
+describe('bundle pull failures surface at draft creation', () => {
+  let dataRoot: string;
+
+  beforeEach(async () => { dataRoot = await mkdtemp(join(tmpdir(), 'hola-bundlefail-')); });
+  afterEach(async () => { await rm(dataRoot, { recursive: true, force: true }); });
+
+  const makeDrafts = (failure: unknown) =>
+    new RealDraftService(new RealStorageService({ holaDir: dataRoot }), makeCatalog(failure), makeValidation());
+
+  test('a blocked registry fails the install instead of producing a placeholder draft', async () => {
+    const blocked = new BundleError(
+      'REF_NOT_ALLOWED',
+      'REF_NOT_ALLOWED: ghcr.io/pofallon/hola-get2know-cms:0.1.13 is not covered by the registry allowlist (ghcr.io/try-hola/*).',
+      { status: 403 },
+    );
+    const drafts = makeDrafts(blocked);
+
+    let err: unknown;
+    try {
+      await drafts.createDraft({ appId: 'get2know-cms', version: '0.1.13', source: 'pofallon' });
+    } catch (e) { err = e; }
+
+    // The real reason reaches the caller, naming the ref and the allowlist.
+    expect(err).toBeInstanceOf(BundleError);
+    expect((err as BundleError).code).toBe('REF_NOT_ALLOWED');
+    expect((err as BundleError).status).toBe(403);
+    expect((err as Error).message).toContain('hola-get2know-cms:0.1.13');
+    expect((err as Error).message).toContain('allowlist');
+  });
+
+  test.each([
+    ['ORAS_PULL_FAILED', new BundleError('ORAS_PULL_FAILED', 'ORAS_PULL_FAILED: could not pull x: 401 Unauthorized')],
+    ['CREDENTIAL_NOT_FOUND', new BundleError('CREDENTIAL_NOT_FOUND', 'CREDENTIAL_NOT_FOUND: gone', { status: 400 })],
+    ['INVALID_BUNDLE_LAYOUT', new BundleError('INVALID_BUNDLE_LAYOUT', 'INVALID_BUNDLE_LAYOUT: no manifest.json', { status: 422 })],
+    ['MANIFEST_UNAVAILABLE', new BundleError('MANIFEST_UNAVAILABLE', 'MANIFEST_UNAVAILABLE: bad json', { status: 422 })],
+    ['SIGNATURE_VERIFICATION_FAILED', new BundleError('SIGNATURE_VERIFICATION_FAILED', 'SIGNATURE_VERIFICATION_FAILED: x')],
+  ])('%s propagates rather than falling back', async (_label, failure) => {
+    const drafts = makeDrafts(failure);
+    await expect(
+      drafts.createDraft({ appId: 'get2know-cms', source: 'pofallon' }),
+    ).rejects.toBeInstanceOf(BundleError);
+  });
+
+  test('an unexpected error still propagates — the fallback is opt-in, not default', async () => {
+    // Anything not explicitly marked "no bundle here" is treated as a hard
+    // failure. A new failure mode added later fails loudly by default.
+    const drafts = makeDrafts(new Error('something nobody anticipated'));
+    await expect(
+      drafts.createDraft({ appId: 'get2know-cms', source: 'pofallon' }),
+    ).rejects.toThrow('something nobody anticipated');
+  });
+
+  test('a genuinely bundle-less app still falls back to generic defaults', async () => {
+    // The legitimate case this catch existed for: no OCI ref / unpublished
+    // version, where the operator supplies their own compose. Must keep working.
+    const drafts = makeDrafts(new BundleUnavailableError('NO_OCI_REF: get2know-cms@1.0.0', 'NO_OCI_REF'));
+
+    const res = await drafts.createDraft({ appId: 'get2know-cms', source: 'pofallon' });
+
+    expect(res.draftId).toBeTruthy();
+    expect(res.appEnv.map(e => e.key)).toContain('APP_PORT');
+    expect(res.defaults.ports).toEqual([{ host: 8080, container: 80, protocol: 'tcp' }]);
+  });
+});

--- a/packages/server/src/middleware/error-mapping.ts
+++ b/packages/server/src/middleware/error-mapping.ts
@@ -72,6 +72,50 @@ export function asPromoteValidationError(err: unknown): unknown {
   return err;
 }
 
+/**
+ * A bundle (OCI package) exists but could not be fetched or is unusable: a
+ * registry outside the allowlist, a failed or denied pull, an unverifiable
+ * signature, an unresolvable credential, or a malformed layout.
+ *
+ * These are HARD failures. They must reach the operator with the real reason —
+ * never be papered over with placeholder defaults, which is how a blocked pull
+ * used to reappear much later as "Active release has no compose file". Callers
+ * discriminate on the CLASS (not the message), so the `code` is free to gain
+ * detail without breaking them.
+ */
+export class BundleError extends Error implements ApiError {
+  status: number;
+  details?: unknown;
+
+  constructor(public code: string, message: string, opts?: { status?: number; details?: unknown; cause?: unknown }) {
+    super(message, opts && 'cause' in opts ? { cause: opts.cause } : undefined);
+    this.name = 'BundleError';
+    // 502 by default: the failure is upstream (a registry we proxy to), not the
+    // operator's request. Individual sites override (403 blocked, 422 malformed).
+    this.status = opts?.status ?? 502;
+    this.details = opts?.details;
+  }
+}
+
+/**
+ * No bundle exists for this app/version at all — the catalog entry carries no
+ * OCI ref, or the version isn't published.
+ *
+ * This is the one SOFT outcome: it's the legitimate install-from-ref /
+ * bundle-less case where a caller may fall back to generic defaults and let the
+ * operator supply their own compose. Anything else is a `BundleError`.
+ */
+export class BundleUnavailableError extends Error implements ApiError {
+  code: string;
+  status = 404;
+
+  constructor(message: string, code = 'BUNDLE_UNAVAILABLE') {
+    super(message);
+    this.name = 'BundleUnavailableError';
+    this.code = code;
+  }
+}
+
 export class NotFoundError extends Error implements ApiError {
   code = 'NOT_FOUND';
   status = 404;

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -52,6 +52,7 @@ import {
   type InstallFromRefRequest,
   type InstallFromRefResponse,
   type AddCatalogSourceRequest,
+  type UpdateCatalogSourceRequest,
   type ListCatalogSourcesResponse,
   type RefreshCatalogResponse,
 } from '@hola/shared';
@@ -481,7 +482,11 @@ async function route(url: URL, req: Request): Promise<Response> {
       return json(payload);
     } catch (error) {
       logger.warn('Catalog version detail failed', { appId, version, error: error instanceof Error ? error.message : String(error) });
-      return notFound();
+      // A blanket 404 told the operator the version doesn't exist when the real
+      // cause was a blocked registry, a bad credential or an unreachable pull.
+      // BundleUnavailableError still maps to 404 (it genuinely is "not there");
+      // BundleError carries its own status and reason.
+      return errorResponse(req, error);
     }
   }
 
@@ -574,6 +579,25 @@ async function route(url: URL, req: Request): Promise<Response> {
   }
 
   const sourceMatch = pathname.match(/^\/api\/catalog-sources\/([^/]+)$/);
+  // PATCH a source in place. Chiefly so `allowRegistries` can be added after the
+  // fact — the usual fix for a REF_NOT_ALLOWED pull — without delete-and-re-add.
+  if (sourceMatch && (req.method === 'PATCH' || req.method === 'PUT')) {
+    const id = decodeURIComponent(sourceMatch[1]);
+    try {
+      const body = (await req.json().catch(() => ({}))) as UpdateCatalogSourceRequest;
+      const record = await getServices().catalogSources.update(id, body);
+      return json(record);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (message === 'SOURCE_NOT_FOUND') return notFound();
+      const status = message === 'SOURCE_ID_RESERVED' ? 400
+        : message.startsWith('SOURCE_') ? 400
+        : 500;
+      logger.warn('Failed to update catalog source', { id, error: message });
+      return json({ error: { code: 'SOURCE_UPDATE_FAILED', message } }, { status });
+    }
+  }
+
   if (sourceMatch && req.method === 'DELETE') {
     const id = decodeURIComponent(sourceMatch[1]);
     try {
@@ -643,10 +667,12 @@ async function route(url: URL, req: Request): Promise<Response> {
         requestId: context?.requestId,
         appId: body?.appId,
       });
-      return json(
-        { error: { code: 'DRAFT_CREATION_FAILED', message: 'Failed to create draft' } },
-        { status: 500 }
-      );
+      // Surface the real reason. A blanket "Failed to create draft"/500 hid
+      // actionable failures (registry not in the allowlist, bad credential,
+      // unreachable registry) behind a message the operator can do nothing with.
+      // Typed errors map to their own status + code; anything untyped still
+      // lands as a 500, so this only ever adds information.
+      return errorResponse(req, error);
     }
   }
 

--- a/packages/server/src/services/core/bundles.ts
+++ b/packages/server/src/services/core/bundles.ts
@@ -7,6 +7,7 @@ import { getLogger } from '../../lib/logger';
 import { getHolaDataDir } from '../../config/paths';
 import type { ServiceHealth, HealthCheckable } from './types';
 import { catalogConfig } from '../../config/catalog';
+import { BundleError } from '../../middleware/error-mapping';
 import { BundleCacheManager } from './bundle-cache';
 
 const execAsync = promisify(exec);
@@ -160,7 +161,11 @@ export class RealBundleService implements BundleService, HealthCheckable {
         this.logger.debug('ORAS pull output', { stdout: stdout?.slice(0, 500), stderr: stderr?.slice(0, 500) });
       } catch (error) {
         this.logger.error('ORAS pull failed', error as Error, { ref: opts.ociRef });
-        throw new Error('ORAS_PULL_FAILED', { cause: error });
+        // Carry oras's own stderr forward — auth failures (401/403), unreachable
+        // registries and 5xx all arrive here, and the distinction only exists in
+        // that text. Swallowing it leaves the operator with nothing to act on.
+        const detail = error instanceof Error ? error.message : String(error);
+        throw new BundleError('ORAS_PULL_FAILED', `ORAS_PULL_FAILED: could not pull ${opts.ociRef}: ${detail}`, { cause: error });
       } finally {
         if (authDir) { try { rmSync(authDir, { recursive: true, force: true }); } catch { /* best effort */ } }
       }
@@ -171,7 +176,10 @@ export class RealBundleService implements BundleService, HealthCheckable {
         if (catalogConfig.signaturePolicy === 'required' && !verifyResult.verified) {
           this.logger.error('Bundle signature verification failed', undefined, { ref: opts.ociRef, error: verifyResult.error });
           rmSync(dest, { recursive: true, force: true });
-          throw new Error('SIGNATURE_VERIFICATION_FAILED');
+          throw new BundleError(
+            'SIGNATURE_VERIFICATION_FAILED',
+            `SIGNATURE_VERIFICATION_FAILED: ${opts.ociRef}${verifyResult.error ? `: ${verifyResult.error}` : ''}`,
+          );
         } else if (!verifyResult.verified) {
           this.logger.warn('Bundle signature verification failed but policy is optional', { ref: opts.ociRef, error: verifyResult.error });
         }
@@ -306,7 +314,15 @@ export class RealBundleService implements BundleService, HealthCheckable {
     const allowed = [...catalogConfig.registryAllowlist, ...extraAllowed];
     const ok = allowed.some(pattern => matchesAllowlist(pattern, ref));
     if (!ok) {
-      throw new Error(`REF_NOT_ALLOWED: ${ref}`);
+      // Name the allowlist in the message: the operator's fix is either to add
+      // `allowRegistries` to the catalog source or to widen HOLA_REGISTRY_ALLOWLIST,
+      // and neither is guessable from "not allowed" alone.
+      throw new BundleError(
+        'REF_NOT_ALLOWED',
+        `REF_NOT_ALLOWED: ${ref} is not covered by the registry allowlist (${allowed.join(', ') || 'empty'}). ` +
+          `Add the registry to this catalog source's allowRegistries, or to HOLA_REGISTRY_ALLOWLIST.`,
+        { status: 403 },
+      );
     }
   }
 

--- a/packages/server/src/services/core/catalog-sources.ts
+++ b/packages/server/src/services/core/catalog-sources.ts
@@ -15,7 +15,8 @@ import { getLogger } from '../../lib/logger';
 import { catalogConfig } from '../../config/catalog';
 import type { HealthCheckable, ServiceHealth } from './types';
 import type { StorageService } from './storage';
-import type { CatalogSourceRecord, AddCatalogSourceRequest } from '@hola/shared';
+import type { CatalogSourceRecord, AddCatalogSourceRequest, UpdateCatalogSourceRequest } from '@hola/shared';
+import { ServiceError } from '../../middleware/error-mapping';
 
 /** Reserved source ids that a custom source may not use. */
 export const RESERVED_SOURCE_IDS = new Set(['hola', 'ref', '(ref)']);
@@ -64,6 +65,12 @@ export interface CatalogSourceService extends HealthCheckable {
   /** Only the enabled sources (what the catalog aggregator fans out over). */
   listEnabled(): Promise<CatalogSourceRecord[]>;
   add(req: AddCatalogSourceRequest): Promise<CatalogSourceRecord>;
+  /**
+   * Patch a custom source in place. Only the supplied fields change — notably
+   * `allowRegistries`, which otherwise required deleting and re-adding the
+   * source (losing nothing but making a routine fix feel destructive).
+   */
+  update(id: string, req: UpdateCatalogSourceRequest): Promise<CatalogSourceRecord>;
   remove(id: string): Promise<void>;
   /** A single source by id (built-in or custom), or undefined. */
   get(id: string): Promise<CatalogSourceRecord | undefined>;
@@ -110,10 +117,15 @@ export class RealCatalogSourceService implements CatalogSourceService {
       const parsed = JSON.parse(await this.storage.readFileAsString(STORE_PATH)) as SourceFile;
       return Array.isArray(parsed?.sources) ? parsed.sources : [];
     } catch (error) {
-      this.logger.warn('Failed to read catalog sources; treating as empty', {
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return [];
+      // Do NOT substitute an empty list. `fileExists` above already covers "no
+      // sources yet", so reaching here means the file exists but is corrupt or
+      // unreadable — and add()/update() are read-modify-write over this result,
+      // so pretending it's empty would silently DELETE every configured source
+      // on the next write. Fail loudly instead; healthCheck() reports it.
+      this.logger.error('Failed to read catalog sources', error as Error, { path: STORE_PATH });
+      throw new ServiceError(
+        `Catalog source store at ${STORE_PATH} is unreadable or corrupt: ${error instanceof Error ? error.message : String(error)}`,
+      );
     }
   }
 
@@ -162,6 +174,44 @@ export class RealCatalogSourceService implements CatalogSourceService {
     return record;
   }
 
+  async update(id: string, req: UpdateCatalogSourceRequest): Promise<CatalogSourceRecord> {
+    // The built-in `hola` source is synthesized from env at read time, so there's
+    // nothing persisted to patch.
+    if (RESERVED_SOURCE_IDS.has(id)) throw new Error('SOURCE_ID_RESERVED');
+
+    const custom = await this.loadCustom();
+    const idx = custom.findIndex(s => s.id === id);
+    if (idx < 0) throw new Error('SOURCE_NOT_FOUND');
+
+    // Validate before mutating, with the same rules `add` applies — a patch must
+    // not be able to write a record `add` would have rejected.
+    if (req.url !== undefined && !isHttpUrl(req.url)) throw new Error('SOURCE_URL_INVALID');
+    if (req.auth && (!req.auth.registry || !req.auth.credentialRef)) throw new Error('SOURCE_AUTH_INVALID');
+
+    const current = custom[idx];
+    const allowRegistries = req.allowRegistries !== undefined
+      ? normalizeAllowRegistries(req.allowRegistries)
+      : undefined;
+
+    const next: CatalogSourceRecord = {
+      ...current,
+      ...(req.name !== undefined ? { name: req.name.trim() || current.id } : {}),
+      ...(req.url !== undefined ? { url: req.url.trim() } : {}),
+      // `auth: null` clears the credential; omitting it leaves it untouched.
+      ...(req.auth !== undefined ? { auth: req.auth ?? undefined } : {}),
+      // An empty array clears the allowlist (back to the baseline only).
+      ...(allowRegistries !== undefined ? { allowRegistries: allowRegistries.length > 0 ? allowRegistries : undefined } : {}),
+      ...(req.enabled !== undefined ? { enabled: req.enabled } : {}),
+    };
+
+    custom[idx] = next;
+    await this.saveCustom(custom);
+    this.logger.info('Catalog source updated', {
+      id, url: next.url, hasAuth: Boolean(next.auth), allowRegistries: next.allowRegistries ?? [], enabled: next.enabled,
+    });
+    return next;
+  }
+
   async remove(id: string): Promise<void> {
     if (RESERVED_SOURCE_IDS.has(id)) throw new Error('SOURCE_ID_RESERVED');
     const custom = await this.loadCustom();
@@ -200,6 +250,22 @@ export class MockCatalogSourceService implements CatalogSourceService {
     };
     this.custom.push(record);
     return record;
+  }
+  async update(id: string, req: UpdateCatalogSourceRequest): Promise<CatalogSourceRecord> {
+    if (RESERVED_SOURCE_IDS.has(id)) throw new Error('SOURCE_ID_RESERVED');
+    const idx = this.custom.findIndex(s => s.id === id);
+    if (idx < 0) throw new Error('SOURCE_NOT_FOUND');
+    const allowRegistries = req.allowRegistries !== undefined ? normalizeAllowRegistries(req.allowRegistries) : undefined;
+    const next: CatalogSourceRecord = {
+      ...this.custom[idx],
+      ...(req.name !== undefined ? { name: req.name } : {}),
+      ...(req.url !== undefined ? { url: req.url } : {}),
+      ...(req.auth !== undefined ? { auth: req.auth ?? undefined } : {}),
+      ...(allowRegistries !== undefined ? { allowRegistries: allowRegistries.length > 0 ? allowRegistries : undefined } : {}),
+      ...(req.enabled !== undefined ? { enabled: req.enabled } : {}),
+    };
+    this.custom[idx] = next;
+    return next;
   }
   async remove(id: string): Promise<void> {
     if (RESERVED_SOURCE_IDS.has(id)) throw new Error('SOURCE_ID_RESERVED');

--- a/packages/server/src/services/core/catalog.ts
+++ b/packages/server/src/services/core/catalog.ts
@@ -29,6 +29,7 @@ import { coerceConsumes } from './app-registry';
 import { coerceManifestUpgrade } from './manifest-upgrade';
 import { coerceManifestBackup } from './manifest-backup';
 import { validateParamSpec, PARAM_TYPES, GENERATE_KINDS } from '@hola/shared/param-validate';
+import { BundleError, BundleUnavailableError } from '../../middleware/error-mapping';
 
 /**
  * Coerce one raw `manifest.defaultEnv[]` row into an `AppEnvVar`, including the
@@ -425,15 +426,23 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
     const v = (!version || version === 'latest')
       ? pickLatestVersion(versions)
       : versions.find(x => x.version === version);
-    if (!v) throw new Error('VERSION_NOT_FOUND');
+    // Soft: no bundle to fetch. A caller may legitimately fall back to generic
+    // defaults and let the operator supply their own compose.
+    if (!v) throw new BundleUnavailableError(`VERSION_NOT_FOUND: ${appId}@${version}`, 'VERSION_NOT_FOUND');
     const ref = v.refs?.oci;
-    if (!ref) throw new Error('NO_OCI_REF');
+    if (!ref) throw new BundleUnavailableError(`NO_OCI_REF: ${appId}@${v.version}`, 'NO_OCI_REF');
 
     // Resolve the source's stored credential (if any) for a private package pull.
     let credentials: PullCredentials | undefined;
     if (record.auth?.credentialRef) {
       credentials = await (await this.credentialsService()).resolve(record.auth.credentialRef);
-      if (!credentials) throw new Error(`CREDENTIAL_NOT_FOUND: ${record.auth.credentialRef}`);
+      if (!credentials) {
+        throw new BundleError(
+          'CREDENTIAL_NOT_FOUND',
+          `CREDENTIAL_NOT_FOUND: catalog source '${record.id}' references registry credential '${record.auth.credentialRef}', which no longer exists.`,
+          { status: 400 },
+        );
+      }
     }
 
     // Key the cache by the RESOLVED concrete version (`v.version`) + source, so a
@@ -476,7 +485,11 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
     const validation = await bundles.validateLayout(info.localPath);
     if (!validation.ok) {
       this.logger.warn('Bundle layout invalid', { appId: opts.appId, version: opts.version, errors: validation.errors });
-      throw new Error('INVALID_BUNDLE_LAYOUT');
+      throw new BundleError(
+        'INVALID_BUNDLE_LAYOUT',
+        `INVALID_BUNDLE_LAYOUT: ${opts.ociRef}: ${validation.errors.join('; ')}`,
+        { status: 422, details: { errors: validation.errors } },
+      );
     }
     return this.buildDetailFromBundle(info.localPath, opts.version, opts.appId);
   }
@@ -593,7 +606,11 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
       return { ...merged, version, composeOverride, auth, consumes, security, upgrade, backup, ingressService } satisfies GetCatalogAppVersionDetailResponse;
     } catch (error) {
       this.logger.warn('Failed to read or parse bundle manifest', { version, error: error instanceof Error ? error.message : String(error) });
-      throw new Error('MANIFEST_UNAVAILABLE', { cause: error });
+      // Keep the underlying reason in the message, not just the cause: a missing
+      // compose.yaml, malformed manifest.json and a bad env spec are all distinct
+      // operator problems that used to collapse into one opaque string.
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new BundleError('MANIFEST_UNAVAILABLE', `MANIFEST_UNAVAILABLE: ${detail}`, { status: 422, cause: error });
     }
   }
 
@@ -642,11 +659,14 @@ export class MockCatalogService implements CatalogService {
   async getVersions(): Promise<GetCatalogAppVersionsResponse> {
     throw new Error('APP_NOT_FOUND');
   }
+  // Soft, deliberately: the mock catalog is empty, and callers (the draft
+  // service) rely on falling back to generic defaults so test/dev installs work
+  // without a real bundle. A hard BundleError here would break that path.
   async getVersionDetail(): Promise<GetCatalogAppVersionDetailResponse> {
-    throw new Error('VERSION_NOT_FOUND');
+    throw new BundleUnavailableError('VERSION_NOT_FOUND', 'VERSION_NOT_FOUND');
   }
   async getVersionDetailByRef(): Promise<GetCatalogAppVersionDetailResponse & { appId: string }> {
-    throw new Error('VERSION_NOT_FOUND');
+    throw new BundleUnavailableError('VERSION_NOT_FOUND', 'VERSION_NOT_FOUND');
   }
   async refresh(): Promise<Array<{ id: string; name: string; ok: boolean; error?: string }>> { return []; }
 }

--- a/packages/server/src/services/core/draft.ts
+++ b/packages/server/src/services/core/draft.ts
@@ -29,7 +29,7 @@ import type {
 import { createHash } from 'crypto';
 
 import { getLogger } from '../../lib/logger';
-import { NotFoundError, ConflictError, ValidationError, DraftValidationError } from '../../middleware/error-mapping';
+import { NotFoundError, ConflictError, ValidationError, DraftValidationError, BundleUnavailableError } from '../../middleware/error-mapping';
 import { validateComposeDocument, APP_HOST_TOKEN, BASE_DOMAIN_TOKEN } from '@hola/shared/compose-validate';
 import type { HealthCheckable, ServiceHealth } from './types';
 import type { StorageService } from './storage';
@@ -886,7 +886,22 @@ export class RealDraftService implements DraftService {
         resolvedVersion: versionDetail.version,
       };
     } catch (error) {
-      this.logger.warn('Failed to get app defaults, using fallback', { appId, version, error: error instanceof Error ? error.message : String(error) });
+      // Only "this app has no bundle" is a legitimate fallback. Everything else —
+      // a registry outside the allowlist, a denied or unreachable pull, an
+      // unresolvable credential, a malformed bundle — is a hard failure that must
+      // reach the caller NOW.
+      //
+      // This catch used to be unconditional, so a blocked pull produced a draft
+      // built from placeholders (APP_PORT=8080, no defaultEnv, no compose). That
+      // draft finalized cleanly and cut a release with no compose file, and the
+      // operator only saw it as "Active release has no compose file" from the
+      // deploy job seconds later — with the real reason buried in a WARN.
+      if (!(error instanceof BundleUnavailableError)) {
+        this.logger.error('Failed to resolve app defaults from the catalog', error as Error, { appId, version, source });
+        throw error;
+      }
+
+      this.logger.info('No catalog bundle for this app; seeding generic defaults', { appId, version, source, reason: error.code });
 
       // Fallback defaults (no bundle compose available — the user supplies one)
       return {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -514,6 +514,23 @@ export type AddCatalogSourceRequest = {
   enabled?: boolean;
 };
 
+/**
+ * Patch an existing custom catalog source. Every field is optional; only the
+ * ones supplied change. `id`, `type` and `trust` are not patchable — the id is
+ * the key, and the other two are derived.
+ *
+ * Chiefly exists so `allowRegistries` can be added to a source after the fact
+ * (the usual fix for a `REF_NOT_ALLOWED` pull) without deleting and re-adding it.
+ * Pass `allowRegistries: []` to clear it.
+ */
+export type UpdateCatalogSourceRequest = {
+  name?: string;
+  url?: string;
+  auth?: { registry: string; credentialRef: string } | null;
+  allowRegistries?: string[];
+  enabled?: boolean;
+};
+
 export type ListCatalogSourcesResponse = {
   items: CatalogSourceRecord[];
 };


### PR DESCRIPTION
## The bug

`getDraftDefaults` (`draft.ts:888`) caught **every** error from
`catalogService.getVersionDetail` and substituted placeholder defaults —
`APP_PORT=8080`, ports `8080:80`, a `./data` volume, empty `composeOverride`.

So a pull blocked by the registry allowlist produced a draft built from placeholders,
which finalized cleanly and cut a release with `images: []` and no compose file. The
first the operator saw of it was the deploy job failing with **"Active release has no
compose file"** — while the real cause sat 9 seconds earlier in a WARN:

```
warn "Failed to get app defaults, using fallback"
  error: "REF_NOT_ALLOWED: ghcr.io/pofallon/hola-get2know-cms:0.1.13"
```

The allowlist was working correctly. Only the error handling was wrong.

## The fix

Two typed errors, following the existing `ApiError` convention in
`middleware/error-mapping.ts` (per the "prefer typed errors over string matching" note —
the convention was already there, `bundles.ts` just wasn't using it):

| | |
|---|---|
| **`BundleUnavailableError`** (soft, 404) | No bundle for this app/version. The legitimate fallback: operator supplies their own compose. |
| **`BundleError`** (hard, per-site status) | Blocked registry (403), denied/unreachable pull (502), unresolvable credential (400), malformed bundle (422), bad signature. |

`getDraftDefaults` falls back **only** on `BundleUnavailableError`. Everything else
propagates — including error types added later, since the fallback is now opt-in rather
than the default. A new failure mode fails loudly instead of silently.

Callers discriminate on the **class**, not the message. Messages keep their `CODE:`
prefix so existing assertions still match, and now carry what an operator needs: the ref,
the allowlist that rejected it, and oras's own stderr (the only place a 401 is
distinguishable from a network error).

## Making the operator actually see it

Two routes were discarding the reason even once it propagated:

- `POST /api/drafts` returned a hardcoded `'Failed to create draft'` / 500
- `GET /api/catalog/apps/:id/versions/:v` collapsed everything into a bare **404** —
  telling the operator the version doesn't exist when the cause was a blocked registry

Both now go through `errorResponse`, so typed errors carry their own status/code/message
and untyped ones still land as 500. `BundleUnavailableError` still 404s, because there it
genuinely is "not there".

## Catalog source `update()`

Added `update()` + `PATCH`/`PUT /api/catalog-sources/:id`, so `allowRegistries` can be
added to an existing source without delete-and-re-add.

⚠️ **The reported `update()` at `catalog-sources.ts:195` does not exist** — that line is
inside `MockCatalogSourceService.add`, and the interface only has
list/listEnabled/add/remove/get. So this is new code, not a route wired to an existing
method: interface + `Real` + `Mock`. It applies the same validation as `add()`, so a patch
can't write a record `add()` would have rejected.

### A latent data-loss bug found while adding it

`loadCustom()` returned `[]` when the store was corrupt. `add()`/`update()` are
read-modify-write over that result — so **one bad read would have persisted an empty list
and destroyed every configured source.** The `fileExists` guard above it already handles
"no sources yet", so the catch only ever fired on genuine corruption. It now fails loudly;
`healthCheck()` reports it. Test asserts the store is left untouched.

## The wider sweep

You asked whether this pattern exists elsewhere. **It does**, and I deliberately left it
out of this PR — it's mostly in `deployment.ts` and is security-relevant enough to deserve
its own review rather than riding along. Filed separately with full detail. Highlights:

- `readActiveAuth` (`deployment.ts:1230`) — a corrupt manifest silently deploys the app
  with **no SSO/forward-auth wiring**. Note the code 12 lines below it deliberately does
  the opposite and says so: *"NOT swallowed: a failure here must fail the deploy rather
  than silently ship an app whose auth was never wired"*.
- `getActiveConfig` (`:1332`) — the promote carry-forward source; an empty return **drops
  the operator's entire config on upgrade**.
- `attachToHolaNetwork` (`:1110`) — deploys unrouted compose on failure; Traefik then 502s
  with only a warn in the log.

## Tests

- `drafts/bundle-failure-surfaces.test.ts` (new, 8 cases) — reproduces the exact reported
  scenario, covers each hard failure code, asserts an unanticipated error propagates, and
  asserts the legitimate bundle-less fallback still works.
- `catalog/catalog-sources.test.ts` (+4) — `update()` semantics, validation parity with
  `add()`, and the corrupt-store guard.

Mutation-verified: restoring the blanket catch fails **7 of 8** new tests.

`typecheck` · `lint` · `test` (564 server, +12 · 200 web) · `build` all green.
Baseline allowlist default unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)