### PR TITLE
chore(devcontainer): refresh feature lockfile and pin base image to ubuntu-24.04

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,49 +1,49 @@
 {
   "features": {
     "ghcr.io/devcontainers/features/aws-cli:1": {
-      "integrity": "sha256:3a80c965daf1f48f02466ccaf51d6f0610728f84da2be87a5295b7265d65870b",
-      "resolved": "ghcr.io/devcontainers/features/aws-cli@sha256:3a80c965daf1f48f02466ccaf51d6f0610728f84da2be87a5295b7265d65870b",
-      "version": "1.1.4"
+      "version": "1.1.4",
+      "resolved": "ghcr.io/devcontainers/features/aws-cli@sha256:1f93c8315b7a6d76982ebb2269f8b0d50413fc0f965c032edf4aee0caceb73ef",
+      "integrity": "sha256:1f93c8315b7a6d76982ebb2269f8b0d50413fc0f965c032edf4aee0caceb73ef"
     },
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
-      "integrity": "sha256:1463f632a3b9d9c8fcba3fcc4dd1c00a586a3926e04f09ebc7f5323e2a9bf94e",
-      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:1463f632a3b9d9c8fcba3fcc4dd1c00a586a3926e04f09ebc7f5323e2a9bf94e",
-      "version": "2.17.0"
+      "version": "2.17.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:25b9f05705ffba7dbe503230ac76081419306f8c8bc88e0ce78c4ecd99a0c78c",
+      "integrity": "sha256:25b9f05705ffba7dbe503230ac76081419306f8c8bc88e0ce78c4ecd99a0c78c"
     },
     "ghcr.io/devcontainers/features/github-cli:1": {
-      "integrity": "sha256:db9e34b5d71932018fd043ec4129f33cfe423bbd350063107fa5e56148efc43c",
-      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:db9e34b5d71932018fd043ec4129f33cfe423bbd350063107fa5e56148efc43c",
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
     },
     "ghcr.io/devcontainers/features/node:1": {
-      "integrity": "sha256:fdb79b02336bfce18522defa1249d6880e0de5a185b4f25fe53d1a6bfb6f07ba",
-      "resolved": "ghcr.io/devcontainers/features/node@sha256:fdb79b02336bfce18522defa1249d6880e0de5a185b4f25fe53d1a6bfb6f07ba",
-      "version": "1.7.1"
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
     },
     "ghcr.io/eitsupi/devcontainer-features/jq-likes:2": {
-      "integrity": "sha256:d76db08bc7c8d1c1afbc99f9912e1009544f12f87cc39f377d59e364f3ac805c",
-      "resolved": "ghcr.io/eitsupi/devcontainer-features/jq-likes@sha256:d76db08bc7c8d1c1afbc99f9912e1009544f12f87cc39f377d59e364f3ac805c",
-      "version": "2.1.1"
+      "version": "2.1.1",
+      "resolved": "ghcr.io/eitsupi/devcontainer-features/jq-likes@sha256:6a8b044f9f424097ec6d212167836b26994a76a556cbcb202084be79fe8032bd",
+      "integrity": "sha256:6a8b044f9f424097ec6d212167836b26994a76a556cbcb202084be79fe8032bd"
     },
     "ghcr.io/get2knowio/devcontainer-features/ai-clis:2": {
-      "integrity": "sha256:b1bab8dbca43944a27c3ef9b6783f321d735b12eab56a3ca38da5177fbf63956",
-      "resolved": "ghcr.io/get2knowio/devcontainer-features/ai-clis@sha256:b1bab8dbca43944a27c3ef9b6783f321d735b12eab56a3ca38da5177fbf63956",
-      "version": "2.0.7"
+      "version": "2.0.7",
+      "resolved": "ghcr.io/get2knowio/devcontainer-features/ai-clis@sha256:cd27a72e2f9efb25e629e04f3e887ab99f12fce608abee4dbc390723b1759e44",
+      "integrity": "sha256:cd27a72e2f9efb25e629e04f3e887ab99f12fce608abee4dbc390723b1759e44"
     },
     "ghcr.io/get2knowio/devcontainer-features/github-actions-tools:2": {
-      "integrity": "sha256:2dc6e3c1f78b6c96eec6180ec3672f5fe23043d7f86bc2aab09a7a0d0a46c387",
-      "resolved": "ghcr.io/get2knowio/devcontainer-features/github-actions-tools@sha256:2dc6e3c1f78b6c96eec6180ec3672f5fe23043d7f86bc2aab09a7a0d0a46c387",
-      "version": "2.0.2"
+      "version": "2.0.2",
+      "resolved": "ghcr.io/get2knowio/devcontainer-features/github-actions-tools@sha256:63c152ec19fd3270976a89903ee93c4c8472be0fd3cbc6aef087257ab2630e06",
+      "integrity": "sha256:63c152ec19fd3270976a89903ee93c4c8472be0fd3cbc6aef087257ab2630e06"
     },
     "ghcr.io/get2knowio/devcontainer-features/modern-cli-tools:2": {
-      "integrity": "sha256:d2321a76d3b40f6cdc058e370ee915c148ccfbf0c0f72baff3ae6228e23921b3",
-      "resolved": "ghcr.io/get2knowio/devcontainer-features/modern-cli-tools@sha256:d2321a76d3b40f6cdc058e370ee915c148ccfbf0c0f72baff3ae6228e23921b3",
-      "version": "2.0.4"
+      "version": "2.0.4",
+      "resolved": "ghcr.io/get2knowio/devcontainer-features/modern-cli-tools@sha256:810cae57e0b927af1be32d95b29a803caf8fae9bbdda6e6f4af4ed0277a05390",
+      "integrity": "sha256:810cae57e0b927af1be32d95b29a803caf8fae9bbdda6e6f4af4ed0277a05390"
     },
     "ghcr.io/get2knowio/devcontainer-features/node-dev-tools:2": {
-      "integrity": "sha256:333ca76e3b1b7748be73615d84f320d95198ca9b37c9996fa2feb0681dc6a922",
-      "resolved": "ghcr.io/get2knowio/devcontainer-features/node-dev-tools@sha256:333ca76e3b1b7748be73615d84f320d95198ca9b37c9996fa2feb0681dc6a922",
-      "version": "2.0.2"
+      "version": "2.0.2",
+      "resolved": "ghcr.io/get2knowio/devcontainer-features/node-dev-tools@sha256:bcdefb033ce24be39706fc5f92a0226f799aabcbe31a9b0edf619adae434d037",
+      "integrity": "sha256:bcdefb033ce24be39706fc5f92a0226f799aabcbe31a9b0edf619adae434d037"
     }
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Node.js Agentic Development",
-  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
   "remoteUser": "vscode",
   "features": {
     "ghcr.io/devcontainers/features/node:1": {


### PR DESCRIPTION
## Why

`devcontainer up --workspace-folder .` failed outright:

```
Could not resolve Feature manifest for 'ghcr.io/devcontainers/features/node:1'.
  If necessary, provide registry credentials with 'docker login <registry>'.
Error: ERR: Feature 'ghcr.io/devcontainers/features/node:1' could not be processed.
  You may not have permission to access this Feature, or may not be logged in.
```

The message blames registry auth, which is a red herring — these features are
public, and `--log-level trace` shows the CLI falling back to anonymous access
successfully and *then* 404ing on the pinned digest:

```
manifest url: .../features/node/manifests/sha256:fdb79b02336bfce...
[httpOci] No authentication credentials found for registry 'ghcr.io'. Accessing anonymously.
[httpOci] 404 on reattempt after auth: .../manifests/sha256:fdb79b02336bfce...
{"errors":[{"code":"MANIFEST_UNKNOWN"}]}
```

Checking each pinned digest directly against ghcr.io: **all nine 404**. The
feature publishers re-pushed the same version tags with new content, orphaning
every manifest we had pinned. Resolving by tag works fine.

## Changes

**Refresh the lockfile.** Every `version` is unchanged — only the digests moved:

| Feature | Version | Old digest | New digest |
|---|---|---|---|
| `features/node:1` | 1.7.1 | `fdb79b02…` (404) | `8c0de469…` |
| `features/aws-cli:1` | 1.1.4 | `3a80c965…` (404) | `1f93c831…` |
| `features/docker-in-docker:2` | 2.17.0 | `1463f632…` (404) | `25b9f057…` |
| `features/github-cli:1` | 1.1.0 | `db9e34b5…` (404) | `d22f50b7…` |
| …plus the 5 `eitsupi`/`get2knowio` features | all unchanged | all 404 | all new |

`devcontainer upgrade` can't fix this on its own — it reads the stale lockfile
first and dies with the same error — so the file was removed and regenerated.
Key order follows the CLI's own output (`version`/`resolved`/`integrity`) rather
than the alphabetized form that was committed.

**Pin the base image.** `mcr.microsoft.com/devcontainers/base:ubuntu` is a
floating tag and has rolled forward to Ubuntu 26.04:

```
ubuntu        sha256:36c0ae9fe6bfa914cf7eb05b08b09a3a31961dc76eed6fbb75179382c817582c
ubuntu26.04   sha256:36c0ae9fe6bfa914cf7eb05b08b09a3a31961dc76eed6fbb75179382c817582c   <- same
ubuntu-24.04  sha256:d94c97dd9cacf183d0a6fd12a8e87b526e9e928307674ae9c94139139c0c6eae
```

Pinning keeps the devcontainer on 24.04 LTS instead of tracking whatever release
that tag points at next.

These two changes are independent — only the lockfile was breaking the build.
Feature resolution happens before image resolution, so the failing run never
reached the base image; the 26.04 float was not a factor.

## Verification

Full `devcontainer up` after both changes:

```
{"outcome":"success","containerId":"b1ebba9d…","remoteUser":"vscode","remoteWorkspaceFolder":"/workspaces/hola"}
```

All nine features install, and inside the container:

```
PRETTY_NAME="Ubuntu 24.04.3 LTS"
node v22.23.1 · bun 1.3.14 · gh 2.96.0 · docker 29.6.2 (docker-in-docker)
```

No application code touched, so the usual typecheck/lint/test/build matrix isn't
affected by this PR — CI on the PR is the check that matters.

## Note

This will recur. Pinning to floating majors (`node:1`) while locking digests
means any upstream republish orphans the lockfile again, and the error surfaces
as a misleading auth failure. Worth knowing the recovery is `rm` the lockfile +
`devcontainer upgrade`, not `devcontainer upgrade` alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
