### PR TITLE
chore(release): 0.7.8

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/cli": {
       "name": "@hola/cli",
-      "version": "0.7.7",
+      "version": "0.7.8",
       "bin": {
         "hola": "./bin/hola",
       },
@@ -37,11 +37,11 @@
     },
     "packages/compose": {
       "name": "@hola/compose",
-      "version": "0.7.7",
+      "version": "0.7.8",
     },
     "packages/sdk": {
       "name": "@hola/sdk",
-      "version": "0.7.7",
+      "version": "0.7.8",
       "dependencies": {
         "@hola/shared": "workspace:*",
       },
@@ -55,7 +55,7 @@
     },
     "packages/server": {
       "name": "@hola/server",
-      "version": "0.7.7",
+      "version": "0.7.8",
       "dependencies": {
         "@hola/shared": "workspace:*",
         "jose": "^5.9.6",
@@ -71,7 +71,7 @@
     },
     "packages/shared": {
       "name": "@hola/shared",
-      "version": "0.7.7",
+      "version": "0.7.8",
       "dependencies": {
         "yaml": "^2.9.0",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.7.7';
+export const CLI_VERSION = '0.7.8';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Patch release. Bumps `cli`, `server`, `shared`, `sdk`, `compose` to **0.7.8** (plus
`packages/cli/src/version.ts` and `bun.lock`); `web` stays unversioned at `0.0.0`.

Three PRs since `cli-v0.7.7` — two of them fixes for failures that were swallowed and
resurfaced later as something unrecognizable.

| PR | |
|---|---|
| #368 | **fix(server): surface blocked/failed bundle pulls** — a pull blocked by the registry allowlist produced a draft built from placeholders, which finalized and cut a release with no compose. The operator saw only "Active release has no compose file", with the real cause (`REF_NOT_ALLOWED`) buried in a WARN. Adds typed `BundleError`/`BundleUnavailableError`, surfaces the reason through the API, and adds catalog-source `update()` + `PATCH`. |
| #370 | **fix(server): stop deploying with silent defaults when a manifest is corrupt** — a corrupt release manifest read as "field absent", so an app declaring `forward-auth` deployed with **no auth wiring** and reported success. Also stops unrouted deploys reporting success, and surfaces job failure reasons (`Job.error`) that were recorded and then dropped before reaching the API. |
| #367 | feat(web): show installed apps as installed in the catalog |

### Operator-visible behaviour changes

Both fixes convert previously-silent degradation into a hard failure, which is the point —
but it does mean an install or deploy that used to "succeed" wrongly will now fail loudly:

- An install from a catalog source whose registry isn't in the allowlist now **fails at
  draft creation** naming the ref and the allowlist, instead of producing a broken
  deployment. Fix with the new `PATCH /api/catalog-sources/:id` to add `allowRegistries`.
- A deployment whose release manifest is corrupt now **refuses to deploy** rather than
  coming up with no auth/config. Deletion still works, so nothing is strandable.

`typecheck` · `lint` · `test` (570 server · 204 web) · `build` all green.

Tag `cli-v0.7.8` follows on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)