### PR TITLE
fix(server): re-pin embedded outpost host on forward-auth reuse (#137)

### DIFF
--- a/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
+++ b/packages/server/src/__tests__/provisioner/authentik-contract.test.ts
@@ -557,6 +557,42 @@ describe('RealAuthentikProvisionerService (REST contract)', () => {
     expect(result.ref).toMatchObject({ mode: 'forward-auth', providerPk: 55 });
   });
 
+  test('forward-auth reuse re-pins the embedded outpost browser host (#137)', async () => {
+    // A deployment first provisioned before the host-pinning fix hits the reuse
+    // branch on every redeploy. If that branch never touches the outpost, its
+    // `config.authentik_host` stays at Authentik's unroutable `0.0.0.0:9000`
+    // default and forward-auth login 302s to a dead address. The reuse path must
+    // re-bind the provider so the host is re-pinned, healing such deployments.
+    installFetch((call) => {
+      // Existing outpost still carries the broken default host + already has the
+      // provider bound; the reuse re-pin must overwrite the host regardless.
+      if (call.method === 'GET' && call.path === '/api/v3/outposts/instances/') {
+        return json({ results: [{ pk: 1, providers: [55], config: { authentik_host: 'http://0.0.0.0:9000' } }] });
+      }
+      return undefined;
+    });
+    const svc = new RealAuthentikProvisionerService(CONFIG);
+
+    await svc.provision({
+      deploymentId: 'dep-abcdef0123456789',
+      appName: 'grafana',
+      mode: 'forward-auth',
+      host: 'grafana.example.com',
+      existingRef: { mode: 'forward-auth', providerPk: 55, applicationSlug: 'grafana-dep-abcd', outpostPk: 1 },
+    });
+
+    // The reuse path PATCHed the outpost, pinning the browser host to the public URL.
+    const outpostPatch = calls.find(c => c.method === 'PATCH' && c.path.startsWith('/api/v3/outposts/instances/'))!;
+    expect(outpostPatch).toBeDefined();
+    const cfg = (outpostPatch.body as { config?: Record<string, unknown>; providers?: number[] });
+    expect(cfg.config?.authentik_host).toBe('https://auth.example.com');
+    expect(cfg.config?.authentik_host_browser).toBe('https://auth.example.com');
+    // Provider stays bound (deduped, not duplicated).
+    expect(cfg.providers).toContain(55);
+    // Still a reuse — no new provider created.
+    expect(calls.some(c => c.method === 'POST' && c.path === '/api/v3/providers/proxy/')).toBe(false);
+  });
+
   test('forward-auth reuse with NO declared groups skips the policy-bindings lookup (scoped token can 403 it)', async () => {
     // The reuse/restart path calls reconcileForwardAuthGroups WITHOUT an
     // applicationPk. `GET /api/v3/policies/bindings/` is forbidden for the

--- a/packages/server/src/services/core/provisioner.ts
+++ b/packages/server/src/services/core/provisioner.ts
@@ -654,6 +654,14 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
         mode: 'forward_single',
         external_host: externalHost,
       });
+      // Re-pin the embedded outpost's browser host on every reuse. The fresh-provision
+      // path already pins `authentik_host`, but a deployment first provisioned before
+      // that fix (or on a host whose outpost still carries Authentik's `0.0.0.0:9000`
+      // default) never re-binds the outpost here, so its OAuth `authorize` redirect
+      // stays pointed at an unroutable address. Re-adding the provider is idempotent
+      // (deduped) and rewrites `config.authentik_host`, healing such deployments on the
+      // next redeploy (#137).
+      await this.addProviderToEmbeddedOutpost(existing.providerPk);
       const reuseSlug = existing.applicationSlug ?? slug;
       // Re-reconcile the group restriction so it tracks manifest changes across redeploys.
       await this.reconcileForwardAuthGroups(reuseSlug, input.forwardAuth?.allowedGroups ?? []);


### PR DESCRIPTION
## Summary

Fixes #137. A forward-auth-gated app redirected the OAuth `authorize` request to
Authentik's internal bind address (`http://0.0.0.0:9000`) instead of the public
URL, so users couldn't complete SSO login even though the gate itself worked.

## Root cause

The fresh-provision path (`addProviderToEmbeddedOutpost`) already pins the
embedded outpost's `config.authentik_host` to `HOLA_AUTHENTIK_PUBLIC_URL`
(landed in #163). But the **idempotent reuse branch** in `provisionForwardAuth`
PATCHes the proxy provider and reconciles groups, then returns early — it never
re-touches the outpost. So any deployment first provisioned before that pinning
existed (or on a host whose embedded outpost still carries Authentik's
`0.0.0.0:9000` default) hits the reuse branch on every redeploy and is never
healed.

## Change

The reuse branch now re-calls `addProviderToEmbeddedOutpost(existing.providerPk)`.
Re-adding the provider is idempotent (deduped into the outpost's provider set)
and rewrites `config.authentik_host` / `authentik_host_browser`, so affected
deployments self-heal on their next redeploy.

## Test

`forward-auth reuse re-pins the embedded outpost browser host (#137)` — starts
from an existing outpost still carrying `http://0.0.0.0:9000`, runs a reuse
provision, and asserts the outpost PATCH re-pins the host to the public URL while
keeping the provider bound and creating no new provider.

Verified: `typecheck` · `lint` · `test` (589 server + 205 web) · `build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)