### PR TITLE
fix(server): remove host bind-mount data root on uninstall (#341)

### DIFF
--- a/packages/server/src/__tests__/deployments/persistence.test.ts
+++ b/packages/server/src/__tests__/deployments/persistence.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { mkdtemp, rm } from 'fs/promises';
+import { mkdtemp, rm, mkdir, writeFile, access } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
@@ -124,6 +124,36 @@ describe('Deployment persistence (real service)', () => {
     // Survives a restart (fresh service over the same data root rehydrates metadata).
     const restarted = makeSystem();
     expect(await restarted.deployments.getDeploymentSource(depCustom.deploymentId)).toBe('get2know');
+  });
+
+  test('deleteDeployment reclaims the host bind-mount data root (#341)', async () => {
+    const bindRoot = await mkdtemp(join(tmpdir(), 'hola-appsbind-'));
+    const prevBindRoot = process.env.HOLA_APPS_BIND_ROOT;
+    process.env.HOLA_APPS_BIND_ROOT = bindRoot;
+    try {
+      const { drafts, deployments } = makeSystem();
+      const draftId = await finalizedDraft(drafts, 'services:\n  gitea:\n    image: gitea/gitea\n');
+      const created = await deployments.createFromDraft({ draftId, name: 'gitea', options: { autoStart: false } });
+
+      // Simulate the app's persistent data written into its bind root by a real
+      // `docker compose up` (Postgres db/, uploaded media/, etc.).
+      const exists = async (p: string) => access(p).then(() => true, () => false);
+      const appRoot = join(bindRoot, created.deploymentId);
+      await mkdir(join(appRoot, 'db'), { recursive: true });
+      await writeFile(join(appRoot, 'db', 'data'), 'rows');
+      expect(await exists(appRoot)).toBe(true);
+
+      await deployments.deleteDeployment(created.deploymentId);
+
+      // The data root is gone — uninstall no longer leaves orphaned data on disk.
+      expect(await exists(appRoot)).toBe(false);
+      // The bind root itself is untouched (guard only deletes strictly within it).
+      expect(await exists(bindRoot)).toBe(true);
+    } finally {
+      if (prevBindRoot === undefined) delete process.env.HOLA_APPS_BIND_ROOT;
+      else process.env.HOLA_APPS_BIND_ROOT = prevBindRoot;
+      await rm(bindRoot, { recursive: true, force: true });
+    }
   });
 
   test('promotes a finalized draft into a deployment with a persisted active release', async () => {

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -321,6 +321,16 @@ abstract class InMemoryDeploymentService implements DeploymentService {
     void deploymentId;
   }
   /**
+   * Remove a deployment's host bind-mount data root (`<HOLA_APPS_BIND_ROOT>/<id>`
+   * — the app's persistent Postgres/media data). Distinct from {@link removeStorage},
+   * which only covers the internal `/data/deployments/<id>` tree. Base is a no-op
+   * (mock/in-memory has no host data); the real service overrides it. Called on
+   * delete so uninstall doesn't accumulate orphaned data dirs (#341).
+   */
+  protected async removeAppData(deploymentId: string): Promise<void> {
+    void deploymentId;
+  }
+  /**
    * Tear down a deployment's running containers (`docker compose down`).
    * Base is a no-op; the real service overrides it. Called synchronously during
    * delete BEFORE {@link removeStorage} so the compose file still exists on disk.
@@ -825,6 +835,18 @@ abstract class InMemoryDeploymentService implements DeploymentService {
       await this.removeStorage(deploymentId);
     } catch (error) {
       this.logger.warn('Failed to delete deployment storage', {
+        deploymentId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
+    // Reclaim the host bind-mount data root (Postgres/media/etc). Best-effort and
+    // non-fatal, mirroring removeStorage: a failure here must never block delete —
+    // it leaves reclaimable data on disk, logged for manual cleanup (#341).
+    try {
+      await this.removeAppData(deploymentId);
+    } catch (error) {
+      this.logger.warn('Failed to delete deployment app data root', {
         deploymentId,
         error: error instanceof Error ? error.message : String(error),
       });
@@ -2247,6 +2269,25 @@ export class RealDeploymentService extends InMemoryDeploymentService {
 
   protected override async removeStorage(deploymentId: string): Promise<void> {
     await this.storageService.deleteDir(`deployments/${deploymentId}`, true);
+  }
+
+  /**
+   * Remove the deployment's host bind-mount data root (`<HOLA_APPS_BIND_ROOT>/<id>`).
+   * Guarded to only ever delete strictly *within* the apps bind root — never the
+   * root itself nor any path escaping it — so a malformed id can't widen the blast
+   * radius. No-ops when the dir doesn't exist (apps with no `${HOLA_APP_DATA}` mount
+   * never create one), keeping the delete path quiet for those (#341).
+   */
+  protected override async removeAppData(deploymentId: string): Promise<void> {
+    const base = this.appsBindRoot();
+    const appRoot = this.appRootFor(deploymentId);
+    if (appRoot === base || !appRoot.startsWith(`${base}/`)) {
+      this.logger.warn('Refusing to remove app data outside the apps bind root', { deploymentId, appRoot, base });
+      return;
+    }
+    if (!(await dirHasContents(appRoot))) return;
+    await this.storageService.deleteDir(appRoot, true);
+    this.logger.info('Removed deployment app data root', { deploymentId, appRoot });
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #341. Uninstalling a deployment left its **host bind data root**
(`${HOLA_APPS_BIND_ROOT}/<deploymentId>`, default `/srv/hola/apps/<id>` — the
app's Postgres `db/`, uploaded `media/`, etc.) on disk. `deleteDeployment` ran
`teardownContainers` → `onDeprovision` → `removeStorage` → `onDeploymentRemoved`,
none of which touched the bind root, so orphaned data accumulated with every
install/uninstall cycle.

## Change

- New `removeAppData` lifecycle hook: base is a no-op (mock/in-memory has no host
  data); `RealDeploymentService` overrides it to delete `appRootFor(deploymentId)`.
- Wired into `deleteDeployment` as a **best-effort, non-fatal** step (mirrors the
  existing `removeStorage` try/catch) so a failure never blocks uninstall — it
  just leaves reclaimable data on disk, logged for manual cleanup.
- **Guarded**: only ever deletes strictly *within* the apps bind root (never the
  root itself nor an escaping path). No-ops when the app declared no
  `${HOLA_APP_DATA}` mount (nothing to reclaim), keeping the delete path quiet.

## Test

`deleteDeployment reclaims the host bind-mount data root (#341)` — creates a
deployment, seeds data under its bind root, deletes it, asserts the data root is
gone and the bind root itself is untouched.

## Notes

- Scope is *remove-on-delete*, matching the issue's default expectation. A
  `keepData` opt-out flag and a GC pass for already-orphaned dirs (from installs
  predating this fix) are reasonable follow-ups but intentionally out of scope here.

Verified: `typecheck` · `lint` · `test` (589 server + 205 web) · `build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)