### PR TITLE
fix(server): best-effort deprovision by name for failed installs (#346 Defect 2)

### DIFF
--- a/packages/server/src/__tests__/deployments/auth-provisioning.test.ts
+++ b/packages/server/src/__tests__/deployments/auth-provisioning.test.ts
@@ -609,6 +609,28 @@ describe('Auth provisioning lifecycle', () => {
     expect(text).toMatch(/action '\w+' failed: simulated provisioning failure/i);
   });
 
+  test('delete of a failed-provisioning deployment cleans up orphaned auth objects by name (#346 Defect 2)', async () => {
+    const spy = new SpyProvisioner();
+    spy.failNext = true;
+    const sys = makeSystem({ auth: OIDC_AUTH, provisioner: spy });
+
+    const created = await sys.deployments.createFromDraft({ draftId: await finalizedDraft(sys.drafts), name: 'gitea' });
+    await waitForJob(sys.jobs, created.jobId!);
+    expect((await sys.deployments.getDeployment(created.deploymentId)).status).toBe('error');
+
+    // Provisioning threw before a ref was persisted, so any Authentik objects it
+    // created before the throw have no recorded pk. A naive delete (ref-only) would
+    // strand them forever. Delete must instead ask the backend to clean up by the
+    // app's DECLARED mode + deterministic name.
+    await sys.deployments.deleteDeployment(created.deploymentId);
+
+    const byName = spy.deprovisions.find(d => !d.ref);
+    expect(byName).toBeDefined();
+    expect(byName!.mode).toBe('native-oidc');
+    expect(byName!.appName).toBe('gitea');
+    expect(byName!.deploymentId).toBe(created.deploymentId);
+  });
+
   test('forward-auth under HOLA_AUTH_MODE=none is rejected up front, creating no error-state deployment', async () => {
     // The None backend (production with no Authentik) cannot gate a forward-auth
     // route. Installing such an app must fail at create time with the clear,

--- a/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
+++ b/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
@@ -677,6 +677,90 @@ describe('RealAuthentikProvisionerService (REST contract)', () => {
     expect(deletes).toContain('/api/v3/core/applications/grafana-x/');
     expect(deletes).toContain('/api/v3/providers/proxy/55/');
   });
+
+  // ---- #346 Defect 2: best-effort deprovision by deterministic name ----------
+  // When provisioning throws before a ref is persisted, uninstall passes only the
+  // app name + declared mode (no ref). The backend must reconstruct the object
+  // names and clean up the orphan, so it isn't stranded forever.
+
+  test('forward-auth deprovision-by-name cleans up an orphan when no ref was persisted (#346)', async () => {
+    installFetch((call) => {
+      if (call.method === 'GET' && call.path.startsWith('/api/v3/providers/proxy/?name__iexact=')) {
+        return json({ results: [{ pk: 55, name: 'hola-webtop-1c3379a4' }] });
+      }
+      return undefined;
+    });
+    const svc = new RealAuthentikProvisionerService(CONFIG);
+
+    // No `ref` — mirrors a deploy whose provisioning threw before persisting one.
+    await svc.deprovision({ deploymentId: 'webtop-1c3379a4', appName: 'webtop', mode: 'forward-auth' });
+
+    // Located the orphan by its deterministic name, detached it from the embedded
+    // outpost, then deleted the application (by slug) and the provider.
+    expect(calls.some(c => c.method === 'GET' && c.path === '/api/v3/providers/proxy/?name__iexact=hola-webtop-1c3379a4')).toBe(true);
+    expect(calls.some(c => c.method === 'PATCH' && c.path === '/api/v3/outposts/instances/1/')).toBe(true);
+    const deletes = calls.filter(c => c.method === 'DELETE').map(c => c.path);
+    expect(deletes).toContain('/api/v3/core/applications/hola-webtop-1c3379a4/');
+    expect(deletes).toContain('/api/v3/providers/proxy/55/');
+  });
+
+  test('native-oidc deprovision-by-name deletes the app + provider by deterministic name (#346)', async () => {
+    installFetch((call) => {
+      if (call.method === 'GET' && call.path.startsWith('/api/v3/providers/oauth2/?name__iexact=')) {
+        return json({ results: [{ pk: 42, name: 'hola-gitea-abcd0000' }] });
+      }
+      return undefined;
+    });
+    const svc = new RealAuthentikProvisionerService(CONFIG);
+
+    await svc.deprovision({ deploymentId: 'gitea-abcd0000', appName: 'gitea', mode: 'native-oidc' });
+
+    const deletes = calls.filter(c => c.method === 'DELETE').map(c => c.path);
+    expect(deletes).toContain('/api/v3/core/applications/hola-gitea-abcd0000/');
+    expect(deletes).toContain('/api/v3/providers/oauth2/42/');
+  });
+
+  test('native-ldap deprovision-by-name deletes the bind account by username (#346)', async () => {
+    installFetch((call) => {
+      if (call.method === 'GET' && call.path.startsWith('/api/v3/core/users/?username=')) {
+        return json({ results: [{ pk: 88, username: 'hola-nextcloud-abcd0000-ldap' }] });
+      }
+      return undefined;
+    });
+    const svc = new RealAuthentikProvisionerService(CONFIG);
+
+    await svc.deprovision({ deploymentId: 'nextcloud-abcd0000', appName: 'nextcloud', mode: 'native-ldap' });
+
+    expect(calls.some(c => c.method === 'DELETE' && c.path === '/api/v3/core/users/88/')).toBe(true);
+  });
+
+  test('deprovision-by-name tolerates a missing orphan (provider not found) and still clears the app', async () => {
+    installFetch((call) => {
+      // No provider matches the name — the orphan hunt finds nothing to delete,
+      // but must not throw and must still attempt the application slug.
+      if (call.method === 'GET' && call.path.startsWith('/api/v3/providers/proxy/?name__iexact=')) {
+        return json({ results: [] });
+      }
+      return undefined;
+    });
+    const svc = new RealAuthentikProvisionerService(CONFIG);
+
+    await svc.deprovision({ deploymentId: 'webtop-1c3379a4', appName: 'webtop', mode: 'forward-auth' });
+
+    expect(calls.some(c => c.method === 'DELETE' && c.path === '/api/v3/core/applications/hola-webtop-1c3379a4/')).toBe(true);
+    // No provider pk resolved → no provider DELETE, no outpost detach.
+    expect(calls.some(c => c.method === 'DELETE' && c.path.startsWith('/api/v3/providers/proxy/'))).toBe(false);
+    expect(calls.some(c => c.method === 'PATCH' && c.path.startsWith('/api/v3/outposts/instances/'))).toBe(false);
+  });
+
+  test('deprovision with neither a ref nor app/mode is a no-op (no orphan hunt)', async () => {
+    installFetch();
+    const svc = new RealAuthentikProvisionerService(CONFIG);
+
+    await svc.deprovision({ deploymentId: 'x' });
+
+    expect(calls.length).toBe(0);
+  });
 });
 
 describe('RealAuthentikProvisionerService — scoped-token bootstrap', () => {

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -33,6 +33,7 @@ import type {
   Job,
   DeploymentListItem,
   ProvisionedAuthRef,
+  AuthMode,
   GetLogsResponse,
   LogEntry,
   GetDeploymentConfigResponse,
@@ -2112,7 +2113,25 @@ export class RealDeploymentService extends InMemoryDeploymentService {
 
   protected override async onDeprovision(deployment: EnhancedDeploymentDetail): Promise<void> {
     const auth = deployment.metadata.auth;
-    if (!auth) return;
+    if (!auth) {
+      // No provisioned ref recorded. Provisioning may have created Authentik
+      // objects and then thrown before persisting the ref (#346 Defect 2), which
+      // would otherwise strand them permanently — uninstall couldn't ever remove
+      // them. Best-effort clean up by the deterministic names derived from the
+      // app's DECLARED auth mode (read from the manifest, still available here).
+      const declared = await this.readActiveAuth(deployment);
+      if (!declared) return;
+      const modes: AuthMode[] = [];
+      if (declared.mode !== 'none') modes.push(declared.mode);
+      if (declared.fallback === 'forward-auth' && declared.mode !== 'forward-auth') modes.push('forward-auth');
+      if (modes.length === 0) return;
+      const results = await Promise.allSettled(
+        modes.map(mode => this.provisioner.deprovision({ deploymentId: deployment.id, appName: deployment.app, mode }))
+      );
+      const failed = results.find((r): r is PromiseRejectedResult => r.status === 'rejected');
+      if (failed) throw failed.reason;
+      return;
+    }
     // Tear down both refs independently: a failure deprovisioning the primary
     // must not leave the `fallback: forward-auth` provider (and its outpost
     // binding) orphaned in the auth backend. Surface the first error after both

--- a/packages/server/src/services/core/provisioner.ts
+++ b/packages/server/src/services/core/provisioner.ts
@@ -81,6 +81,16 @@ export interface ProvisionResult {
 export interface DeprovisionInput {
   deploymentId: string;
   ref?: ProvisionedAuthRef;
+  /**
+   * For best-effort cleanup of a provisioning failure that threw before a `ref`
+   * was persisted (#346 Defect 2): the app's name and DECLARED auth mode. Only
+   * consulted when `ref` is absent — the backend reconstructs the deterministic
+   * object names `provision()` would have used and removes whatever it finds, so
+   * a mid-provision failure can't strand orphaned objects that uninstall could
+   * otherwise never clean up.
+   */
+  appName?: string;
+  mode?: AuthMode;
 }
 
 /** Input for provisioning the Hola dashboard's OWN OIDC client (not a deployed app). */
@@ -292,7 +302,15 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
 
   async deprovision(input: DeprovisionInput): Promise<void> {
     const ref = input.ref;
-    if (!ref) return;
+    if (!ref) {
+      // No persisted ref: provisioning may have created Authentik objects and then
+      // thrown before the ref was recorded (#346 Defect 2). Best-effort clean them
+      // up by their deterministic names so uninstall isn't left with orphans.
+      if (input.appName && input.mode && input.mode !== 'none') {
+        await this.deprovisionByName(input.deploymentId, input.appName, input.mode);
+      }
+      return;
+    }
     if (ref.mode === 'native-oidc') {
       // Delete the application first (it points at the provider), then the provider.
       if (ref.applicationSlug) {
@@ -323,6 +341,88 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
         await this.apiDeleteIgnoreMissing(`/api/v3/core/users/${ref.bindAccountPk}/`);
       }
       this.logger.info('Deprovisioned LDAP bind account', { deploymentId: input.deploymentId, bindAccountPk: ref.bindAccountPk });
+    }
+  }
+
+  /**
+   * Best-effort teardown of Authentik objects by their DETERMINISTIC names, for a
+   * deployment whose provisioning threw before persisting a ref (#346 Defect 2).
+   * Reconstructs the exact names `provision*` would have used (from the deployment
+   * id's unique suffix) and deletes whatever exists. Tolerant of missing objects.
+   */
+  private async deprovisionByName(deploymentId: string, appName: string, mode: AuthMode): Promise<void> {
+    const suffix = deploymentSuffix(deploymentId);
+    const providerName = `hola-${appName}-${suffix}`;
+    const slug = slugify(providerName);
+
+    if (mode === 'native-oidc') {
+      await this.apiDeleteIgnoreMissing(`/api/v3/core/applications/${encodeURIComponent(slug)}/`);
+      const pk = await this.findProviderPkByName('oauth2', providerName);
+      if (pk != null) await this.apiDeleteIgnoreMissing(`/api/v3/providers/oauth2/${pk}/`);
+      this.logger.info('Best-effort deprovisioned OIDC client by name', { deploymentId, providerName, providerPk: pk });
+      return;
+    }
+    if (mode === 'forward-auth') {
+      const pk = await this.findProviderPkByName('proxy', providerName);
+      if (pk != null) {
+        const outpostPk = await this.findEmbeddedOutpostPk();
+        if (outpostPk != null) await this.removeProviderFromOutpost(outpostPk, pk);
+      }
+      await this.apiDeleteIgnoreMissing(`/api/v3/core/applications/${encodeURIComponent(slug)}/`);
+      if (pk != null) await this.apiDeleteIgnoreMissing(`/api/v3/providers/proxy/${pk}/`);
+      this.logger.info('Best-effort deprovisioned forward-auth provider by name', { deploymentId, providerName, providerPk: pk });
+      return;
+    }
+    if (mode === 'native-ldap') {
+      const username = slugify(`hola-${appName}-${suffix}-ldap`);
+      const pk = await this.findUserPkByUsername(username);
+      if (pk != null) await this.apiDeleteIgnoreMissing(`/api/v3/core/users/${pk}/`);
+      this.logger.info('Best-effort deprovisioned LDAP bind account by name', { deploymentId, username, bindAccountPk: pk });
+    }
+  }
+
+  /** Look up a provider pk by its exact name, or undefined if none/unreadable. */
+  private async findProviderPkByName(kind: 'oauth2' | 'proxy', name: string): Promise<number | undefined> {
+    try {
+      const list = await this.api<{ results?: Array<{ pk: number; name: string }> }>(
+        'GET', `/api/v3/providers/${kind}/?name__iexact=${encodeURIComponent(name)}`
+      );
+      return list.results?.find(p => p.name === name)?.pk;
+    } catch (error) {
+      this.logger.warn('Failed to look up provider by name; skipping', {
+        kind, name, error: error instanceof Error ? error.message : String(error),
+      });
+      return undefined;
+    }
+  }
+
+  /** Look up a user pk by its exact username, or undefined if none/unreadable. */
+  private async findUserPkByUsername(username: string): Promise<number | undefined> {
+    try {
+      const list = await this.api<{ results?: Array<{ pk: number; username: string }> }>(
+        'GET', `/api/v3/core/users/?username=${encodeURIComponent(username)}`
+      );
+      return list.results?.find(u => u.username === username)?.pk;
+    } catch (error) {
+      this.logger.warn('Failed to look up user by username; skipping', {
+        username, error: error instanceof Error ? error.message : String(error),
+      });
+      return undefined;
+    }
+  }
+
+  /** The embedded outpost's pk, or undefined if not found/unreadable. */
+  private async findEmbeddedOutpostPk(): Promise<number | undefined> {
+    try {
+      const list = await this.api<{ results?: Array<{ pk: number }> }>(
+        'GET', `/api/v3/outposts/instances/?name__iexact=${encodeURIComponent('authentik Embedded Outpost')}`
+      );
+      return list.results?.[0]?.pk;
+    } catch (error) {
+      this.logger.warn('Failed to look up embedded outpost; skipping detach', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return undefined;
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes **Defect 2 of #346**, stacked on the Defect 1 naming fix (#378).

When app provisioning throws **before** the deploy job persists an `auth` ref — an Authentik object gets created and a later step fails — the deployment record ends up with no ref. `onDeprovision` read `deployment.metadata.auth`, found nothing, and returned early:

```ts
const auth = deployment.metadata.auth;
if (!auth) return;   // ← orphaned provider/app/outpost binding left behind forever
```

So uninstall could **never** clean up the stranded Authentik objects. This was self-perpetuating: the orphan survived every re-install.

## Fix

On delete with no persisted ref, reconstruct the app's **declared** auth mode from the release manifest (still readable at delete time) and ask the backend to clean up by the **deterministic object names** `provision()` would have used:

- **`DeprovisionInput`** gains optional `appName` + `mode`, consulted **only** when `ref` is absent.
- **`RealAuthentikProvisionerService.deprovision`** gains a `deprovisionByName` path:
  - `native-oidc` — delete the application by slug, look up the oauth2 provider by exact name, delete it.
  - `forward-auth` — look up the proxy provider by name, detach it from the embedded outpost, delete the application by slug, delete the provider.
  - `native-ldap` — look up the bind service account by username, delete it.
  - Best-effort throughout: tolerant of missing objects (`apiDeleteIgnoreMissing`) and unreadable lookups (returns `undefined`, logs, continues).
- **`onDeprovision`** runs the by-name cleanup for the primary declared mode and, when declared, the `forward-auth` fallback.

Naming is reconstructed from the deployment id's unique suffix — consistent with the Defect 1 fix — so the by-name path targets exactly what `provision()` created.

Mock/None backends are unaffected (they only read `ref`).

## Tests

- **Contract** (`authentik-contract.test.ts`): a by-name teardown test per mode (oidc/forward-auth/ldap), a missing-orphan case (provider not found → still clears the app, no false provider delete), and a no-op guard (neither ref nor app/mode → zero API calls).
- **Lifecycle** (`auth-provisioning.test.ts`): a failed-provisioning deploy, when deleted, invokes deprovision with `{ appName, mode }` and no ref.

## Verification

- `bun run typecheck` ✅ · `bun run lint` ✅ · `bun run test` ✅ (577 server + 204 web) · `bun run build` ✅

## Review note

Base is `fix/forward-auth-provider-naming` (#378), not `main` — this stacks on it (uses the same `deploymentSuffix` helper). After #378 squash-merges, I'll rebase this onto `main`.

Refs #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)