### PR TITLE
chore(release): 0.8.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/cli": {
       "name": "@hola/cli",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "bin": {
         "hola": "./bin/hola",
       },
@@ -37,11 +37,11 @@
     },
     "packages/compose": {
       "name": "@hola/compose",
-      "version": "0.8.0",
+      "version": "0.8.1",
     },
     "packages/sdk": {
       "name": "@hola/sdk",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "dependencies": {
         "@hola/shared": "workspace:*",
       },
@@ -55,7 +55,7 @@
     },
     "packages/server": {
       "name": "@hola/server",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "dependencies": {
         "@hola/shared": "workspace:*",
         "jose": "^6.2.3",
@@ -71,7 +71,7 @@
     },
     "packages/shared": {
       "name": "@hola/shared",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "dependencies": {
         "yaml": "^2.9.0",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.8.0';
+export const CLI_VERSION = '0.8.1';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Patch release cutting the dashboard session fix that landed in #396.

Bumps `cli`, `compose`, `sdk`, `server`, and `shared` to `0.8.1`, plus
`packages/cli/src/version.ts` and `bun.lock` — the same 7-file footprint as
previous release commits. No functional changes in this PR.

## Included

- **fix(web,server): make dashboard token renewal work, and recover a stale
  token in place (#396)** — returning to a backgrounded dashboard tab surfaced
  "Could not load apps: Authentication failed", while an immediate page refresh
  loaded fine. Three compounding defects:
  1. Silent renew lands on `/auth/callback` (`silent_redirect_uri` defaults to
     `redirect_uri`) and was completed with `signinRedirectCallback()`, which
     never posts the result to the parent frame — so `signinSilent()` always
     timed out and renewal never actually worked.
  2. The dashboard never requested `offline_access`, so the IdP issued no refresh
     token and renewal had no alternative to that broken iframe.
  3. `safeFetchEnhanced` treated the resulting 401 as terminal, via a branch that
     was in fact unreachable — so it surfaced as a rendered error rather than
     either recovering or dropping to login.

## Upgrade notes

Existing sessions gain a refresh token only once users re-authenticate, since
scopes are granted at authorization time. Until then they use the iframe renewal
path, which this release repairs — so the symptom is resolved either way.

Operators who pin `HOLA_OIDC_SCOPES` explicitly keep exactly what they set; add
`offline_access` to opt into refresh-token renewal.

## Verification

`bun run typecheck` · `lint` · `test` · `build` all pass locally
(613 server tests, 222 web tests). Built CLI reports `hola, 0.8.1`.

After merge, tagging `cli-v0.8.1` triggers `cli-release.yml` to publish the GHCR
images, compose bundle, and CLI binaries, and to move `:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)