### PR TITLE
fix(server): name Authentik objects off the deployment-id suffix (#346)

### DIFF
--- a/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
+++ b/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
@@ -487,6 +487,33 @@ describe('RealAuthentikProvisionerService (REST contract)', () => {
     expect(result.ref).toMatchObject({ mode: 'forward-auth', providerPk: 55, outpostPk: 1 });
   });
 
+  test('forward-auth provider name uses the full deployment-id suffix, so two installs of the same app do not collide (#346)', async () => {
+    const svc = new RealAuthentikProvisionerService(CONFIG);
+
+    // Deployment ids are `<slug>-<8 hex>`; these two are distinct installs of the
+    // same app whose random suffixes happen to share a first character. The old
+    // `deploymentId.slice(0, 8)` derived the provider name from `<slug>-<first hex
+    // char>` — both collapsed to "webtop-a", so Authentik (which enforces unique
+    // provider names) rejected the second install with HTTP 400 and tombstoned it
+    // as `error` before any container started.
+    const nameForProxyPost = async (deploymentId: string): Promise<string> => {
+      calls = [];
+      installFetch();
+      await svc.provision({ deploymentId, appName: 'webtop', mode: 'forward-auth', host: 'webtop.example.com' });
+      const post = calls.find(c => c.method === 'POST' && c.path === '/api/v3/providers/proxy/')!;
+      return (post.body as Record<string, unknown>).name as string;
+    };
+
+    const nameA = await nameForProxyPost('webtop-a1111111');
+    const nameB = await nameForProxyPost('webtop-a2222222');
+
+    // The whole 8-hex suffix is carried into the name (not the slug + one char).
+    expect(nameA).toBe('hola-webtop-a1111111');
+    expect(nameB).toBe('hola-webtop-a2222222');
+    // ...so the two installs get distinct names — no collision.
+    expect(nameA).not.toBe(nameB);
+  });
+
   test('forward-auth reuse resends mode on the PATCH (Authentik rejects a mode-less partial update with 400)', async () => {
     // Authentik's ProxyProviderSerializer validates against attrs.get("mode",
     // ProxyMode.PROXY): a partial update that omits `mode` is validated as PROXY,

--- a/packages/server/src/services/core/provisioner.ts
+++ b/packages/server/src/services/core/provisioner.ts
@@ -220,6 +220,23 @@ function slugify(s: string): string {
 }
 
 /**
+ * The unique, stable disambiguator of a deployment id. Deployment ids are
+ * `<app-slug>-<random-suffix>` (see `makeDeploymentId` in deployment.ts) where
+ * the entropy is the LAST hyphen-delimited segment. Naming Authentik objects off
+ * this suffix keeps them unique per install.
+ *
+ * Do NOT use `deploymentId.slice(0, 8)` here: for `webtop-1c3379a4` that returns
+ * `webtop-1` (the app slug plus a single hex char), so two installs of the same
+ * app collide whenever their random suffixes share a first character — Authentik
+ * rejects the duplicate provider name and the deploy tombstones as `error`
+ * before any container starts (#346).
+ */
+function deploymentSuffix(deploymentId: string): string {
+  const idx = deploymentId.lastIndexOf('-');
+  return idx >= 0 ? deploymentId.slice(idx + 1) : deploymentId;
+}
+
+/**
  * Build the Authentik `redirect_uris` list: the primary URI (from redirectPath)
  * plus any manifest-declared extras, with the `${HOLA_APP_HOST}` token expanded
  * to the app's public host. Extras may be full https URLs or a non-http scheme
@@ -317,7 +334,7 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
 
     const redirectUri = `https://${input.host}${oidc.redirectPath}`;
     const redirectUris = buildRedirectUris(input.host, redirectUri, oidc.extraRedirectUris);
-    const slug = slugify(`hola-${input.appName}-${input.deploymentId.slice(0, 8)}`);
+    const slug = slugify(`hola-${input.appName}-${deploymentSuffix(input.deploymentId)}`);
 
     // Idempotent re-provision: reuse the existing client, refresh its redirect URIs.
     const existing = input.existingRef;
@@ -374,7 +391,7 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
     // JWKS, and standards-compliant OIDC clients that verify the id_token via JWKS
     // (e.g. authlib — Hangar) fail with `KeyError: 'keys'`. Mirrors the dashboard path.
     const provider = await this.api<AuthentikOAuth2Provider>('POST', '/api/v3/providers/oauth2/', {
-      name: `hola-${input.appName}-${input.deploymentId.slice(0, 8)}`,
+      name: `hola-${input.appName}-${deploymentSuffix(input.deploymentId)}`,
       authorization_flow: authFlow,
       invalidation_flow: invalidationFlow,
       client_type: 'confidential',
@@ -390,7 +407,7 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
     // leave a half-provisioned orphan.
     try {
       await this.api('POST', '/api/v3/core/applications/', {
-        name: `${input.appName} (${input.deploymentId.slice(0, 8)})`,
+        name: `${input.appName} (${deploymentSuffix(input.deploymentId)})`,
         slug,
         provider: provider.pk,
         meta_launch_url: `https://${input.host}/`,
@@ -520,7 +537,7 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
 
   private async provisionForwardAuth(input: ProvisionInput): Promise<ProvisionResult> {
     const externalHost = `https://${input.host}`;
-    const slug = slugify(`hola-${input.appName}-${input.deploymentId.slice(0, 8)}`);
+    const slug = slugify(`hola-${input.appName}-${deploymentSuffix(input.deploymentId)}`);
 
     // Idempotent re-provision: reuse the existing proxy provider, refresh its host.
     const existing = input.existingRef;
@@ -550,7 +567,7 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
     ]);
 
     const provider = await this.api<{ pk: number }>('POST', '/api/v3/providers/proxy/', {
-      name: `hola-${input.appName}-${input.deploymentId.slice(0, 8)}`,
+      name: `hola-${input.appName}-${deploymentSuffix(input.deploymentId)}`,
       authorization_flow: authFlow,
       invalidation_flow: invalidationFlow,
       mode: 'forward_single',
@@ -560,7 +577,7 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
     let applicationPk: string;
     try {
       const app = await this.api<{ pk: string }>('POST', '/api/v3/core/applications/', {
-        name: `${input.appName} (${input.deploymentId.slice(0, 8)})`,
+        name: `${input.appName} (${deploymentSuffix(input.deploymentId)})`,
         slug,
         provider: provider.pk,
         meta_launch_url: externalHost,
@@ -1062,7 +1079,7 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
     const ldap = input.ldap;
     if (!ldap) throw new ProvisioningError('native-ldap requires an ldap config block');
 
-    const username = slugify(`hola-${input.appName}-${input.deploymentId.slice(0, 8)}-ldap`);
+    const username = slugify(`hola-${input.appName}-${deploymentSuffix(input.deploymentId)}-ldap`);
     const password = randomBytes(24).toString('hex');
     const baseDn = this.config.ldapBaseDn;
     const bindDn = `cn=${username},ou=users,${baseDn}`;
@@ -1422,9 +1439,9 @@ export class MockProvisionerService implements ProvisionerService {
 
   async provision(input: ProvisionInput): Promise<ProvisionResult> {
     if (input.mode === 'native-oidc' && input.oidc) {
-      const slug = slugify(`hola-${input.appName}-${input.deploymentId.slice(0, 8)}`);
-      const clientId = input.existingRef?.clientId ?? `mock-client-${input.deploymentId.slice(0, 8)}`;
-      const clientSecret = `mock-secret-${input.deploymentId.slice(0, 8)}`;
+      const slug = slugify(`hola-${input.appName}-${deploymentSuffix(input.deploymentId)}`);
+      const clientId = input.existingRef?.clientId ?? `mock-client-${deploymentSuffix(input.deploymentId)}`;
+      const clientSecret = `mock-secret-${deploymentSuffix(input.deploymentId)}`;
       const redirectUri = `https://${input.host}${input.oidc.redirectPath}`;
       const issuer = `https://auth.mock/application/o/${slug}/`;
       const names = input.oidc.env;
@@ -1443,7 +1460,7 @@ export class MockProvisionerService implements ProvisionerService {
       };
     }
     if (input.mode === 'forward-auth') {
-      const slug = slugify(`hola-${input.appName}-${input.deploymentId.slice(0, 8)}`);
+      const slug = slugify(`hola-${input.appName}-${deploymentSuffix(input.deploymentId)}`);
       return {
         env: {},
         ref: input.existingRef ?? { mode: 'forward-auth', providerPk: 2, applicationSlug: slug, outpostPk: 1 },
@@ -1451,14 +1468,14 @@ export class MockProvisionerService implements ProvisionerService {
       };
     }
     if (input.mode === 'native-ldap' && input.ldap) {
-      const username = slugify(`hola-${input.appName}-${input.deploymentId.slice(0, 8)}-ldap`);
+      const username = slugify(`hola-${input.appName}-${deploymentSuffix(input.deploymentId)}-ldap`);
       const e = input.ldap.env;
       return {
         env: {
           [e.host]: 'authentik-ldap',
           [e.port]: '3389',
           [e.bindDn]: `cn=${username},ou=users,dc=hola,dc=internal`,
-          [e.bindPassword]: `mock-ldap-pw-${input.deploymentId.slice(0, 8)}`,
+          [e.bindPassword]: `mock-ldap-pw-${deploymentSuffix(input.deploymentId)}`,
           [e.baseDn]: 'dc=hola,dc=internal',
         },
         ref: input.existingRef ?? { mode: 'native-ldap', bindAccountPk: 3 },


### PR DESCRIPTION
## Summary

Fixes **Defect 1 of #346**: installing a forward-auth app could tombstone the deployment as `error` before any container starts, and every re-install then failed the same way.

Deployment ids are `<app-slug>-<8 hex>` with the entropy in the **last** hyphen-delimited segment, but the provisioner derived Authentik provider / application / LDAP-bind names from `deploymentId.slice(0, 8)` — the **front** of the id, i.e. the app slug plus a single hex char:

```
"webtop-1c3379a4".slice(0, 8) === "webtop-1"   // app slug + 1 hex char
```

Two installs of the same app then collide whenever their random suffixes share a first character (1-in-16 for any pair; guaranteed on re-install once an orphan exists). Authentik enforces unique provider names, so the create `POST` returns `400`, `provisionAuth` throws, and `runLifecycleJob` sets `status: 'error'` before `materializeCompose`/pull/`up`.

## Fix

Add a `deploymentSuffix()` helper that returns the id's last hyphen-delimited segment (the full 8-hex disambiguator) and use it in place of every `deploymentId.slice(0, 8)` in the provisioner — across **OIDC, forward-auth, LDAP, and the mock backend**, since all three modes had the same latent collision bug.

**Safe for existing deployments:** names are only computed on the fresh-create path. Reuse and deprovision act on the stored provider `pk` / `applicationSlug` from the deployment's `auth` ref, not on a recomputed name — so already-provisioned apps are unaffected.

## Test

Adds a regression test: two forward-auth installs of the same app with suffixes sharing a first character (`webtop-a1111111`, `webtop-a2222222`) now get distinct provider names (`hola-webtop-a1111111` vs `hola-webtop-a2222222`) instead of colliding.

## Verification

- `bun run typecheck` ✅ · `bun run lint` ✅ · `bun run test` ✅ (571 server + 204 web) · `bun run build` ✅

## Scope

This is **Defect 1** only. **Defect 2** (a provisioning failure orphans Authentik objects that uninstall can't clean up, because the `auth` ref is never persisted) is real but separate — it remains tracked in #346 and wants its own change.

## Note

The `grantLdapSearch` API-path bug mentioned in #102's comments (`assigned/users` → `assigned_by_users`) is **already fixed** on `main` (`provisioner.ts:1104`), so it's not included here.

Refs #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)