### PR TITLE
fix(compose): gate Traefik on server health for DNS-01 wildcard issuance (#154)

### DIFF
--- a/packages/compose/docker-compose.dns01.yml
+++ b/packages/compose/docker-compose.dns01.yml
@@ -14,6 +14,22 @@
 # "Private/homelab TLS (DNS-01)".
 services:
   traefik:
+    # Wait for the server to be HEALTHY before starting (merged with the base
+    # `depends_on: traefik-init`). Proactive wildcard issuance is driven by a
+    # ROUTER carrying `tls.domains` (entrypoint-level domains alone are not
+    # proactively resolved — see the note below), and those routers only exist
+    # once the server writes `core.yml` into the file-provider dir. The server
+    # emits `core.yml` synchronously BEFORE it starts listening, so `service_healthy`
+    # (its Dockerfile healthcheck hits `/healthz`) guarantees the wildcard routers
+    # are present the moment Traefik first reads the file provider. Without this,
+    # on a fresh `hola-data` volume Traefik can win the race, boot on an empty dir
+    # with no wildcard router, and get "stuck" serving its default self-signed cert
+    # with an empty `acme.json` (#154). Scoped to this DNS-01 overlay: HTTP-01 mode
+    # issues per-router on demand and the file-watch reload covers plain routing;
+    # only proactive wildcard issuance is fragile to the empty-first-read race.
+    depends_on:
+      server:
+        condition: service_healthy
     # `command` REPLACES the base command (compose does not merge lists), so the
     # full set is restated here with DNS-01 + the wildcard request.
     command:


### PR DESCRIPTION
## Summary

Closes #154. On a **fresh** install with DNS-01 wildcard TLS, Traefik came up
with an empty `acme.json` and never obtained the `*.${HOLA_BASE_DOMAIN}` wildcard
— it kept serving its self-signed `TRAEFIK DEFAULT CERT`.

## Root cause (first-boot race)

Proactive wildcard issuance is driven by a **router carrying `tls.domains`** — an
entrypoint-level `tls.domains` is *not* proactively resolved in Traefik v3 (see
the note in `docker-compose.dns01.yml` and `routing.ts` `routerTlsBlock`). Those
wildcard-bearing routers only exist once the server writes `core.yml` into the
file-provider dir (`/data/runtime/traefik`).

Traefik's only dependency is `traefik-init` (which merely creates the watched
dir); it has **no dependency on the server**, and `server` has no `depends_on` at
all — the two start concurrently. On a fresh `hola-data` volume Traefik can win
the race, boot watching an empty dir → zero routers → no wildcard request → it
serves the default cert with `acme.json` still `{}`.

## Change

Add `depends_on: server (condition: service_healthy)` to Traefik in the DNS-01
overlay (merges with the base `depends_on: traefik-init`). The server emits
`core.yml` **synchronously, before `Bun.serve` starts listening**
(`initializeInfrastructure()` is awaited at module top-level, ahead of the
listener), so `service_healthy` — the server image's existing Dockerfile
healthcheck on `/healthz` — guarantees the wildcard routers are present the moment
Traefik first reads the file provider.

**Scoped to the DNS-01 overlay** on purpose:
- HTTP-01 mode issues per-router **on demand** when traffic arrives, and the
  file-provider `watch` reload reliably covers plain routing — only *proactive*
  wildcard issuance is fragile to the empty-first-read.
- The dev overlay swaps `server` for the base `oven/bun:1` image (no healthcheck)
  and uses the Docker provider over HTTP, so a base-compose `service_healthy`
  dependency would break `docker compose up` there. The overlay keeps dev
  untouched.

## Validation

Verified the ordering mechanism locally against the **real released
`ghcr.io/try-hola/server:0.7.9`** image with this branch's overlay (the Proxmox
VM path wasn't reachable from the devcontainer):

- Merged compose gives Traefik `depends_on` both `traefik-init` (completed) and
  `server` (`service_healthy`).
- Docker event timeline: `hola-server` reached `healthy` **before** `traefik`
  started (it held until then).
- At Traefik's first file-provider read, `core.yml` was present carrying the
  wildcard `tls.domains`, and Traefik immediately attempted issuance — the
  opposite of the bug's "zero ACME activity." (Full detail in the PR comment.)

This proves the first-boot **race is eliminated**. A real cert *issuing* still
depends on real route53/Cloudflare creds against a controlled zone, which the
local run can't exercise — worth a confirming fresh DNS-01 install as follow-up,
but the mechanism that caused #154 is fixed.

Related: #149 (move the ACME store into a named volume) is complementary and still
open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)