### PR TITLE
chore(release): 0.7.9

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/cli": {
       "name": "@hola/cli",
-      "version": "0.7.8",
+      "version": "0.7.9",
       "bin": {
         "hola": "./bin/hola",
       },
@@ -37,11 +37,11 @@
     },
     "packages/compose": {
       "name": "@hola/compose",
-      "version": "0.7.8",
+      "version": "0.7.9",
     },
     "packages/sdk": {
       "name": "@hola/sdk",
-      "version": "0.7.8",
+      "version": "0.7.9",
       "dependencies": {
         "@hola/shared": "workspace:*",
       },
@@ -55,7 +55,7 @@
     },
     "packages/server": {
       "name": "@hola/server",
-      "version": "0.7.8",
+      "version": "0.7.9",
       "dependencies": {
         "@hola/shared": "workspace:*",
         "jose": "^5.9.6",
@@ -71,7 +71,7 @@
     },
     "packages/shared": {
       "name": "@hola/shared",
-      "version": "0.7.8",
+      "version": "0.7.9",
       "dependencies": {
         "yaml": "^2.9.0",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.7.8';
+export const CLI_VERSION = '0.7.9';

--- a/packages/compose/.env.example
+++ b/packages/compose/.env.example
@@ -130,6 +130,9 @@ HOLA_AUTHENTIK_API_TOKEN=
 # LDAP (only for `native-ldap` apps). Base DN of the shared directory, and the
 # token of the LDAP outpost you create in Authentik (one-time; see README). Leave
 # the token blank until you've created the outpost — the authentik-ldap container
-# won't connect without it.
+# exits on an empty token, which is why it sits behind its own `authentik-ldap`
+# compose profile rather than starting with the rest of the Authentik stack.
+# To enable it: create the outpost, set the token below, then append
+# `authentik-ldap` to COMPOSE_PROFILES (e.g. COMPOSE_PROFILES=authentik,authentik-ldap).
 HOLA_AUTHENTIK_LDAP_BASE_DN=dc=hola,dc=internal
 AUTHENTIK_LDAP_OUTPOST_TOKEN=

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -273,7 +273,10 @@ shared LDAP directory needs an outpost you create once:
    **Outpost** of type *LDAP* bound to it.
 2. Copy the outpost's **token** into `AUTHENTIK_LDAP_OUTPOST_TOKEN` in `.env`, and set
    `HOLA_AUTHENTIK_LDAP_BASE_DN` to the same Base DN.
-3. `docker compose up -d authentik-ldap` — the outpost connects and serves the directory at
+3. Append `authentik-ldap` to `COMPOSE_PROFILES` in `.env` — the outpost has its own profile
+   so a token-less install doesn't start (and crash-loop) it:
+   `COMPOSE_PROFILES=authentik,authentik-ldap`.
+4. `docker compose up -d authentik-ldap` — the outpost connects and serves the directory at
    `authentik-ldap:3389` on the `hola` network. native-LDAP apps then bind automatically.
 
 (Pinning the outpost token without this manual copy is a known Authentik gap; revisit when upstream

--- a/packages/compose/docker-compose.yml
+++ b/packages/compose/docker-compose.yml
@@ -268,10 +268,16 @@ services:
   # reachable internally on the `hola` network at authentik-ldap:3389. Requires a
   # one-time setup: create an LDAP provider + outpost in Authentik and copy the
   # outpost token into AUTHENTIK_LDAP_OUTPOST_TOKEN (see README "Authentication & SSO").
+  #
+  # Deliberately on its OWN profile, not `authentik`: the outpost exits 1 on an
+  # empty AUTHENTIK_TOKEN, so enabling it by default crash-loops on every SSO
+  # install until that manual setup is done. Enable it only once you've created
+  # the outpost AND you're installing an app that declares `auth.mode:
+  # native-ldap` — add `authentik-ldap` to COMPOSE_PROFILES in .env.
   authentik-ldap:
     image: ghcr.io/goauthentik/ldap:2025.10
     container_name: authentik-ldap
-    profiles: [authentik]
+    profiles: [authentik-ldap]
     restart: unless-stopped
     environment:
       AUTHENTIK_HOST: http://authentik-server:9000

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Patch release. One fix, for a failure that surfaced only as log noise but churned continuously on every SSO install.

- **fix(compose): stop crash-looping the LDAP outpost on every SSO install (#372)** — `authentik-ldap` sat on the `authentik` profile that `install.sh` enables for every SSO install, but its `AUTHENTIK_TOKEN` defaults to empty and the outpost exits 1 on an empty token. With `restart: unless-stopped` that's a restart every ~15s indefinitely — 1614 in a day on an observed host. No catalog app declares `auth.mode: native-ldap` (all 16 are forward-auth, native-oidc, or none), so it was serving nothing. Moved to its own `authentik-ldap` profile, matching what the README already instructed.

Version bump only: the same 7 files as the 0.7.8 release commit (5 package.json + `packages/cli/src/version.ts` + `bun.lock`). `web` stays `0.0.0` by convention.

**Merge #372 first** — this PR carries no code, only the bump.

## Upgrade note

Installs that had a working LDAP outpost must append `authentik-ldap` to `COMPOSE_PROFILES` in `.env` to keep it running. Expected to affect no one, since no catalog app uses `native-ldap`.

## Verification

`typecheck` · `lint` · `test` (570 server + 204 web, 0 fail) · `build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)