### PR TITLE
chore(release): 0.8.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/cli": {
       "name": "@hola/cli",
-      "version": "0.7.9",
+      "version": "0.8.0",
       "bin": {
         "hola": "./bin/hola",
       },
@@ -37,11 +37,11 @@
     },
     "packages/compose": {
       "name": "@hola/compose",
-      "version": "0.7.9",
+      "version": "0.8.0",
     },
     "packages/sdk": {
       "name": "@hola/sdk",
-      "version": "0.7.9",
+      "version": "0.8.0",
       "dependencies": {
         "@hola/shared": "workspace:*",
       },
@@ -55,7 +55,7 @@
     },
     "packages/server": {
       "name": "@hola/server",
-      "version": "0.7.9",
+      "version": "0.8.0",
       "dependencies": {
         "@hola/shared": "workspace:*",
         "jose": "^6.2.3",
@@ -71,7 +71,7 @@
     },
     "packages/shared": {
       "name": "@hola/shared",
-      "version": "0.7.9",
+      "version": "0.8.0",
       "dependencies": {
         "yaml": "^2.9.0",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.7.9",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.7.9';
+export const CLI_VERSION = '0.8.0';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.7.9",
+  "version": "0.8.0",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.7.9",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.7.9",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.7.9",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Minor release cutting everything on `main` since `cli-v0.7.9` (28 commits).

Bumps `cli`, `compose`, `sdk`, `server`, and `shared` to `0.8.0`, plus
`packages/cli/src/version.ts` and `bun.lock` — the same 7-file footprint as
previous release commits. No functional changes in this PR.

Minor rather than patch: three new user-facing capabilities landed since 0.7.9
(per-app Compose profiles, multiple instances per app, richer update-check),
matching how 0.6.0 and 0.7.0 were cut.

## Included

**Features**
- per-app Compose profiles (#162) — server, CLI `--profile`, wizard checkboxes
- multiple instances per app (#246) — per-deployment subdomain, singleton-by-default, `--allow-multiple`
- richer update-check (#299) — on-demand endpoint + deployment detail page
- bootstrap SSH multiplexing via ControlMaster (#181)
- merge-by-key semantics for deployment env PATCH (#332)

**Fixes**
- re-pin embedded outpost host on forward-auth reuse (#137)
- remove host bind-mount data root on uninstall (#341)
- gate Traefik on server health for DNS-01 wildcard issuance (#154)
- only reuse a detected `.env` if it's actually a Hola config (#345)
- name Authentik objects off the deployment-id suffix + best-effort deprovision for failed installs (#346)

**Chores** — repo hygiene + hardened CI workflows (#374), dependency bumps.

## Upgrade notes

- Installs are **singleton-by-default**: a second instance of an app now needs
  `--allow-multiple` (CLI) or the wizard's "install another".
- Uninstall now **removes the app's host bind-mount data root**. Back up app
  data before uninstalling if you intend to reinstall onto it.

## Verification

`bun run typecheck` · `lint` · `test` · `build` all pass locally
(611 server tests, 213 web tests). Built CLI reports `hola, 0.8.0`.

After merge, tagging `cli-v0.8.0` triggers `cli-release.yml` to publish the
GHCR images, compose bundle, and CLI binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)