### PR TITLE
feat(server): on-demand richer update-check endpoint (#299)

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -13,6 +13,7 @@ import {
   RollbackRequest, RollbackResponse, GetDeploymentHistoryResponse,
   PromoteDeploymentRequest, PromoteDeploymentResponse,
   GetDeploymentConfigResponse,
+  GetDeploymentUpdateCheckResponse,
   GetSubdomainAvailabilityResponse,
   // Catalog types
   GetCatalogAppsRequest, GetCatalogAppsResponse, GetCatalogAppResponse,
@@ -156,6 +157,9 @@ export class HolaSdk {
     promote: (deploymentId: string, promote: PromoteDeploymentRequest = {}) => this.post<PromoteDeploymentResponse>(API.deployments.promote(deploymentId), promote),
     logs: (deploymentId: string, qs?: Record<string, string | number | boolean | undefined>) => this.get(`${API.deployments.logs(deploymentId)}${buildQuery(qs)}`),
     config: (deploymentId: string) => this.get<GetDeploymentConfigResponse>(API.deployments.config(deploymentId)),
+    // On-demand richer update check for one deployment (#299): safe-bump vs.
+    // guided-upgrade, with the target's breaking/backup/notes + a path verdict.
+    updateCheck: (deploymentId: string) => this.get<GetDeploymentUpdateCheckResponse>(API.deployments.updateCheck(deploymentId)),
   };
 
   jobs = {

--- a/packages/server/src/__tests__/deployments/update-info.test.ts
+++ b/packages/server/src/__tests__/deployments/update-info.test.ts
@@ -19,10 +19,25 @@ import type { CatalogService } from '../../services/core/catalog';
 type CatalogArg = ConstructorParameters<typeof RealDraftService>[1];
 type JobArg = ConstructorParameters<typeof RealDeploymentService>[1];
 
-function makeCatalog(versions: string[]) {
+type UpgradeMeta = {
+  breaking?: boolean;
+  minFromVersion?: string;
+  waypoints?: string[];
+  upgradeNotesUrl?: string;
+  preUpgradeBackup?: 'required' | 'recommended' | 'none';
+};
+
+function makeCatalog(versions: string[], opts?: { upgrade?: UpgradeMeta; detailThrows?: boolean }) {
   return {
     getApp: async (appId: string) => ({ id: appId, name: 'Gitea', icon: '🍵' }),
-    getVersionDetail: async () => ({ defaultEnv: [], defaults: { ports: [], volumes: [] } }),
+    // #299: the on-demand update-check pulls this for the target version's
+    // `upgrade` metadata. `detailThrows` simulates an unreachable *target* bundle
+    // (only the newest version, never the 1.0.0 install path draft-create uses) so
+    // the fail-safe fallback (cheap signal only) is exercised.
+    getVersionDetail: async (_appId: string, version: string) => {
+      if (opts?.detailThrows && version === versions[versions.length - 1]) throw new Error('bundle unreachable');
+      return { version, defaultEnv: [], defaults: { ports: [], volumes: [] }, ...(opts?.upgrade ? { upgrade: opts.upgrade } : {}) };
+    },
     getVersions: async () => ({ items: versions.map((v) => ({ version: v, createdAt: '2020-01-01' })), total: versions.length }),
   };
 }
@@ -47,9 +62,9 @@ describe('Per-app update notifications (#284)', () => {
   beforeEach(async () => { dataRoot = await mkdtemp(join(tmpdir(), 'hola-upd-')); });
   afterEach(async () => { await rm(dataRoot, { recursive: true, force: true }); });
 
-  function makeSystem(catalogVersions: string[] | null) {
+  function makeSystem(catalogVersions: string[] | null, opts?: { upgrade?: UpgradeMeta; detailThrows?: boolean }) {
     const storage = new RealStorageService({ holaDir: dataRoot });
-    const catalog = makeCatalog(catalogVersions ?? ['1.0.0']);
+    const catalog = makeCatalog(catalogVersions ?? ['1.0.0'], opts);
     const drafts = new RealDraftService(storage, catalog as unknown as CatalogArg, makeValidation() as unknown as ConstructorParameters<typeof RealDraftService>[2]);
     const routing = new RealRoutingService(storage, { baseDomain: 'local.hola' });
     const deployments = new RealDeploymentService(
@@ -103,5 +118,96 @@ describe('Per-app update notifications (#284)', () => {
     const list = await deployments.listDeployments({ page: 1, limit: 10 });
     expect(list.items[0].latestVersion).toBeUndefined();
     expect(list.items[0].updateAvailable).toBeUndefined();
+  });
+});
+
+describe('On-demand richer update check (#299)', () => {
+  let dataRoot: string;
+  beforeEach(async () => { dataRoot = await mkdtemp(join(tmpdir(), 'hola-upd299-')); });
+  afterEach(async () => { await rm(dataRoot, { recursive: true, force: true }); });
+
+  function makeSystem(catalogVersions: string[] | null, opts?: { upgrade?: UpgradeMeta; detailThrows?: boolean }) {
+    const storage = new RealStorageService({ holaDir: dataRoot });
+    const catalog = makeCatalog(catalogVersions ?? ['1.0.0'], opts);
+    const drafts = new RealDraftService(storage, catalog as unknown as CatalogArg, makeValidation() as unknown as ConstructorParameters<typeof RealDraftService>[2]);
+    const routing = new RealRoutingService(storage, { baseDomain: 'local.hola' });
+    const deployments = new RealDeploymentService(
+      storage, makeJobs(), new MockDockerService(), drafts, routing, noLogging, new MockProvisionerService(),
+      catalogVersions === null ? undefined : (catalog as unknown as CatalogService),
+    );
+    return { drafts, deployments };
+  }
+
+  async function deploy(drafts: RealDraftService, deployments: RealDeploymentService, version: string) {
+    const { draftId } = await drafts.createDraft({ appId: 'gitea', version });
+    await drafts.updateDraft(draftId, { composeOverride: 'services:\n  gitea:\n    image: gitea/gitea:latest\n' });
+    await drafts.finalizeDraft(draftId);
+    return deployments.createFromDraft({ draftId, name: 'gitea', options: { autoStart: false } });
+  }
+
+  test('surfaces breaking + waypoint path + backup + notes for a guided upgrade', async () => {
+    const { drafts, deployments } = makeSystem(['1.0.0', '1.5.0', '2.0.0'], {
+      upgrade: { breaking: true, waypoints: ['1.5.0'], preUpgradeBackup: 'required', upgradeNotesUrl: 'https://notes.example/2' },
+    });
+    const dep = await deploy(drafts, deployments, '1.0.0');
+
+    const check = await deployments.getUpdateCheck(dep.deploymentId);
+    expect(check.installedVersion).toBe('1.0.0');
+    expect(check.latestVersion).toBe('2.0.0');
+    expect(check.updateAvailable).toBe(true);
+    expect(check.breaking).toBe(true);
+    expect(check.preUpgradeBackup).toBe('required');
+    expect(check.upgradeNotesUrl).toBe('https://notes.example/2');
+    // Can't jump 1.0.0 → 2.0.0 past the 1.5.0 waypoint.
+    expect(check.path).toEqual({
+      ok: false,
+      code: 'waypoint-required',
+      message: expect.stringContaining('1.5.0'),
+      suggestedVersion: '1.5.0',
+    });
+  });
+
+  test('a clean upgrade reports a passable path and no breaking flag', async () => {
+    const { drafts, deployments } = makeSystem(['1.0.0', '2.0.0'], { upgrade: { preUpgradeBackup: 'recommended' } });
+    const dep = await deploy(drafts, deployments, '1.0.0');
+
+    const check = await deployments.getUpdateCheck(dep.deploymentId);
+    expect(check.updateAvailable).toBe(true);
+    expect(check.path).toEqual({ ok: true });
+    expect(check.breaking).toBeUndefined();
+    expect(check.preUpgradeBackup).toBe('recommended');
+  });
+
+  test('no update available → cheap signal only, no path / no bundle richness', async () => {
+    const { drafts, deployments } = makeSystem(['1.0.0', '2.0.0'], { upgrade: { breaking: true } });
+    const dep = await deploy(drafts, deployments, '2.0.0'); // already newest
+
+    const check = await deployments.getUpdateCheck(dep.deploymentId);
+    expect(check.updateAvailable).toBe(false);
+    expect(check.latestVersion).toBe('2.0.0');
+    expect(check.path).toBeUndefined();
+    expect(check.breaking).toBeUndefined();
+  });
+
+  test('fail-safe: a bundle pull error falls back to the cheap signal', async () => {
+    const { drafts, deployments } = makeSystem(['1.0.0', '2.0.0'], { detailThrows: true });
+    const dep = await deploy(drafts, deployments, '1.0.0');
+
+    const check = await deployments.getUpdateCheck(dep.deploymentId);
+    // The cheap #284 signal still resolves...
+    expect(check.updateAvailable).toBe(true);
+    expect(check.latestVersion).toBe('2.0.0');
+    // ...but the target-bundle richness is absent rather than throwing.
+    expect(check.path).toBeUndefined();
+    expect(check.breaking).toBeUndefined();
+  });
+
+  test('mock service (no catalog) → base signal, no throw', async () => {
+    const { drafts, deployments } = makeSystem(null);
+    const dep = await deploy(drafts, deployments, '1.0.0');
+    const check = await deployments.getUpdateCheck(dep.deploymentId);
+    expect(check.installedVersion).toBe('1.0.0');
+    expect(check.updateAvailable).toBe(false);
+    expect(check.path).toBeUndefined();
   });
 });

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1046,6 +1046,21 @@ async function route(url: URL, req: Request): Promise<Response> {
     }
   }
 
+  // On-demand richer update check (#299): pulls the target bundle for its
+  // upgrade metadata + skip-guard verdict. Matched before the generic `:id` GET
+  // (its `$`-anchored pattern excludes this sub-path anyway).
+  const updateCheckMatch = pathname.match(/^\/api\/deployments\/([^/]+)\/update-check$/);
+  if (updateCheckMatch && req.method === 'GET') {
+    const id = updateCheckMatch[1];
+    try {
+      const services = getServices();
+      const payload = await services.deployments.getUpdateCheck(id);
+      return json(payload);
+    } catch (err) {
+      return errorResponse(req, err);
+    }
+  }
+
   const deploymentMatch = pathname.match(/^\/api\/deployments\/([^/]+)$/);
   if (deploymentMatch && req.method === 'GET') {
     const id = deploymentMatch[1];

--- a/packages/server/src/services/core/deployment.ts
+++ b/packages/server/src/services/core/deployment.ts
@@ -19,6 +19,7 @@ import type {
   GetDeploymentsRequest,
   GetDeploymentsResponse,
   GetDeploymentResponse,
+  GetDeploymentUpdateCheckResponse,
   PatchDeploymentRequest,
   PatchDeploymentResponse,
   GetDeploymentHistoryResponse,
@@ -165,6 +166,11 @@ export interface DeploymentService extends HealthCheckable {
   // Deployment management
   listDeployments(request: GetDeploymentsRequest): Promise<GetDeploymentsResponse>;
   getDeployment(deploymentId: string): Promise<GetDeploymentResponse>;
+  /** On-demand richer update check for one deployment (#299): the cheap #284
+   *  signal plus, when an update is available, the target's `upgrade` metadata
+   *  (breaking / pre-upgrade backup / notes) and a `checkUpgradePath` verdict —
+   *  the expensive part (a target-bundle pull) the list deliberately skips. */
+  getUpdateCheck(deploymentId: string): Promise<GetDeploymentUpdateCheckResponse>;
   updateDeployment(deploymentId: string, request: PatchDeploymentRequest): Promise<PatchDeploymentResponse>;
   deleteDeployment(deploymentId: string): Promise<void>;
 
@@ -821,6 +827,32 @@ abstract class InMemoryDeploymentService implements DeploymentService {
     const detail = toDetailResponse(this.requireDeployment(deploymentId));
     await this.enrichUpdateInfo([detail]);
     return detail;
+  }
+
+  async getUpdateCheck(deploymentId: string): Promise<GetDeploymentUpdateCheckResponse> {
+    await this.ensureLoaded();
+    this.logger.info('Update-check for deployment', { deploymentId });
+    const detail = toDetailResponse(this.requireDeployment(deploymentId));
+    // Reuse the cheap #284 signal for installed/latest/updateAvailable, then let
+    // the (real) service layer add the target-bundle richness on top.
+    await this.enrichUpdateInfo([detail]);
+    return this.buildUpdateCheck(detail);
+  }
+
+  /**
+   * Assemble the update-check payload from an already-enriched detail. Base:
+   * the cheap signal only (no bundle pull, so no breaking/path/backup richness —
+   * the mock/in-memory service has no catalog). RealDeploymentService overrides
+   * it to pull the target bundle's `upgrade` metadata.
+   */
+  protected async buildUpdateCheck(
+    detail: GetDeploymentResponse,
+  ): Promise<GetDeploymentUpdateCheckResponse> {
+    return {
+      installedVersion: detail.version,
+      latestVersion: detail.latestVersion,
+      updateAvailable: !!detail.updateAvailable,
+    };
   }
 
   /**
@@ -1706,6 +1738,45 @@ export class RealDeploymentService extends InMemoryDeploymentService {
       // latest-install as out-of-date — so report "no update available" instead.
       const installed = item.version;
       item.updateAvailable = !!installed && installed !== 'latest' && isNewerVersion(latest, installed);
+    }
+  }
+
+  /**
+   * Add the on-demand richness (#299) the cheap list signal can't afford: when an
+   * update is available, pull the *target* version's bundle for its `upgrade`
+   * metadata (breaking / pre-upgrade backup / notes) and compute a
+   * `checkUpgradePath` verdict (safe one-shot vs. floor/waypoint required). One
+   * deployment, one bundle pull — fine for a detail-page call, unlike the list.
+   * Fail-safe: any catalog/bundle error falls back to the cheap signal so the
+   * detail page still renders a plain "update available".
+   */
+  protected override async buildUpdateCheck(
+    detail: GetDeploymentResponse,
+  ): Promise<GetDeploymentUpdateCheckResponse> {
+    const base: GetDeploymentUpdateCheckResponse = {
+      installedVersion: detail.version,
+      latestVersion: detail.latestVersion,
+      updateAvailable: !!detail.updateAvailable,
+    };
+    if (!this.catalogService || !detail.updateAvailable || !detail.latestVersion) return base;
+    try {
+      const source = await this.getDeploymentSource(detail.id);
+      const target = await this.catalogService.getVersionDetail(detail.app, detail.latestVersion, source);
+      const upgrade = target.upgrade;
+      return {
+        ...base,
+        path: checkUpgradePath(detail.version, detail.latestVersion, upgrade),
+        ...(upgrade?.breaking !== undefined ? { breaking: upgrade.breaking } : {}),
+        ...(upgrade?.preUpgradeBackup !== undefined ? { preUpgradeBackup: upgrade.preUpgradeBackup } : {}),
+        ...(upgrade?.upgradeNotesUrl !== undefined ? { upgradeNotesUrl: upgrade.upgradeNotesUrl } : {}),
+      };
+    } catch (err) {
+      // Bundle unreachable / app gone from catalog — keep the cheap signal.
+      this.logger.warn('Update-check richness unavailable; returning cheap signal', {
+        deploymentId: detail.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return base;
     }
   }
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -65,6 +65,10 @@ export const API = {
     // Active release's full config (typed appEnv rows + system overrides), for the
     // DeploymentDetail Configuration tab.
     config: (deploymentId: string) => `/api/deployments/${deploymentId}/config`,
+    // On-demand richer update check for one deployment (#299): pulls the target
+    // bundle to answer safe-bump vs. guided-upgrade. Returns
+    // GetDeploymentUpdateCheckResponse. The list keeps the cheap #284 badge.
+    updateCheck: (deploymentId: string) => `/api/deployments/${deploymentId}/update-check`,
   },
 
   jobs: {
@@ -1031,6 +1035,32 @@ export type DeploymentDetail = {
 };
 
 export type GetDeploymentResponse = DeploymentDetail;
+
+/**
+ * Richer, on-demand update check for a single deployment (#299). The cheap
+ * `latestVersion`/`updateAvailable` signal that rides on every list/detail row
+ * (#284) says only *that* a newer version exists; this says *what kind* of update
+ * it is — a safe one-click bump vs. a guided multi-step upgrade — by pulling the
+ * target bundle's manifest and reading its `upgrade` metadata + `checkUpgradePath`.
+ * That bundle pull is why it's a separate endpoint the detail page calls, not a
+ * field on the list. Everything beyond the cheap signal is absent (fail-safe) when
+ * the catalog/bundle is unavailable or the app declares no upgrade metadata.
+ */
+export type GetDeploymentUpdateCheckResponse = {
+  /** The deployment's current version (absent for a `latest`-pinned install). */
+  installedVersion?: string;
+  /** Newest catalog version for this app (the update target). */
+  latestVersion?: string;
+  updateAvailable: boolean;
+  /** Target release migrates/breaks — surface a "review notes" acknowledgement. */
+  breaking?: boolean;
+  /** Whether the jump is a legal one-shot, or must pass a floor/waypoint first
+   *  (carries the next safe version + message when not). Present only when an
+   *  update is available and the target's upgrade metadata was resolved. */
+  path?: UpgradePathResult;
+  preUpgradeBackup?: 'required' | 'recommended' | 'none';
+  upgradeNotesUrl?: string;
+};
 
 export type PatchDeploymentRequest = {
   /**


### PR DESCRIPTION
## What

Closes #299 (server half). Adds an on-demand `GET /api/deployments/:id/update-check` that answers *what kind* of update a deployment has — a **safe one-click bump** vs. a **guided multi-step upgrade** — instead of just "an update exists".

## Why

#284 gave every deployment list/detail row a cheap `latestVersion` + `updateAvailable` signal (in-memory catalog version list, no bundle pull). That's all the list can afford. But whether the newest version is *breaking*, requires passing a *waypoint*, or needs a *pre-upgrade backup* lives in the target bundle's `upgrade` metadata — which needs an OCI pull, unsuited to list rendering. So it's a separate endpoint the **detail page** calls (one deployment, one pull).

## How

- **shared** — `GetDeploymentUpdateCheckResponse` + `API.deployments.updateCheck`.
- **server** — `DeploymentService.getUpdateCheck`: base returns the cheap #284 signal; `RealDeploymentService` overrides to pull `getVersionDetail(app, latest)` and return its `upgrade` metadata (`breaking` / `preUpgradeBackup` / `upgradeNotesUrl`) plus a `checkUpgradePath` verdict (`{ ok }` or `{ code: 'waypoint-required' | 'min-from-version', suggestedVersion, message }`). Fail-safe: any catalog/bundle error falls back to the cheap signal. New route wired next to the `:id` GET.
- **sdk** — `deployments.updateCheck(id)`.

## Tests

Extends the #284 harness with a catalog stub that returns `upgrade` metadata. New `#299` block covers: guided upgrade (breaking + waypoint path + backup + notes), clean bump (`path.ok`, no breaking), no-update (cheap signal only), **bundle-error fail-safe**, and no-catalog mock. Full server suite **611 pass / 0 fail**; typecheck + lint + build green.

## Acceptance (#299)

- ✅ Breaking / waypoint-required latest → detail can show the warning + next safe version instead of a bare "update available" (endpoint returns it).
- ✅ No extra bundle pulls in the deployments **list** (list path untouched).

Next in the stack: **web** — the deployment detail page consumes `updateCheck` and renders the richer surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)