### PR TITLE
feat(server): per-app Compose profile support (#162)

### DIFF
--- a/packages/server/src/__tests__/bundles/catalog-compose-override.test.ts
+++ b/packages/server/src/__tests__/bundles/catalog-compose-override.test.ts
@@ -36,6 +36,11 @@ const MANIFEST = JSON.stringify({
   ingress: { service: 'fixtureapp', port: 80 },
   // #246: this fixture app opts into multiple instances.
   multiInstance: true,
+  // #162: an optional Compose profile the operator can enable at install time.
+  profiles: [
+    { key: 'elasticsearch', label: 'Elasticsearch advanced visibility', default: false },
+    { key: 'bogus profile' }, // invalid key grammar — must be dropped by coercion
+  ],
   defaultEnv: [
     { key: 'APP_ENV', value: 'production', isSecret: false },
     // A bogus/future param type must degrade to untyped rather than reject the
@@ -116,6 +121,11 @@ describe('RealCatalogService composeOverride (#82)', () => {
     // The manifest's multiInstance flag (#246) is carried through so the singleton
     // guard can honor it at install time.
     expect(detail.multiInstance).toBe(true);
+    // The manifest's optional Compose profiles (#162) carry through, with the
+    // invalid-key entry dropped by narrow-shape coercion.
+    expect(detail.profiles).toEqual([
+      { key: 'elasticsearch', label: 'Elasticsearch advanced visibility' },
+    ]);
   });
 
   test('defaultEnv carries typed-spec fields through and degrades an unknown type without rejecting the bundle (ADR 0003)', async () => {

--- a/packages/server/src/__tests__/bundles/manifest-profiles.test.ts
+++ b/packages/server/src/__tests__/bundles/manifest-profiles.test.ts
@@ -1,0 +1,56 @@
+/**
+ * coerceManifestProfiles — narrow-shape coercion of the bundle manifest's
+ * optional `profiles` block (#162). Mirrors the manifest-upgrade coercion tests:
+ * malformed/unknown entries are dropped, keys are grammar-checked, duplicates
+ * collapse, and an empty result degrades to undefined (the app has no profiles).
+ */
+import { describe, test, expect } from 'bun:test';
+
+import { coerceManifestProfiles } from '../../services/core/manifest-profiles';
+
+describe('coerceManifestProfiles', () => {
+  test('returns undefined for non-arrays', () => {
+    expect(coerceManifestProfiles(undefined)).toBeUndefined();
+    expect(coerceManifestProfiles(null)).toBeUndefined();
+    expect(coerceManifestProfiles({ key: 'x' })).toBeUndefined();
+    expect(coerceManifestProfiles('elasticsearch')).toBeUndefined();
+  });
+
+  test('returns undefined when no entry survives coercion', () => {
+    expect(coerceManifestProfiles([])).toBeUndefined();
+    // missing/blank key, non-object entries, and invalid key grammar are all dropped.
+    expect(coerceManifestProfiles([{ label: 'no key' }, 'x', 42, null])).toBeUndefined();
+    expect(coerceManifestProfiles([{ key: '   ' }, { key: '-bad' }, { key: 'has space' }])).toBeUndefined();
+  });
+
+  test('carries a full, valid entry and defaults label to key', () => {
+    expect(
+      coerceManifestProfiles([
+        { key: 'elasticsearch', label: 'Elasticsearch advanced visibility', description: 'Heavier, opt-in', default: true },
+        { key: 'metrics' },
+      ]),
+    ).toEqual([
+      { key: 'elasticsearch', label: 'Elasticsearch advanced visibility', description: 'Heavier, opt-in', default: true },
+      { key: 'metrics', label: 'metrics' },
+    ]);
+  });
+
+  test('drops a non-true default and a blank description', () => {
+    expect(coerceManifestProfiles([{ key: 'es', label: 'ES', default: 'yes', description: '  ' }])).toEqual([
+      { key: 'es', label: 'ES' },
+    ]);
+  });
+
+  test('collapses duplicate keys to the first occurrence and preserves order', () => {
+    expect(
+      coerceManifestProfiles([
+        { key: 'a', label: 'first A' },
+        { key: 'b', label: 'B' },
+        { key: 'a', label: 'second A' },
+      ]),
+    ).toEqual([
+      { key: 'a', label: 'first A' },
+      { key: 'b', label: 'B' },
+    ]);
+  });
+});

--- a/packages/server/src/__tests__/deployments/lifecycle.test.ts
+++ b/packages/server/src/__tests__/deployments/lifecycle.test.ts
@@ -28,12 +28,14 @@ import { MockDockerService, type DockerService } from '../../services/core/docke
 type CatalogArg = ConstructorParameters<typeof RealDraftService>[1];
 type ValidationArg = ConstructorParameters<typeof RealDraftService>[2];
 
-function makeCatalog(): CatalogArg {
+function makeCatalog(opts?: { profiles?: Array<{ key: string; label: string; default?: boolean }> }): CatalogArg {
   return {
     getApp: async (appId: string) => ({ id: appId, name: 'Gitea', icon: '🍵' }),
     getVersionDetail: async () => ({
       defaultEnv: [],
       defaults: { ports: [{ host: 3000, container: 3000, protocol: 'tcp' as const }], volumes: [] },
+      // #162: optional Compose profiles the app declares.
+      ...(opts?.profiles ? { profiles: opts.profiles } : {}),
     }),
   } as unknown as CatalogArg;
 }
@@ -68,13 +70,13 @@ describe('Deployment lifecycle (real orchestration wiring)', () => {
     await rm(dataRoot, { recursive: true, force: true });
   });
 
-  function makeSystem(docker: DockerService = new MockDockerService()) {
+  function makeSystem(docker: DockerService = new MockDockerService(), catalogOpts?: { profiles?: Array<{ key: string; label: string; default?: boolean }> }) {
     const storage = new RealStorageService({ holaDir: dataRoot });
     const database = new RealDatabaseService(storage);
     const logging = new RealLoggingService(storage);
     const jobs = new RealJobService(database, logging);
     const routing = new RealRoutingService(storage, { baseDomain: 'local.hola' });
-    const drafts = new RealDraftService(storage, makeCatalog(), makeValidation());
+    const drafts = new RealDraftService(storage, makeCatalog(catalogOpts), makeValidation());
     const deployments = new RealDeploymentService(storage, jobs, docker, drafts, routing, logging, new MockProvisionerService());
     return { storage, jobs, logging, drafts, deployments };
   }
@@ -242,6 +244,69 @@ describe('Deployment lifecycle (real orchestration wiring)', () => {
 
     const failedJobs = (await jobs.listJobs({ deploymentId: created.deploymentId, status: 'failed' }));
     expect(failedJobs.length).toBe(0);
+  });
+
+  test('selected Compose profiles are threaded through the up/down lifecycle (#162)', async () => {
+    // Capture the profiles arg each compose command receives, so we can assert the
+    // enabled set reaches `up`/`pull` at install and `down` at stop — the "keep
+    // them consistent across the lifecycle" requirement (down tears down what up
+    // started).
+    const upProfiles: (string[] | undefined)[] = [];
+    const pullProfiles: (string[] | undefined)[] = [];
+    const downProfiles: (string[] | undefined)[] = [];
+    const docker = new MockDockerService();
+    docker.composeUp = async (_p, _n, _auth, profiles) => { upProfiles.push(profiles); return { success: true, output: '' }; };
+    docker.composePull = async (_p, _n, _auth, profiles) => { pullProfiles.push(profiles); return { success: true, output: '' }; };
+    docker.composeDown = async (_p, _n, profiles) => { downProfiles.push(profiles); return { success: true, output: '' }; };
+
+    // The app declares two profiles; `metrics` defaults on, `elasticsearch` off.
+    const { jobs, drafts, deployments } = makeSystem(docker, {
+      profiles: [
+        { key: 'elasticsearch', label: 'Elasticsearch', default: false },
+        { key: 'metrics', label: 'Metrics', default: true },
+      ],
+    });
+
+    // The operator explicitly enables only `elasticsearch` (overriding the default
+    // set) — the request is authoritative.
+    const created = await deployments.createFromDraft({
+      draftId: await finalizedDraft(drafts),
+      name: 'gitea',
+      profiles: ['elasticsearch'],
+    });
+    await waitForJob(jobs, created.jobId!);
+
+    expect(pullProfiles).toEqual([['elasticsearch']]);
+    expect(upProfiles).toEqual([['elasticsearch']]);
+
+    // The resolved set is persisted on the deployment record.
+    const restarted = makeSystem(new MockDockerService());
+    const stored = await restarted.storage.readFileAsString(`deployments/${created.deploymentId}/metadata.json`);
+    expect(JSON.parse(stored).selectedProfiles).toEqual(['elasticsearch']);
+
+    // Stop tears the same profiled services down.
+    const action = await deployments.executeAction(created.deploymentId, { action: 'stop' });
+    await waitForJob(jobs, action.jobId!);
+    expect(downProfiles).toEqual([['elasticsearch']]);
+  });
+
+  test('with no profiles requested, the manifest defaults are activated (#162)', async () => {
+    const upProfiles: (string[] | undefined)[] = [];
+    const docker = new MockDockerService();
+    docker.composeUp = async (_p, _n, _auth, profiles) => { upProfiles.push(profiles); return { success: true, output: '' }; };
+
+    const { jobs, drafts, deployments } = makeSystem(docker, {
+      profiles: [
+        { key: 'elasticsearch', label: 'Elasticsearch', default: false },
+        { key: 'metrics', label: 'Metrics', default: true },
+      ],
+    });
+
+    // No `profiles` on the request (e.g. a plain CLI install) → fall back to the
+    // manifest's default-on profiles.
+    const created = await deployments.createFromDraft({ draftId: await finalizedDraft(drafts), name: 'gitea' });
+    await waitForJob(jobs, created.jobId!);
+    expect(upProfiles).toEqual([['metrics']]);
   });
 
   test('lifecycle logs are streamed to the deployment log target', async () => {

--- a/packages/server/src/__tests__/validation/compose-validate.test.ts
+++ b/packages/server/src/__tests__/validation/compose-validate.test.ts
@@ -43,6 +43,26 @@ services:
     expect(validateComposeDocument(yaml)).toEqual([]);
   });
 
+  test('a service gated behind a Compose profile passes clean (#162)', () => {
+    // An optional heavy dependency (e.g. Postiz's Elasticsearch) is gated behind a
+    // `profiles:` key. The validator must not choke on it — it is how the platform
+    // makes a service opt-in. `profiles:` publishes no host port, so it is allowed.
+    const yaml = `
+services:
+  app:
+    image: ghcr.io/acme/app:1.2.3
+    expose:
+      - "3000"
+  elasticsearch:
+    image: elasticsearch:8.15.0
+    profiles:
+      - elasticsearch
+    expose:
+      - "9200"
+`;
+    expect(validateComposeDocument(yaml)).toEqual([]);
+  });
+
   test('a valid multi-service bundle with defined resources passes clean', () => {
     const yaml = `
 services:

--- a/packages/server/src/services/core/catalog.ts
+++ b/packages/server/src/services/core/catalog.ts
@@ -25,6 +25,7 @@ import type { CatalogSourceService } from './catalog-sources';
 import type { RegistryCredentialService } from './registry-credentials';
 import { coerceManifestAuth } from './manifest-auth';
 import { coerceManifestSecurity } from './manifest-security';
+import { coerceManifestProfiles } from './manifest-profiles';
 import { coerceConsumes } from './app-registry';
 import { coerceManifestUpgrade } from './manifest-upgrade';
 import { coerceManifestBackup } from './manifest-backup';
@@ -518,6 +519,7 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
         security?: unknown;
         upgrade?: unknown;
         backup?: unknown;
+        profiles?: unknown;
         ingress?: { service?: unknown; port?: unknown };
       };
 
@@ -600,6 +602,12 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
       // transaction-consistent backups. Coerced narrowly like `auth`.
       const backup = coerceManifestBackup(manifest.backup);
 
+      // Optional Compose profiles the app declares (#162): each gates an opt-in
+      // service (e.g. a heavy dependency). Coerced narrowly like `auth`; the
+      // wizard renders a checkbox per profile and the enabled set is threaded into
+      // the compose lifecycle as `COMPOSE_PROFILES`.
+      const profiles = coerceManifestProfiles(manifest.profiles);
+
       // Which compose service is the web/ingress one — the app's bundle manifest
       // declares it as `ingress.service`. Lets the server route to / inject auth
       // env into the right service for a multi-service app whose ingress isn't
@@ -609,7 +617,7 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
           ? manifest.ingress.service.trim()
           : undefined;
 
-      return { ...merged, version, composeOverride, auth, consumes, multiInstance, security, upgrade, backup, ingressService } satisfies GetCatalogAppVersionDetailResponse;
+      return { ...merged, version, composeOverride, auth, consumes, multiInstance, security, upgrade, backup, profiles, ingressService } satisfies GetCatalogAppVersionDetailResponse;
     } catch (error) {
       this.logger.warn('Failed to read or parse bundle manifest', { version, error: error instanceof Error ? error.message : String(error) });
       // Keep the underlying reason in the message, not just the cause: a missing

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -37,7 +37,8 @@ import type {
   GetLogsResponse,
   LogEntry,
   GetDeploymentConfigResponse,
-  AppSecurityConfig
+  AppSecurityConfig,
+  AppProfileConfig
 } from '@hola/shared';
 import { checkUpgradePath, isNewerVersion, slugifySubdomain } from '@hola/shared';
 import { requestsPrivilegeEscalation } from './manifest-security';
@@ -92,6 +93,27 @@ function makeDeploymentId(appId: string): string {
  */
 function deriveSubdomain(name: string | undefined, appId: string): string {
   return slugifySubdomain(name || '') || slugifySubdomain(appId) || 'app';
+}
+
+/**
+ * Resolve the Compose profiles (#162) to activate for an install from the app's
+ * declared set and the operator's requested keys. An explicit request (even an
+ * empty array, from the wizard's checkboxes) is authoritative but intersected
+ * with the declared keys — an unknown key can't smuggle an arbitrary profile into
+ * the lifecycle. When no request is given (e.g. a plain CLI install), fall back to
+ * the profiles the manifest marks `default`. Declared order is preserved so
+ * `COMPOSE_PROFILES` is deterministic.
+ */
+function resolveSelectedProfiles(
+  declared: AppProfileConfig[] | undefined,
+  requested: string[] | undefined,
+): string[] {
+  if (!declared || declared.length === 0) return [];
+  if (requested !== undefined) {
+    const want = new Set(requested);
+    return declared.filter(p => want.has(p.key)).map(p => p.key);
+  }
+  return declared.filter(p => p.default === true).map(p => p.key);
 }
 
 type ProvisionCredentials = NonNullable<ProvisionResult['credentials']>;
@@ -597,6 +619,12 @@ abstract class InMemoryDeploymentService implements DeploymentService {
       // The DNS label this deployment routes under; stable for the install's life.
       const subdomain = deriveSubdomain(request.name, app);
 
+      // Compose profiles to activate for this install (#162): the operator's
+      // requested set intersected with what the manifest declares, or the declared
+      // defaults when the caller didn't specify. Persisted on the deployment and
+      // threaded into every compose lifecycle command below.
+      const selectedProfiles = resolveSelectedProfiles(artifacts?.manifest.profiles, request.profiles);
+
       // Reject a routing (host) conflict — a taken, reserved, or invalid subdomain
       // — before creating any deployment state.
       await this.onBeforeCreate(deploymentId, app, subdomain);
@@ -618,6 +646,9 @@ abstract class InMemoryDeploymentService implements DeploymentService {
         // The routed DNS label (#246); reconciled from here, never recomputed from
         // the name — so the URL stays put even if the display name later changes.
         subdomain,
+        // Active Compose profiles (#162); empty for the common no-optional-service
+        // case, so it stays absent in the persisted record rather than `[]`.
+        ...(selectedProfiles.length ? { selectedProfiles } : {}),
         // Persist the catalog icon (emoji or image URL) carried through the
         // finalized manifest, so the launcher and registry feed have a stable
         // icon without a live catalog lookup. Falls back to a generic glyph.
@@ -1531,13 +1562,16 @@ export class RealDeploymentService extends InMemoryDeploymentService {
     const backup = await this.readReleaseBackupConfig(deploymentId, fromReleaseId);
     const dir = this.runtimeDir(deploymentId);
     const projectName = this.projectName(deploymentId);
+    // A backup hook may target a profiled service (#162); carry the active profiles
+    // so Compose can resolve it.
+    const profiles = this.deployments.get(deploymentId)?.selectedProfiles;
 
     // preHook failure propagates — `promote` decides fail-closed (when the target
     // declares `preUpgradeBackup: required`) vs. best-effort. A consistent dump is
     // worthless if we snapshot anyway.
     if (backup?.preHook) {
       this.logger.info('Running backup preHook before snapshot', { deploymentId, service: backup.preHook.service });
-      const res = await this.dockerService.composeExec(dir, projectName, backup.preHook.service, backup.preHook.command);
+      const res = await this.dockerService.composeExec(dir, projectName, backup.preHook.service, backup.preHook.command, { profiles });
       if (!res.success) throw new Error(`backup preHook failed: ${res.output}`);
     }
 
@@ -1566,7 +1600,7 @@ export class RealDeploymentService extends InMemoryDeploymentService {
       // Best-effort — a cleanup failure must not fail the upgrade.
       if (backup?.postHook) {
         try {
-          const res = await this.dockerService.composeExec(dir, projectName, backup.postHook.service, backup.postHook.command);
+          const res = await this.dockerService.composeExec(dir, projectName, backup.postHook.service, backup.postHook.command, { profiles });
           if (!res.success) this.logger.warn('backup postHook failed', { deploymentId, output: res.output });
         } catch (err) {
           this.logger.warn('backup postHook errored', { deploymentId, error: err instanceof Error ? err.message : String(err) });
@@ -1835,7 +1869,7 @@ export class RealDeploymentService extends InMemoryDeploymentService {
       if (attempt > 1) await new Promise(r => setTimeout(r, this.authSetupIntervalMs));
 
       if (setup.check) {
-        const chk = await this.dockerService.composeExec(dir, projectName, service, apply(setup.check), { user: setup.user });
+        const chk = await this.dockerService.composeExec(dir, projectName, service, apply(setup.check), { user: setup.user, profiles: deployment.selectedProfiles });
         if (!chk.success) {
           await logBoth('info', `Auth setup: app not ready yet (attempt ${attempt}/${this.authSetupMaxAttempts})`);
           continue; // app likely still starting; retry
@@ -1846,7 +1880,7 @@ export class RealDeploymentService extends InMemoryDeploymentService {
         }
       }
 
-      const cmd = await this.dockerService.composeExec(dir, projectName, service, apply(setup.command), { user: setup.user });
+      const cmd = await this.dockerService.composeExec(dir, projectName, service, apply(setup.command), { user: setup.user, profiles: deployment.selectedProfiles });
       if (cmd.success) {
         await logBoth('info', 'Auth setup: OIDC source configured');
         return;
@@ -1952,7 +1986,7 @@ export class RealDeploymentService extends InMemoryDeploymentService {
       let nextLifecycle: EnhancedDeploymentDetail['lifecycleState'];
 
       if (action === 'stop' || action === 'delete') {
-        const res = await this.dockerService.composeDown(this.runtimeDir(deploymentId), projectName);
+        const res = await this.dockerService.composeDown(this.runtimeDir(deploymentId), projectName, deployment.selectedProfiles);
         output = res.output;
         if (!res.success && action !== 'delete') throw new Error(res.output);
         nextStatus = 'stopped';
@@ -1967,7 +2001,7 @@ export class RealDeploymentService extends InMemoryDeploymentService {
         // wiring) would silently never reach the app. `up -d` recreates only the
         // services whose config changed, using the already-present images.
         const registryAuth = await this.resolveRegistryAuth(deployment);
-        const res = await this.dockerService.composeUp(composeDir, projectName, registryAuth);
+        const res = await this.dockerService.composeUp(composeDir, projectName, registryAuth, deployment.selectedProfiles);
         output = res.output;
         if (!res.success) throw new Error(res.output);
         if (provisioned) await this.completeAuthWiring(deployment, provisioned, projectName, logBoth);
@@ -1985,7 +2019,7 @@ export class RealDeploymentService extends InMemoryDeploymentService {
         if (action === 'rollback' && ctx.payload.restoreData === true) {
           const targetReleaseId = (ctx.payload.targetReleaseId as string | undefined) ?? deployment.currentReleaseId ?? '';
           await logBoth('info', 'Data-aware rollback: stopping containers before restoring app data…');
-          await this.dockerService.composeDown(this.runtimeDir(deploymentId), projectName);
+          await this.dockerService.composeDown(this.runtimeDir(deploymentId), projectName, deployment.selectedProfiles);
           await this.restoreAppDataSnapshot(deploymentId, targetReleaseId, logBoth);
         }
 
@@ -2000,7 +2034,7 @@ export class RealDeploymentService extends InMemoryDeploymentService {
         // Resolve any private-registry credential once for both pull and up.
         const registryAuth = await this.resolveRegistryAuth(deployment);
         await logBoth('info', 'Pulling images (first install can take several minutes)…');
-        const pull = await this.dockerService.composePull(composeDir, projectName, registryAuth);
+        const pull = await this.dockerService.composePull(composeDir, projectName, registryAuth, deployment.selectedProfiles);
         if (!pull.success) throw new Error(`Image pull failed: ${pull.output}`);
         await ctx.setProgress(60);
 
@@ -2008,7 +2042,7 @@ export class RealDeploymentService extends InMemoryDeploymentService {
         // irreversible step) if the job was cancelled during the long pull.
         if (ctx.isCancelled()) throw new JobCancelledError();
 
-        const res = await this.dockerService.composeUp(composeDir, projectName, registryAuth);
+        const res = await this.dockerService.composeUp(composeDir, projectName, registryAuth, deployment.selectedProfiles);
         output = res.output;
         if (!res.success) throw new Error(res.output);
         if (provisioned) await this.completeAuthWiring(deployment, provisioned, projectName, logBoth);
@@ -2197,7 +2231,10 @@ export class RealDeploymentService extends InMemoryDeploymentService {
    * being removed.
    */
   protected override async teardownContainers(deploymentId: string): Promise<void> {
-    const res = await this.dockerService.composeDown(this.runtimeDir(deploymentId), this.projectName(deploymentId));
+    // Carry the install's active profiles (#162) so `down` removes profiled
+    // services too rather than orphaning them.
+    const profiles = this.deployments.get(deploymentId)?.selectedProfiles;
+    const res = await this.dockerService.composeDown(this.runtimeDir(deploymentId), this.projectName(deploymentId), profiles);
     if (!res.success) {
       this.logger.warn('compose down reported a failure during delete; continuing with teardown', {
         deploymentId,

--- a/packages/server/src/services/core/docker.ts
+++ b/packages/server/src/services/core/docker.ts
@@ -59,11 +59,11 @@ export interface DockerService {
   /** Pull all images for a project ahead of `up`, with a generous timeout.
    *  Image pulls for large multi-service apps (e.g. Postiz) routinely exceed the
    *  short `up` timeout; pulling first means `up` only has to start local images. */
-  composePull(projectPath: string, projectName: string, registryAuth?: PullCredentials[]): Promise<{ success: boolean; output: string }>;
-  composeUp(projectPath: string, projectName: string, registryAuth?: PullCredentials[]): Promise<{ success: boolean; output: string }>;
-  composeDown(projectPath: string, projectName: string): Promise<{ success: boolean; output: string }>;
+  composePull(projectPath: string, projectName: string, registryAuth?: PullCredentials[], profiles?: string[]): Promise<{ success: boolean; output: string }>;
+  composeUp(projectPath: string, projectName: string, registryAuth?: PullCredentials[], profiles?: string[]): Promise<{ success: boolean; output: string }>;
+  composeDown(projectPath: string, projectName: string, profiles?: string[]): Promise<{ success: boolean; output: string }>;
   composePs(projectPath: string, projectName: string): Promise<ComposeProject>;
-  composeRestart(projectPath: string, projectName: string, serviceName?: string): Promise<{ success: boolean; output: string }>;
+  composeRestart(projectPath: string, projectName: string, serviceName?: string, profiles?: string[]): Promise<{ success: boolean; output: string }>;
   /** Run a command inside a running compose service (no shell). Used for post-deploy
    *  auth setup (e.g. `gitea admin auth add-oauth`). */
   composeExec(
@@ -71,7 +71,7 @@ export interface DockerService {
     projectName: string,
     service: string,
     command: string[],
-    opts?: { user?: string }
+    opts?: { user?: string; profiles?: string[] }
   ): Promise<{ success: boolean; output: string }>;
 
   // Log operations
@@ -178,8 +178,21 @@ export class RealDockerService implements DockerService, HealthCheckable {
     return { env: { ...process.env, DOCKER_CONFIG: dir }, dir };
   }
 
-  async composePull(projectPath: string, projectName: string, registryAuth?: PullCredentials[]): Promise<{ success: boolean; output: string }> {
-    const { env, dir } = this.makeRegistryAuthEnv(registryAuth);
+  /**
+   * Layer the active Compose profiles (#162) onto a base env as `COMPOSE_PROFILES`
+   * (comma-joined). Docker Compose reads it to decide which profiled services to
+   * act on — set identically across up/down/restart/exec so `down` tears down the
+   * profiled services `up` started (a plain `down` leaves them orphaned). Returns
+   * the base unchanged when no profile is active (undefined ⇒ inherit process env).
+   */
+  private withComposeProfiles(base: NodeJS.ProcessEnv | undefined, profiles?: string[]): NodeJS.ProcessEnv | undefined {
+    if (!profiles || profiles.length === 0) return base;
+    return { ...(base ?? process.env), COMPOSE_PROFILES: profiles.join(',') };
+  }
+
+  async composePull(projectPath: string, projectName: string, registryAuth?: PullCredentials[], profiles?: string[]): Promise<{ success: boolean; output: string }> {
+    const { env: authEnv, dir } = this.makeRegistryAuthEnv(registryAuth);
+    const env = this.withComposeProfiles(authEnv, profiles);
     try {
       this.logger.info('Pulling compose images', { projectPath, projectName, authenticated: Boolean(dir) });
 
@@ -211,8 +224,9 @@ export class RealDockerService implements DockerService, HealthCheckable {
     }
   }
 
-  async composeUp(projectPath: string, projectName: string, registryAuth?: PullCredentials[]): Promise<{ success: boolean; output: string }> {
-    const { env, dir } = this.makeRegistryAuthEnv(registryAuth);
+  async composeUp(projectPath: string, projectName: string, registryAuth?: PullCredentials[], profiles?: string[]): Promise<{ success: boolean; output: string }> {
+    const { env: authEnv, dir } = this.makeRegistryAuthEnv(registryAuth);
+    const env = this.withComposeProfiles(authEnv, profiles);
     try {
       this.logger.info('Starting compose project', { projectPath, projectName });
 
@@ -250,18 +264,20 @@ export class RealDockerService implements DockerService, HealthCheckable {
     }
   }
 
-  async composeDown(projectPath: string, projectName: string): Promise<{ success: boolean; output: string }> {
+  async composeDown(projectPath: string, projectName: string, profiles?: string[]): Promise<{ success: boolean; output: string }> {
     try {
       this.logger.info('Stopping compose project', { projectPath, projectName });
-      
+
       const composeFile = join(projectPath, 'docker-compose.yml');
       if (!existsSync(composeFile)) {
         throw new Error(`docker-compose.yml not found at ${composeFile}`);
       }
-      
+
+      // Pass the same profiles `up` used so `down` removes the profiled services
+      // too — without them Compose leaves profiled containers orphaned (#162).
       const { stdout, stderr } = await execAsync(
         `docker compose -f "${composeFile}" -p "${projectName}" down`,
-        { cwd: projectPath, timeout: 60000 } // 1 minute timeout
+        { cwd: projectPath, timeout: 60000, env: this.withComposeProfiles(undefined, profiles) } // 1 minute timeout
       );
       
       const output = [stdout, stderr].filter(Boolean).join('\n');
@@ -334,16 +350,16 @@ export class RealDockerService implements DockerService, HealthCheckable {
     }
   }
 
-  async composeRestart(projectPath: string, projectName: string, serviceName?: string): Promise<{ success: boolean; output: string }> {
+  async composeRestart(projectPath: string, projectName: string, serviceName?: string, profiles?: string[]): Promise<{ success: boolean; output: string }> {
     try {
       this.logger.info('Restarting compose service(s)', { projectPath, projectName, serviceName });
-      
+
       const composeFile = join(projectPath, 'docker-compose.yml');
       const serviceArg = serviceName ? ` ${serviceName}` : '';
-      
+
       const { stdout, stderr } = await execAsync(
         `docker compose -f "${composeFile}" -p "${projectName}" restart${serviceArg}`,
-        { cwd: projectPath, timeout: 60000 }
+        { cwd: projectPath, timeout: 60000, env: this.withComposeProfiles(undefined, profiles) }
       );
       
       const output = [stdout, stderr].filter(Boolean).join('\n');
@@ -371,7 +387,7 @@ export class RealDockerService implements DockerService, HealthCheckable {
     projectName: string,
     service: string,
     command: string[],
-    opts?: { user?: string }
+    opts?: { user?: string; profiles?: string[] }
   ): Promise<{ success: boolean; output: string }> {
     const composeFile = join(projectPath, 'docker-compose.yml');
     // Build argv directly (no shell) so provisioned values can't be injected.
@@ -379,7 +395,10 @@ export class RealDockerService implements DockerService, HealthCheckable {
     if (opts?.user) args.push('--user', opts.user);
     args.push(service, ...command);
     try {
-      const { stdout, stderr } = await execFileAsync('docker', args, { cwd: projectPath, timeout: 60000 });
+      // Carry active profiles so an exec targeting a profiled service (#162) still
+      // resolves it — Compose treats a service in an inactive profile as unknown.
+      const env = this.withComposeProfiles(undefined, opts?.profiles);
+      const { stdout, stderr } = await execFileAsync('docker', args, { cwd: projectPath, timeout: 60000, env });
       const output = [stdout, stderr].filter(Boolean).join('\n');
       this.logger.info('Compose exec succeeded', { projectName, service, output: output.substring(0, 1000) });
       return { success: true, output };
@@ -690,18 +709,18 @@ export class MockDockerService implements DockerService {
     return true;
   }
 
-  async composePull(projectPath: string, projectName: string, registryAuth?: PullCredentials[]): Promise<{ success: boolean; output: string }> {
-    this.logger.debug('Mock compose pull', { projectPath, projectName, authenticated: Boolean(registryAuth?.length) });
+  async composePull(projectPath: string, projectName: string, registryAuth?: PullCredentials[], profiles?: string[]): Promise<{ success: boolean; output: string }> {
+    this.logger.debug('Mock compose pull', { projectPath, projectName, authenticated: Boolean(registryAuth?.length), profiles });
     return { success: true, output: `[mock] Project ${projectName} images pulled` };
   }
 
-  async composeUp(projectPath: string, projectName: string, registryAuth?: PullCredentials[]): Promise<{ success: boolean; output: string }> {
-    this.logger.debug('Mock compose up', { projectPath, projectName, authenticated: Boolean(registryAuth?.length) });
+  async composeUp(projectPath: string, projectName: string, registryAuth?: PullCredentials[], profiles?: string[]): Promise<{ success: boolean; output: string }> {
+    this.logger.debug('Mock compose up', { projectPath, projectName, authenticated: Boolean(registryAuth?.length), profiles });
     return { success: true, output: `[mock] Project ${projectName} created and started` };
   }
 
-  async composeDown(projectPath: string, projectName: string): Promise<{ success: boolean; output: string }> {
-    this.logger.debug('Mock compose down', { projectPath, projectName });
+  async composeDown(projectPath: string, projectName: string, profiles?: string[]): Promise<{ success: boolean; output: string }> {
+    this.logger.debug('Mock compose down', { projectPath, projectName, profiles });
     return { success: true, output: `[mock] Project ${projectName} stopped and removed` };
   }
 
@@ -715,8 +734,8 @@ export class MockDockerService implements DockerService {
     };
   }
 
-  async composeRestart(projectPath: string, projectName: string): Promise<{ success: boolean; output: string }> {
-    this.logger.debug('Mock compose restart', { projectPath, projectName });
+  async composeRestart(projectPath: string, projectName: string, serviceName?: string, profiles?: string[]): Promise<{ success: boolean; output: string }> {
+    this.logger.debug('Mock compose restart', { projectPath, projectName, serviceName, profiles });
     return { success: true, output: `[mock] Project ${projectName} restarted` };
   }
 
@@ -724,9 +743,10 @@ export class MockDockerService implements DockerService {
     projectPath: string,
     projectName: string,
     service: string,
-    command: string[]
+    command: string[],
+    opts?: { user?: string; profiles?: string[] }
   ): Promise<{ success: boolean; output: string }> {
-    this.logger.debug('Mock compose exec', { projectPath, projectName, service, command });
+    this.logger.debug('Mock compose exec', { projectPath, projectName, service, command, profiles: opts?.profiles });
     return { success: true, output: `[mock] exec ${service}: ${command.join(' ')}` };
   }
 

--- a/packages/server/src/services/core/draft.ts
+++ b/packages/server/src/services/core/draft.ts
@@ -23,7 +23,8 @@ import type {
   AppAuthConfig,
   AppSecurityConfig,
   AppUpgradeMeta,
-  AppBackupConfig
+  AppBackupConfig,
+  AppProfileConfig
 } from '@hola/shared';
 
 import { createHash } from 'crypto';
@@ -91,6 +92,10 @@ export interface FinalizedManifest {
   // Per-app pre/post-backup hooks (#121) carried from the bundle manifest so the
   // snapshot path can run them around the file capture.
   backup?: AppBackupConfig;
+  // Optional Compose profiles (#162) carried from the bundle manifest so
+  // createFromDraft can resolve the operator's enabled set against the declared
+  // keys without re-reading the bundle.
+  profiles?: AppProfileConfig[];
   files: FinalizedManifestFile[];
   checksum: string;
   finalizedAt: string;
@@ -470,6 +475,7 @@ export class RealDraftService implements DraftService {
         ingressService: defaults.ingressService,
         upgrade: defaults.upgrade,
         backup: defaults.backup,
+        profiles: defaults.profiles,
         files: [],
       };
 
@@ -506,6 +512,9 @@ export class RealDraftService implements DraftService {
         // Surface any elevated permissions the app requested so the wizard can
         // prompt for consent before install.
         security: defaults.security,
+        // Surface any optional Compose profiles so the wizard can render an opt-in
+        // checkbox per profile (#162).
+        profiles: defaults.profiles,
       };
 
       this.logger.info('Draft created successfully', { draftId, appId: request.appId });
@@ -563,6 +572,7 @@ export class RealDraftService implements DraftService {
         ingressService: detail.ingressService,
         upgrade: detail.upgrade,
         backup: detail.backup,
+        profiles: detail.profiles,
         files: [],
       };
 
@@ -827,6 +837,7 @@ export class RealDraftService implements DraftService {
         ingressService: draft.ingressService,
         upgrade: draft.upgrade,
         backup: draft.backup,
+        profiles: draft.profiles,
         files: specFiles,
       };
 
@@ -910,7 +921,7 @@ export class RealDraftService implements DraftService {
     };
   }
 
-  async getDraftDefaults(appId: string, version?: string, source?: string): Promise<{ env: AppEnvVar[]; defaults: DraftDefaults; composeOverride: string; auth?: AppAuthConfig; consumes?: string[]; multiInstance?: boolean; security?: AppSecurityConfig; ingressService?: string; upgrade?: AppUpgradeMeta; backup?: AppBackupConfig; resolvedVersion?: string }> {
+  async getDraftDefaults(appId: string, version?: string, source?: string): Promise<{ env: AppEnvVar[]; defaults: DraftDefaults; composeOverride: string; auth?: AppAuthConfig; consumes?: string[]; multiInstance?: boolean; security?: AppSecurityConfig; ingressService?: string; upgrade?: AppUpgradeMeta; backup?: AppBackupConfig; profiles?: AppProfileConfig[]; resolvedVersion?: string }> {
     try {
       const versionDetail = await this.catalogService.getVersionDetail(appId, version || 'latest', source);
       return {
@@ -924,6 +935,7 @@ export class RealDraftService implements DraftService {
         ingressService: versionDetail.ingressService,
         upgrade: versionDetail.upgrade,
         backup: versionDetail.backup,
+        profiles: versionDetail.profiles,
         // The concrete version the catalog resolved (e.g. "latest" → "1.4.1"), so
         // the draft persists a real version for display + update detection.
         resolvedVersion: versionDetail.version,

--- a/packages/server/src/services/core/manifest-profiles.ts
+++ b/packages/server/src/services/core/manifest-profiles.ts
@@ -1,0 +1,50 @@
+import type { AppProfileConfig } from '@hola/shared';
+
+/**
+ * Narrow-shape coercion for the bundle manifest's optional `profiles` block
+ * (#162), mirroring `coerceManifestUpgrade` / `coerceManifestAuth`: unknown or
+ * malformed entries are dropped rather than trusted, so a hand-edited manifest
+ * can't smuggle arbitrary shapes into the deploy lifecycle.
+ *
+ * Each entry needs a valid compose profile `key` (the activation token) and a
+ * `label`; `description` and `default` are optional. `key` is validated against
+ * Compose's profile-name grammar so it can be threaded into `COMPOSE_PROFILES`
+ * safely. Duplicate keys collapse to the first occurrence. Returns `undefined`
+ * when nothing valid is present (the app then has no optional profiles).
+ */
+
+// Compose profile names: start alphanumeric, then alphanumerics, `_`, `.`, `-`.
+const PROFILE_KEY_RE = /^[a-zA-Z0-9][a-zA-Z0-9_.-]*$/;
+
+function asString(v: unknown): string | undefined {
+  return typeof v === 'string' && v.trim().length > 0 ? v.trim() : undefined;
+}
+
+export function coerceManifestProfiles(value: unknown): AppProfileConfig[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+
+  const out: AppProfileConfig[] = [];
+  const seen = new Set<string>();
+  for (const raw of value) {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) continue;
+    const rec = raw as Record<string, unknown>;
+
+    const key = asString(rec.key);
+    if (!key || !PROFILE_KEY_RE.test(key) || seen.has(key)) continue;
+
+    // A label is what the wizard shows; fall back to the key so a terse manifest
+    // still renders something sensible rather than a blank checkbox.
+    const label = asString(rec.label) ?? key;
+    const description = asString(rec.description);
+
+    seen.add(key);
+    out.push({
+      key,
+      label,
+      ...(description ? { description } : {}),
+      ...(rec.default === true ? { default: true } : {}),
+    });
+  }
+
+  return out.length ? out : undefined;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -185,6 +185,22 @@ export type AppBackupConfig = {
   postHook?: AppBackupHook;
 };
 
+/**
+ * An optional Docker Compose profile an app declares in its bundle manifest
+ * (#162). A profiled compose service (`profiles: [<key>]`) is NOT started unless
+ * its profile is active, so this is how an app offers an *optional* heavy
+ * dependency (e.g. Postiz's Elasticsearch visibility store) that the operator can
+ * turn on at install time. `key` is the compose profile name (the activation
+ * token); `label`/`description` drive the wizard checkbox; `default` pre-selects
+ * it when the caller doesn't specify a set.
+ */
+export type AppProfileConfig = {
+  key: string;
+  label: string;
+  description?: string;
+  default?: boolean;
+};
+
 /** Result of {@link checkUpgradePath}: ok, or a rejection with an actionable next step. */
 export type UpgradePathResult =
   | { ok: true }
@@ -700,6 +716,11 @@ export type GetCatalogAppVersionDetailResponse = {
   // install wizard and relaxes the corresponding platform hardening at deploy
   // time. Optional: apps that don't declare it run fully hardened.
   security?: AppSecurityConfig;
+  // Optional Compose profiles the app declares (#162), each gating an optional
+  // service (e.g. an opt-in heavy dependency). The install wizard renders one
+  // checkbox per profile; the enabled set is threaded into the compose lifecycle
+  // as `COMPOSE_PROFILES`. Absent when the app has no optional services.
+  profiles?: AppProfileConfig[];
 };
 
 // ------------------------------------------------------
@@ -906,6 +927,10 @@ export type Draft = {
   // carried through finalize so the snapshot path can quiesce/dump around the
   // file capture (read-only; not user-editable).
   backup?: AppBackupConfig;
+  // Optional Compose profiles the app declares (#162), seeded from the bundle
+  // manifest so the install wizard can render a checkbox per profile. The
+  // selected keys are sent on create; the declared list itself is read-only.
+  profiles?: AppProfileConfig[];
   files: Array<{ uploadId: string; name: string; size: number; kind: 'composeOverride' | 'additionalFile' | 'env' | 'secret' }>;
 };
 
@@ -933,6 +958,9 @@ export type CreateDraftResponse = {
   // manifest), so the install wizard can surface each for explicit operator
   // consent. Absent when the app requests none (the fully-hardened default).
   security?: AppSecurityConfig;
+  // Optional Compose profiles the app declares (#162), so the install wizard can
+  // render one opt-in checkbox per profile. Absent when the app has none.
+  profiles?: AppProfileConfig[];
 };
 
 export type GetDraftResponse = Draft;
@@ -1479,6 +1507,12 @@ export type EnhancedDeploymentDetail = DeploymentDetail & {
   // from the name. Absent on deployments created before multi-instance (#246); the
   // routing layer falls back to the app id, so their host is unchanged.
   subdomain?: string;
+  // Compose profiles active for this install (#162): the resolved subset of the
+  // app's declared `profiles` keys that the operator enabled at create time.
+  // Threaded into every compose lifecycle command as `COMPOSE_PROFILES` so the
+  // profiled services `up` starts are the same ones `down` tears down. Absent
+  // when no optional profile is enabled (the default).
+  selectedProfiles?: string[];
   metadata: {
     createdAt: string;
     owner?: string;
@@ -1520,6 +1554,11 @@ export type CreateDeploymentFromDraftRequest = {
   // does not set `multiInstance: true`; this per-install override bypasses that
   // singleton guard (it still requires a distinct subdomain). Client-supplied.
   allowMultiple?: boolean;
+  // Optional Compose profiles to enable for this install (#162): a subset of the
+  // app's manifest-declared profile keys. The server intersects it with the
+  // declared set and persists the result as the deployment's active profiles. When
+  // omitted, the server falls back to the profiles the manifest marks `default`.
+  profiles?: string[];
 };
 
 export type CreateDeploymentFromDraftResponse = {


### PR DESCRIPTION
Server + shared slice of #162: let a catalog app declare **optional Compose profiles** and let the operator enable them at install time.

## Why
The deploy path runs `docker compose up` with no `--profile`/`COMPOSE_PROFILES`, so any service tagged with a `profiles:` key is **never started** and there's no per-app way to activate one. That means an app can't offer an *optional* service (e.g. Postiz's Elasticsearch visibility store — currently baked off). This adds the missing mechanism.

## What's here (PR 1 of 3: server → CLI → web)
- **shared** — `AppProfileConfig { key, label, description?, default? }`, carried through the same path as `security`/`upgrade`/`backup`: catalog detail → draft defaults → `Draft`/`CreateDraftResponse` → `FinalizedManifest`. New `selectedProfiles` on the deployment record and `profiles` on `CreateDeploymentFromDraftRequest`.
- **`coerceManifestProfiles`** — narrow-shape coercion mirroring `coerceManifestUpgrade`: invalid profile keys (grammar-checked), duplicates, and malformed entries are dropped.
- **`resolveSelectedProfiles`** — the operator's requested set ∩ declared keys; falls back to the manifest's `default: true` profiles when the caller specifies none (e.g. a plain CLI install).
- **docker** — threads the active profiles into `composePull/Up/Down/Restart/Exec` as `COMPOSE_PROFILES`. Setting it on `down` (and exec) too is what makes `down` tear down the profiled services `up` started rather than orphaning them — the "consistent across the lifecycle" acceptance criterion.
- **validator** — a `profiles:` key on a service was already accepted (no host port); locked with a test.

## Acceptance criteria
- [x] An app can declare an optional profile; the enabled set is persisted on the deployment and activated at deploy.
- [x] Enabling it adds the profile to the compose lifecycle; disabling it omits the profiled services.
- [x] `down` tears down exactly what `up` started (same `COMPOSE_PROFILES`).
- [ ] Wizard checkboxes — **PR 3 (web)**.
- [ ] `hola install --profile` — **PR 2 (CLI)**.

## Tests
`coerceManifestProfiles` unit tests; carry-through in the catalog bundle test; lifecycle threading (explicit set overrides defaults; no-request falls back to defaults; `down` carries the set; persisted across restart); validator accepts `profiles:`. Full suite: typecheck · lint · build · server (606) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)