### PR TITLE
fix(compose): stop crash-looping the LDAP outpost on every SSO install

### DIFF
--- a/packages/compose/.env.example
+++ b/packages/compose/.env.example
@@ -130,6 +130,9 @@ HOLA_AUTHENTIK_API_TOKEN=
 # LDAP (only for `native-ldap` apps). Base DN of the shared directory, and the
 # token of the LDAP outpost you create in Authentik (one-time; see README). Leave
 # the token blank until you've created the outpost — the authentik-ldap container
-# won't connect without it.
+# exits on an empty token, which is why it sits behind its own `authentik-ldap`
+# compose profile rather than starting with the rest of the Authentik stack.
+# To enable it: create the outpost, set the token below, then append
+# `authentik-ldap` to COMPOSE_PROFILES (e.g. COMPOSE_PROFILES=authentik,authentik-ldap).
 HOLA_AUTHENTIK_LDAP_BASE_DN=dc=hola,dc=internal
 AUTHENTIK_LDAP_OUTPOST_TOKEN=

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -273,7 +273,10 @@ shared LDAP directory needs an outpost you create once:
    **Outpost** of type *LDAP* bound to it.
 2. Copy the outpost's **token** into `AUTHENTIK_LDAP_OUTPOST_TOKEN` in `.env`, and set
    `HOLA_AUTHENTIK_LDAP_BASE_DN` to the same Base DN.
-3. `docker compose up -d authentik-ldap` — the outpost connects and serves the directory at
+3. Append `authentik-ldap` to `COMPOSE_PROFILES` in `.env` — the outpost has its own profile
+   so a token-less install doesn't start (and crash-loop) it:
+   `COMPOSE_PROFILES=authentik,authentik-ldap`.
+4. `docker compose up -d authentik-ldap` — the outpost connects and serves the directory at
    `authentik-ldap:3389` on the `hola` network. native-LDAP apps then bind automatically.
 
 (Pinning the outpost token without this manual copy is a known Authentik gap; revisit when upstream

--- a/packages/compose/docker-compose.yml
+++ b/packages/compose/docker-compose.yml
@@ -268,10 +268,16 @@ services:
   # reachable internally on the `hola` network at authentik-ldap:3389. Requires a
   # one-time setup: create an LDAP provider + outpost in Authentik and copy the
   # outpost token into AUTHENTIK_LDAP_OUTPOST_TOKEN (see README "Authentication & SSO").
+  #
+  # Deliberately on its OWN profile, not `authentik`: the outpost exits 1 on an
+  # empty AUTHENTIK_TOKEN, so enabling it by default crash-loops on every SSO
+  # install until that manual setup is done. Enable it only once you've created
+  # the outpost AND you're installing an app that declares `auth.mode:
+  # native-ldap` — add `authentik-ldap` to COMPOSE_PROFILES in .env.
   authentik-ldap:
     image: ghcr.io/goauthentik/ldap:2025.10
     container_name: authentik-ldap
-    profiles: [authentik]
+    profiles: [authentik-ldap]
     restart: unless-stopped
     environment:
       AUTHENTIK_HOST: http://authentik-server:9000


### PR DESCRIPTION
## The bug

`authentik-ldap` sits on the `authentik` compose profile — the same profile `install.sh` enables for **every** SSO install — but its token defaults to empty:

```yaml
AUTHENTIK_TOKEN: ${AUTHENTIK_LDAP_OUTPOST_TOKEN:-}
```

The Go outpost rejects an empty token and exits 1. With `restart: unless-stopped` that's a restart roughly every 15 seconds, forever, on any install that hasn't performed the manual one-time outpost setup in Authentik. Found on a live host with **1614 restarts in a single day**.

The compose file documented the required setup but nothing enforced it, and no install path performs it.

## Why it's safe to make opt-in

No catalog app needs it. All 16 apps in [`try-hola/apps`](https://github.com/try-hola/apps) declare `forward-auth` (7), `native-oidc` (6), or `none` (2). `native-ldap` exists in the schema enum and the server implementation, but has no consumer yet — so on a default install the outpost is crash-looping in service of nothing.

## The change

Move it to its own `authentik-ldap` profile. This matches what `README.md` already instructed (`docker compose up -d authentik-ldap` as an explicit post-setup step) — the compose file just never reflected that intent.

- `docker-compose.yml` — `profiles: [authentik-ldap]`, with a comment explaining why it's separate
- `.env.example` — note that enabling it means appending to `COMPOSE_PROFILES`
- `README.md` — new step 3 in the native-LDAP setup covering the profile

Service name and `container_name` are unchanged, so the `authentik-ldap:3389` hostname injected by `provisioner.ts` (`config/auth.ts:76`) still resolves once the profile is on.

## Verification

```
COMPOSE_PROFILES=authentik                → authentik-ldap absent
COMPOSE_PROFILES=authentik,authentik-ldap → authentik-ldap present
```

`typecheck` · `lint` · `test` (570 server + 204 web, 0 fail) · `build` all pass.

## Upgrade note

Existing installs with a working LDAP outpost must append `authentik-ldap` to `COMPOSE_PROFILES` in `/opt/hola/.env` to keep it running. Given no catalog app uses `native-ldap`, this is expected to affect no one in practice — but it is a behavior change worth calling out in release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)