### PR TITLE
fix(cli): only reuse a detected .env if it's actually a Hola config (#345)

### DIFF
--- a/packages/cli/src/__tests__/bootstrap.test.ts
+++ b/packages/cli/src/__tests__/bootstrap.test.ts
@@ -288,6 +288,28 @@ describe('hola bootstrap', () => {
     }
   });
 
+  it('ignores a detected .env that is not a Hola config — never offers to reuse it (#345)', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'hola-boot-'));
+    const envPath = join(tmp, '.env');
+    // A foreign project's .env: no HOLA_ keys, so it is not a Hola install config.
+    await writeFile(envPath, 'DATABASE_URL=postgres://user:pw@db/other\nPORT=3000\nSECRET=nope\n');
+    const runner = makeRunner();
+    try {
+      // Even if the operator would say "yes" to a reuse prompt, the file must not
+      // be offered: detection is skipped, so the wizard runs and aborts on the
+      // first unanswered required field — the foreign file is never shipped.
+      const res = await runBootstrap(
+        { host: 'me@vm', skipChecks: true },
+        { prompter: scriptedPrompter({ _use_env: 'true' }), runner, findEnvFile: async () => envPath }
+      );
+      expect(res).toBeUndefined();
+      expect(process.exitCode).toBe(1);
+      expect(runner.calls.some((c) => c.input?.includes('postgres://'))).toBe(false);
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
   it('does NOT reuse a detected .env by default — it runs the wizard instead', async () => {
     const tmp = await mkdtemp(join(tmpdir(), 'hola-boot-'));
     const envPath = join(tmp, '.env');

--- a/packages/cli/src/commands/bootstrap/bootstrap.ts
+++ b/packages/cli/src/commands/bootstrap/bootstrap.ts
@@ -63,6 +63,19 @@ function releaseBase(repo: string): string {
  * pulls the published images), and verify. Returns the result, or undefined on
  * failure (after setting a non-zero exit code).
  */
+/**
+ * Whether a parsed `.env` actually looks like a Hola install config. Detection
+ * finds a file by name/existence alone, so an unrelated project's `.env` sitting
+ * in the cwd (or in `packages/compose/`) would otherwise be offered for reuse —
+ * and, if accepted, streamed to the host as the Hola config (#345). Every Hola
+ * config the wizard writes carries the `HOLA_`-prefixed dashboard/base domain;
+ * that prefix makes a false positive from a foreign `.env` effectively
+ * impossible, while still recognizing a hand-trimmed but genuine Hola file.
+ */
+function looksLikeHolaConfig(config: ConfigMap): boolean {
+  return !!config.HOLA_DOMAIN?.trim() || !!config.HOLA_BASE_DOMAIN?.trim();
+}
+
 /** First existing `.env` a freshly-run `hola init` would have written, or null. */
 async function defaultFindEnvFile(): Promise<string | null> {
   const candidates = [
@@ -120,23 +133,28 @@ export async function runBootstrap(
     if (!reuse && !opts.json) {
       const found = await (injected?.findEnvFile ?? defaultFindEnvFile)();
       if (found) {
-        // Show WHAT the file would deploy (a stale leftover is easy to ship blind),
-        // and default to NO so reuse is a deliberate choice, not an Enter-through.
         const existing = parseEnv(await fs.readFile(found, 'utf8').catch(() => ''));
-        const summary = [
-          existing.HOLA_BASE_DOMAIN ? `domain ${existing.HOLA_BASE_DOMAIN}` : existing.HOLA_DOMAIN ? `dashboard ${existing.HOLA_DOMAIN}` : null,
-          existing.HOLA_ADMIN_EMAIL ? `admin ${existing.HOLA_ADMIN_EMAIL}` : null,
-        ].filter(Boolean).join(' · ');
-        out(`Found an existing config: ${found}`);
-        if (summary) out(`  it would deploy: ${colors.bold(summary)}`);
-        const ans = await prompter.prompt({
-          key: '_use_env',
-          type: 'confirm',
-          message: 'Reuse it and skip the setup questions?',
-          default: 'false',
-        });
-        if (ans === 'true') reuse = found;
-        else out('  Starting fresh — answering the questions below.');
+        // Only offer reuse when the file is actually a Hola config; a foreign
+        // `.env` that merely happens to sit here is silently ignored so the
+        // wizard runs, rather than being shipped to the host as our config (#345).
+        if (looksLikeHolaConfig(existing)) {
+          // Show WHAT the file would deploy (a stale leftover is easy to ship blind),
+          // and default to NO so reuse is a deliberate choice, not an Enter-through.
+          const summary = [
+            existing.HOLA_BASE_DOMAIN ? `domain ${existing.HOLA_BASE_DOMAIN}` : existing.HOLA_DOMAIN ? `dashboard ${existing.HOLA_DOMAIN}` : null,
+            existing.HOLA_ADMIN_EMAIL ? `admin ${existing.HOLA_ADMIN_EMAIL}` : null,
+          ].filter(Boolean).join(' · ');
+          out(`Found an existing config: ${found}`);
+          if (summary) out(`  it would deploy: ${colors.bold(summary)}`);
+          const ans = await prompter.prompt({
+            key: '_use_env',
+            type: 'confirm',
+            message: 'Reuse it and skip the setup questions?',
+            default: 'false',
+          });
+          if (ans === 'true') reuse = found;
+          else out('  Starting fresh — answering the questions below.');
+        }
       }
     }
     if (reuse) {


### PR DESCRIPTION
Closes #345.

## Problem

`hola bootstrap` offered to reuse a detected `.env` based purely on **filename/existence** — `defaultFindEnvFile()` returns the first existing file among `packages/compose/.env` and `./.env` without inspecting its contents. So an unrelated project's `.env` sitting in the working directory triggered the "Reuse it and skip the setup questions?" prompt, and if the operator accepted, that arbitrary file was streamed to the host as the Hola config and `install.sh` ran against it.

## Fix

Gate the reuse offer on the parsed file actually looking like a Hola config. A new `looksLikeHolaConfig()` check requires the `HOLA_`-prefixed dashboard/base domain that every wizard-produced config carries — the prefix makes a false positive from a foreign `.env` effectively impossible, while still recognizing a hand-trimmed but genuine Hola file. When the detected file isn't a Hola config, it's **silently ignored** and the setup wizard runs (matching the issue's requested behavior).

## Testing

- New unit test: a foreign `.env` (no `HOLA_` keys) is never offered for reuse — even when the operator would answer "yes", the file is not shipped and the wizard runs instead.
- Existing detection/reuse tests unchanged and green.
- `bun run typecheck` · `lint` · `test` · `build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)