### PR TITLE
feat(web): surface richer update-check on the deployment detail page (#299)

### DIFF
--- a/packages/web/src/__tests__/pages/DeploymentDetail.test.tsx
+++ b/packages/web/src/__tests__/pages/DeploymentDetail.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor, cleanup, act } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, cleanup, act, within } from '@testing-library/react';
 import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
 import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -73,6 +73,7 @@ const deploymentsApi = {
   action: vi.fn(),
   promote: vi.fn(),
   remove: vi.fn(),
+  updateCheck: vi.fn(),
 };
 
 vi.mock('../../utils/api-hybrid', () => ({
@@ -311,5 +312,89 @@ describe('DeploymentDetail deletion-while-viewing redirect (T018)', () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(screen.queryByText('Deployments List')).not.toBeInTheDocument();
     expect(screen.getByText('Running')).toBeInTheDocument();
+  });
+});
+
+// #299: the deployment detail page pulls the richer, on-demand update check and
+// the upgrade dialog states what kind of update it is (safe bump vs. guided
+// multi-step) instead of a bare confirmation. Appended last so the byId/promote
+// impl overrides below don't leak into the earlier describes.
+describe('DeploymentDetail richer update check (#299)', () => {
+  const updatable: GetDeploymentResponse = {
+    ...deployment,
+    version: '1.0.0',
+    updateAvailable: true,
+    latestVersion: '2.0.0',
+  };
+
+  beforeEach(() => {
+    deploymentsApi.byId.mockResolvedValue(updatable);
+    deploymentsApi.promote.mockResolvedValue({ deploymentId, releaseId: 'r1', jobId: 'j1' });
+    deploymentsApi.updateCheck.mockReset();
+  });
+
+  it('surfaces a guided (waypoint) upgrade and promotes to the next safe version', async () => {
+    deploymentsApi.updateCheck.mockResolvedValue({
+      installedVersion: '1.0.0',
+      latestVersion: '2.0.0',
+      updateAvailable: true,
+      breaking: true,
+      preUpgradeBackup: 'required',
+      upgradeNotesUrl: 'https://notes.example/v2',
+      path: { ok: false, code: 'waypoint-required', suggestedVersion: '1.5.0', message: 'Must pass through 1.5.0 first.' },
+    });
+    renderDetail();
+
+    // Open the upgrade dialog from the header action ("Upgrade to 2.0.0").
+    const openBtn = await screen.findByRole('button', { name: /upgrade to 2\.0\.0/i });
+    fireEvent.click(openBtn);
+
+    // Once the on-demand check resolves, the dialog states what kind of upgrade
+    // this is — guided (waypoint) + breaking — instead of a bare confirmation.
+    await waitFor(() => expect(screen.getByText('Guided upgrade')).toBeInTheDocument());
+    expect(screen.getByText('Must pass through 1.5.0 first.')).toBeInTheDocument();
+    expect(screen.getByText(/Breaking change/i)).toBeInTheDocument();
+    const notes = screen.getByRole('link', { name: /review the upgrade notes/i });
+    expect(notes).toHaveAttribute('href', 'https://notes.example/v2');
+
+    // The confirm button targets the next safe waypoint version, not latest.
+    const confirm = await screen.findByRole('button', { name: /^upgrade to 1\.5\.0$/i });
+    fireEvent.click(confirm);
+    await waitFor(() => expect(deploymentsApi.promote).toHaveBeenCalledWith(deploymentId, { version: '1.5.0' }));
+  });
+
+  it('a clean bump shows no warnings and promotes straight to latest', async () => {
+    deploymentsApi.updateCheck.mockResolvedValue({
+      installedVersion: '1.0.0',
+      latestVersion: '2.0.0',
+      updateAvailable: true,
+      preUpgradeBackup: 'recommended',
+      path: { ok: true },
+    });
+    renderDetail();
+
+    const openBtn = await screen.findByRole('button', { name: /upgrade to 2\.0\.0/i });
+    fireEvent.click(openBtn);
+
+    // The dialog resolves the check (recommended-backup copy appears) but shows
+    // neither a guided-upgrade nor a breaking warning.
+    await waitFor(() => expect(screen.getByText(/pre-upgrade snapshot is recommended/i)).toBeInTheDocument());
+    expect(screen.queryByText('Guided upgrade')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Breaking change/i)).not.toBeInTheDocument();
+
+    // Scope to the dialog: the header action shares the "Upgrade to 2.0.0" label.
+    const confirm = within(screen.getByRole('dialog')).getByRole('button', { name: /^upgrade to 2\.0\.0$/i });
+    fireEvent.click(confirm);
+    // Straight-to-latest: promote with no explicit version.
+    await waitFor(() => expect(deploymentsApi.promote).toHaveBeenCalledWith(deploymentId, undefined));
+  });
+
+  it('never calls update-check when no update is available', async () => {
+    deploymentsApi.byId.mockResolvedValue(deployment); // updateAvailable unset
+    renderDetail();
+    await waitFor(() => expect(screen.getByText('My App')).toBeInTheDocument());
+    // Give the (disabled) query a chance to (not) fire.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(deploymentsApi.updateCheck).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/hooks/useDeploymentDetailApi.ts
+++ b/packages/web/src/hooks/useDeploymentDetailApi.ts
@@ -5,6 +5,7 @@ import type {
   GetDeploymentResponse,
   GetDeploymentHistoryResponse,
   GetDeploymentConfigResponse,
+  GetDeploymentUpdateCheckResponse,
   PatchDeploymentRequest,
   PostDeploymentActionRequest
 } from '@hola/shared';
@@ -113,6 +114,27 @@ export function useDeploymentHistoryApi(deploymentId: string | undefined, page: 
     loading: query.isLoading,
     error: query.error ? (query.error instanceof Error ? query.error.message : 'Unknown error') : null,
     refetch: () => query.refetch(),
+  };
+}
+
+/**
+ * Hook for the on-demand richer update check (#299): whether the available
+ * update is a safe one-click bump or a guided multi-step upgrade (breaking,
+ * waypoint/floor path, pre-upgrade backup, notes link). This pulls the target
+ * bundle server-side, so it's `enabled`-gated by the caller — only fetch when
+ * an update actually exists, keeping the detail view free of needless pulls.
+ */
+export function useDeploymentUpdateCheckApi(deploymentId: string | undefined, enabled: boolean) {
+  const query = useQuery({
+    queryKey: queryKeys.deployments.updateCheck(deploymentId ?? ''),
+    queryFn: () => api.deployments.updateCheck(deploymentId!) as Promise<GetDeploymentUpdateCheckResponse>,
+    enabled: !!deploymentId && enabled,
+  });
+
+  return {
+    data: query.data ?? null,
+    loading: query.isLoading,
+    error: query.error ? (query.error instanceof Error ? query.error.message : 'Unknown error') : null,
   };
 }
 

--- a/packages/web/src/pages/DeploymentDetail.tsx
+++ b/packages/web/src/pages/DeploymentDetail.tsx
@@ -35,7 +35,7 @@ import { validateParams, generateSecretValue, hasParamSpec } from '@hola/shared/
 import { AppIcon } from '../components/ui/AppIcon';
 import { StatusDot, StatusBadge } from '../components/ui/StatusBadge';
 import { ParamField } from '../components/ui/fields/ParamField';
-import { useDeploymentDetailApi, useDeploymentHistoryApi, useDeploymentConfigApi } from '../hooks/useDeploymentDetailApi';
+import { useDeploymentDetailApi, useDeploymentHistoryApi, useDeploymentConfigApi, useDeploymentUpdateCheckApi } from '../hooks/useDeploymentDetailApi';
 import { subscribeDeploymentDeleted } from '../state/useGlobalQueryEvents';
 
 // `hasParamSpec` (whether a row is catalog-declared vs a deletable custom var)
@@ -104,6 +104,17 @@ export const DeploymentDetail: React.FC = () => {
     upgradeDeployment,
     removeDeployment
   } = useDeploymentDetailApi(deploymentId);
+
+  // Richer, on-demand update check (#299). Only fires when the cheap
+  // updateAvailable signal is set, so a bundle pull happens for an actual update
+  // — never on every detail view. Feeds the upgrade dialog the real facts
+  // (breaking / pre-upgrade backup / notes) and, for a guided upgrade, the next
+  // safe waypoint version instead of a bare "update available".
+  const { data: updateCheck } = useDeploymentUpdateCheckApi(deploymentId, !!deployment?.updateAvailable);
+  // A non-ok path (waypoint/floor) means the server would reject a one-shot jump
+  // to latest, so the dialog steers to the suggested version rather than offering
+  // a promote that fails.
+  const guidedPath = updateCheck?.path && updateCheck.path.ok === false ? updateCheck.path : null;
 
   const navigate = useNavigate();
 
@@ -310,12 +321,15 @@ export const DeploymentDetail: React.FC = () => {
 
   // Confirmed upgrade to the latest catalog version. The server carries env/secrets +
   // system overrides forward and snapshots first when the target requires it.
-  const confirmUpgrade = async () => {
+  const confirmUpgrade = async (version?: string) => {
     if (!deployment || !deployment.updateAvailable) return;
     setUpgradeError(null);
     setOperationLoading(prev => ({ ...prev, upgrade: true }));
     try {
-      await upgradeDeployment();
+      // #299: for a guided upgrade the target latest is unreachable in one hop
+      // (server skip-guard rejects it), so promote to the next safe waypoint
+      // version instead; a plain bump promotes straight to latest.
+      await upgradeDeployment(version ? { version } : undefined);
       setShowUpgradeConfirm(false);
     } catch (error) {
       console.error('Error upgrading deployment:', error);
@@ -399,7 +413,16 @@ export const DeploymentDetail: React.FC = () => {
     { label: 'Status', value: deployment.status },
     ...(deployment.version ? [{ label: 'Version', value: deployment.version, mono: true }] : []),
     ...(deployment.updateAvailable && deployment.latestVersion
-      ? [{ label: 'Latest', value: `${deployment.latestVersion} (update available)`, mono: true }]
+      ? [{
+          label: 'Latest',
+          // #299: at-a-glance kind of update, not just "available".
+          value: `${deployment.latestVersion} ${
+            guidedPath ? `(upgrade via ${guidedPath.suggestedVersion} first)`
+              : updateCheck?.breaking ? '(breaking update)'
+              : '(update available)'
+          }`,
+          mono: true,
+        }]
       : []),
     ...(deployment.uptime ? [{ label: 'Uptime', value: deployment.uptime }] : []),
     { label: 'Last updated', value: deployment.lastUpdated },
@@ -962,14 +985,62 @@ export const DeploymentDetail: React.FC = () => {
                 </div>
                 <div className="min-w-0">
                   <h2 id="upgrade-dialog-title" className="text-lg font-semibold m-0">
-                    Upgrade {deployment.name} to {deployment.latestVersion}?
+                    {guidedPath
+                      ? `Upgrade ${deployment.name} to ${guidedPath.suggestedVersion} first`
+                      : `Upgrade ${deployment.name} to ${deployment.latestVersion}?`}
                   </h2>
                   <p className="mt-1.5 text-sm text-text-muted">
-                    Your settings and secrets carry forward. If this release is marked breaking or
-                    requires a backup, Hola takes a pre-upgrade snapshot first — you can roll back to it.
+                    Your settings and secrets carry forward.
+                    {updateCheck?.preUpgradeBackup === 'required'
+                      ? ' Hola takes a pre-upgrade snapshot first — you can roll back to it.'
+                      : updateCheck?.preUpgradeBackup === 'recommended'
+                        ? ' A pre-upgrade snapshot is recommended before you continue.'
+                        : ''}
                   </p>
                 </div>
               </div>
+
+              {/* #299 richness: what kind of upgrade this actually is. */}
+              {guidedPath && (
+                <div className="mt-4 flex items-start gap-2 text-sm text-warning bg-warning/10 border border-warning/30 rounded-[9px] p-3">
+                  <AlertTriangle className="w-4 h-4 flex-shrink-0 mt-0.5" />
+                  <div className="min-w-0">
+                    <div className="font-semibold text-text-strong">Guided upgrade</div>
+                    <p className="mt-0.5 text-text-muted">{guidedPath.message}</p>
+                    <p className="mt-1 text-text-muted">
+                      Upgrade to <span className="font-mono text-text-strong">{guidedPath.suggestedVersion}</span> now,
+                      let it settle, then repeat toward <span className="font-mono">{deployment.latestVersion}</span>.
+                    </p>
+                  </div>
+                </div>
+              )}
+
+              {updateCheck?.breaking && (
+                <div className="mt-3 flex items-start gap-2 text-sm bg-danger-weak border border-danger/30 rounded-[9px] p-3">
+                  <AlertTriangle className="w-4 h-4 flex-shrink-0 mt-0.5 text-danger" />
+                  <div className="min-w-0 text-text-muted">
+                    <span className="font-semibold text-text-strong">Breaking change.</span>{' '}
+                    This release migrates data or changes behavior.
+                    {updateCheck.upgradeNotesUrl ? (
+                      <>
+                        {' '}
+                        <a
+                          href={updateCheck.upgradeNotesUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1 text-primary hover:underline font-medium"
+                        >
+                          Review the upgrade notes
+                          <ExternalLink className="w-3.5 h-3.5" />
+                        </a>{' '}
+                        before you continue.
+                      </>
+                    ) : (
+                      ' Review the app’s upgrade notes before you continue.'
+                    )}
+                  </div>
+                </div>
+              )}
 
               {upgradeError && (
                 <div className="mt-4 flex items-start gap-2 text-sm text-danger bg-danger-weak rounded-[9px] p-3">
@@ -987,12 +1058,14 @@ export const DeploymentDetail: React.FC = () => {
                   Cancel
                 </button>
                 <button
-                  onClick={confirmUpgrade}
+                  onClick={() => confirmUpgrade(guidedPath ? guidedPath.suggestedVersion : undefined)}
                   disabled={operationLoading.upgrade}
                   className="h-[38px] px-[14px] flex items-center gap-[7px] bg-primary text-white border border-transparent rounded-[9px] text-[13.5px] font-semibold hover:brightness-110 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
                 >
                   {operationLoading.upgrade ? <RotateCw className="w-4 h-4 animate-spin" /> : <ArrowUpCircle className="w-4 h-4" />}
-                  {operationLoading.upgrade ? 'Upgrading…' : `Upgrade to ${deployment.latestVersion}`}
+                  {operationLoading.upgrade
+                    ? 'Upgrading…'
+                    : `Upgrade to ${guidedPath ? guidedPath.suggestedVersion : deployment.latestVersion}`}
                 </button>
               </div>
             </div>

--- a/packages/web/src/state/queryKeys.ts
+++ b/packages/web/src/state/queryKeys.ts
@@ -30,6 +30,7 @@ export const queryKeys = {
       ['deployments', 'list', normalizeParams(params)] as const,
     detail: (id: string) => ['deployments', 'detail', id] as const,
     config: (id: string) => ['deployments', 'config', id] as const,
+    updateCheck: (id: string) => ['deployments', 'update-check', id] as const,
     history: (id: string, page: number) =>
       ['deployments', 'history', id, page] as const,
   },

--- a/packages/web/src/utils/api.ts
+++ b/packages/web/src/utils/api.ts
@@ -392,6 +392,11 @@ export const api = {
       const query = apiClient.buildQuery(params || {});
       return apiClient.get(`${API.deployments.logs(deploymentId)}${query}`, false); // Don't cache logs
     },
+
+    // On-demand richer update check (#299): breaking/backup/notes + skip-guard
+    // path for one deployment. Pulls the target bundle, so callers gate it on
+    // updateAvailable.
+    updateCheck: (deploymentId: string) => apiClient.get(API.deployments.updateCheck(deploymentId)),
   },
 
   // Jobs with frequent updates

--- a/packages/web/src/utils/sdk-adapter.ts
+++ b/packages/web/src/utils/sdk-adapter.ts
@@ -24,7 +24,7 @@ import type {
   PatchDeploymentRequest, PatchDeploymentResponse,
   PostDeploymentActionRequest, PostDeploymentActionResponse,
   PromoteDeploymentRequest, PromoteDeploymentResponse,
-  GetDeploymentHistoryResponse, GetDeploymentConfigResponse,
+  GetDeploymentHistoryResponse, GetDeploymentConfigResponse, GetDeploymentUpdateCheckResponse,
   // Job types
   GetJobsResponse, GetJobResponse, GetLogsResponse, DeleteJobsRequest, DeleteJobsResponse,
   // Backup types  
@@ -502,6 +502,15 @@ export class SdkAdapter {
     config: (deploymentId: string): Promise<GetDeploymentConfigResponse> => {
       const path = `/api/deployments/${deploymentId}/config`;
       return this.getWithCache(path, () => this.sdk.deployments.config(deploymentId));
+    },
+
+    // On-demand richer update check (#299): safe-bump vs. guided upgrade, with the
+    // target's breaking/backup/notes + a skip-guard path verdict. Distinct from the
+    // cheap latestVersion/updateAvailable that already rides on byId/list — this
+    // pulls the target bundle, so it's only called when an update is available.
+    updateCheck: (deploymentId: string): Promise<GetDeploymentUpdateCheckResponse> => {
+      const path = `/api/deployments/${deploymentId}/update-check`;
+      return this.getWithCache(path, () => this.sdk.deployments.updateCheck(deploymentId));
     },
   };
 


### PR DESCRIPTION
## What

Closes #299 (web half, on top of #392). The deployment detail page now consumes `GET /api/deployments/:id/update-check` and the upgrade dialog says **what kind** of update it is — safe one-click bump vs. guided multi-step — instead of a bare confirmation.

## Before / after

The upgrade dialog used to *guess*: _"If this release is marked breaking or requires a backup, Hola takes a pre-upgrade snapshot first."_ It had only the cheap #284 `updateAvailable` flag. Now it states the facts pulled from the target bundle.

## How

- **hook** — `useDeploymentUpdateCheckApi(id, enabled)` (TanStack Query). **`enabled`-gated on `updateAvailable`**, so the bundle-pulling endpoint is only hit for an actual update — never on a plain detail view (satisfies "no extra pulls").
- **adapters** — `deployments.updateCheck` on `sdk-adapter` (the active path for `deployments`) and `api.ts` (parity); `queryKeys.deployments.updateCheck`.
- **dialog** —
  - **Guided upgrade** (path `waypoint-required` / `min-from-version`): a warning with the server's message, and the confirm button promotes to the **next safe version** (`confirmUpgrade(suggestedVersion)` → `promote({ version })`) instead of a straight-to-latest jump the server's skip-guard would reject.
  - **Breaking**: a "Breaking change" callout + a "Review the upgrade notes" link.
  - **Pre-upgrade backup**: required/recommended copy in the subtext.
- **at-a-glance** — the Overview "Latest" fact row reads `(breaking update)` / `(upgrade via <v> first)` rather than a bare `(update available)`.

## Tests

New `#299` block in `DeploymentDetail.test.tsx`: guided upgrade (waypoint + breaking + notes link → **promotes to the waypoint version**), clean bump (no warnings → promotes to latest), and no-update (endpoint never called). Full web suite **213 pass**; typecheck + lint + build green.

## Acceptance (#299)

- ✅ Breaking / waypoint-required latest → the page shows the warning + next safe version instead of a bare "update available".
- ✅ No extra bundle pulls in the deployments list (hook is detail-only and gated on `updateAvailable`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)