### PR TITLE
fix(web,server): make dashboard token renewal work, and recover a stale token in place

### DIFF
--- a/packages/server/src/__tests__/auth/oidc-provider.test.ts
+++ b/packages/server/src/__tests__/auth/oidc-provider.test.ts
@@ -102,6 +102,21 @@ describe('OidcAuthProvider', () => {
     expect(resolveOidcConfig().adminGroup).toBe('custom-admins');
   });
 
+  // The dashboard renews its access token from a refresh token. Without
+  // offline_access the IdP issues none, and renewal falls back to a hidden iframe
+  // that depends on the IdP allowing itself to be framed — when that fails the
+  // session just dies early, with a 401 on the next refetch.
+  it('requests offline_access by default so the IdP issues a refresh token', () => {
+    delete process.env.HOLA_OIDC_SCOPES;
+    expect(resolveOidcConfig().scopes).toEqual(['openid', 'profile', 'email', 'offline_access']);
+  });
+
+  it('HOLA_OIDC_SCOPES overrides the defaults verbatim', () => {
+    process.env.HOLA_OIDC_SCOPES = 'openid, profile';
+    expect(resolveOidcConfig().scopes).toEqual(['openid', 'profile']);
+    delete process.env.HOLA_OIDC_SCOPES;
+  });
+
   it('accepts a valid token (aud = clientId) and maps the principal identity', async () => {
     process.env.HOLA_OIDC_ADMIN_GROUP = 'hola-admins';
     const provider = new OidcAuthProvider();

--- a/packages/server/src/config/oidc.ts
+++ b/packages/server/src/config/oidc.ts
@@ -76,10 +76,18 @@ export function clearProvisionedOidc(): void {
   provisioned = undefined;
 }
 
+/**
+ * `offline_access` earns its place: it makes the IdP issue a refresh token, which
+ * lets the dashboard renew via a token grant instead of a hidden iframe. The
+ * iframe path depends on the Authentik session cookie surviving a framed,
+ * cross-origin request and on the IdP permitting itself to be framed — brittle,
+ * and invisible when it breaks (the session simply dies early). An operator who
+ * sets HOLA_OIDC_SCOPES explicitly still gets exactly what they asked for.
+ */
 function defaultScopes(): string[] {
   const raw = process.env.HOLA_OIDC_SCOPES?.trim();
   if (raw) return raw.split(/[,\s]+/).filter(Boolean);
-  return ['openid', 'profile', 'email'];
+  return ['openid', 'profile', 'email', 'offline_access'];
 }
 
 /**

--- a/packages/web/src/__tests__/pages/AuthCallback-silent.test.tsx
+++ b/packages/web/src/__tests__/pages/AuthCallback-silent.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+
+import { AuthCallback } from '../../pages/AuthCallback';
+
+/**
+ * oidc-client-ts renews by loading `silent_redirect_uri` in a hidden iframe. That
+ * URI defaults to `redirect_uri`, so renewals land on /auth/callback — the same
+ * route as an interactive login. The two must NOT be completed the same way:
+ * only signinSilentCallback() posts the result back to the parent frame, and
+ * without it the parent's signinSilent() hangs until it times out. That failure
+ * is invisible: the session simply expires early and the next focus refetch 401s.
+ */
+
+const completeOidcLogin = vi.fn(async () => {});
+const completeOidcSilentRenew = vi.fn(async () => {});
+
+vi.mock('../../hooks/useAuth', () => ({
+  useAuth: () => ({
+    mode: 'oidc',
+    completeOidcLogin,
+    completeOidcSilentRenew,
+  }),
+}));
+
+function renderCallback() {
+  return render(
+    <MemoryRouter>
+      <AuthCallback />
+    </MemoryRouter>,
+  );
+}
+
+describe('AuthCallback silent-renew handling', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('relays the result to the parent when framed, without running the login path', async () => {
+    // window.self !== window.top is what a renewal iframe looks like.
+    vi.stubGlobal('top', {} as Window);
+
+    const { container } = renderCallback();
+
+    await waitFor(() => expect(completeOidcSilentRenew).toHaveBeenCalledTimes(1));
+    expect(completeOidcLogin).not.toHaveBeenCalled();
+    // The frame is throwaway — it must not paint a "Completing sign-in…" screen.
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('completes an interactive login normally when not framed', async () => {
+    vi.stubGlobal('top', window);
+
+    renderCallback();
+
+    await waitFor(() => expect(completeOidcLogin).toHaveBeenCalledTimes(1));
+    expect(completeOidcSilentRenew).not.toHaveBeenCalled();
+    expect(screen.getByText(/Completing sign-in|Signed in/)).toBeTruthy();
+  });
+});

--- a/packages/web/src/__tests__/utils/auth-refresh-401.test.ts
+++ b/packages/web/src/__tests__/utils/auth-refresh-401.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import {
+  refreshAuthToken,
+  setAuthTokenGetter,
+  setTokenRefresher,
+  setUnauthorizedHandler,
+} from '../../utils/auth-token';
+import { safeFetchEnhanced } from '../../utils/error-enhanced';
+
+/**
+ * Regression cover for the background-tab 401.
+ *
+ * Returning to a tab that sat in the background fires `refetchOnWindowFocus` for
+ * every mounted query. The renewal timer is throttled while hidden, so those
+ * refetches can carry an access token that expired even though the session is
+ * still valid. That 401 must be recovered in place, not surfaced as
+ * "Could not load apps: Authentication failed".
+ */
+
+const unauthorized = new Response(JSON.stringify({ error: { message: 'Authentication failed' } }), {
+  status: 401,
+  headers: { 'content-type': 'application/json' },
+});
+const ok = () =>
+  new Response(JSON.stringify({ apps: [] }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+
+function authHeaderOf(call: [RequestInfo | URL, RequestInit?]): string | null {
+  return new Headers(call[1]?.headers).get('Authorization');
+}
+
+describe('safeFetchEnhanced 401 refresh-and-retry', () => {
+  beforeEach(() => {
+    setAuthTokenGetter(() => 'stale-token');
+    setTokenRefresher(undefined);
+    setUnauthorizedHandler(undefined);
+  });
+
+  afterEach(() => {
+    setAuthTokenGetter(undefined);
+    setTokenRefresher(undefined);
+    setUnauthorizedHandler(undefined);
+    vi.unstubAllGlobals();
+  });
+
+  it('refreshes the token and replays the request instead of failing the query', async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) =>
+      new Headers(init?.headers).get('Authorization') === 'Bearer fresh-token'
+        ? ok()
+        : unauthorized.clone(),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const onUnauthorized = vi.fn();
+    setUnauthorizedHandler(onUnauthorized);
+    setTokenRefresher(async () => 'fresh-token');
+
+    const res = await safeFetchEnhanced('/api/deployments');
+
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(authHeaderOf(fetchMock.mock.calls[0])).toBe('Bearer stale-token');
+    expect(authHeaderOf(fetchMock.mock.calls[1])).toBe('Bearer fresh-token');
+    // The session was recoverable, so the app must NOT be dropped to login.
+    expect(onUnauthorized).not.toHaveBeenCalled();
+  });
+
+  it('drops to login when the refresh itself fails', async () => {
+    const fetchMock = vi.fn(async () => unauthorized.clone());
+    vi.stubGlobal('fetch', fetchMock);
+
+    const onUnauthorized = vi.fn();
+    setUnauthorizedHandler(onUnauthorized);
+    setTokenRefresher(async () => {
+      throw new Error('silent renew failed');
+    });
+
+    await expect(safeFetchEnhanced('/api/deployments')).rejects.toThrow();
+    expect(onUnauthorized).toHaveBeenCalledTimes(1);
+    // One attempt only — a failed refresh means there is nothing to replay with.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops to login when the replayed request is also rejected', async () => {
+    const fetchMock = vi.fn(async () => unauthorized.clone());
+    vi.stubGlobal('fetch', fetchMock);
+
+    const onUnauthorized = vi.fn();
+    setUnauthorizedHandler(onUnauthorized);
+    setTokenRefresher(async () => 'fresh-but-still-rejected');
+
+    await expect(safeFetchEnhanced('/api/deployments')).rejects.toThrow();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(onUnauthorized).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not attempt a refresh for the auth endpoints themselves', async () => {
+    const fetchMock = vi.fn(async () => unauthorized.clone());
+    vi.stubGlobal('fetch', fetchMock);
+
+    const refresher = vi.fn(async () => 'fresh-token');
+    setTokenRefresher(refresher);
+
+    await expect(safeFetchEnhanced('/api/auth/login')).rejects.toThrow();
+    // A 401 from login is "wrong key", not an expired session.
+    expect(refresher).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('cookie mode has no refresher, so a 401 drops straight to login', async () => {
+    setAuthTokenGetter(() => undefined);
+    const fetchMock = vi.fn(async () => unauthorized.clone());
+    vi.stubGlobal('fetch', fetchMock);
+
+    const onUnauthorized = vi.fn();
+    setUnauthorizedHandler(onUnauthorized);
+
+    await expect(safeFetchEnhanced('/api/deployments')).rejects.toThrow();
+    expect(onUnauthorized).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('refreshAuthToken concurrency', () => {
+  afterEach(() => setTokenRefresher(undefined));
+
+  it('shares one renewal across a burst of parallel 401s', async () => {
+    // The whole point: a focus refetch 401s every mounted query at once, and they
+    // must not each fire their own silent renew.
+    let resolveRenewal: (t: string) => void = () => {};
+    const refresher = vi.fn(
+      () => new Promise<string | undefined>((resolve) => { resolveRenewal = resolve; }),
+    );
+    setTokenRefresher(refresher);
+
+    const inFlight = [refreshAuthToken(), refreshAuthToken(), refreshAuthToken()];
+    resolveRenewal('fresh-token');
+
+    expect(await Promise.all(inFlight)).toEqual(['fresh-token', 'fresh-token', 'fresh-token']);
+    expect(refresher).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows a new renewal after the previous one settles', async () => {
+    const refresher = vi.fn(async () => 'fresh-token');
+    setTokenRefresher(refresher);
+
+    expect(await refreshAuthToken()).toBe('fresh-token');
+    expect(await refreshAuthToken()).toBe('fresh-token');
+    expect(refresher).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/web/src/hooks/useAuth.tsx
+++ b/packages/web/src/hooks/useAuth.tsx
@@ -4,7 +4,12 @@ import { UserManager, WebStorageStateStore, type User } from 'oidc-client-ts';
 import type { AuthConfigResponse, Principal } from '@hola/shared';
 
 import { getWebBaseUrl } from '../utils/sdk-adapter';
-import { setAuthTokenGetter, setUnauthorizedHandler } from '../utils/auth-token';
+import {
+  refreshAuthToken,
+  setAuthTokenGetter,
+  setTokenRefresher,
+  setUnauthorizedHandler,
+} from '../utils/auth-token';
 
 /**
  * Dashboard authentication. Reads /api/auth/config at boot to learn the mode:
@@ -176,6 +181,48 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     })();
     return () => { cancelled = true; };
   }, [applyOidcUser]);
+
+  // Let the fetch layer recover a stale access token in place. A backgrounded tab
+  // has its automaticSilentRenew timer throttled (browsers clamp or freeze timers
+  // in hidden tabs), so returning to the tab can fire refetches carrying a token
+  // that expired while we were away — even though the session is still valid.
+  useEffect(() => {
+    if (mode !== 'oidc') {
+      setTokenRefresher(undefined);
+      return;
+    }
+    setTokenRefresher(async () => {
+      const m = managerRef.current;
+      if (!m) return undefined;
+      // The user store is localStorage and therefore shared across tabs: another
+      // tab may have already renewed, in which case no round-trip is needed. This
+      // also re-syncs accessTokenRef, which only tracks this tab's userLoaded events.
+      const existing = await m.getUser();
+      if (existing && !existing.expired) {
+        applyOidcUser(existing);
+        return existing.access_token;
+      }
+      const renewed = await m.signinSilent();
+      if (renewed && !renewed.expired) {
+        applyOidcUser(renewed);
+        return renewed.access_token;
+      }
+      return undefined;
+    });
+    return () => setTokenRefresher(undefined);
+  }, [mode, applyOidcUser]);
+
+  // Belt-and-braces: re-sync the token the moment the tab becomes visible, so the
+  // focus refetch usually goes out with a good token rather than 401-ing first.
+  // Cheap when nothing expired — it only reads the local store.
+  useEffect(() => {
+    if (mode !== 'oidc') return;
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') void refreshAuthToken();
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => document.removeEventListener('visibilitychange', onVisibility);
+  }, [mode]);
 
   // On a 401 from any API call, drop to unauthenticated so the guard shows login.
   useEffect(() => {

--- a/packages/web/src/hooks/useAuth.tsx
+++ b/packages/web/src/hooks/useAuth.tsx
@@ -39,6 +39,12 @@ interface AuthContextValue {
   loginError: string | null;
   /** Completes the OIDC redirect; called by the /auth/callback route. */
   completeOidcLogin: () => Promise<void>;
+  /**
+   * Completes a *silent* renewal. oidc-client-ts renews by loading
+   * `silent_redirect_uri` in a hidden iframe and waiting for that page to post
+   * the result back to the opener — which only happens via this call.
+   */
+  completeOidcSilentRenew: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null);
@@ -286,8 +292,27 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     applyOidcUser(u);
   }, [applyOidcUser]);
 
+  const completeOidcSilentRenew = useCallback(async () => {
+    const m = managerRef.current;
+    if (!m) throw new Error('OIDC is not configured');
+    // Posts the result to the parent frame and resolves its pending signinSilent().
+    // Deliberately does NOT touch this frame's state — we're inside a throwaway iframe.
+    await m.signinSilentCallback();
+  }, []);
+
   return (
-    <AuthContext.Provider value={{ status, mode, user, login, logout, loginError, completeOidcLogin }}>
+    <AuthContext.Provider
+      value={{
+        status,
+        mode,
+        user,
+        login,
+        logout,
+        loginError,
+        completeOidcLogin,
+        completeOidcSilentRenew,
+      }}
+    >
       {children}
     </AuthContext.Provider>
   );

--- a/packages/web/src/pages/AuthCallback.tsx
+++ b/packages/web/src/pages/AuthCallback.tsx
@@ -9,17 +9,39 @@ import { useAuth } from '../hooks/useAuth';
  * its UserManager (mode resolves to 'oidc'), exchange the authorization code and
  * return to the app. Any other mode means we shouldn't be here — go home.
  */
+/**
+ * True when we're running inside oidc-client-ts's hidden silent-renew iframe.
+ * `silent_redirect_uri` defaults to `redirect_uri`, so renewals land on this very
+ * route — but they must be completed with signinSilentCallback(), which posts the
+ * result up to the parent frame. Completing them as a normal redirect instead
+ * leaves the parent's signinSilent() hanging until it times out.
+ */
+function isSilentRenewFrame(): boolean {
+  try {
+    return window.self !== window.top;
+  } catch {
+    // Cross-origin access threw — we're framed.
+    return true;
+  }
+}
+
 export const AuthCallback: React.FC = () => {
-  const { mode, completeOidcLogin } = useAuth();
+  const { mode, completeOidcLogin, completeOidcSilentRenew } = useAuth();
   const navigate = useNavigate();
   const [error, setError] = useState<string | null>(null);
   const [done, setDone] = useState(false);
+  const silent = isSilentRenewFrame();
 
   useEffect(() => {
     if (mode !== 'oidc') return;
     let cancelled = false;
     (async () => {
       try {
+        if (silent) {
+          // Hand the result to the parent tab; this frame is then discarded.
+          await completeOidcSilentRenew();
+          return;
+        }
         await completeOidcLogin();
         if (!cancelled) { setDone(true); navigate('/', { replace: true }); }
       } catch (e) {
@@ -27,7 +49,10 @@ export const AuthCallback: React.FC = () => {
       }
     })();
     return () => { cancelled = true; };
-  }, [mode, completeOidcLogin, navigate]);
+  }, [mode, completeOidcLogin, completeOidcSilentRenew, navigate, silent]);
+
+  // Nothing renders in the renewal iframe — it exists only to relay the result.
+  if (silent) return null;
 
   // We landed here with an authorization code. If auth resolved to non-OIDC, the
   // boot config likely mis-resolved (e.g. it failed and fell back to apikey) —

--- a/packages/web/src/utils/auth-token.ts
+++ b/packages/web/src/utils/auth-token.ts
@@ -10,13 +10,44 @@
  */
 
 type TokenGetter = () => string | undefined;
+type TokenRefresher = () => Promise<string | undefined>;
 
 let tokenGetter: TokenGetter | undefined;
+let tokenRefresher: TokenRefresher | undefined;
+let inFlightRefresh: Promise<string | undefined> | undefined;
 let unauthorizedHandler: (() => void) | undefined;
 
 /** Register (or clear) the source of the current Bearer access token. */
 export function setAuthTokenGetter(getter: TokenGetter | undefined): void {
   tokenGetter = getter;
+}
+
+/**
+ * Register (or clear) the way to obtain a *fresh* access token after the current
+ * one is rejected. Only the OIDC flow can refresh; the admin-key cookie mode
+ * registers nothing, so `refreshAuthToken` resolves undefined there.
+ */
+export function setTokenRefresher(refresher: TokenRefresher | undefined): void {
+  tokenRefresher = refresher;
+  inFlightRefresh = undefined;
+}
+
+/**
+ * Obtain a fresh access token, or undefined if refresh isn't possible/failed.
+ *
+ * Returning to a backgrounded tab fires a refetch for every mounted query at
+ * once (`refetchOnWindowFocus`), so a stale token produces a burst of parallel
+ * 401s. They must not each trigger their own renewal — the in-flight promise is
+ * shared so one renewal serves the whole burst.
+ */
+export function refreshAuthToken(): Promise<string | undefined> {
+  if (!tokenRefresher) return Promise.resolve(undefined);
+  if (!inFlightRefresh) {
+    inFlightRefresh = tokenRefresher()
+      .catch(() => undefined)
+      .finally(() => { inFlightRefresh = undefined; });
+  }
+  return inFlightRefresh;
 }
 
 /** The current Bearer access token, or undefined (cookie/no-auth modes). */

--- a/packages/web/src/utils/error-enhanced.ts
+++ b/packages/web/src/utils/error-enhanced.ts
@@ -3,7 +3,7 @@
 
 import type { ErrorResponse as SharedErrorResponse } from '@hola/shared';
 
-import { getAuthToken, notifyUnauthorized } from './auth-token';
+import { getAuthToken, notifyUnauthorized, refreshAuthToken } from './auth-token';
 
 export type ErrorResponse = SharedErrorResponse;
 
@@ -345,6 +345,22 @@ function isAuthEndpoint(input: RequestInfo | URL): boolean {
   return url.includes('/api/auth/');
 }
 
+/** True when an error (or response) represents a rejected credential. */
+function isUnauthorized(err: unknown): boolean {
+  return (
+    typeof err === 'object' && err !== null && (err as EnhancedError).statusCode === 401
+  );
+}
+
+/**
+ * A request body can only be sent once, so a retry is only safe for bodies we
+ * can replay. Strings/FormData/URLSearchParams/Blob are fine; a stream is not.
+ */
+function isReplayable(init?: RequestInit): boolean {
+  const body = init?.body;
+  return body == null || typeof body === 'string' || !(body instanceof ReadableStream);
+}
+
 // Enhanced safeFetch replacement with retry support
 export async function safeFetchEnhanced(
   input: RequestInfo | URL,
@@ -354,29 +370,48 @@ export async function safeFetchEnhanced(
   // Attach auth: a Bearer access token for the OIDC flow (cookie auth needs none),
   // and always send same-origin credentials so the admin-key session cookie rides
   // along. The token getter is registered by the React AuthProvider.
-  const token = getAuthToken();
-  const withAuth: RequestInit = { credentials: 'include', ...init };
-  if (token) {
-    const headers = new Headers(withAuth.headers);
-    if (!headers.has('Authorization')) headers.set('Authorization', `Bearer ${token}`);
-    withAuth.headers = headers;
-  }
+  const attempt = (token: string | undefined): Promise<Response> => {
+    const withAuth: RequestInit = { credentials: 'include', ...init };
+    if (token) {
+      const headers = new Headers(withAuth.headers);
+      if (!headers.has('Authorization')) headers.set('Authorization', `Bearer ${token}`);
+      withAuth.headers = headers;
+    }
+    return enhancedFetch(input, withAuth, retryConfig);
+  };
+
+  const normalize = (err: unknown): unknown =>
+    err instanceof Error && !(err as EnhancedError).type ? createEnhancedError(err) : err;
 
   try {
-    const res = await enhancedFetch(input, withAuth, retryConfig);
-    // A 401 on a real API call means our credential is gone/expired — let the app
-    // drop to login. Ignore the auth endpoints themselves (login returning 401 is
-    // a normal "wrong key", not a session expiry).
+    const res = await attempt(getAuthToken());
+    // Defensive: enhancedFetch throws on !ok, so a 401 normally surfaces via the
+    // catch below rather than here.
     if (res.status === 401 && !isAuthEndpoint(input)) {
       notifyUnauthorized();
     }
     return res;
   } catch (err) {
-    // Ensure we always throw an EnhancedError
-    if (err instanceof Error && !(err as EnhancedError).type) {
-      throw createEnhancedError(err);
+    // A 401 is not necessarily terminal. A backgrounded tab has its renewal timer
+    // throttled, so the token in memory can be stale while a valid session still
+    // exists (another tab may even have renewed it into the shared store). Try one
+    // refresh + replay before dropping the user to the login screen.
+    if (isUnauthorized(err) && !isAuthEndpoint(input) && isReplayable(init)) {
+      const fresh = await refreshAuthToken();
+      if (fresh) {
+        try {
+          return await attempt(fresh);
+        } catch (retryErr) {
+          if (isUnauthorized(retryErr)) notifyUnauthorized();
+          throw normalize(retryErr);
+        }
+      }
+      // No refresh available (cookie mode) or it failed — the session really is gone.
+      notifyUnauthorized();
+    } else if (isUnauthorized(err) && !isAuthEndpoint(input)) {
+      notifyUnauthorized();
     }
-    throw err;
+    throw normalize(err);
   }
 }
 

--- a/packages/web/src/utils/sse-client.ts
+++ b/packages/web/src/utils/sse-client.ts
@@ -1,6 +1,6 @@
 import type { SSEEvent, SSEConnectionState } from '@hola/shared';
 import type { EventSourceFactory, SSEOptions, SSEState } from './sse-types';
-import { getAuthToken, notifyUnauthorized } from './auth-token';
+import { getAuthToken, notifyUnauthorized, refreshAuthToken } from './auth-token';
 
 export interface SSEClient {
   connect(): void;
@@ -216,7 +216,7 @@ export function createSSEClient(initialOptions: SSEOptions = {}): SSEClient {
   // the OIDC Bearer token (and same-origin credentials for the admin-key cookie),
   // so authenticated log streams actually connect instead of 401-looping. Mirrors
   // the REST layer's auth (safeFetchEnhanced).
-  function connectFetch(url: string) {
+  function connectFetch(url: string, authRetried = false) {
     const controller = new AbortController();
     abortController = controller;
     const token = getAuthToken();
@@ -227,6 +227,16 @@ export function createSSEClient(initialOptions: SSEOptions = {}): SSEClient {
       .then(async response => {
         if (controller.signal.aborted) return;
         if (response.status === 401) {
+          // As in the REST layer: a 401 can just be a token that went stale while
+          // the tab was backgrounded. Refresh once and reconnect before giving up.
+          if (!authRetried) {
+            const fresh = await refreshAuthToken();
+            if (controller.signal.aborted) return;
+            if (fresh) {
+              connectFetch(url, true);
+              return;
+            }
+          }
           notifyUnauthorized();
           handleError('Unauthorized');
           return;


### PR DESCRIPTION
Fixes the background-tab error: leaving the dashboard open in an unfocused tab
and returning to it showed **"Could not load apps: Authentication failed"**,
while an immediate page refresh loaded everything fine.

Confirmed against an **Authentik SSO** install (`mode: oidc`). Three defects
compounded — the first two meant token renewal *never worked at all*, so the
session was always destined to expire out from under a backgrounded tab.

## 1. Silent renew was completed as if it were an interactive login

oidc-client-ts renews by loading `silent_redirect_uri` in a hidden iframe. That
URI **defaults to `redirect_uri`** (oidc-client-ts 3.5.0), so renewals land on
`/auth/callback` — the same route as a login. `AuthCallback` unconditionally
called `signinRedirectCallback()`, which never posts the result up to the parent
frame, so the parent's `signinSilent()` hung until it timed out. Every time.

**This is why refreshing the page fixed it.** `signinRedirectCallback()` in the
iframe *does* consume the code and write a fresh user into `localStorage`, which
the parent shares. The renewal genuinely happened — the parent just never learned
of it, and re-reading the store at boot picked it up.

`AuthCallback` now detects the frame and calls `signinSilentCallback()`,
rendering nothing.

## 2. The dashboard never requested `offline_access`

Default scopes were `['openid','profile','email']`, so Authentik issued **no
refresh token** and renewal had no option but the iframe — which additionally
depends on the IdP session cookie surviving a framed cross-origin request and on
the IdP permitting itself to be framed. Adding the scope lets oidc-client-ts renew
via a **refresh-token grant**, skipping the iframe entirely.

Authentik ships a managed `scope-offline_access` mapping, which
`resolveScopeMappingPks` already matches by name. An Authentik without it logs a
warning and continues, falling back to the now-correct iframe path.
`HOLA_OIDC_SCOPES` still overrides verbatim.

## 3. A 401 was terminal — and its handler was unreachable

`refetchOnWindowFocus: true` refires every mounted query the instant the tab
regains focus, ahead of any renewal. And `safeFetchEnhanced` treated the
resulting 401 as fatal — worse, its `res.status === 401` branch was
**unreachable**, because `enhancedFetch` throws on any non-ok response
(`error-enhanced.ts:273-277`). `notifyUnauthorized()` was never called for REST
calls at all, so the 401 became a rendered error string and the app didn't even
drop to login.

Now: refresh once, **replay** the request, and call `notifyUnauthorized()` only if
the refresh or the replay also fails. Auth endpoints stay excluded (a 401 from
login is a wrong key, not an expired session); replay is skipped for
non-replayable stream bodies.

Supporting pieces:

- The refresher shares an **in-flight promise**, so the burst of parallel 401s a
  focus refetch produces triggers exactly one renewal rather than one per query.
- It prefers a valid user already in the shared `localStorage` store before paying
  for a round-trip — which also fixes a **related staleness bug**:
  `accessTokenRef` only tracked *this* tab's `userLoaded` events, so a renewal in
  another Hola tab left this one holding a dead token.
- A `visibilitychange` listener re-syncs on focus, so the refetch usually goes out
  with a good token to begin with.
- `sse-client.ts` had the identical give-up-on-401 logic for log streams; it now
  refreshes and reconnects once too.

## Tests

11 new cases (`auth-refresh-401.test.ts`, `AuthCallback-silent.test.tsx`,
`oidc-provider.test.ts`):

- refresh + replay succeeds and does **not** drop to login
- refresh fails / replay also 401s → drops to login
- auth endpoints never trigger a refresh
- cookie mode (no refresher) drops straight to login
- a burst of parallel 401s shares one renewal
- framed callback relays via `signinSilentCallback()` and paints nothing
- unframed callback still completes an interactive login
- `offline_access` requested by default; `HOLA_OIDC_SCOPES` overrides verbatim

## Verification

`bun run typecheck` · `lint` · `test` · `build` all pass
(613 server, 222 web — up from 611/213).

Unchanged for `mode: none` and the admin-key cookie flow, which has nothing to
refresh and still drops to login as before.

Related: `specs/001-web-state-freshness` introduced the focus-refetch behaviour;
this is its unhandled interaction with token expiry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)