### PR TITLE
feat(web): install-wizard name/subdomain + "install another" (#246)

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -13,6 +13,7 @@ import {
   RollbackRequest, RollbackResponse, GetDeploymentHistoryResponse,
   PromoteDeploymentRequest, PromoteDeploymentResponse,
   GetDeploymentConfigResponse,
+  GetSubdomainAvailabilityResponse,
   // Catalog types
   GetCatalogAppsRequest, GetCatalogAppsResponse, GetCatalogAppResponse,
   GetCatalogAppVersionsResponse, GetCatalogAppVersionDetailResponse,
@@ -142,6 +143,9 @@ export class HolaSdk {
 
   deployments = {
     create: (data: CreateDeploymentFromDraftRequest) => this.post<CreateDeploymentFromDraftResponse>(API.deployments.base, data),
+    // Live check for the install wizard: is `<subdomain>.<base>` free (#246)?
+    subdomainAvailable: (subdomain: string) =>
+      this.get<GetSubdomainAvailabilityResponse>(`${API.deployments.subdomainAvailable}${buildQuery({ subdomain })}`),
     list: (qs?: GetDeploymentsRequest) => this.get<GetDeploymentsResponse>(`${API.deployments.base}${buildQuery(qs)}`),
     byId: (deploymentId: string) => this.get<GetDeploymentResponse>(API.deployments.byId(deploymentId)),
     update: (deploymentId: string, data: PatchDeploymentRequest) => this.patch<PatchDeploymentResponse>(API.deployments.byId(deploymentId), data),

--- a/packages/web/src/__tests__/hooks/useDraftFinalization.test.tsx
+++ b/packages/web/src/__tests__/hooks/useDraftFinalization.test.tsx
@@ -1,0 +1,44 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// #246: finalizeDraft must pass the chosen instance name (→ subdomain) and the
+// allow-multiple override through to the deployment create call.
+const finalize = vi.fn(async () => ({ ok: true }));
+const create = vi.fn(async () => ({ deploymentId: 'dep1', releaseId: 'r1', jobId: 'j1' }));
+
+vi.mock('../../utils/api-hybrid', () => ({
+  api: {
+    drafts: { finalize: (id: string) => finalize(id) },
+    deployments: { create: (data: unknown) => create(data) },
+  },
+}));
+
+const { useDraftFinalization } = await import('../../hooks/useDraftFinalization');
+
+beforeEach(() => {
+  finalize.mockClear();
+  create.mockClear();
+});
+
+describe('useDraftFinalization', () => {
+  it('passes the name and allowMultiple override through to deployments.create', async () => {
+    const { result } = renderHook(() => useDraftFinalization());
+
+    await act(async () => {
+      await result.current.finalizeDraft('draft-1', { name: 'Second Desk', allowMultiple: true });
+    });
+
+    expect(finalize).toHaveBeenCalledWith('draft-1');
+    expect(create).toHaveBeenCalledWith({ draftId: 'draft-1', name: 'Second Desk', allowMultiple: true });
+  });
+
+  it('defaults to no name / no override for a plain install', async () => {
+    const { result } = renderHook(() => useDraftFinalization());
+
+    await act(async () => {
+      await result.current.finalizeDraft('draft-1');
+    });
+
+    expect(create).toHaveBeenCalledWith({ draftId: 'draft-1', name: undefined, allowMultiple: undefined });
+  });
+});

--- a/packages/web/src/__tests__/pages/Catalog.test.tsx
+++ b/packages/web/src/__tests__/pages/Catalog.test.tsx
@@ -93,6 +93,16 @@ describe('Catalog', () => {
         .toHaveAttribute('href', '/deployments/webtop-ab12cd34');
     });
 
+    it('offers an "install another" link that opens the wizard with the override (#246)', async () => {
+      mockApi([app()], [deployment()]);
+
+      renderCatalog();
+
+      await waitFor(() => expect(screen.getByText('Installed')).toBeInTheDocument());
+      expect(screen.getByRole('link', { name: /another/i }))
+        .toHaveAttribute('href', '/catalog/webtop/install?another=1');
+    });
+
     it('counts a non-running deployment as installed', async () => {
       // The Traefik host is owned by app name regardless of status, so a stopped
       // or errored deployment still blocks a second install server-side.

--- a/packages/web/src/hooks/useDraftFinalization.ts
+++ b/packages/web/src/hooks/useDraftFinalization.ts
@@ -17,12 +17,14 @@ export function useDraftFinalization() {
   // Finalize the draft (stage immutable artifacts) and then create + start a
   // deployment from it. Finalize alone produces no running app — creating the
   // deployment is what enqueues the install job that runs `docker compose up`.
-  const finalizeDraft = React.useCallback(async (draftId: string) => {
+  const finalizeDraft = React.useCallback(async (draftId: string, opts?: { name?: string; allowMultiple?: boolean }) => {
     setState(prev => ({ ...prev, loading: true, error: null }));
 
     try {
       await api.drafts.finalize(draftId);
-      const deployment = await api.deployments.create({ draftId });
+      // #246: `name` sets the deployment's subdomain (<name>.<base>); `allowMultiple`
+      // opts past the single-instance guard for a deliberate second install.
+      const deployment = await api.deployments.create({ draftId, name: opts?.name, allowMultiple: opts?.allowMultiple });
 
       setState({
         data: deployment,

--- a/packages/web/src/pages/Catalog.tsx
+++ b/packages/web/src/pages/Catalog.tsx
@@ -336,6 +336,11 @@ export const Catalog: React.FC = () => {
               // multi-instance follow-up), so installed always means manage.
               const installedId = installedByApp.get(app.id);
               const goTo = installedId ? `/deployments/${installedId}` : installTo;
+              // #246: for an already-installed app, offer a deliberate second
+              // install. The wizard passes the allow-multiple override and asks for
+              // a distinct name (→ distinct subdomain); the server rejects it if the
+              // app is single-instance and no distinct host is chosen.
+              const installAnotherTo = `${installTo}${installTo.includes('?') ? '&' : '?'}another=1`;
               return (
                 <div
                   key={`${app.source}/${app.id}`}
@@ -379,6 +384,15 @@ export const Catalog: React.FC = () => {
                           <Check className="w-3.5 h-3.5 text-success" />
                           Installed
                         </span>
+                        <Link
+                          to={installAnotherTo}
+                          onClick={(e) => e.stopPropagation()}
+                          title="Install another instance"
+                          className="h-[34px] px-[12px] flex items-center gap-[5px] bg-surface-2 text-text-muted border border-border rounded-lg text-[13px] font-semibold hover:border-primary hover:text-text-strong transition-colors"
+                        >
+                          <Plus className="w-4 h-4" />
+                          Another
+                        </Link>
                         <Link
                           to={goTo}
                           onClick={(e) => e.stopPropagation()}

--- a/packages/web/src/pages/InstallWizard.tsx
+++ b/packages/web/src/pages/InstallWizard.tsx
@@ -10,7 +10,9 @@ import type {
   PatchDraftRequest,
   ValidationIssue,
   AppSecurityConfig,
+  GetSubdomainAvailabilityResponse,
 } from '@hola/shared';
+import { slugifySubdomain } from '@hola/shared';
 import { validateParams, generateSecretValue, isEffectivelyRequired } from '@hola/shared/param-validate';
 import { useCreateDraft, useDraftApi } from '../hooks/useDraftApi';
 import { useDraftValidation } from '../hooks/useDraftValidation';
@@ -121,6 +123,16 @@ export const InstallWizard: React.FC = () => {
   const [editMode, setEditMode] = useState(false);
   const [isDragOver, setIsDragOver] = useState(false);
 
+  // #246: the instance name drives the deployment's subdomain (`<slug>.<base>`).
+  // Defaults to the catalog display name once the draft loads; the user can change
+  // it to install a second instance at a distinct host. `?another=1` (from the
+  // catalog's "install another") opts past the single-instance guard.
+  const [instanceName, setInstanceName] = useState('');
+  const [nameTouched, setNameTouched] = useState(false);
+  const [availability, setAvailability] = useState<GetSubdomainAvailabilityResponse | null>(null);
+  const allowMultiple = searchParams.get('another') === '1';
+  const subdomain = slugifySubdomain(instanceName);
+
   // Real app metadata, resolved from the catalog when the draft is created.
   // Falls back to the route's appId for the brief window before the draft loads.
   const app = createDraftHook.data?.app ?? { id: appId ?? ociRef ?? '', name: appId ?? ociRef ?? 'app', icon: '📦' };
@@ -199,6 +211,33 @@ export const InstallWizard: React.FC = () => {
     initializeDraft();
   }, [appId, ociRef, credentialRef, source, createDraftHook]); // Include the whole hook object
 
+  // Seed the instance name from the catalog display name once the draft resolves
+  // (until the user edits it) — so a normal install keeps the app's own name/host.
+  const appName = createDraftHook.data?.app?.name;
+  useEffect(() => {
+    if (!nameTouched && !instanceName && appName) setInstanceName(appName);
+  }, [appName, nameTouched, instanceName]);
+
+  // Live subdomain-availability check (#246), debounced. An empty/invalid slug is
+  // reported locally; otherwise the server says whether the host is free.
+  useEffect(() => {
+    if (!subdomain) {
+      setAvailability({ subdomain: '', host: '', available: false, reason: 'invalid' });
+      return;
+    }
+    let cancelled = false;
+    setAvailability(null); // "checking…" until the debounced call returns
+    const t = setTimeout(async () => {
+      try {
+        const res = await api.deployments.subdomainAvailable(subdomain);
+        if (!cancelled) setAvailability(res);
+      } catch {
+        if (!cancelled) setAvailability(null);
+      }
+    }, 300);
+    return () => { cancelled = true; clearTimeout(t); };
+  }, [subdomain]);
+
   // Update draft data helper function
   const updateDraftData = React.useCallback(async (updates: PatchDraftRequest) => {
     if (!draftId || !draftApi.updateDraft) return;
@@ -241,7 +280,9 @@ export const InstallWizard: React.FC = () => {
     if (!draftId) return false;
     
     try {
-      await draftFinalization.finalizeDraft(draftId);
+      // #246: send the chosen name (→ subdomain) and, for a deliberate second
+      // install of a single-instance app, the allow-multiple override.
+      await draftFinalization.finalizeDraft(draftId, { name: instanceName.trim() || undefined, allowMultiple });
       return true;
     } catch (err) {
       console.error('Failed to finalize draft:', err);
@@ -1313,6 +1354,44 @@ services:
 
             <div className="space-y-4 mb-4">
               <div>
+                <h4 className="text-[13.5px] font-semibold text-text-strong mb-2">Deployment name &amp; address</h4>
+                <input
+                  type="text"
+                  value={instanceName}
+                  onChange={(e) => { setInstanceName(e.target.value); setNameTouched(true); }}
+                  placeholder={app.name}
+                  className="w-full h-[38px] px-3 bg-surface-2 border border-border rounded-[10px] text-sm outline-none focus:border-primary transition"
+                />
+                <div className="mt-2 text-[12.5px] flex items-center gap-1.5 flex-wrap">
+                  <span className="text-text-muted">Address:</span>
+                  {availability ? (
+                    <>
+                      <span className="font-mono text-text-strong">https://{availability.host || `${subdomain || '…'}.…`}</span>
+                      {availability.available ? (
+                        <span className="inline-flex items-center gap-1 text-success"><Check className="w-3.5 h-3.5" /> available</span>
+                      ) : (
+                        <span className="text-danger">
+                          {availability.reason === 'taken'
+                            ? '· already in use — pick a different name'
+                            : availability.reason === 'reserved'
+                              ? '· reserved — pick a different name'
+                              : '· enter a valid name'}
+                        </span>
+                      )}
+                    </>
+                  ) : (
+                    <span className="font-mono text-text-faint">checking {subdomain}.…</span>
+                  )}
+                </div>
+                {allowMultiple && (
+                  <div className="mt-2 flex items-start gap-2 px-3 py-2 rounded-[10px] bg-warning/10 text-[12.5px] text-text-muted">
+                    <AlertTriangle className="w-4 h-4 text-warning flex-none mt-px" />
+                    <span>Installing an additional instance. Give it a distinct name so it gets its own address and data.</span>
+                  </div>
+                )}
+              </div>
+
+              <div>
                 <h4 className="text-[13.5px] font-semibold text-text-strong mb-2">System variable overrides</h4>
                 {Object.keys(systemOverrides).length > 0 ? (
                   <div className="bg-surface-2 border border-border-soft rounded-[11px] overflow-hidden">
@@ -1486,7 +1565,7 @@ services:
               {isLastStep ? (
                 <button
                   onClick={handleInstall}
-                  disabled={isLoading}
+                  disabled={isLoading || availability?.available === false}
                   className="h-[42px] px-[22px] flex items-center gap-2 bg-primary text-white rounded-[10px] text-sm font-semibold shadow-primary-glow hover:brightness-110 disabled:opacity-50 transition"
                 >
                   {isLoading ? (

--- a/packages/web/src/utils/sdk-adapter.ts
+++ b/packages/web/src/utils/sdk-adapter.ts
@@ -19,6 +19,7 @@ import type {
   UploadDraftFileResponse, DeleteDraftFileResponse,
   // Deployment types
   CreateDeploymentFromDraftRequest, CreateDeploymentFromDraftResponse,
+  GetSubdomainAvailabilityResponse,
   GetDeploymentsRequest, GetDeploymentsResponse, GetDeploymentResponse,
   PatchDeploymentRequest, PatchDeploymentResponse,
   PostDeploymentActionRequest, PostDeploymentActionResponse,
@@ -436,6 +437,11 @@ export class SdkAdapter {
   deployments = {
     create: (data: CreateDeploymentFromDraftRequest): Promise<CreateDeploymentFromDraftResponse> =>
       this.enhancedRequest('POST', '/api/deployments', () => this.sdk.deployments.create(data), data, true),
+
+    // Live subdomain-availability check for the install wizard (#246). Not cached —
+    // availability changes as deployments come and go.
+    subdomainAvailable: (subdomain: string): Promise<GetSubdomainAvailabilityResponse> =>
+      this.sdk.deployments.subdomainAvailable(subdomain),
 
     // Full teardown: stops containers, deprovisions auth, releases the Traefik
     // route, and removes the record (DELETE /api/deployments/:id). The `delete`


### PR DESCRIPTION
Part 3 (final) of #246, stacked on the merged server (#386) and CLI (#387) changes. Gives the dashboard the multi-instance flow both other surfaces already have.

## Changes
- **Install wizard** — a "Deployment name & address" field on the summary step with a **live availability check** (debounced call to the new endpoint): it shows the resulting `https://<slug>.<base>`, marks it ✓ available or explains taken/reserved/invalid, and **disables Install** while the name is unavailable. The chosen name is sent to create and becomes the deployment's subdomain.
- **Catalog** — an already-installed app's card gains an **"Another"** action (next to Manage) that opens the wizard with `?another=1`; the wizard then sends the `allowMultiple` override and warns to choose a distinct name.
- **Plumbing** — `sdk.deployments.subdomainAvailable(subdomain)`, surfaced through the web SDK adapter and hybrid `api`; `useDraftFinalization` now forwards `name` + `allowMultiple` to `deployments.create`.

## Tests
- `useDraftFinalization` forwards name + allowMultiple (and defaults to neither for a plain install).
- Catalog renders the "Another" link → `/catalog/<app>/install?another=1` for an installed app.
- Existing wizard/catalog suites still green.

Full gate green: `typecheck` · `lint` · `build` · web (208) · server (598) · CLI (187).

## Design note
The name drives the subdomain (`subdomain = slug(name)`), matching the server contract — so editing the name configures the host and the live preview shows it. A fully independent display-name-vs-subdomain split (a separate editable subdomain field, needing the server to accept `subdomain` directly) is a small possible follow-up.

Closes #246. (Also supersedes the duplicate #366.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)