### PR TITLE
fix(server): stop deploying with silent defaults when a manifest is corrupt

### DIFF
--- a/packages/server/src/__tests__/deployments/corrupt-manifest.test.ts
+++ b/packages/server/src/__tests__/deployments/corrupt-manifest.test.ts
@@ -1,0 +1,193 @@
+/**
+ * A corrupt release manifest must stop the operation, not silently change it.
+ *
+ * The readActive* family was uniformly `fileExists`-guarded and then
+ * `catch { return undefined }`, which made a CORRUPT manifest indistinguishable
+ * from one that simply omits the field. The consequences were not cosmetic:
+ *
+ *   - readActiveAuth    -> app deploys with NO auth wiring (silent SSO bypass)
+ *   - getActiveConfig   -> promote carries NO env/secrets forward (config loss)
+ *   - readActiveAppEnv  -> runtime/.env written empty (opaque crash-loop)
+ *
+ * All of them now go through readReleaseManifest, which returns undefined only
+ * when there is genuinely nothing to read and throws when the file exists but
+ * cannot be parsed.
+ */
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { RealDeploymentService } from '../../services/core/deployment';
+import { MockProvisionerService } from '../../services/core/provisioner';
+import { RealDraftService } from '../../services/core/draft';
+import { RealStorageService } from '../../services/core/storage';
+import { RealRoutingService } from '../../services/core/routing';
+import { RealDatabaseService } from '../../services/core/database';
+import { RealLoggingService } from '../../services/core/logging';
+import { RealJobService } from '../../services/core/jobs';
+import { MockDockerService } from '../../services/core/docker';
+import type { DockerService } from '../../services/core/docker';
+
+async function waitForJob(jobs: RealJobService, id: string, timeoutMs = 5000) {
+  const start = Date.now();
+  for (;;) {
+    const job = await jobs.getJob(id);
+    if (job && (job.status === 'completed' || job.status === 'failed')) return job;
+    if (Date.now() - start > timeoutMs) throw new Error(`Job ${id} did not finish (last status: ${job?.status})`);
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+type CatalogArg = ConstructorParameters<typeof RealDraftService>[1];
+type ValidationArg = ConstructorParameters<typeof RealDraftService>[2];
+type JobArg = ConstructorParameters<typeof RealDeploymentService>[1];
+
+const makeCatalog = () => ({
+  getApp: async (appId: string) => ({ id: appId, name: 'Gitea', icon: '🍵' }),
+  getVersionDetail: async () => ({
+    defaultEnv: [{ key: 'DB_PASSWORD', value: 's3cret', isSecret: true, description: 'db' }],
+    defaults: { ports: [{ container: 3000, protocol: 'tcp' as const }], volumes: [] },
+    auth: { mode: 'forward-auth' as const },
+  }),
+}) as unknown as CatalogArg;
+
+const makeValidation = () => ({
+  validateDraft: async () => ({ ok: true, errors: [], warnings: [] }),
+  preflightCheck: async () => ({ ok: true, checks: [] }),
+}) as unknown as ValidationArg;
+
+const makeJobs = () => {
+  const jobs: Array<Record<string, unknown>> = [];
+  return {
+    createJob: async (p: { type: string; deploymentId?: string }) => {
+      const job = { id: crypto.randomUUID(), type: p.type, status: 'queued', startedAt: new Date().toISOString(), deploymentId: p.deploymentId };
+      jobs.push(job);
+      return job;
+    },
+    listJobs: async () => jobs,
+    cancelJob: async () => {},
+    getJob: async () => null,
+    onJobUpdate: () => ({ unsubscribe() {} }),
+    setExecutor: () => {},
+    healthCheck: async () => ({ healthy: true, lastCheck: new Date() }),
+  } as unknown as JobArg;
+};
+
+const noDocker = {} as unknown as DockerService;
+type LoggingArg = ConstructorParameters<typeof RealDeploymentService>[5];
+const noLogging = {
+  log: async () => {}, onLog: () => ({ unsubscribe() {} }), logJob: async () => {},
+  logDeployment: async () => {}, healthCheck: async () => ({ healthy: true, lastCheck: new Date() }),
+} as unknown as LoggingArg;
+
+describe('corrupt release manifest', () => {
+  let dataRoot: string;
+  let storage: RealStorageService;
+
+  beforeEach(async () => {
+    dataRoot = await mkdtemp(join(tmpdir(), 'hola-corrupt-manifest-'));
+    storage = new RealStorageService({ holaDir: dataRoot });
+  });
+  afterEach(async () => { await rm(dataRoot, { recursive: true, force: true }); });
+
+  function makeSystem() {
+    const drafts = new RealDraftService(storage, makeCatalog(), makeValidation());
+    const routing = new RealRoutingService(storage, { baseDomain: 'local.hola' });
+    const deployments = new RealDeploymentService(storage, makeJobs(), noDocker, drafts, routing, noLogging, new MockProvisionerService());
+    return { drafts, deployments };
+  }
+
+  async function install() {
+    const { drafts, deployments } = makeSystem();
+    const { draftId } = await drafts.createDraft({ appId: 'gitea', version: '1.0.0' });
+    await drafts.updateDraft(draftId, { composeOverride: 'services:\n  gitea:\n    image: gitea:1.0.0\n' });
+    await drafts.finalizeDraft(draftId);
+    const dep = await deployments.createFromDraft({ draftId, name: 'gitea', options: { autoStart: false } });
+    return { deployments, drafts, ...dep };
+  }
+
+  const corrupt = (deploymentId: string, releaseId: string) =>
+    storage.writeFile(`deployments/${deploymentId}/releases/${releaseId}/manifest.json`, '{ "auth": tr');
+
+  test('getConfig throws instead of reporting an empty config', async () => {
+    const { deployments, deploymentId, releaseId } = await install();
+    // Sanity: intact manifest reads fine and carries the app's env.
+    expect((await deployments.getConfig(deploymentId)).appEnv.map(e => e.key)).toContain('DB_PASSWORD');
+
+    await corrupt(deploymentId, releaseId);
+
+    await expect(deployments.getConfig(deploymentId)).rejects.toThrow(/unreadable or corrupt/);
+  });
+
+  test('getActiveConfig throws rather than dropping the operator config on upgrade', async () => {
+    const { deployments, deploymentId, releaseId } = await install();
+    expect((await deployments.getActiveConfig(deploymentId)).appEnv.DB_PASSWORD).toBe('s3cret');
+
+    await corrupt(deploymentId, releaseId);
+
+    // Silently returning {} here would promote a new release with none of the
+    // operator's env or secrets carried forward.
+    await expect(deployments.getActiveConfig(deploymentId)).rejects.toThrow(/unreadable or corrupt/);
+  });
+
+  test('the error names the deployment and release so it can be repaired', async () => {
+    const { deployments, deploymentId, releaseId } = await install();
+    await corrupt(deploymentId, releaseId);
+
+    const err = await deployments.getConfig(deploymentId).catch(e => e);
+    expect(err.message).toContain(deploymentId);
+    expect(err.message).toContain(releaseId);
+    expect(err.status).toBe(500);
+  });
+
+  test('a genuinely absent manifest is still treated as "no config", not an error', async () => {
+    // The legitimate case the catch existed for must keep working: nothing to
+    // read is different from something unreadable.
+    const { deployments, deploymentId, releaseId } = await install();
+    await storage.deleteFile(`deployments/${deploymentId}/releases/${releaseId}/manifest.json`);
+
+    await expect(deployments.getConfig(deploymentId)).resolves.toEqual({ appEnv: [], systemOverrides: {} });
+    await expect(deployments.getActiveConfig(deploymentId)).resolves.toEqual({ appEnv: {}, systemOverrides: {} });
+  });
+
+  test('SECURITY: a corrupt manifest fails the deploy instead of shipping the app with no auth', async () => {
+    // The headline case. The app declares auth.mode = forward-auth. With the old
+    // `catch { return undefined }`, a corrupt manifest read as "no auth block",
+    // so the deploy succeeded and the app came up publicly reachable with the SSO
+    // gate silently absent. The job must fail instead.
+    const storage2 = new RealStorageService({ holaDir: dataRoot });
+    const database = new RealDatabaseService(storage2);
+    const logging = new RealLoggingService(storage2);
+    const jobs = new RealJobService(database, logging);
+    const routing = new RealRoutingService(storage2, { baseDomain: 'example.com' });
+    const drafts = new RealDraftService(storage2, makeCatalog(), makeValidation());
+    const deployments = new RealDeploymentService(
+      storage2, jobs, new MockDockerService(), drafts, routing, logging, new MockProvisionerService(),
+    );
+
+    const { draftId } = await drafts.createDraft({ appId: 'gitea', version: '1.0.0' });
+    await drafts.updateDraft(draftId, { composeOverride: 'services:\n  gitea:\n    image: gitea:1.0.0\n' });
+    await drafts.finalizeDraft(draftId);
+    const created = await deployments.createFromDraft({ draftId, name: 'gitea', options: { autoStart: false } });
+
+    await corrupt(created.deploymentId, created.releaseId);
+
+    // Restart drives the same lifecycle job a deploy does.
+    const action = await deployments.executeAction(created.deploymentId, { action: 'restart' });
+    const job = await waitForJob(jobs, action.jobId!);
+
+    expect(job.status).toBe('failed');
+    expect(String(job.error ?? '')).toMatch(/unreadable or corrupt/);
+  });
+
+  test('a corrupt manifest never blocks deletion', async () => {
+    // Deletion must stay possible — otherwise a corrupt manifest would strand the
+    // deployment with no way to remove it. The delete path wraps every step.
+    const { deployments, deploymentId, releaseId } = await install();
+    await corrupt(deploymentId, releaseId);
+
+    await expect(deployments.deleteDeployment(deploymentId)).resolves.toBeUndefined();
+    await expect(deployments.getDeployment(deploymentId)).rejects.toThrow();
+  });
+});

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -43,7 +43,7 @@ import { requestsPrivilegeEscalation } from './manifest-security';
 import { validateParams } from '@hola/shared/param-validate';
 
 import { getLogger } from '../../lib/logger';
-import { NotFoundError, ConflictError, ValidationError, DraftValidationError } from '../../middleware/error-mapping';
+import { NotFoundError, ConflictError, ValidationError, DraftValidationError, ServiceError } from '../../middleware/error-mapping';
 import { dirHasContents, fileSize, tarGzipDir, restoreTarGzInto } from './snapshot-fs';
 import type { HealthCheckable, ServiceHealth } from './types';
 import type { StorageService } from './storage';
@@ -1104,14 +1104,26 @@ export class RealDeploymentService extends InMemoryDeploymentService {
 
     // Attach the ingress service to the Traefik network so the emitted routing
     // config can reach it (the alias must match the routing service name).
-    let content = raw;
+    //
+    // NOT swallowed, for the same reason as the auth injection below: deploying
+    // the compose as-is produces an app that starts, reports success, and is
+    // unreachable — Traefik gets a routing rule pointing at a service that was
+    // never joined to the network, so every request 502s with nothing but a warn
+    // in the log. Failing the deploy surfaces the real problem while the operator
+    // is still watching.
+    let content: string;
     try {
       content = attachToHolaNetwork(raw, { alias: rule.serviceName, ingressService });
     } catch (error) {
-      this.logger.warn('Could not attach app to Traefik network; deploying compose as-is', {
+      const detail = error instanceof Error ? error.message : String(error);
+      this.logger.error('Could not attach app to the Traefik network', error as Error, {
         deploymentId: deployment.id,
-        error: error instanceof Error ? error.message : String(error),
+        ingressService,
       });
+      throw new ServiceError(
+        `Could not attach ${deployment.id} to the Traefik network (ingress service '${ingressService}'): ${detail}. ` +
+          `Deploying without it would start the app unreachable behind a 502.`,
+      );
     }
 
     // Inject provisioned auth env into the ingress service. NOT swallowed: a
@@ -1217,63 +1229,65 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     return this.runtimeDir(deployment.id);
   }
 
-  /** Read the active release's declared auth config (if any). */
-  private async readActiveAuth(deployment: EnhancedDeploymentDetail): Promise<FinalizedManifest['auth']> {
-    const releaseId = deployment.currentReleaseId;
+  /**
+   * Read a release's finalized manifest.
+   *
+   * Returns `undefined` when there is genuinely nothing to read — no active
+   * release, or no manifest file. That's a legitimate state and callers treat it
+   * as "field absent".
+   *
+   * THROWS when the file exists but cannot be read or parsed. That distinction is
+   * the entire point of this helper. Every caller derives deploy-time behaviour
+   * from this file, and the readers used to `catch { return undefined }` — making
+   * a CORRUPT manifest indistinguishable from one that simply omits the field. A
+   * truncated write therefore silently deployed the app with no auth wiring, no
+   * env, or no config carried forward on upgrade, with nothing in the log but the
+   * absence of a problem. Corruption must stop the operation, not quietly change
+   * what it does.
+   */
+  private async readReleaseManifest(deploymentId: string, releaseId: string | undefined): Promise<FinalizedManifest | undefined> {
     if (!releaseId) return undefined;
-    const manifestPath = `deployments/${deployment.id}/releases/${releaseId}/manifest.json`;
+    const manifestPath = `deployments/${deploymentId}/releases/${releaseId}/manifest.json`;
     if (!(await this.storageService.fileExists(manifestPath))) return undefined;
     try {
-      const manifest = JSON.parse(await this.storageService.readFileAsString(manifestPath)) as FinalizedManifest;
-      return manifest.auth;
-    } catch {
-      return undefined;
+      return JSON.parse(await this.storageService.readFileAsString(manifestPath)) as FinalizedManifest;
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      this.logger.error('Release manifest is unreadable or corrupt', error as Error, { deploymentId, releaseId, manifestPath });
+      throw new ServiceError(
+        `Release manifest for ${deploymentId} (release ${releaseId}) is unreadable or corrupt: ${detail}. ` +
+          `Refusing to operate on this deployment with unknown auth/config — roll back to a good release or repair the file.`,
+      );
     }
+  }
+
+  /** The active release's manifest, or undefined when there isn't one. Throws on corruption. */
+  private async readActiveManifest(deployment: EnhancedDeploymentDetail): Promise<FinalizedManifest | undefined> {
+    return this.readReleaseManifest(deployment.id, deployment.currentReleaseId);
+  }
+
+  /** Read the active release's declared auth config (if any). */
+  private async readActiveAuth(deployment: EnhancedDeploymentDetail): Promise<FinalizedManifest['auth']> {
+    return (await this.readActiveManifest(deployment))?.auth;
   }
 
   /** Cross-app capabilities the active release declares it consumes (ADR 0002). */
   private async readActiveConsumes(deployment: EnhancedDeploymentDetail): Promise<string[]> {
-    const releaseId = deployment.currentReleaseId;
-    if (!releaseId) return [];
-    const manifestPath = `deployments/${deployment.id}/releases/${releaseId}/manifest.json`;
-    if (!(await this.storageService.fileExists(manifestPath))) return [];
-    try {
-      const manifest = JSON.parse(await this.storageService.readFileAsString(manifestPath)) as FinalizedManifest;
-      return manifest.consumes ?? [];
-    } catch {
-      return [];
-    }
+    return (await this.readActiveManifest(deployment))?.consumes ?? [];
   }
 
   /** Elevated container permissions the active release's manifest declares. */
   private async readActiveSecurity(deployment: EnhancedDeploymentDetail): Promise<AppSecurityConfig | undefined> {
-    const releaseId = deployment.currentReleaseId;
-    if (!releaseId) return undefined;
-    const manifestPath = `deployments/${deployment.id}/releases/${releaseId}/manifest.json`;
-    if (!(await this.storageService.fileExists(manifestPath))) return undefined;
-    try {
-      const manifest = JSON.parse(await this.storageService.readFileAsString(manifestPath)) as FinalizedManifest;
-      return manifest.security;
-    } catch {
-      return undefined;
-    }
+    return (await this.readActiveManifest(deployment))?.security;
   }
 
   /** The active release's app env (manifest `defaultEnv` + any user overrides), as
    *  a flat map — the source for the runtime `.env` Compose interpolates from. */
   private async readActiveAppEnv(deployment: EnhancedDeploymentDetail): Promise<Record<string, string>> {
-    const releaseId = deployment.currentReleaseId;
-    if (!releaseId) return {};
-    const manifestPath = `deployments/${deployment.id}/releases/${releaseId}/manifest.json`;
-    if (!(await this.storageService.fileExists(manifestPath))) return {};
-    try {
-      const manifest = JSON.parse(await this.storageService.readFileAsString(manifestPath)) as FinalizedManifest;
-      const out: Record<string, string> = {};
-      for (const e of manifest.appEnv ?? []) out[e.key] = e.value ?? '';
-      return out;
-    } catch {
-      return {};
-    }
+    const manifest = await this.readActiveManifest(deployment);
+    const out: Record<string, string> = {};
+    for (const e of manifest?.appEnv ?? []) out[e.key] = e.value ?? '';
+    return out;
   }
 
   /** Absolute path to the active release's manifest, or undefined if there's no
@@ -1295,15 +1309,7 @@ export class RealDeploymentService extends InMemoryDeploymentService {
   private async resolveRegistryAuth(deployment: EnhancedDeploymentDetail): Promise<PullCredentials[] | undefined> {
     const releaseId = deployment.currentReleaseId;
     if (!releaseId) return undefined;
-    const manifestPath = `deployments/${deployment.id}/releases/${releaseId}/manifest.json`;
-    if (!(await this.storageService.fileExists(manifestPath))) return undefined;
-    let credentialRef: string | undefined;
-    try {
-      const manifest = JSON.parse(await this.storageService.readFileAsString(manifestPath)) as FinalizedManifest;
-      credentialRef = manifest.credentialRef;
-    } catch {
-      return undefined;
-    }
+    const credentialRef = (await this.readActiveManifest(deployment))?.credentialRef;
     if (!credentialRef) return undefined;
     const creds = await this.registryCredentials?.resolve(credentialRef);
     if (!creds) {
@@ -1321,16 +1327,14 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     const releaseId = deployment.currentReleaseId;
     const empty = { appEnv: {} as Record<string, string>, systemOverrides: {} as Record<string, string> };
     if (!releaseId) return empty;
-    const manifestPath = `deployments/${deployment.id}/releases/${releaseId}/manifest.json`;
-    if (!(await this.storageService.fileExists(manifestPath))) return empty;
-    try {
-      const manifest = JSON.parse(await this.storageService.readFileAsString(manifestPath)) as FinalizedManifest;
-      const appEnv: Record<string, string> = {};
-      for (const e of manifest.appEnv ?? []) appEnv[e.key] = e.value ?? '';
-      return { appEnv, systemOverrides: manifest.systemOverrides ?? {} };
-    } catch {
-      return empty;
-    }
+    // Corruption throws rather than returning `empty`: this is the promote
+    // carry-forward source, so an empty return silently ships the upgraded
+    // release with none of the operator's env or secrets.
+    const manifest = await this.readReleaseManifest(deployment.id, releaseId);
+    if (!manifest) return empty;
+    const appEnv: Record<string, string> = {};
+    for (const e of manifest.appEnv ?? []) appEnv[e.key] = e.value ?? '';
+    return { appEnv, systemOverrides: manifest.systemOverrides ?? {} };
   }
 
   /** Full config for the DeploymentDetail Configuration tab: the active release's
@@ -1344,13 +1348,10 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     await this.ensureLoaded();
     const deployment = this.requireDeployment(deploymentId);
     const manifestPath = this.activeManifestPath(deployment);
-    if (!manifestPath || !(await this.storageService.fileExists(manifestPath))) return { appEnv: [], systemOverrides: {} };
-    try {
-      const manifest = JSON.parse(await this.storageService.readFileAsString(manifestPath)) as FinalizedManifest;
-      return { appEnv: manifest.appEnv ?? [], systemOverrides: manifest.systemOverrides ?? {} };
-    } catch {
-      return { appEnv: [], systemOverrides: {} };
-    }
+    if (!manifestPath) return { appEnv: [], systemOverrides: {} };
+    const manifest = await this.readActiveManifest(deployment);
+    if (!manifest) return { appEnv: [], systemOverrides: {} };
+    return { appEnv: manifest.appEnv ?? [], systemOverrides: manifest.systemOverrides ?? {} };
   }
 
   /**
@@ -1419,16 +1420,7 @@ export class RealDeploymentService extends InMemoryDeploymentService {
 
   /** The active release's declared ingress/web compose service, if any. */
   private async readActiveIngressService(deployment: EnhancedDeploymentDetail): Promise<string | undefined> {
-    const releaseId = deployment.currentReleaseId;
-    if (!releaseId) return undefined;
-    const manifestPath = `deployments/${deployment.id}/releases/${releaseId}/manifest.json`;
-    if (!(await this.storageService.fileExists(manifestPath))) return undefined;
-    try {
-      const manifest = JSON.parse(await this.storageService.readFileAsString(manifestPath)) as FinalizedManifest;
-      return manifest.ingressService;
-    } catch {
-      return undefined;
-    }
+    return (await this.readActiveManifest(deployment))?.ingressService;
   }
 
   /** Absolute host base that holds every app's data root. */
@@ -1520,14 +1512,7 @@ export class RealDeploymentService extends InMemoryDeploymentService {
 
   /** Read the per-app backup hooks (#121) from a release's finalized manifest. */
   private async readReleaseBackupConfig(deploymentId: string, releaseId: string): Promise<FinalizedManifest['backup']> {
-    const path = `deployments/${deploymentId}/releases/${releaseId}/manifest.json`;
-    if (!(await this.storageService.fileExists(path))) return undefined;
-    try {
-      const manifest = JSON.parse(await this.storageService.readFileAsString(path)) as FinalizedManifest;
-      return manifest.backup;
-    } catch {
-      return undefined;
-    }
+    return (await this.readReleaseManifest(deploymentId, releaseId))?.backup;
   }
 
   /** Snapshot metadata for a deployment, newest first. */
@@ -1645,7 +1630,21 @@ export class RealDeploymentService extends InMemoryDeploymentService {
       const content = buildRegistry(apps);
 
       for (const d of this.deployments.values()) {
-        const consumes = await this.readActiveConsumes(d);
+        // Per-deployment guard: readActiveConsumes now throws on a corrupt
+        // manifest, and this loop spans EVERY deployment — without this, one bad
+        // manifest would stop the registry feed being written for all the others.
+        // Skipping the unreadable one is the right blast radius here; the deploy
+        // paths that actually act on a manifest still fail hard.
+        let consumes: string[];
+        try {
+          consumes = await this.readActiveConsumes(d);
+        } catch (error) {
+          this.logger.warn('Skipping deployment in app-registry feed; its manifest is unreadable', {
+            deploymentId: d.id,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          continue;
+        }
         if (!consumes.includes(APP_REGISTRY_CAPABILITY)) continue;
         try {
           const root = this.appRootFor(d.id);

--- a/packages/server/src/services/core/jobs.ts
+++ b/packages/server/src/services/core/jobs.ts
@@ -84,6 +84,9 @@ function toShared(job: JobEntity): SharedJob {
     finishedAt: job.completedAt?.toISOString(),
     progress: job.progress,
     deploymentId: (job.payload?.deploymentId as string | undefined) || undefined,
+    // Carry the failure reason out. It was always recorded on the entity and
+    // then dropped here, leaving the UI with a failed job and no explanation.
+    ...(job.error ? { error: job.error } : {}),
   };
 }
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1038,6 +1038,13 @@ export type Job = {
   // type). Absent for jobs with no/deleted deployment.
   deploymentName?: string;
   app?: string;
+  /**
+   * Why a failed job failed. Recorded on the job record all along but dropped on
+   * the way out, so a failed deploy surfaced as a red status with no reason —
+   * exactly the dead end that made a swallowed bundle-pull failure so hard to
+   * diagnose. Only set for `failed` jobs.
+   */
+  error?: string;
 };
 
 export type GetJobsRequest = PageRequest & {

--- a/packages/web/src/components/JobStatus.tsx
+++ b/packages/web/src/components/JobStatus.tsx
@@ -147,6 +147,14 @@ export const JobStatus: React.FC<JobStatusProps> = ({
                 )}
               </div>
             )}
+            {/* Why it failed. The server records this on every failed job; without
+                it a failure is just a red pill and the operator has to go digging
+                in the logs for something the UI already knows. */}
+            {showDetails && job.status === 'failed' && job.error && (
+              <div className={`mt-1 break-words text-danger ${size === 'lg' ? 'text-sm' : 'text-xs'}`} title={job.error}>
+                {job.error}
+              </div>
+            )}
           </div>
         </div>
         


### PR DESCRIPTION
Closes #369 (the security-relevant items). Follow-up to #368.

## The pattern

Nine readers of the active release's manifest shared one shape:

```ts
if (!(await this.storageService.fileExists(manifestPath))) return undefined;
try   { return (JSON.parse(...) as FinalizedManifest).auth; }
catch { return undefined; }
```

The `fileExists` guard already covers "no manifest", so the `catch` only ever fired on
a manifest that **exists but cannot be parsed** — and it made that indistinguishable from
one that simply omits the field.

## Why it mattered

| reader | substituted | consequence |
|---|---|---|
| `readActiveAuth` | `undefined` | **App deploys with no auth wiring.** An app declaring `forward-auth` came up publicly reachable with the SSO gate silently absent — and the deploy reported success. |
| `getActiveConfig` | `empty` | Promote carries **no env or secrets forward** — an upgrade silently ships without the operator's config. |
| `readActiveAppEnv` | `{}` | `runtime/.env` written empty; Compose interpolates `${DB_PASSWORD}` to blank → opaque crash-loop. |
| +6 more | | security config, ingress service, consumes, backup hooks, registry credential |

The mutation test makes the first one concrete: with the old swallow restored, the deploy
job **completes successfully** with auth absent. That is the bypass, reproduced.

Notably the code 12 lines below the auth injection already made this exact argument:

```ts
// Inject provisioned auth env into the ingress service. NOT swallowed: a
// failure here must fail the deploy rather than silently ship an app whose
// auth was never wired (a security-relevant bypass).
```

The readers just didn't follow it.

## The fix

All nine route through one `readReleaseManifest` helper: `undefined` only when there is
genuinely nothing to read, **throws** when the file exists but can't be parsed. The message
names the deployment and release so it can be repaired or rolled back.

Two call sites needed deliberate handling rather than a blanket rethrow:

- **The app-registry feed loops over every deployment.** One corrupt manifest would have
  stopped the feed for all of them, so it skips the unreadable one and carries on — the
  right blast radius for a best-effort write, while the deploy paths still fail hard.
- **Deletion** already wraps every step, so a corrupt manifest can't strand a deployment
  with no way to remove it. There's a test asserting that.

## Also fixed

**`attachToHolaNetwork` swallow** (#369 item 3). Deploying the compose as-is produced an
app that started, reported success, and was unreachable — Traefik routing to a service that
was never joined to the network, so every request 502'd with only a warn in the log.

**Job failure reasons never reached the API.** `JobEntity.error` was recorded on every
failed job and then silently dropped by `toShared`, so `Job` had no `error` field at all —
a failed deploy was a red pill with no explanation. That's the same dead end that made the
swallowed bundle-pull failure in #368 so hard to diagnose. Adds `Job.error`, maps it, and
renders it in `JobStatus`.

## Tests

`deployments/corrupt-manifest.test.ts` — 6 cases: the auth-bypass deploy failure, the two
config-loss paths, the error naming deployment + release, an **absent** manifest still
reading as "no config" (the legitimate case must keep working), and deletion still
succeeding.

Mutation-verified: restoring the old swallow fails 4 of 6, including the security case
flipping the deploy job back to `completed`.

`typecheck` · `lint` · `test` (570 server, +6 · 204 web) · `build` all green.

## Left open in #369

The lower-priority items: `bundles.ts` `resolveDigest` (a revoked credential keeps serving
the cached bundle) and rehydration skipping corrupt records. Both are defensible as-is and
neither is a silent security change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)