### PR TITLE
feat(server): per-deployment subdomain + singleton-by-default policy (#246)

### DIFF
--- a/packages/server/src/__tests__/bundles/catalog-compose-override.test.ts
+++ b/packages/server/src/__tests__/bundles/catalog-compose-override.test.ts
@@ -34,6 +34,8 @@ volumes:
 const MANIFEST = JSON.stringify({
   name: APP_ID,
   ingress: { service: 'fixtureapp', port: 80 },
+  // #246: this fixture app opts into multiple instances.
+  multiInstance: true,
   defaultEnv: [
     { key: 'APP_ENV', value: 'production', isSecret: false },
     // A bogus/future param type must degrade to untyped rather than reject the
@@ -111,6 +113,9 @@ describe('RealCatalogService composeOverride (#82)', () => {
     // The manifest's ingress.service is surfaced so the deploy lifecycle can
     // route to / inject auth env into the right service.
     expect(detail.ingressService).toBe('fixtureapp');
+    // The manifest's multiInstance flag (#246) is carried through so the singleton
+    // guard can honor it at install time.
+    expect(detail.multiInstance).toBe(true);
   });
 
   test('defaultEnv carries typed-spec fields through and degrades an unknown type without rejecting the bundle (ADR 0003)', async () => {

--- a/packages/server/src/__tests__/deployments/management.test.ts
+++ b/packages/server/src/__tests__/deployments/management.test.ts
@@ -52,11 +52,7 @@ describe('Deployment Management', () => {
     });
     const draftId = createResponse.data!.draftId;
 
-    // These lifecycle tests spin up several deployments from the same mock app;
-    // opt out of the single-instance-by-default guard (#246) — the mock resolves
-    // every draft to one placeholder app, so distinct installs would otherwise
-    // collide.
-    const deploymentRequest: CreateDeploymentFromDraftRequest = { draftId, name, options, allowMultiple: true };
+    const deploymentRequest: CreateDeploymentFromDraftRequest = { draftId, name, options };
     const deploymentResponse = await makeRequest<CreateDeploymentFromDraftResponse>({
       method: 'POST',
       url: `${baseURL}/api/deployments`,

--- a/packages/server/src/__tests__/deployments/management.test.ts
+++ b/packages/server/src/__tests__/deployments/management.test.ts
@@ -22,6 +22,7 @@ import type {
   PostDeploymentActionResponse,
   RollbackRequest,
   RollbackResponse,
+  GetSubdomainAvailabilityResponse,
 } from '@hola/shared';
 import { setupTestServer, teardownTestServer } from '../utils/bun-server';
 import { makeRequest } from '../utils/phase7-helpers';
@@ -51,7 +52,11 @@ describe('Deployment Management', () => {
     });
     const draftId = createResponse.data!.draftId;
 
-    const deploymentRequest: CreateDeploymentFromDraftRequest = { draftId, name, options };
+    // These lifecycle tests spin up several deployments from the same mock app;
+    // opt out of the single-instance-by-default guard (#246) — the mock resolves
+    // every draft to one placeholder app, so distinct installs would otherwise
+    // collide.
+    const deploymentRequest: CreateDeploymentFromDraftRequest = { draftId, name, options, allowMultiple: true };
     const deploymentResponse = await makeRequest<CreateDeploymentFromDraftResponse>({
       method: 'POST',
       url: `${baseURL}/api/deployments`,
@@ -233,6 +238,28 @@ describe('Deployment Management', () => {
       const res = await makeRequest({ method: 'DELETE', url: `${baseURL}/api/deployments/${unknownId}` });
       expect(res.success).toBe(false);
       expect(res.error!.code).toBe('NOT_FOUND');
+    });
+  });
+
+  describe('Subdomain availability (#246)', () => {
+    test('GET /subdomain-available slugifies and reports availability (not swallowed by /:id)', async () => {
+      const res = await makeRequest<GetSubdomainAvailabilityResponse>({
+        method: 'GET',
+        url: `${baseURL}/api/deployments/subdomain-available?subdomain=${encodeURIComponent('My Desktop')}`,
+      });
+      // Reaches the availability handler (a 404 here would mean the /:id GET route
+      // captured "subdomain-available" as a deployment id).
+      expect(res.success).toBe(true);
+      expect(res.data).toMatchObject({ subdomain: 'my-desktop', host: 'my-desktop.local.hola', available: true });
+    });
+
+    test('reports an invalid subdomain for an empty/punctuation-only input', async () => {
+      const res = await makeRequest<GetSubdomainAvailabilityResponse>({
+        method: 'GET',
+        url: `${baseURL}/api/deployments/subdomain-available?subdomain=${encodeURIComponent('!!!')}`,
+      });
+      expect(res.success).toBe(true);
+      expect(res.data).toMatchObject({ available: false, reason: 'invalid' });
     });
   });
 

--- a/packages/server/src/__tests__/deployments/persistence.test.ts
+++ b/packages/server/src/__tests__/deployments/persistence.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { mkdtemp, rm, mkdir, writeFile, access } from 'fs/promises';
+import { mkdtemp, rm, mkdir, writeFile, access, readFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
@@ -27,7 +27,7 @@ type CatalogArg = ConstructorParameters<typeof RealDraftService>[1];
 type ValidationArg = ConstructorParameters<typeof RealDraftService>[2];
 type JobArg = ConstructorParameters<typeof RealDeploymentService>[1];
 
-function makeCatalog(): CatalogArg {
+function makeCatalog(opts?: { multiInstance?: boolean }): CatalogArg {
   return {
     getApp: async (appId: string) => ({ id: appId, name: 'Test App', icon: '📦' }),
     getVersionDetail: async () => ({
@@ -36,6 +36,8 @@ function makeCatalog(): CatalogArg {
         ports: [{ host: 3000, container: 3000, protocol: 'tcp' as const }],
         volumes: [{ hostPath: './data', containerPath: '/data', readOnly: false }],
       },
+      // #246: a catalog app that declares it supports multiple instances.
+      ...(opts?.multiInstance ? { multiInstance: true } : {}),
     }),
   } as unknown as CatalogArg;
 }
@@ -87,9 +89,9 @@ describe('Deployment persistence (real service)', () => {
   });
 
   /** A fresh service set over the same data root simulates a restart. */
-  function makeSystem() {
+  function makeSystem(opts?: { multiInstance?: boolean }) {
     const storage = new RealStorageService({ holaDir: dataRoot });
-    const drafts = new RealDraftService(storage, makeCatalog(), makeValidation());
+    const drafts = new RealDraftService(storage, makeCatalog(opts), makeValidation());
     const routing = new RealRoutingService(storage, { baseDomain: 'local.hola' });
     const deployments = new RealDeploymentService(storage, makeJobs(), noDocker, drafts, routing, noLogging, new MockProvisionerService());
     return { storage, drafts, routing, deployments };
@@ -299,17 +301,84 @@ describe('Deployment persistence (real service)', () => {
     expect(deleted?.data).toEqual({ deploymentId: dep.deploymentId });
   });
 
-  test('a second deployment of the same app is rejected as a host conflict', async () => {
+  test('a second install of a single-instance app is rejected by the singleton guard (#246)', async () => {
     const { drafts, deployments } = makeSystem();
     await deployments.createFromDraft({ draftId: await finalizedDraft(drafts), name: 'gitea', options: { autoStart: false } });
 
+    // A distinct name would route to a distinct host, so this is NOT a host
+    // conflict — it's the single-instance-by-default guard that rejects it.
     await expect(
       deployments.createFromDraft({ draftId: await finalizedDraft(drafts), name: 'gitea-2', options: { autoStart: false } })
-    ).rejects.toBeInstanceOf(ConflictError);
+    ).rejects.toThrow(/single-instance/);
 
-    // The conflicting second deployment left no state behind.
+    // The rejected second deployment left no state behind.
     const list = await deployments.listDeployments({ page: 1, limit: 100 });
     expect(list.items).toHaveLength(1);
+  });
+
+  test('the operator override installs a second instance at a distinct subdomain (#246)', async () => {
+    const { drafts, deployments, routing } = makeSystem();
+    const first = await deployments.createFromDraft({ draftId: await finalizedDraft(drafts), name: 'gitea', options: { autoStart: false } });
+    // First/default install (name == app id) keeps the historical `<app>.<base>`.
+    expect((await deployments.getDeployment(first.deploymentId)).url).toBe('https://gitea.local.hola');
+
+    const second = await deployments.createFromDraft({
+      draftId: await finalizedDraft(drafts),
+      name: 'Gitea Two',
+      allowMultiple: true,
+      options: { autoStart: false },
+    });
+    // The name is slugified into a distinct DNS label → a distinct host.
+    expect((await deployments.getDeployment(second.deploymentId)).url).toBe('https://gitea-two.local.hola');
+
+    // Both instances coexist as independent deployments and independent routes.
+    const list = await deployments.listDeployments({ page: 1, limit: 100 });
+    expect(list.items).toHaveLength(2);
+    const map = await routing.getRoutingMap();
+    expect(map['gitea.local.hola']?.deploymentId).toBe(first.deploymentId);
+    expect(map['gitea-two.local.hola']?.deploymentId).toBe(second.deploymentId);
+  });
+
+  test('a multiInstance catalog app allows a second install without the override (#246)', async () => {
+    const { drafts, deployments } = makeSystem({ multiInstance: true });
+    await deployments.createFromDraft({ draftId: await finalizedDraft(drafts), name: 'gitea', options: { autoStart: false } });
+    // No allowMultiple needed: the manifest opts into multiples.
+    const second = await deployments.createFromDraft({ draftId: await finalizedDraft(drafts), name: 'gitea-b', options: { autoStart: false } });
+    expect((await deployments.getDeployment(second.deploymentId)).url).toBe('https://gitea-b.local.hola');
+    expect((await deployments.listDeployments({ page: 1, limit: 100 })).items).toHaveLength(2);
+  });
+
+  test('a second instance reusing an existing subdomain is rejected as a host conflict (#246)', async () => {
+    const { drafts, deployments } = makeSystem();
+    await deployments.createFromDraft({ draftId: await finalizedDraft(drafts), name: 'gitea', options: { autoStart: false } });
+
+    // Override past the singleton guard, but reuse the same name → same subdomain →
+    // genuine host conflict.
+    await expect(
+      deployments.createFromDraft({ draftId: await finalizedDraft(drafts), name: 'gitea', allowMultiple: true, options: { autoStart: false } })
+    ).rejects.toThrow(/already in use/);
+
+    expect((await deployments.listDeployments({ page: 1, limit: 100 })).items).toHaveLength(1);
+  });
+
+  test('a persisted subdomain survives a restart and keeps the route stable (#246)', async () => {
+    const s1 = makeSystem({ multiInstance: true });
+    const dep = await s1.deployments.createFromDraft({
+      draftId: await finalizedDraft(s1.drafts),
+      name: 'Second Desk',
+      options: { autoStart: false },
+    });
+    // The derived subdomain is persisted on the deployment record itself.
+    const stored = JSON.parse(await readFile(join(dataRoot, 'deployments', dep.deploymentId, 'metadata.json'), 'utf8'));
+    expect(stored.subdomain).toBe('second-desk');
+
+    // A fresh service set over the same data root rebuilds routing from the stored
+    // deployment (loadFromStorage → reconcile via the stored subdomain), so the
+    // host survives the restart.
+    const s2 = makeSystem({ multiInstance: true });
+    await s2.deployments.getDeployment(dep.deploymentId); // triggers ensureLoaded → reconcile
+    const map = await s2.routing.getRoutingMap();
+    expect(map['second-desk.local.hola']?.deploymentId).toBe(dep.deploymentId);
   });
 
   test('unknown/stale releases and unfinalized drafts fail with typed errors', async () => {

--- a/packages/server/src/__tests__/routing/routing-service.test.ts
+++ b/packages/server/src/__tests__/routing/routing-service.test.ts
@@ -30,6 +30,43 @@ describe('RoutingService', () => {
     expect(rule.port).toBe(3000);
   });
 
+  test('derives the host from the per-deployment subdomain, falling back to appName (#246)', () => {
+    // A subdomain (from the user-supplied name) drives the host…
+    expect(routing.generateRule({ deploymentId: 'gitea-abc', appName: 'gitea', subdomain: 'work-desk' }).host)
+      .toBe('work-desk.local.hola');
+    // …and its absence (a pre-multi-instance deployment) falls back to the app id.
+    expect(routing.generateRule({ deploymentId: 'gitea-abc', appName: 'gitea' }).host)
+      .toBe('gitea.local.hola');
+  });
+
+  test('checkSubdomain reports available / taken / invalid (#246)', async () => {
+    expect(await routing.checkSubdomain('Work Desktop')).toEqual({
+      subdomain: 'work-desktop',
+      host: 'work-desktop.local.hola',
+      available: true,
+    });
+
+    await routing.activateRoute(routing.generateRule({ deploymentId: 'dep-a', appName: 'gitea', subdomain: 'taken' }));
+    expect(await routing.checkSubdomain('taken')).toMatchObject({ available: false, reason: 'taken' });
+
+    // Only punctuation → nothing usable → invalid.
+    expect(await routing.checkSubdomain('!!!')).toMatchObject({ available: false, reason: 'invalid' });
+  });
+
+  test('checkSubdomain rejects a reserved core-route label (#246)', async () => {
+    const prev = process.env.HOLA_DOMAIN;
+    process.env.HOLA_DOMAIN = 'apps.local.hola';
+    try {
+      // A fresh service so it reads the just-set env for its reserved hosts.
+      const r = new RealRoutingService(new MockStorageService(), { baseDomain: 'local.hola' });
+      expect(await r.checkSubdomain('apps')).toMatchObject({ available: false, reason: 'reserved' });
+      expect(await r.checkSubdomain('gitea')).toMatchObject({ available: true });
+    } finally {
+      if (prev === undefined) delete process.env.HOLA_DOMAIN;
+      else process.env.HOLA_DOMAIN = prev;
+    }
+  });
+
   test('base domain comes from option (default local.hola)', () => {
     expect(routing.baseDomain()).toBe('local.hola');
     expect(new RealRoutingService(storage).baseDomain()).toBe('local.hola');

--- a/packages/server/src/__tests__/smoke/workflow.test.ts
+++ b/packages/server/src/__tests__/smoke/workflow.test.ts
@@ -145,7 +145,10 @@ describe('Smoke: full install workflow (mock mode)', () => {
     const deployment = await makeRequest<CreateDeploymentFromDraftResponse>({
       method: 'POST',
       url: `${baseURL}/api/deployments`,
-      body: { draftId, name: 'smoke-stop' },
+      // A prior test in this suite already installed the mock's placeholder app;
+      // opt out of the single-instance guard (#246) since the mock resolves every
+      // draft to one app.
+      body: { draftId, name: 'smoke-stop', allowMultiple: true },
     });
     const deploymentId = deployment.data!.deploymentId;
 

--- a/packages/server/src/__tests__/smoke/workflow.test.ts
+++ b/packages/server/src/__tests__/smoke/workflow.test.ts
@@ -145,10 +145,7 @@ describe('Smoke: full install workflow (mock mode)', () => {
     const deployment = await makeRequest<CreateDeploymentFromDraftResponse>({
       method: 'POST',
       url: `${baseURL}/api/deployments`,
-      // A prior test in this suite already installed the mock's placeholder app;
-      // opt out of the single-instance guard (#246) since the mock resolves every
-      // draft to one app.
-      body: { draftId, name: 'smoke-stop', allowMultiple: true },
+      body: { draftId, name: 'smoke-stop' },
     });
     const deploymentId = deployment.data!.deploymentId;
 

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -55,6 +55,7 @@ import {
   type UpdateCatalogSourceRequest,
   type ListCatalogSourcesResponse,
   type RefreshCatalogResponse,
+  type GetSubdomainAvailabilityResponse,
 } from '@hola/shared';
 
 // Error interface for proper typing
@@ -1006,6 +1007,18 @@ async function route(url: URL, req: Request): Promise<Response> {
         q,
         status: statusParam === 'all' ? 'all' : statusParam as 'running' | 'stopped' | 'installing' | 'updating' | 'error',
       });
+      return json(payload);
+    } catch (err) {
+      return errorResponse(req, err);
+    }
+  }
+
+  if (pathname === API.deployments.subdomainAvailable && req.method === 'GET') {
+    // Live subdomain-availability check for the install wizard (#246).
+    try {
+      const input = searchParams.get('subdomain') ?? '';
+      const services = getServices();
+      const payload: GetSubdomainAvailabilityResponse = await services.routing.checkSubdomain(input);
       return json(payload);
     } catch (err) {
       return errorResponse(req, err);

--- a/packages/server/src/services/core/catalog.ts
+++ b/packages/server/src/services/core/catalog.ts
@@ -514,6 +514,7 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
         };
         auth?: unknown;
         consumes?: unknown;
+        multiInstance?: unknown;
         security?: unknown;
         upgrade?: unknown;
         backup?: unknown;
@@ -580,6 +581,11 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
       // so new capability names need no server change (ADR 0002).
       const consumes = coerceConsumes(manifest.consumes);
 
+      // Whether the app opts into multiple instances (#246). Kept absent unless the
+      // manifest explicitly sets `true`, so singleton (the default) stays the clean
+      // common case in drafts and deployment records.
+      const multiInstance = manifest.multiInstance === true ? true : undefined;
+
       // Elevated container permissions the app requests (e.g. sudo needs
       // privilege escalation). Coerced narrowly like `auth`; the wizard surfaces
       // each for consent and the deploy lifecycle relaxes the matching hardening.
@@ -603,7 +609,7 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
           ? manifest.ingress.service.trim()
           : undefined;
 
-      return { ...merged, version, composeOverride, auth, consumes, security, upgrade, backup, ingressService } satisfies GetCatalogAppVersionDetailResponse;
+      return { ...merged, version, composeOverride, auth, consumes, multiInstance, security, upgrade, backup, ingressService } satisfies GetCatalogAppVersionDetailResponse;
     } catch (error) {
       this.logger.warn('Failed to read or parse bundle manifest', { version, error: error instanceof Error ? error.message : String(error) });
       // Keep the underlying reason in the message, not just the cause: a missing

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -451,23 +451,15 @@ abstract class InMemoryDeploymentService implements DeploymentService {
   }
 
   /**
-   * Enforce single-instance-by-default (#246): reject installing an app that
-   * already has a deployment, unless the app's manifest opts into multiples
-   * (`multiInstance: true`) or the caller passes the per-install override. Pure
-   * (operates on the rehydrated in-memory map), so it runs in both the mock and
-   * real services. Global-capability bolt-ons (backup → apps-data, homepage →
-   * app-registry) assume one instance, so the override is "you know what you're
-   * doing" — it still requires a distinct subdomain, validated separately.
+   * Enforce single-instance-by-default (#246) before creating any state. Default
+   * no-op — the real service overrides this. (Like the other create-time guards,
+   * the mock stays permissive: it resolves every draft to one placeholder app, so
+   * enforcing here would spuriously collide unrelated mock-based tests.)
    */
   protected assertInstanceAllowed(appId: string, multiInstance?: boolean, allowMultiple?: boolean): void {
-    if (multiInstance || allowMultiple) return;
-    const existing = [...this.deployments.values()].find(d => d.app === appId);
-    if (existing) {
-      throw new ConflictError(
-        `'${appId}' is already installed (deployment ${existing.id}). This app is single-instance; ` +
-          `pass --allow-multiple (CLI) or the "install another" option (dashboard) to run a second copy.`,
-      );
-    }
+    void appId;
+    void multiInstance;
+    void allowMultiple;
   }
 
   /** Public URL the app is reachable at; the real service derives it from routing. */
@@ -2127,6 +2119,26 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     await this.routingService.reconcile(rules);
 
     this.logger.info('Rehydrated deployments from storage', { count: this.deployments.size });
+  }
+
+  /**
+   * Enforce single-instance-by-default (#246): reject installing an app that
+   * already has a deployment, unless its manifest opts into multiples
+   * (`multiInstance: true`) or the caller passes the per-install override. Operates
+   * on the rehydrated in-memory map. Global-capability bolt-ons (backup →
+   * apps-data, homepage → app-registry) assume one instance, so the override is
+   * "you know what you're doing" — it still requires a distinct subdomain, which
+   * onBeforeCreate validates separately.
+   */
+  protected override assertInstanceAllowed(appId: string, multiInstance?: boolean, allowMultiple?: boolean): void {
+    if (multiInstance || allowMultiple) return;
+    const existing = [...this.deployments.values()].find(d => d.app === appId);
+    if (existing) {
+      throw new ConflictError(
+        `'${appId}' is already installed (deployment ${existing.id}). This app is single-instance; ` +
+          `pass --allow-multiple (CLI) or the "install another" option (dashboard) to run a second copy.`,
+      );
+    }
   }
 
   protected override async onBeforeCreate(deploymentId: string, app: string, subdomain: string): Promise<void> {

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -39,7 +39,7 @@ import type {
   GetDeploymentConfigResponse,
   AppSecurityConfig
 } from '@hola/shared';
-import { checkUpgradePath, isNewerVersion } from '@hola/shared';
+import { checkUpgradePath, isNewerVersion, slugifySubdomain } from '@hola/shared';
 import { requestsPrivilegeEscalation } from './manifest-security';
 import { validateParams } from '@hola/shared/param-validate';
 
@@ -81,6 +81,17 @@ function makeDeploymentId(appId: string): string {
   const slug = appId.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'app';
   const suffix = crypto.randomUUID().replace(/-/g, '').slice(0, 8);
   return `${slug}-${suffix}`;
+}
+
+/**
+ * Derive the DNS subdomain a deployment routes under (#246) from the user-supplied
+ * name, falling back to the app id. Slugified to a valid DNS label. Computed once
+ * at create time and then persisted on the deployment (stable for the install's
+ * life) — so `<name>` install gets `<name>.<base>` while a first/default install
+ * (name == app id, or no name) keeps the historical `<app>.<base>`.
+ */
+function deriveSubdomain(name: string | undefined, appId: string): string {
+  return slugifySubdomain(name || '') || slugifySubdomain(appId) || 'app';
 }
 
 type ProvisionCredentials = NonNullable<ProvisionResult['credentials']>;
@@ -406,9 +417,10 @@ abstract class InMemoryDeploymentService implements DeploymentService {
   }
 
   /** Validate routing (host) availability before creating a deployment. Default no-op. */
-  protected async onBeforeCreate(deploymentId: string, app: string): Promise<void> {
+  protected async onBeforeCreate(deploymentId: string, app: string, subdomain: string): Promise<void> {
     void deploymentId;
     void app;
+    void subdomain;
   }
 
   /**
@@ -438,10 +450,31 @@ abstract class InMemoryDeploymentService implements DeploymentService {
     void appName;
   }
 
+  /**
+   * Enforce single-instance-by-default (#246): reject installing an app that
+   * already has a deployment, unless the app's manifest opts into multiples
+   * (`multiInstance: true`) or the caller passes the per-install override. Pure
+   * (operates on the rehydrated in-memory map), so it runs in both the mock and
+   * real services. Global-capability bolt-ons (backup → apps-data, homepage →
+   * app-registry) assume one instance, so the override is "you know what you're
+   * doing" — it still requires a distinct subdomain, validated separately.
+   */
+  protected assertInstanceAllowed(appId: string, multiInstance?: boolean, allowMultiple?: boolean): void {
+    if (multiInstance || allowMultiple) return;
+    const existing = [...this.deployments.values()].find(d => d.app === appId);
+    if (existing) {
+      throw new ConflictError(
+        `'${appId}' is already installed (deployment ${existing.id}). This app is single-instance; ` +
+          `pass --allow-multiple (CLI) or the "install another" option (dashboard) to run a second copy.`,
+      );
+    }
+  }
+
   /** Public URL the app is reachable at; the real service derives it from routing. */
-  protected appUrl(deploymentId: string, app: string): string | undefined {
+  protected appUrl(deploymentId: string, app: string, subdomain: string): string | undefined {
     void deploymentId;
     void app;
+    void subdomain;
     return undefined;
   }
 
@@ -563,14 +596,24 @@ abstract class InMemoryDeploymentService implements DeploymentService {
       // hit, but up front so the user gets the clear error instead of a tombstone.
       this.assertAuthProvisionable(artifacts?.manifest.auth, app);
 
-      // Reject a routing (host) conflict before creating any deployment state.
-      await this.onBeforeCreate(deploymentId, app);
+      // Singleton-by-default (#246): reject a second install of an app whose
+      // manifest doesn't opt into multiples, unless the operator overrides it per
+      // install. Checked up front, before any state is created — like the auth and
+      // routing guards. The override still requires a distinct subdomain (below).
+      this.assertInstanceAllowed(app, artifacts?.manifest.multiInstance, request.allowMultiple);
+
+      // The DNS label this deployment routes under; stable for the install's life.
+      const subdomain = deriveSubdomain(request.name, app);
+
+      // Reject a routing (host) conflict — a taken, reserved, or invalid subdomain
+      // — before creating any deployment state.
+      await this.onBeforeCreate(deploymentId, app, subdomain);
 
       await this.ensureLayout(deploymentId);
 
-      // Public URL the app is reachable at (Traefik routes <app>.<base-domain>);
+      // Public URL the app is reachable at (Traefik routes <subdomain>.<base-domain>);
       // the Real service derives it from routing, the mock leaves it unset.
-      const url = this.appUrl(deploymentId, app);
+      const url = this.appUrl(deploymentId, app, subdomain);
 
       const deployment: EnhancedDeploymentDetail = {
         id: deploymentId,
@@ -580,6 +623,9 @@ abstract class InMemoryDeploymentService implements DeploymentService {
         // name wins.
         name: request.name || artifacts?.manifest.displayName || app,
         app,
+        // The routed DNS label (#246); reconciled from here, never recomputed from
+        // the name — so the URL stays put even if the display name later changes.
+        subdomain,
         // Persist the catalog icon (emoji or image URL) carried through the
         // finalized manifest, so the launcher and registry feed have a stable
         // icon without a live catalog lookup. Falls back to a generic glyph.
@@ -1037,9 +1083,9 @@ export class RealDeploymentService extends InMemoryDeploymentService {
   authSetupMaxAttempts = 18;
   authSetupIntervalMs = 5000;
 
-  /** Public URL the app is reachable at (Traefik routes `<app>.<base-domain>`). */
-  protected override appUrl(deploymentId: string, app: string): string {
-    return `https://${this.routingService.generateRule({ deploymentId, appName: app }).host}`;
+  /** Public URL the app is reachable at (Traefik routes `<subdomain>.<base-domain>`). */
+  protected override appUrl(deploymentId: string, app: string, subdomain: string): string {
+    return `https://${this.routingService.generateRule({ deploymentId, appName: app, subdomain }).host}`;
   }
 
   /** Deterministic Compose project name (aligns with the routing network name). */
@@ -1116,7 +1162,7 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     // The routing rule gives us the install-specific values apps reference as
     // tokens (public host, base domain) plus the network alias. generateRule is
     // pure, so compute it once up front and reuse it below.
-    const rule = this.routingService.generateRule({ deploymentId: deployment.id, appName: deployment.app });
+    const rule = this.routingService.generateRule({ deploymentId: deployment.id, appName: deployment.app, subdomain: deployment.subdomain });
 
     // The compose service Traefik routes to and that receives injected auth env.
     // Prefer the manifest-declared ingress service (multi-service apps whose web
@@ -2007,7 +2053,7 @@ export class RealDeploymentService extends InMemoryDeploymentService {
   private routingRuleFor(deployment: EnhancedDeploymentDetail): ReturnType<RoutingService['generateRule']> {
     const release = deployment.currentReleaseId ? this.releases.get(deployment.currentReleaseId) : undefined;
     const port = release?.ports?.[0]?.container;
-    const rule = this.routingService.generateRule({ deploymentId: deployment.id, appName: deployment.app, port });
+    const rule = this.routingService.generateRule({ deploymentId: deployment.id, appName: deployment.app, subdomain: deployment.subdomain, port });
     const middleware = deployment.metadata.auth?.middleware;
     return middleware ? { ...rule, forwardAuth: middleware } : rule;
   }
@@ -2083,8 +2129,19 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     this.logger.info('Rehydrated deployments from storage', { count: this.deployments.size });
   }
 
-  protected override async onBeforeCreate(deploymentId: string, app: string): Promise<void> {
-    const rule = this.routingService.generateRule({ deploymentId, appName: app });
+  protected override async onBeforeCreate(deploymentId: string, app: string, subdomain: string): Promise<void> {
+    // Reject a reserved (core route) or malformed subdomain up front. The `taken`
+    // case falls through to validateRule below, whose conflict message names the
+    // owning deployment.
+    const availability = await this.routingService.checkSubdomain(subdomain);
+    if (!availability.available && availability.reason !== 'taken') {
+      throw new ConflictError(
+        availability.reason === 'reserved'
+          ? `Subdomain '${subdomain}' is reserved by a core Hola route`
+          : `Subdomain '${subdomain}' is not a valid DNS label`,
+      );
+    }
+    const rule = this.routingService.generateRule({ deploymentId, appName: app, subdomain });
     const conflicts = await this.routingService.validateRule(rule);
     if (conflicts.length > 0) {
       throw new ConflictError(conflicts.map(c => c.message).join('; '));

--- a/packages/server/src/services/core/draft.ts
+++ b/packages/server/src/services/core/draft.ts
@@ -74,6 +74,10 @@ export interface FinalizedManifest {
   // Cross-app capabilities consumed (e.g. `app-registry`); carried so the
   // deploy lifecycle can publish the right feeds without re-reading the bundle.
   consumes?: string[];
+  // Whether the app may be installed more than once (#246); carried so
+  // createFromDraft can enforce the singleton-by-default guard without re-reading
+  // the bundle.
+  multiInstance?: boolean;
   // Elevated container permissions the app requested (e.g. privilege escalation
   // for sudo); carried so the deploy lifecycle can relax the matching hardening
   // without re-reading the bundle.
@@ -461,6 +465,7 @@ export class RealDraftService implements DraftService {
         composeOverride,
         auth: defaults.auth,
         consumes: defaults.consumes,
+        multiInstance: defaults.multiInstance,
         security: defaults.security,
         ingressService: defaults.ingressService,
         upgrade: defaults.upgrade,
@@ -553,6 +558,7 @@ export class RealDraftService implements DraftService {
         composeOverride,
         auth: detail.auth,
         consumes: detail.consumes,
+        multiInstance: detail.multiInstance,
         security: detail.security,
         ingressService: detail.ingressService,
         upgrade: detail.upgrade,
@@ -816,6 +822,7 @@ export class RealDraftService implements DraftService {
         composeOverride: draft.composeOverride ?? '',
         auth: draft.auth,
         consumes: draft.consumes,
+        multiInstance: draft.multiInstance,
         security: draft.security,
         ingressService: draft.ingressService,
         upgrade: draft.upgrade,
@@ -903,7 +910,7 @@ export class RealDraftService implements DraftService {
     };
   }
 
-  async getDraftDefaults(appId: string, version?: string, source?: string): Promise<{ env: AppEnvVar[]; defaults: DraftDefaults; composeOverride: string; auth?: AppAuthConfig; consumes?: string[]; security?: AppSecurityConfig; ingressService?: string; upgrade?: AppUpgradeMeta; backup?: AppBackupConfig; resolvedVersion?: string }> {
+  async getDraftDefaults(appId: string, version?: string, source?: string): Promise<{ env: AppEnvVar[]; defaults: DraftDefaults; composeOverride: string; auth?: AppAuthConfig; consumes?: string[]; multiInstance?: boolean; security?: AppSecurityConfig; ingressService?: string; upgrade?: AppUpgradeMeta; backup?: AppBackupConfig; resolvedVersion?: string }> {
     try {
       const versionDetail = await this.catalogService.getVersionDetail(appId, version || 'latest', source);
       return {
@@ -912,6 +919,7 @@ export class RealDraftService implements DraftService {
         composeOverride: versionDetail.composeOverride ?? '',
         auth: versionDetail.auth,
         consumes: versionDetail.consumes,
+        multiInstance: versionDetail.multiInstance,
         security: versionDetail.security,
         ingressService: versionDetail.ingressService,
         upgrade: versionDetail.upgrade,

--- a/packages/server/src/services/core/routing.ts
+++ b/packages/server/src/services/core/routing.ts
@@ -16,7 +16,8 @@
  */
 
 import { stringify as stringifyYAML } from 'yaml';
-import type { TraefikRoutingRule, TraefikRoutingMap, RoutingConflict } from '@hola/shared';
+import type { TraefikRoutingRule, TraefikRoutingMap, RoutingConflict, GetSubdomainAvailabilityResponse } from '@hola/shared';
+import { slugifySubdomain, isValidSubdomain } from '@hola/shared';
 
 import { getLogger } from '../../lib/logger';
 import type { HealthCheckable, ServiceHealth } from './types';
@@ -33,6 +34,12 @@ const DEFAULT_BASE_DOMAIN = 'local.hola';
 export interface GenerateRuleInput {
   deploymentId: string;
   appName: string;
+  /**
+   * DNS label the app is routed under — the host becomes `<subdomain>.<domain>`
+   * (#246). Omitted for pre-multi-instance deployments, which fall back to
+   * `appName` so their host is unchanged.
+   */
+  subdomain?: string;
   /** Internal container/service port Traefik forwards to (defaults to 80). */
   port?: number;
 }
@@ -81,6 +88,8 @@ export interface RoutingService extends HealthCheckable {
   generateRule(input: GenerateRuleInput): TraefikRoutingRule;
   /** Conflicts if the rule's host is already owned by a different deployment. */
   validateRule(rule: TraefikRoutingRule): Promise<RoutingConflict[]>;
+  /** Whether a candidate subdomain (or name to slugify) is free to route (#246). */
+  checkSubdomain(input: string): Promise<GetSubdomainAvailabilityResponse>;
   /** Add/replace a deployment's route and re-emit dynamic config (atomic). */
   activateRoute(rule: TraefikRoutingRule): Promise<void>;
   /** Remove a deployment's route(s) and re-emit dynamic config (atomic). */
@@ -95,7 +104,11 @@ export interface RoutingService extends HealthCheckable {
 
 /** Build a deterministic routing rule (pure; shared by real and mock services). */
 function buildRule(input: GenerateRuleInput, domain: string): TraefikRoutingRule {
-  const host = `${input.appName}.${domain}`;
+  // The public host is derived from the per-deployment subdomain (#246), falling
+  // back to the app id for deployments minted before multi-instance — so an
+  // existing install (and the typical first install, where subdomain == app id)
+  // keeps `<app>.<domain>`.
+  const host = `${input.subdomain || input.appName}.${domain}`;
   // The deployment id is already a compact, unique `<slug>-<hash>` (it embeds the
   // app slug), so use it whole — truncating it would collide between two installs
   // of the same app.
@@ -123,6 +136,32 @@ function conflictsFor(rule: TraefikRoutingRule, map: TraefikRoutingMap): Routing
     }];
   }
   return [];
+}
+
+/**
+ * Resolve whether a candidate subdomain is free (#246). Pure: the caller supplies
+ * the active routing map and the set of reserved core hosts (the dashboard,
+ * Traefik dashboard, Authentik). Slugifies the input, then rejects an invalid DNS
+ * label, a reserved host, or a host already owned by another deployment.
+ */
+function availabilityFor(
+  input: string,
+  map: TraefikRoutingMap,
+  domain: string,
+  reservedHosts: Set<string>,
+): GetSubdomainAvailabilityResponse {
+  const subdomain = slugifySubdomain(input);
+  const host = `${subdomain}.${domain}`;
+  if (!subdomain || !isValidSubdomain(subdomain)) {
+    return { subdomain, host, available: false, reason: 'invalid' };
+  }
+  if (reservedHosts.has(host)) {
+    return { subdomain, host, available: false, reason: 'reserved' };
+  }
+  if (map[host]) {
+    return { subdomain, host, available: false, reason: 'taken' };
+  }
+  return { subdomain, host, available: true };
 }
 
 /** Map keyed by host, in deterministic (sorted) host order. */
@@ -314,6 +353,16 @@ export class RealRoutingService implements RoutingService {
     return conflictsFor(rule, this.map);
   }
 
+  /** Core route hosts that a deployment subdomain must never clobber (#246). */
+  private reservedHosts(): Set<string> {
+    return new Set(coreRoutesFromEnv().map(r => r.host));
+  }
+
+  async checkSubdomain(input: string): Promise<GetSubdomainAvailabilityResponse> {
+    await this.ensureLoaded();
+    return availabilityFor(input, this.map, this.domain, this.reservedHosts());
+  }
+
   async activateRoute(rule: TraefikRoutingRule): Promise<void> {
     await this.ensureLoaded();
     // Drop any prior route owned by this deployment (e.g. a host change), then set.
@@ -395,6 +444,10 @@ export class MockRoutingService implements RoutingService {
 
   async validateRule(rule: TraefikRoutingRule): Promise<RoutingConflict[]> {
     return conflictsFor(rule, this.map);
+  }
+
+  async checkSubdomain(input: string): Promise<GetSubdomainAvailabilityResponse> {
+    return availabilityFor(input, this.map, this.domain, new Set(coreRoutesFromEnv().map(r => r.host)));
   }
 
   async activateRoute(rule: TraefikRoutingRule): Promise<void> {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -51,6 +51,10 @@ export const API = {
 
   deployments: {
     base: '/api/deployments', // list and POST create-from-draft at /api/deployments
+    // Check whether a candidate subdomain is free (#246). GET with `?subdomain=` (a
+    // raw label or a name to slugify); powers the install wizard's live availability
+    // indicator. Returns GetSubdomainAvailabilityResponse.
+    subdomainAvailable: '/api/deployments/subdomain-available',
     byId: (deploymentId: string) => `/api/deployments/${deploymentId}`,
     history: (deploymentId: string) => `/api/deployments/${deploymentId}/history`,
     logs: (deploymentId: string) => `/api/deployments/${deploymentId}/logs`,
@@ -672,6 +676,11 @@ export type GetCatalogAppVersionDetailResponse = {
   // (e.g. `app-registry`). The server writes the corresponding feed into the
   // app's data root on app-set change; rendering is a bundle bolt-on (ADR 0002).
   consumes?: string[];
+  // Whether the app may be installed more than once, declared in its bundle
+  // manifest (#246). Absent/false ⇒ singleton (the default): the server rejects a
+  // second install unless the operator opts in per-install. `true` (e.g. a browser
+  // desktop) lets a user run N independent instances at distinct subdomains.
+  multiInstance?: boolean;
   // The compose service Traefik should route to and that receives injected auth
   // env, for multi-service apps whose web/ingress service isn't named after the
   // app id (the default heuristic). Sourced from the bundle manifest's
@@ -876,6 +885,10 @@ export type Draft = {
   // Cross-app capabilities consumed (e.g. `app-registry`), seeded from the bundle
   // manifest and carried through finalize (ADR 0002).
   consumes?: string[];
+  // Whether the app may be installed more than once (#246), seeded from the bundle
+  // manifest and carried through finalize (read-only; not user-editable). Drives
+  // the server's singleton-by-default guard at create time.
+  multiInstance?: boolean;
   // Elevated container permissions the app requests, seeded from the bundle
   // manifest and carried through finalize (read-only; not user-editable). The
   // install wizard surfaces each for consent; the deploy lifecycle relaxes the
@@ -1459,6 +1472,13 @@ export type EnhancedDeploymentDetail = DeploymentDetail & {
   previousReleaseId?: string;
   draftId?: string;
   rollbackAvailable: boolean;
+  // The DNS label this deployment is routed under: the app is reachable at
+  // `<subdomain>.<HOLA_BASE_DOMAIN>`. Derived from the user-supplied name at
+  // create time (slug, defaulting to the app id) and then STABLE for the
+  // install's life — routing reconciles from this stored value, never recomputing
+  // from the name. Absent on deployments created before multi-instance (#246); the
+  // routing layer falls back to the app id, so their host is unchanged.
+  subdomain?: string;
   metadata: {
     createdAt: string;
     owner?: string;
@@ -1495,6 +1515,11 @@ export type CreateDeploymentFromDraftRequest = {
   // (not sent by clients). Persisted on the deployment so `${HOLA_USER_EMAIL}` can
   // resolve in the async deploy job, which runs without a request context.
   installedBy?: { email?: string; name?: string };
+  // Install a second instance of an app the catalog marks single-instance (#246).
+  // By default the server rejects a duplicate install of an app whose manifest
+  // does not set `multiInstance: true`; this per-install override bypasses that
+  // singleton guard (it still requires a distinct subdomain). Client-supplied.
+  allowMultiple?: boolean;
 };
 
 export type CreateDeploymentFromDraftResponse = {
@@ -1575,6 +1600,40 @@ export type RoutingConflict = {
 };
 
 export type TraefikRoutingMap = Record<string, TraefikRoutingRule>; // "host" -> routing rule
+
+/**
+ * Slugify a user-supplied instance name into a DNS label (#246): lowercase,
+ * `[a-z0-9-]` only, collapsed/trimmed hyphens, capped at 63 chars (the DNS label
+ * limit) with any trailing hyphen from truncation removed. Returns '' when nothing
+ * usable remains (e.g. a name of only punctuation) — the caller then falls back to
+ * the app id. Shared by the server (create-time derivation) and the web wizard
+ * (live preview) so both agree on the resulting host.
+ */
+export function slugifySubdomain(input: string): string {
+  return (input || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 63)
+    .replace(/-+$/g, '');
+}
+
+/** Whether a string is already a valid DNS label (the shape slugifySubdomain emits). */
+export function isValidSubdomain(label: string): boolean {
+  return /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/.test(label);
+}
+
+/** Response for the subdomain-availability check (#246). */
+export type GetSubdomainAvailabilityResponse = {
+  // The normalized DNS label the check resolved to (slug of the input).
+  subdomain: string;
+  // The full host the label would route to (`<subdomain>.<baseDomain>`).
+  host: string;
+  // False when the label is reserved (a core route), already taken by another
+  // deployment, or not a valid DNS label. `reason` explains which.
+  available: boolean;
+  reason?: 'reserved' | 'taken' | 'invalid';
+};
 
 // Directory structure metadata
 export type DeploymentDirectoryLayout = {


### PR DESCRIPTION
Part 1 of #246 (multiple instances of the same catalog app), server-first in a stacked series (server → CLI → web).

## What & why
Everything about a deployment was already keyed by `deploymentId` **except the public routing host**, which was derived from the app id (`<app>.<base>`) — so a second install of the same app collided. This PR derives the host from a **per-deployment subdomain** and adds a **single-instance-by-default** policy so duplicates stay an explicit choice.

## Changes
- **routing** — `GenerateRuleInput.subdomain` drives `host = <subdomain>.<domain>`, falling back to the app id when absent (existing installs unchanged). New `checkSubdomain()` classifies a candidate as `available` / `taken` / `reserved` (the core UI, Traefik, and Authentik hosts) / `invalid`.
- **deployment** — derive + persist a **stable** `subdomain` at create (slug of the user-supplied name, default = app id), reconcile routing from the *stored* value (never recomputed from the name), and enforce **singleton-by-default**: a second install of an app is rejected unless its manifest sets `multiInstance: true` or the request carries the per-install `allowMultiple` override.
- **manifest** — thread `multiInstance` through catalog → draft → finalize → deploy, mirroring how `consumes`/`auth` already flow.
- **api** — accept `allowMultiple` on create; add `GET /api/deployments/subdomain-available` for the wizard's live availability check.
- **shared** — `slugifySubdomain` / `isValidSubdomain` helpers, the availability response type, and the new request/record fields.

## Backwards compatibility
A first/default install (name == app id, or no name) and **every pre-existing deployment** keep `<app>.<base>` — the subdomain falls back to the app id when unset, and routing reconciles from the stored value on restart.

## Tests
- routing: subdomain host derivation + fallback; `checkSubdomain` available/taken/invalid/reserved.
- deployment: singleton rejection; operator override installs a 2nd instance at a distinct host (both routes coexist); `multiInstance` manifest allows a 2nd without the override; same-name → host conflict; subdomain persists across a simulated restart.
- catalog: `multiInstance` carried from a bundle `manifest.json`.
- api: availability endpoint reachable (not swallowed by `/:id`) + invalid case.

Full gate green: `typecheck` · `lint` · `build` · server suite (598) · web suite (205).

## Follow-ups (this series)
- **CLI** — `hola install --allow-multiple` + a friendly "subdomain taken → try `<app>-2`" hint.
- **web** — name/subdomain field with live availability + an "install another" affordance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)