### PR TITLE
feat(web): install-wizard checkboxes for optional Compose profiles (#162)

### DIFF
--- a/packages/web/src/__tests__/hooks/useDraftFinalization.test.tsx
+++ b/packages/web/src/__tests__/hooks/useDraftFinalization.test.tsx
@@ -39,6 +39,16 @@ describe('useDraftFinalization', () => {
       await result.current.finalizeDraft('draft-1');
     });
 
-    expect(create).toHaveBeenCalledWith({ draftId: 'draft-1', name: undefined, allowMultiple: undefined });
+    expect(create).toHaveBeenCalledWith({ draftId: 'draft-1', name: undefined, allowMultiple: undefined, profiles: undefined });
+  });
+
+  it('passes the enabled Compose profiles through to deployments.create (#162)', async () => {
+    const { result } = renderHook(() => useDraftFinalization());
+
+    await act(async () => {
+      await result.current.finalizeDraft('draft-1', { profiles: ['elasticsearch'] });
+    });
+
+    expect(create).toHaveBeenCalledWith({ draftId: 'draft-1', name: undefined, allowMultiple: undefined, profiles: ['elasticsearch'] });
   });
 });

--- a/packages/web/src/__tests__/pages/InstallWizard.profiles.test.tsx
+++ b/packages/web/src/__tests__/pages/InstallWizard.profiles.test.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, cleanup, within } from '@testing-library/react';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import type { CreateDraftResponse, Draft } from '@hola/shared';
+import { globalCache } from '../../utils/cache';
+
+// #162: an app that declares optional Compose profiles must render them as
+// checkboxes on the summary step (pre-checked per `default`), and the enabled
+// set must flow through to the deployment create call. Exercised end to end
+// against the real InstallWizard so the whole draft → render → toggle → install
+// path is faithful.
+const draftId = 'draft-profiles-test';
+
+const PROFILES = [
+  { key: 'elasticsearch', label: 'Elasticsearch advanced visibility', description: 'Heavier, opt-in.', default: false },
+  { key: 'metrics', label: 'Metrics', default: true },
+];
+
+function makeDraft(overrides: Partial<Draft> = {}): Draft {
+  return { draftId, appId: 'testapp', version: '1.0.0', systemOverrides: {}, appEnv: [], ports: [], profiles: PROFILES, ...overrides };
+}
+
+const create = vi.fn(async () => ({ deploymentId: 'dep1', releaseId: 'r1', jobId: 'j1' }));
+
+const draftsApi = {
+  create: vi.fn(async (): Promise<CreateDraftResponse> => ({
+    draftId,
+    app: { id: 'testapp', name: 'Test App', icon: '📦' },
+    systemEnv: [],
+    appEnv: [],
+    defaults: { ports: [], volumes: [] },
+    profiles: PROFILES,
+  })),
+  byId: vi.fn(async () => makeDraft()),
+  update: vi.fn(async (_id: string, updates: Partial<Draft>) => ({ ok: true as const, draft: makeDraft(updates) })),
+  remove: vi.fn(async () => ({ ok: true as const })),
+  validate: vi.fn(async () => ({ ok: true, errors: [], warnings: [] })),
+  preflight: vi.fn(async () => ({ ok: true, checks: [] })),
+  finalize: vi.fn(async () => ({ spec: {}, checksum: 'x' })),
+};
+
+vi.mock('../../utils/api-hybrid', () => ({
+  api: {
+    drafts: draftsApi,
+    deployments: {
+      create: (data: unknown) => create(data),
+      subdomainAvailable: vi.fn(async (subdomain: string) => ({ subdomain, host: `${subdomain}.local.hola`, available: true })),
+    },
+  },
+}));
+
+// Imported after the mock so InstallWizard picks up the mocked api-hybrid.
+const { InstallWizard } = await import('../../pages/InstallWizard');
+
+function renderWizard() {
+  return render(
+    <MemoryRouter initialEntries={['/install/testapp']}>
+      <Routes>
+        <Route path="/install/:appId" element={<InstallWizard />} />
+        <Route path="/deployments" element={<div>Deployments</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+// Advance one step: click Next and wait for handleNext's pre-advance draft
+// save to fire (a reliable per-transition signal that avoids matching the
+// step heading, which the header row duplicates).
+async function clickNext() {
+  const before = draftsApi.update.mock.calls.length;
+  fireEvent.click(screen.getByRole('button', { name: /next/i }));
+  await waitFor(() => expect(draftsApi.update.mock.calls.length).toBeGreaterThan(before));
+}
+
+beforeEach(() => {
+  globalCache.clear();
+  create.mockClear();
+  draftsApi.create.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('InstallWizard optional Compose profiles (#162)', () => {
+  it('renders declared profiles on the summary step and sends the enabled set to create', async () => {
+    renderWizard();
+    // Wait for the draft to resolve (step 0 heading is the app name).
+    await waitFor(() => expect(draftsApi.create).toHaveBeenCalled());
+
+    // Walk from Configuration (0) through to Summary (5): five Next clicks.
+    await clickNext();
+    await clickNext();
+    await clickNext();
+    await clickNext();
+    await clickNext();
+    await waitFor(() => expect(screen.getByText('Optional services')).toBeInTheDocument());
+
+    // Both declared profiles render; `metrics` is pre-checked (default), the
+    // heavier `elasticsearch` is not.
+    const optional = screen.getByText('Optional services').closest('div')!;
+    const metrics = within(optional).getByText('Metrics').closest('label')!;
+    const es = within(optional).getByText('Elasticsearch advanced visibility').closest('label')!;
+    expect(within(metrics).getByRole('checkbox')).toBeChecked();
+    expect(within(es).getByRole('checkbox')).not.toBeChecked();
+
+    // The operator opts into Elasticsearch too.
+    fireEvent.click(within(es).getByRole('checkbox'));
+
+    fireEvent.click(screen.getByRole('button', { name: /^install$/i }));
+
+    await waitFor(() => expect(create).toHaveBeenCalled());
+    const arg = create.mock.calls[0][0] as { profiles?: string[] };
+    // Both the default-on and the just-enabled profile are sent (order-independent).
+    expect([...(arg.profiles ?? [])].sort()).toEqual(['elasticsearch', 'metrics']);
+  });
+});

--- a/packages/web/src/hooks/useDraftFinalization.ts
+++ b/packages/web/src/hooks/useDraftFinalization.ts
@@ -17,14 +17,15 @@ export function useDraftFinalization() {
   // Finalize the draft (stage immutable artifacts) and then create + start a
   // deployment from it. Finalize alone produces no running app — creating the
   // deployment is what enqueues the install job that runs `docker compose up`.
-  const finalizeDraft = React.useCallback(async (draftId: string, opts?: { name?: string; allowMultiple?: boolean }) => {
+  const finalizeDraft = React.useCallback(async (draftId: string, opts?: { name?: string; allowMultiple?: boolean; profiles?: string[] }) => {
     setState(prev => ({ ...prev, loading: true, error: null }));
 
     try {
       await api.drafts.finalize(draftId);
       // #246: `name` sets the deployment's subdomain (<name>.<base>); `allowMultiple`
       // opts past the single-instance guard for a deliberate second install.
-      const deployment = await api.deployments.create({ draftId, name: opts?.name, allowMultiple: opts?.allowMultiple });
+      // #162: `profiles` is the set of optional Compose profiles to enable.
+      const deployment = await api.deployments.create({ draftId, name: opts?.name, allowMultiple: opts?.allowMultiple, profiles: opts?.profiles });
 
       setState({
         data: deployment,

--- a/packages/web/src/pages/InstallWizard.tsx
+++ b/packages/web/src/pages/InstallWizard.tsx
@@ -10,6 +10,7 @@ import type {
   PatchDraftRequest,
   ValidationIssue,
   AppSecurityConfig,
+  AppProfileConfig,
   GetSubdomainAvailabilityResponse,
 } from '@hola/shared';
 import { slugifySubdomain } from '@hola/shared';
@@ -118,6 +119,11 @@ export const InstallWizard: React.FC = () => {
   // requested permission is explicitly acknowledged (see canProceed, case 0).
   const [security, setSecurity] = useState<AppSecurityConfig | undefined>();
   const [ackedPermissions, setAckedPermissions] = useState<Set<string>>(new Set());
+  // #162: optional Compose profiles the app declares. `selectedProfiles` is the
+  // set of enabled keys, seeded from each profile's `default` and toggled by the
+  // operator on the summary step. Sent as the deployment's active profile set.
+  const [profiles, setProfiles] = useState<AppProfileConfig[] | undefined>();
+  const [selectedProfiles, setSelectedProfiles] = useState<Set<string>>(new Set());
   const [showSecrets, setShowSecrets] = useState<{[key: string]: boolean}>({});
   const [composeOverride, setComposeOverride] = useState('');
   const [editMode, setEditMode] = useState(false);
@@ -194,6 +200,10 @@ export const InstallWizard: React.FC = () => {
         setPorts(result.defaults.ports);
         setVolumes(result.defaults.volumes);
         setSecurity(result.security);
+        // #162: surface the app's optional Compose profiles and pre-select the
+        // ones the manifest marks `default`.
+        setProfiles(result.profiles);
+        setSelectedProfiles(new Set((result.profiles ?? []).filter(p => p.default).map(p => p.key)));
 
         // Persist the generated values immediately so a refresh (or abandoning
         // the wizard before clicking Next) doesn't lose them — same durability
@@ -282,7 +292,13 @@ export const InstallWizard: React.FC = () => {
     try {
       // #246: send the chosen name (→ subdomain) and, for a deliberate second
       // install of a single-instance app, the allow-multiple override.
-      await draftFinalization.finalizeDraft(draftId, { name: instanceName.trim() || undefined, allowMultiple });
+      // #162: when the app declares optional profiles, send the enabled set
+      // explicitly (even if empty); otherwise send nothing so defaults apply.
+      await draftFinalization.finalizeDraft(draftId, {
+        name: instanceName.trim() || undefined,
+        allowMultiple,
+        profiles: profiles ? [...selectedProfiles] : undefined,
+      });
       return true;
     } catch (err) {
       console.error('Failed to finalize draft:', err);
@@ -1390,6 +1406,48 @@ services:
                   </div>
                 )}
               </div>
+
+              {/* #162: optional Compose profiles the app declares — each enables an
+                  extra service (e.g. a heavier, opt-in dependency). */}
+              {profiles && profiles.length > 0 && (
+                <div>
+                  <h4 className="text-[13.5px] font-semibold text-text-strong mb-2">Optional services</h4>
+                  <div className="bg-surface-2 border border-border-soft rounded-[11px] overflow-hidden">
+                    {profiles.map((p) => {
+                      const checked = selectedProfiles.has(p.key);
+                      return (
+                        <label
+                          key={p.key}
+                          className="flex items-start gap-3 px-4 py-3 border-b border-border-soft last:border-b-0 cursor-pointer hover:bg-surface-3/40 transition"
+                        >
+                          <input
+                            type="checkbox"
+                            checked={checked}
+                            onChange={(e) => {
+                              setSelectedProfiles((prev) => {
+                                const next = new Set(prev);
+                                if (e.target.checked) next.add(p.key);
+                                else next.delete(p.key);
+                                return next;
+                              });
+                            }}
+                            className="mt-0.5 h-4 w-4 flex-none accent-primary"
+                          />
+                          <span className="min-w-0">
+                            <span className="block text-[13px] text-text-strong">{p.label}</span>
+                            {p.description && (
+                              <span className="block text-[12px] text-text-muted mt-0.5">{p.description}</span>
+                            )}
+                          </span>
+                        </label>
+                      );
+                    })}
+                  </div>
+                  <p className="mt-1.5 text-[12px] text-text-muted">
+                    Enabling an optional service starts extra containers and uses more resources.
+                  </p>
+                </div>
+              )}
 
               <div>
                 <h4 className="text-[13.5px] font-semibold text-text-strong mb-2">System variable overrides</h4>


### PR DESCRIPTION
Web slice of #162 (final of 3: server #389 → CLI #390 → web): surface an app's optional Compose profiles in the install wizard.

## What's here
- **InstallWizard** — an "Optional services" checklist on the summary step, one checkbox per profile the app declares, **pre-checked** per the manifest's `default`. Toggling drives `selectedProfiles`; the enabled keys are sent to the deployment create. Apps with no declared profiles show nothing (no summary clutter).
- **useDraftFinalization** — forwards `profiles` to `deployments.create`. When the app declares profiles the wizard sends the explicit enabled set (even if empty); otherwise it sends nothing so the server's manifest-default resolution applies.

The SDK/adapter already forward the whole `CreateDeploymentFromDraftRequest`, so no client-plumbing change was needed beyond the hook.

## Tests
- New full-journey component test: draft with two declared profiles → walk to summary → assert both render, `metrics` (default) is checked and `elasticsearch` isn't → enable `elasticsearch` → Install → assert `create` receives `['elasticsearch','metrics']`.
- `useDraftFinalization` forwards `profiles`; plain install sends `profiles: undefined`.
- Web suite (210) green; typecheck · lint · build clean.

Closes #162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)