### PR TITLE
feat: merge-by-key semantics for deployment env PATCH (#332)

### DIFF
--- a/packages/cli/src/__tests__/deployment-config.test.ts
+++ b/packages/cli/src/__tests__/deployment-config.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { runConfig } from '../commands/deployments/config';
+import type { HolaSdk } from '@hola/sdk';
+
+function makeSdk(overrides: { deployments?: Record<string, unknown>; jobs?: Record<string, unknown> } = {}) {
+  return {
+    deployments: {
+      update: vi.fn(async () => ({ ok: true, jobId: 'j1' })),
+      config: vi.fn(async () => ({
+        appEnv: [
+          { key: 'MAX_CONNECTIONS', value: '10', isSecret: false },
+          { key: 'API_TOKEN', value: 'sekret', isSecret: true },
+        ],
+        systemOverrides: { CUSTOM_DOMAIN: 'app.example.com' },
+      })),
+      ...(overrides.deployments ?? {}),
+    },
+    jobs: { byId: vi.fn(async () => ({ status: 'completed' })), ...(overrides.jobs ?? {}) },
+  };
+}
+
+describe('hola config', () => {
+  beforeEach(() => {
+    process.exitCode = 0;
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => { vi.restoreAllMocks(); process.exitCode = 0; });
+
+  it('with no --set/--unset reads and prints the current config (masking secrets)', async () => {
+    const sdk = makeSdk();
+    const logs: string[] = [];
+    (console.log as unknown as ReturnType<typeof vi.fn>).mockImplementation((m: string) => { logs.push(m); });
+
+    await runConfig('dep1', {}, { sdk: sdk as unknown as HolaSdk });
+
+    expect(sdk.deployments.config).toHaveBeenCalledWith('dep1');
+    expect(sdk.deployments.update).not.toHaveBeenCalled();
+    expect(logs).toContain('MAX_CONNECTIONS=10');
+    expect(logs).toContain('API_TOKEN=***'); // secret masked
+  });
+
+  it('--set sends an env upsert (isSecret:false; server re-imposes spec) and watches the restart', async () => {
+    const sdk = makeSdk();
+    await runConfig('dep1', { set: 'LOG_LEVEL=debug', noStream: true }, { sdk: sdk as unknown as HolaSdk });
+
+    expect(sdk.deployments.update).toHaveBeenCalledWith('dep1', {
+      env: [{ key: 'LOG_LEVEL', value: 'debug', isSecret: false }],
+    });
+    expect(sdk.jobs.byId).toHaveBeenCalledWith('j1');
+    expect(sdk.deployments.config).not.toHaveBeenCalled();
+  });
+
+  it('preserves = signs in the value and trims the key', async () => {
+    const sdk = makeSdk();
+    await runConfig('dep1', { set: ' DATABASE_URL =postgres://u:p@h/db?x=1', noStream: true }, { sdk: sdk as unknown as HolaSdk });
+    expect(sdk.deployments.update).toHaveBeenCalledWith('dep1', {
+      env: [{ key: 'DATABASE_URL', value: 'postgres://u:p@h/db?x=1', isSecret: false }],
+    });
+  });
+
+  it('--unset sends removeEnvKeys', async () => {
+    const sdk = makeSdk();
+    await runConfig('dep1', { unset: 'OLD_FLAG', noStream: true }, { sdk: sdk as unknown as HolaSdk });
+    expect(sdk.deployments.update).toHaveBeenCalledWith('dep1', { removeEnvKeys: ['OLD_FLAG'] });
+  });
+
+  it('combines multiple --set and --unset into one PATCH', async () => {
+    const sdk = makeSdk();
+    await runConfig(
+      'dep1',
+      { set: ['A=1', 'B=2'], unset: ['C', 'D'], noStream: true },
+      { sdk: sdk as unknown as HolaSdk },
+    );
+    expect(sdk.deployments.update).toHaveBeenCalledWith('dep1', {
+      env: [
+        { key: 'A', value: '1', isSecret: false },
+        { key: 'B', value: '2', isSecret: false },
+      ],
+      removeEnvKeys: ['C', 'D'],
+    });
+  });
+
+  it('rejects a --set without = and does not call the API', async () => {
+    const sdk = makeSdk();
+    const res = await runConfig('dep1', { set: 'NOEQUALS', noStream: true }, { sdk: sdk as unknown as HolaSdk });
+    expect(res).toBeUndefined();
+    expect(sdk.deployments.update).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('sets exit code 1 when the restart job fails', async () => {
+    const sdk = makeSdk({ jobs: { byId: vi.fn(async () => ({ status: 'failed' })) } });
+    await runConfig('dep1', { set: 'A=1', noStream: true }, { sdk: sdk as unknown as HolaSdk });
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/packages/cli/src/commands/deployments/config.ts
+++ b/packages/cli/src/commands/deployments/config.ts
@@ -1,0 +1,99 @@
+import { HolaSdk } from '@hola/sdk';
+import type { AppEnvVar, GetDeploymentConfigResponse, PatchDeploymentResponse } from '@hola/shared';
+
+import { watchJob, reportDeployError } from '../../lib/deploy-flow';
+import { maybeNotifyUpdate } from '../../lib/update-notice';
+
+export interface ConfigOptions {
+  /** `KEY=VALUE` upserts (repeatable). */
+  set?: string | string[];
+  /** Keys to remove (repeatable). */
+  unset?: string | string[];
+  noStream?: boolean;
+  json?: boolean;
+}
+
+/** Normalize a repeatable string option into an array (sade yields string | string[]). */
+function toArray(v?: string | string[]): string[] {
+  if (v === undefined) return [];
+  return Array.isArray(v) ? v : [v];
+}
+
+/** Parse `KEY=VALUE` upserts into env rows. `isSecret` is left false — the server
+ *  re-imposes the manifest spec (incl. isSecret) on any key it already knows. */
+function parseUpserts(set?: string | string[]): AppEnvVar[] {
+  return toArray(set).map((item) => {
+    const eq = String(item).indexOf('=');
+    if (eq <= 0) throw new Error(`Invalid --set '${item}' (expected KEY=VALUE)`);
+    return { key: String(item).slice(0, eq).trim(), value: String(item).slice(eq + 1), isSecret: false };
+  });
+}
+
+/**
+ * `hola config <deploymentId>` — view or edit a deployment's environment.
+ *
+ * With no `--set`/`--unset`, prints the current config. Otherwise sends a single
+ * merge-by-key PATCH (issue #332): `--set` upserts a var, `--unset` removes one,
+ * and any var not mentioned is left untouched. The PATCH restarts the app to
+ * apply the change (watched unless `--no-stream`).
+ */
+export async function runConfig(
+  deploymentId: string,
+  opts: ConfigOptions,
+  injected?: { sdk?: HolaSdk }
+): Promise<PatchDeploymentResponse | GetDeploymentConfigResponse | undefined> {
+  const sdk = injected?.sdk ?? new HolaSdk();
+  const out = (m: string) => console.log(m);
+  try {
+    const upserts = parseUpserts(opts.set);
+    const removeEnvKeys = toArray(opts.unset).map((k) => k.trim());
+
+    // No mutation requested → show the current config.
+    if (upserts.length === 0 && removeEnvKeys.length === 0) {
+      const cfg = (await sdk.deployments.config(deploymentId)) as GetDeploymentConfigResponse;
+      if (opts.json) {
+        console.log(JSON.stringify(cfg, null, 2));
+      } else {
+        if (cfg.appEnv.length === 0) out('(no environment variables)');
+        for (const e of cfg.appEnv) out(`${e.key}=${e.isSecret ? '***' : e.value}`);
+        const overrides = Object.entries(cfg.systemOverrides ?? {});
+        if (overrides.length > 0) {
+          out('\n# system overrides');
+          for (const [k, v] of overrides) out(`${k}=${v}`);
+        }
+      }
+      await maybeNotifyUpdate(sdk, opts);
+      return cfg;
+    }
+
+    const summary = [
+      upserts.length ? `set ${upserts.map((u) => u.key).join(', ')}` : '',
+      removeEnvKeys.length ? `unset ${removeEnvKeys.join(', ')}` : '',
+    ].filter(Boolean).join('; ');
+    out(`Updating ${deploymentId} config (${summary})…`);
+
+    const res = (await sdk.deployments.update(deploymentId, {
+      ...(upserts.length ? { env: upserts } : {}),
+      ...(removeEnvKeys.length ? { removeEnvKeys } : {}),
+    })) as PatchDeploymentResponse;
+
+    let status: string | undefined;
+    if (res.jobId && !opts.noStream) {
+      status = await watchJob(sdk, res.jobId, (m) => out(m));
+    } else if (res.jobId) {
+      const job = (await sdk.jobs.byId(res.jobId)) as { status?: string };
+      status = job.status ?? 'queued';
+    }
+
+    if (opts.json) {
+      console.log(JSON.stringify({ ...res, status }, null, 2));
+    } else {
+      out(status ? `Done (${status}).` : 'Done.');
+    }
+    if (status === 'failed') process.exitCode = 1;
+    await maybeNotifyUpdate(sdk, opts);
+    return res;
+  } catch (err) {
+    return reportDeployError(err);
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -258,6 +258,23 @@ prog
     await runUpgrade(deploymentId, streamOpts(opts));
   });
 
+// config — view or edit a deployment's environment variables. Merge-by-key:
+// --set upserts, --unset removes, and vars not mentioned are left untouched.
+prog
+  .command('config <deploymentId>')
+  .describe("View or edit a deployment's environment variables")
+  .example('config gitea-ab12cd34                                  # show current env')
+  .example('config gitea-ab12cd34 --set LOG_LEVEL=debug            # upsert one var')
+  .example('config gitea-ab12cd34 --set A=1 --set B=2 --unset OLD  # combined, one restart')
+  .option('--set', 'Upsert a KEY=VALUE env var (repeatable)')
+  .option('--unset', 'Remove an env var by key (repeatable)')
+  .option('--no-stream', 'Do not watch the restart job', false)
+  .option('--json', 'Print raw JSON output', false)
+  .action(async (deploymentId, opts) => {
+    const { runConfig } = await load(import('./commands/deployments/config'));
+    await runConfig(deploymentId, streamOpts(opts));
+  });
+
 // Fallback banner when no args
 if (process.argv.length <= 2) {
   // Minimal banner when no args. Lead with setup for first-time users, then the

--- a/packages/server/src/__tests__/deployments/config.test.ts
+++ b/packages/server/src/__tests__/deployments/config.test.ts
@@ -201,6 +201,82 @@ describe('Deployment configuration (getConfig + real updateDeployment)', () => {
     expect(dotenv).toContain('ADMIN_USER="root"');
   });
 
+  test('a partial env update leaves omitted vars untouched (merge-by-key, issue #332)', async () => {
+    const { drafts, deployments, jobs } = makeSystem();
+    const deploymentId = await createRunningDeployment(drafts, deployments, jobs);
+
+    // Send ONLY ADMIN_USER. Under the old full-replace this silently wiped
+    // MAX_CONNECTIONS; merge-by-key must leave it (and its spec) intact.
+    const result = await deployments.updateDeployment(deploymentId, {
+      env: [{ key: 'ADMIN_USER', value: 'root', isSecret: false }],
+    });
+    expect(result.ok).toBe(true);
+    await waitForJob(jobs, result.jobId!);
+
+    const config = await deployments.getConfig(deploymentId);
+    expect(config.appEnv.find((e) => e.key === 'ADMIN_USER')?.value).toBe('root');
+    const maxConn = config.appEnv.find((e) => e.key === 'MAX_CONNECTIONS');
+    expect(maxConn?.value).toBe('10'); // NOT dropped
+    expect(maxConn?.type).toBe('integer'); // spec still intact
+  });
+
+  test('adding a new custom var merges it without dropping existing vars', async () => {
+    const { drafts, deployments, jobs } = makeSystem();
+    const deploymentId = await createRunningDeployment(drafts, deployments, jobs);
+
+    const result = await deployments.updateDeployment(deploymentId, {
+      env: [{ key: 'EXTRA_FLAG', value: 'on', isSecret: false }],
+    });
+    await waitForJob(jobs, result.jobId!);
+
+    const config = await deployments.getConfig(deploymentId);
+    expect(config.appEnv.find((e) => e.key === 'EXTRA_FLAG')?.value).toBe('on');
+    expect(config.appEnv.find((e) => e.key === 'MAX_CONNECTIONS')?.value).toBe('10');
+    expect(config.appEnv.find((e) => e.key === 'ADMIN_USER')?.value).toBe('admin');
+  });
+
+  test('removeEnvKeys deletes the named vars (idempotent) and leaves the rest', async () => {
+    const { drafts, deployments, jobs } = makeSystem();
+    const deploymentId = await createRunningDeployment(drafts, deployments, jobs);
+
+    // Seed a custom var, then remove it plus a key that never existed.
+    await waitForJob(
+      jobs,
+      (await deployments.updateDeployment(deploymentId, { env: [{ key: 'EXTRA_FLAG', value: 'on', isSecret: false }] })).jobId!,
+    );
+
+    const result = await deployments.updateDeployment(deploymentId, {
+      removeEnvKeys: ['EXTRA_FLAG', 'NEVER_EXISTED'],
+    });
+    expect(result.ok).toBe(true);
+    await waitForJob(jobs, result.jobId!);
+
+    const config = await deployments.getConfig(deploymentId);
+    expect(config.appEnv.some((e) => e.key === 'EXTRA_FLAG')).toBe(false);
+    expect(config.appEnv.find((e) => e.key === 'MAX_CONNECTIONS')?.value).toBe('10');
+    expect(config.appEnv.find((e) => e.key === 'ADMIN_USER')?.value).toBe('admin');
+  });
+
+  test('a combined set + unset applies in a single update', async () => {
+    const { drafts, deployments, jobs } = makeSystem();
+    const deploymentId = await createRunningDeployment(drafts, deployments, jobs);
+    await waitForJob(
+      jobs,
+      (await deployments.updateDeployment(deploymentId, { env: [{ key: 'OLD', value: '1', isSecret: false }] })).jobId!,
+    );
+
+    const result = await deployments.updateDeployment(deploymentId, {
+      env: [{ key: 'ADMIN_USER', value: 'root', isSecret: false }],
+      removeEnvKeys: ['OLD'],
+    });
+    await waitForJob(jobs, result.jobId!);
+
+    const config = await deployments.getConfig(deploymentId);
+    expect(config.appEnv.find((e) => e.key === 'ADMIN_USER')?.value).toBe('root');
+    expect(config.appEnv.some((e) => e.key === 'OLD')).toBe(false);
+    expect(config.appEnv.find((e) => e.key === 'MAX_CONNECTIONS')?.value).toBe('10');
+  });
+
   test('updateDeployment with systemOverrides persists them and is reflected in getConfig', async () => {
     const { drafts, deployments, jobs } = makeSystem();
     const deploymentId = await createRunningDeployment(drafts, deployments, jobs);

--- a/packages/server/src/__tests__/deployments/merge-app-env.test.ts
+++ b/packages/server/src/__tests__/deployments/merge-app-env.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests for `mergeAppEnv` — the per-key ("PATCH") merge that backs the
+ * deployment config update (issue #332). Full-replace lived in `hardenAppEnv`;
+ * this must instead preserve omitted vars, upsert listed ones (re-imposing the
+ * stored spec), and delete only what `removeKeys` names.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import type { AppEnvVar } from '@hola/shared';
+
+import { mergeAppEnv } from '../../services/core/draft';
+
+const stored: AppEnvVar[] = [
+  { key: 'MAX_CONNECTIONS', value: '10', isSecret: false, type: 'integer', min: 1, max: 100 },
+  { key: 'ADMIN_USER', value: 'admin', isSecret: false },
+  { key: 'API_TOKEN', value: 'seed', isSecret: true },
+];
+
+describe('mergeAppEnv', () => {
+  test('a partial upsert leaves omitted vars untouched (the #332 fix)', () => {
+    const merged = mergeAppEnv(stored, [{ key: 'ADMIN_USER', value: 'root', isSecret: false }]);
+    expect(merged.find((e) => e.key === 'ADMIN_USER')?.value).toBe('root');
+    // Omitted vars survive, unlike the old full-replace.
+    expect(merged.find((e) => e.key === 'MAX_CONNECTIONS')?.value).toBe('10');
+    expect(merged.find((e) => e.key === 'API_TOKEN')?.value).toBe('seed');
+  });
+
+  test('an upsert re-imposes the stored spec — a client only owns value', () => {
+    const merged = mergeAppEnv(stored, [
+      // A forged spec (wrong type/max, and trying to flip isSecret) must be ignored.
+      { key: 'MAX_CONNECTIONS', value: '50', isSecret: true, type: 'string', max: 999999 } as AppEnvVar,
+    ]);
+    const row = merged.find((e) => e.key === 'MAX_CONNECTIONS')!;
+    expect(row.value).toBe('50'); // value is honored
+    expect(row.type).toBe('integer'); // spec preserved from stored
+    expect(row.max).toBe(100);
+    expect(row.isSecret).toBe(false);
+  });
+
+  test('removeKeys drops vars; unknown keys are ignored (idempotent)', () => {
+    const merged = mergeAppEnv(stored, [], ['API_TOKEN', 'NOPE']);
+    expect(merged.some((e) => e.key === 'API_TOKEN')).toBe(false);
+    expect(merged.map((e) => e.key)).toEqual(['MAX_CONNECTIONS', 'ADMIN_USER']);
+  });
+
+  test('a brand-new key is appended after the stored rows, in upsert order', () => {
+    const merged = mergeAppEnv(stored, [
+      { key: 'B_NEW', value: '2', isSecret: false },
+      { key: 'A_NEW', value: '1', isSecret: false },
+    ]);
+    expect(merged.map((e) => e.key)).toEqual(['MAX_CONNECTIONS', 'ADMIN_USER', 'API_TOKEN', 'B_NEW', 'A_NEW']);
+  });
+
+  test('a key in both upserts and removeKeys is removed (delete wins)', () => {
+    const merged = mergeAppEnv(stored, [{ key: 'ADMIN_USER', value: 'root', isSecret: false }], ['ADMIN_USER']);
+    expect(merged.some((e) => e.key === 'ADMIN_USER')).toBe(false);
+  });
+
+  test('empty request returns the stored env unchanged', () => {
+    expect(mergeAppEnv(stored, [])).toEqual(stored);
+  });
+});

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -52,7 +52,7 @@ import type { JobService, JobContext } from './jobs';
 import { JobCancelledError } from './jobs';
 import type { DockerService } from './docker';
 import type { DraftService, FinalizedArtifacts, FinalizedManifest } from './draft';
-import { hardenAppEnv } from './draft';
+import { mergeAppEnv } from './draft';
 import type { RegistryCredentialService } from './registry-credentials';
 import type { PullCredentials } from './bundles';
 import type { CatalogService } from './catalog';
@@ -1370,7 +1370,8 @@ export class RealDeploymentService extends InMemoryDeploymentService {
 
     this.logger.info('Updating deployment configuration', { deploymentId });
 
-    if (!request.env && !request.systemOverrides) {
+    const hasEnvChange = request.env !== undefined || (request.removeEnvKeys?.length ?? 0) > 0;
+    if (!hasEnvChange && !request.systemOverrides) {
       // Nothing to do — mirror the base class's cheap no-op path (still bumps
       // lastUpdated) rather than requiring an active release for a no-op call.
       deployment.lastUpdated = new Date().toISOString();
@@ -1385,11 +1386,14 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     }
     const manifest = JSON.parse(await this.storageService.readFileAsString(manifestPath)) as FinalizedManifest;
 
-    if (request.env) {
-      // Re-impose spec (type/required/pattern/etc.) from the stored manifest
-      // onto the incoming rows — a client only owns `value`, never the spec —
-      // then validate the merged result against that same spec.
-      const merged = hardenAppEnv(manifest.appEnv ?? [], request.env);
+    if (hasEnvChange) {
+      // Merge-by-key (issue #332): `env` rows are upserted (spec re-imposed from
+      // the stored manifest — a client only owns `value`, never the spec),
+      // `removeEnvKeys` are dropped, and any stored var omitted from the request
+      // is left untouched. Then validate the merged result against that spec, so
+      // e.g. removing a required var is rejected rather than silently breaking
+      // the app.
+      const merged = mergeAppEnv(manifest.appEnv ?? [], request.env ?? [], request.removeEnvKeys ?? []);
       const issues = validateParams(merged);
       const errors = issues.filter((i) => i.severity === 'error');
       if (errors.length > 0) {

--- a/packages/server/src/services/core/draft.ts
+++ b/packages/server/src/services/core/draft.ts
@@ -207,6 +207,41 @@ export function hardenAppEnv(storedEnv: AppEnvVar[], incomingEnv: AppEnvVar[]): 
   });
 }
 
+/**
+ * Merge a PATCH into a deployment's stored env with per-key ("PATCH") semantics
+ * (issue #332), instead of the full-replace `hardenAppEnv` does for the draft
+ * wizard. Keys in `upserts` are added or have their `value` replaced (spec
+ * re-imposed from the stored row, exactly like `hardenAppEnv`); keys in
+ * `removeKeys` are dropped; every other stored key is left untouched — so a
+ * partial request no longer silently wipes the vars it omits.
+ *
+ * Stored order is preserved (with brand-new keys appended in `upserts` order).
+ * A key that appears in both `upserts` and `removeKeys` is removed (delete wins).
+ */
+export function mergeAppEnv(
+  storedEnv: AppEnvVar[],
+  upserts: AppEnvVar[],
+  removeKeys: string[] = [],
+): AppEnvVar[] {
+  const remove = new Set(removeKeys);
+  const upsertByKey = new Map(upserts.map((e) => [e.key, e]));
+  const storedKeys = new Set(storedEnv.map((e) => e.key));
+
+  const result: AppEnvVar[] = [];
+  // Existing rows: drop if removed, else apply an upsert's value (spec preserved).
+  for (const stored of storedEnv) {
+    if (remove.has(stored.key)) continue;
+    const up = upsertByKey.get(stored.key);
+    result.push(up ? { ...stored, value: up.value } : stored);
+  }
+  // Brand-new keys (not already stored), minus any also flagged for removal.
+  for (const up of upserts) {
+    if (storedKeys.has(up.key) || remove.has(up.key)) continue;
+    result.push(up);
+  }
+  return result;
+}
+
 export class RealDraftService implements DraftService {
   private logger = getLogger().child({ service: 'DraftService' });
   private drafts = new Map<string, DraftRecord>();

--- a/packages/shared/src/docs/api-explorer.ts
+++ b/packages/shared/src/docs/api-explorer.ts
@@ -545,7 +545,7 @@ export const API_ENDPOINTS: EndpointMetadata[] = [
     method: 'PATCH',
     operationId: 'updateDeployment',
     summary: 'Update Deployment Configuration',
-    description: 'Update configuration of an existing deployment',
+    description: 'Update configuration of an existing deployment. Env changes merge by key: vars in `env` are upserted, vars omitted are left untouched, and keys in `removeEnvKeys` are deleted.',
     tags: ['deployments'],
     parameters: [
       {
@@ -1136,7 +1136,10 @@ export function generateTypeScriptSchemas(): Record<string, string> {
 }`,
 
     PatchDeploymentRequest: `{
+  // Merge-by-key: vars listed are upserted; stored vars omitted here are left
+  // untouched. Use removeEnvKeys to delete. (issue #332)
   env?: AppEnvVar[];
+  removeEnvKeys?: string[];
   systemOverrides?: Record<string, string>;
 }`,
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -992,7 +992,16 @@ export type DeploymentDetail = {
 export type GetDeploymentResponse = DeploymentDetail;
 
 export type PatchDeploymentRequest = {
+  /**
+   * Env vars to add or update, keyed by `key` (issue #332). This PATCH has
+   * **merge-by-key** semantics: a var listed here is upserted (its `value` is
+   * set; the manifest-declared spec is preserved server-side), and any stored
+   * var NOT listed is left untouched — a partial request never wipes the vars it
+   * omits. To remove a var, list its key in `removeEnvKeys`.
+   */
   env?: AppEnvVar[];
+  /** Keys to delete from the deployment's env. Idempotent (unknown keys are ignored). */
+  removeEnvKeys?: string[];
   systemOverrides?: Record<string, string>;
 };
 // `jobId` is present when the update triggered a real redeploy (a restart job

--- a/packages/web/src/__tests__/pages/DeploymentDetail.test.tsx
+++ b/packages/web/src/__tests__/pages/DeploymentDetail.test.tsx
@@ -171,6 +171,30 @@ describe('DeploymentDetail Configuration tab', () => {
     const [calledId, payload] = deploymentsApi.update.mock.calls[0];
     expect(calledId).toBe(deploymentId);
     expect(payload.env.find((e: { key: string }) => e.key === 'ADMIN_USER').value).toBe('root');
+    // A pure edit (nothing deleted) sends no removeEnvKeys — merge-by-key leaves
+    // every omitted var untouched, so there's nothing to delete.
+    expect(payload.removeEnvKeys).toBeUndefined();
+  });
+
+  it('sends removeEnvKeys for a var deleted from the working copy (merge-by-key, #332)', async () => {
+    renderDetail();
+    await waitFor(() => expect(screen.getByText('ADMIN_USER')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /edit configuration/i }));
+
+    // ADMIN_USER is a specless (custom) row, so it has a remove button. Delete it.
+    const removeBtn = await screen.findByRole('button', { name: /remove custom variable/i });
+    fireEvent.click(removeBtn);
+
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => expect(deploymentsApi.update).toHaveBeenCalledTimes(1));
+    const [, payload] = deploymentsApi.update.mock.calls[0];
+    // The deletion is stated explicitly now, not expressed by omission.
+    expect(payload.removeEnvKeys).toEqual(['ADMIN_USER']);
+    expect(payload.env.some((e: { key: string }) => e.key === 'ADMIN_USER')).toBe(false);
+    // The var still in the form is upserted (and untouched vars survive server-side).
+    expect(payload.env.some((e: { key: string }) => e.key === 'MAX_CONNECTIONS')).toBe(true);
   });
 
   it('blocks saving an out-of-range typed value client-side without calling the API', async () => {

--- a/packages/web/src/pages/DeploymentDetail.tsx
+++ b/packages/web/src/pages/DeploymentDetail.tsx
@@ -361,9 +361,20 @@ export const DeploymentDetail: React.FC = () => {
     setOperationLoading(prev => ({ ...prev, 'save-config': true }));
 
     try {
+      // The server PATCH merges by key (issue #332): the rows we send are
+      // upserted and any var we omit is left untouched — so a deletion must be
+      // stated explicitly. Derive the removed keys (present in the loaded config,
+      // now gone from the working copy) and drop any half-added blank-key rows
+      // from the upserts.
+      const currentKeys = new Set(envVars.map((e) => e.key));
+      const removeEnvKeys = (configData?.appEnv ?? [])
+        .map((e) => e.key)
+        .filter((k) => k && !currentKeys.has(k));
+
       await updateConfiguration({
-        env: envVars,
-        systemOverrides
+        env: envVars.filter((e) => e.key),
+        ...(removeEnvKeys.length ? { removeEnvKeys } : {}),
+        systemOverrides,
       });
       setIsEditing(false);
       // Force a fresh read: updateConfiguration only invalidates the


### PR DESCRIPTION
## Summary

Fixes **#332**. `PATCH /api/deployments/:id` treated `env` as a **full replace** — any stored var whose key was absent from the request was silently dropped and wiped from the running container on the triggered restart. The wire contract never said "full replace", so a direct SDK/CLI/API caller sending a subset reasonably expected a partial update and got silent data loss on every other var.

This switches to **faithful PATCH (merge-by-key) semantics** across the API, CLI, and web:

- vars listed in `env` are **upserted** (spec preserved server-side — a client only owns `value`),
- vars **omitted** are left untouched,
- deletion is **explicit** via a new `removeEnvKeys: string[]`.

## Changes

**shared** — `PatchDeploymentRequest` gains `removeEnvKeys?: string[]`; `env` documented as upserts; API-explorer docs updated.

**server** — new `mergeAppEnv(stored, upserts, removeKeys)` (alongside the draft wizard's unchanged full-replace `hardenAppEnv`). `updateDeployment` upserts listed vars, drops `removeEnvKeys`, leaves the rest intact, then **validates the merged result** — so removing a required var is rejected rather than silently breaking the app.

**cli** — new `hola config <deploymentId>`:
```
hola config gitea-ab12cd34                                   # show env (secrets masked)
hola config gitea-ab12cd34 --set LOG_LEVEL=debug             # upsert (repeatable)
hola config gitea-ab12cd34 --set A=1 --unset OLD             # combined, one restart
```
Greenfield — no prior CLI command touched the deployment-config endpoint. With merge semantics it sends only the delta (no read-modify-write).

**web** — the Configuration tab's Save derives explicit `removeEnvKeys` from vars removed from the working copy (deletion was previously expressed by omission, which merge semantics no longer honors) and drops half-added blank-key rows.

## Design note

The **draft/install path stays full-replace** (`hardenAppEnv` unchanged) — the install wizard submits the whole form, so full-replace is correct there. The two PATCH paths now deliberately diverge, which is exactly the risk #332 flagged about naively changing the shared `hardenAppEnv`; keeping them separate avoids it.

The delete signal is a separate `removeEnvKeys` array rather than a per-entry `_delete` flag, to keep the rich shared `AppEnvVar` type clean.

## Tests

- **mergeAppEnv unit** (`merge-app-env.test.ts`): order preservation, delete-wins-over-upsert, spec re-imposition (client can't forge type/isSecret), idempotent removes, empty request.
- **server config integration** (`config.test.ts`): a partial update leaves omitted vars untouched (the #332 regression), add-new-without-dropping, `removeEnvKeys` deletes + is idempotent, combined set+unset.
- **CLI** (`deployment-config.test.ts`): set/unset/show, secret masking, `=`-in-value + key-trim, combined, invalid `--set` rejected, failed-job exit code.
- **web** (`DeploymentDetail.test.tsx`): a pure edit sends no `removeEnvKeys`; deleting a row sends `removeEnvKeys: [key]` and omits it from `env`.

## Verification

`bun run typecheck` ✅ · `bun run lint` ✅ · `bun run test` ✅ (587 server + 205 web) · CLI suite ✅ (180) · `bun run build` ✅

## Backward compatibility

The web already sent the full `env` list, so existing clients keep working (a full list upserts everything — no data loss); only the deletion path needed the new explicit signal, which the web now sends.

Closes #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)