### PR TITLE
feat(server,compose): provision the LDAP outpost automatically

### DIFF
--- a/packages/compose/.env.example
+++ b/packages/compose/.env.example
@@ -127,12 +127,13 @@ HOLA_AUTHENTIK_API_TOKEN=
 # HOLA_AUTHENTIK_URL=http://authentik-server:9000
 # HOLA_AUTHENTIK_PUBLIC_URL=https://auth.local.hola
 
-# LDAP (only for `native-ldap` apps). Base DN of the shared directory, and the
-# token of the LDAP outpost you create in Authentik (one-time; see README). Leave
-# the token blank until you've created the outpost — the authentik-ldap container
-# exits on an empty token, which is why it sits behind its own `authentik-ldap`
-# compose profile rather than starting with the rest of the Authentik stack.
-# To enable it: create the outpost, set the token below, then append
-# `authentik-ldap` to COMPOSE_PROFILES (e.g. COMPOSE_PROFILES=authentik,authentik-ldap).
+# LDAP (serves `native-ldap` apps). Base DN of the shared directory.
+#
+# AUTHENTIK_LDAP_OUTPOST_TOKEN is AUTO-MANAGED — leave it blank. The server
+# provisions the LDAP provider and outpost against Authentik at startup, and
+# install.sh writes the resulting token here and starts the outpost. This happens
+# on install and on every `hola update`, so a token that was rotated or lost is
+# re-synced on the next run. Setting it by hand is only useful if you point Hola
+# at an outpost you manage yourself.
 HOLA_AUTHENTIK_LDAP_BASE_DN=dc=hola,dc=internal
 AUTHENTIK_LDAP_OUTPOST_TOKEN=

--- a/packages/compose/docker-compose.yml
+++ b/packages/compose/docker-compose.yml
@@ -265,15 +265,17 @@ services:
       - authentik-certs:/certs
 
   # LDAP outpost — serves the shared directory that `native-ldap` apps bind to,
-  # reachable internally on the `hola` network at authentik-ldap:3389. Requires a
-  # one-time setup: create an LDAP provider + outpost in Authentik and copy the
-  # outpost token into AUTHENTIK_LDAP_OUTPOST_TOKEN (see README "Authentication & SSO").
+  # reachable internally on the `hola` network at authentik-ldap:3389. The LDAP
+  # provider, the outpost, and its token are all provisioned by the server at
+  # startup (ProvisionerService.ensureLdapOutpost) — no manual Authentik setup.
   #
-  # Deliberately on its OWN profile, not `authentik`: the outpost exits 1 on an
-  # empty AUTHENTIK_TOKEN, so enabling it by default crash-loops on every SSO
-  # install until that manual setup is done. Enable it only once you've created
-  # the outpost AND you're installing an app that declares `auth.mode:
-  # native-ldap` — add `authentik-ldap` to COMPOSE_PROFILES in .env.
+  # Its own `authentik-ldap` profile is a STAGING mechanism, not an operator
+  # switch. The outpost exits 1 on an empty AUTHENTIK_TOKEN, and that token only
+  # exists once Authentik is up and the server has provisioned the outpost — so it
+  # cannot be present on the first `up`. install.sh therefore brings the stack up
+  # without this service, reads the token the server minted, writes it to .env, and
+  # only then activates the profile. Operators never set either by hand; both
+  # install and upgrade converge on a running outpost automatically.
   authentik-ldap:
     image: ghcr.io/goauthentik/ldap:2025.10
     container_name: authentik-ldap

--- a/packages/compose/scripts/install.sh
+++ b/packages/compose/scripts/install.sh
@@ -77,6 +77,23 @@ if [[ "$AUTH_MODE" == "authentik" ]]; then
   fi
 fi
 
+# --- LDAP staging -------------------------------------------------------------
+# The outpost exits 1 on an empty AUTHENTIK_TOKEN, and that token only exists once
+# Authentik is up and the server has provisioned the outpost — so it cannot be set
+# on a first `up`. Hold the service back until we have the token (wired below,
+# after the stack is running); a stale profile with a blank token would otherwise
+# restart-loop indefinitely. Compose can't guard this itself: `${VAR:?}` is
+# evaluated before profile filtering, so it would break every non-LDAP install.
+if [[ "$AUTH_MODE" == "authentik" && -z "$(env_get AUTHENTIK_LDAP_OUTPOST_TOKEN | xargs || true)" ]]; then
+  staged_profiles="$(env_get COMPOSE_PROFILES | xargs || true)"
+  if [[ ",${staged_profiles}," == *",authentik-ldap,"* ]]; then
+    # Strip just this profile, preserving the rest and their order.
+    stripped="$(printf '%s' "$staged_profiles" | tr ',' '\n' | grep -vx 'authentik-ldap' | paste -sd, -)"
+    env_set COMPOSE_PROFILES "$stripped"
+    echo "[install] LDAP outpost token not issued yet — starting without it; will wire it up below."
+  fi
+fi
+
 # --- TLS challenge sanity check ----------------------------------------------
 # DNS-01 (for private/homelab hosts) is opt-in via ACME_DNS_PROVIDER; _common.sh
 # auto-includes the overlay. Warn early if the provider is set but credentials are
@@ -141,6 +158,45 @@ if [[ "${HOLA_BUILD:-}" == "1" || "${HOLA_BUILD:-}" == "true" ]]; then
   "$SCRIPT_DIR/up.sh" --build
 else
   "$SCRIPT_DIR/up.sh"
+fi
+
+# --- LDAP outpost wiring ------------------------------------------------------
+# The server provisions the LDAP provider + outpost against Authentik on startup
+# and writes the outpost's token under its data root. Collect it here and hand it
+# to the container, so LDAP comes up on its own like every other component rather
+# than needing a click-through in the Authentik UI.
+#
+# Authentik's first boot (migrations + worker bootstrap) can take minutes, so poll
+# rather than assume. Never fatal: the rest of the stack is already serving, and a
+# later run (any `hola update`) picks the token up.
+if [[ "$AUTH_MODE" == "authentik" ]]; then
+  ldap_token="$(env_get AUTHENTIK_LDAP_OUTPOST_TOKEN | xargs || true)"
+  if [[ -z "$ldap_token" ]]; then
+    echo "[install] Waiting for the LDAP outpost token (Authentik first boot can take a few minutes)…"
+    for _ in $(seq 1 60); do
+      ldap_token="$(docker compose exec -T server cat /data/config/ldap-outpost-token 2>/dev/null | tr -d '\r\n' || true)"
+      [[ -n "$ldap_token" ]] && break
+      sleep 5
+    done
+  fi
+
+  if [[ -n "$ldap_token" ]]; then
+    if [[ "$(env_get AUTHENTIK_LDAP_OUTPOST_TOKEN | xargs || true)" != "$ldap_token" ]]; then
+      env_set AUTHENTIK_LDAP_OUTPOST_TOKEN "$ldap_token"
+      echo "[install]   stored the LDAP outpost token in .env"
+    fi
+    # Activate the profile now that the token exists, then start just this service.
+    profiles="$(env_get COMPOSE_PROFILES | xargs || true)"
+    if [[ ",$profiles," != *",authentik-ldap,"* ]]; then
+      env_set COMPOSE_PROFILES "${profiles:+${profiles},}authentik-ldap"
+    fi
+    echo "[install] Starting the LDAP outpost"
+    "$SCRIPT_DIR/up.sh" authentik-ldap
+  else
+    echo "[install] WARNING: the LDAP outpost token was not issued in time. The rest of the" >&2
+    echo "[install]   stack is up; LDAP stays off until the next run. Check 'docker compose" >&2
+    echo "[install]   logs server' for LDAP provisioning errors." >&2
+  fi
 fi
 
 # Credential hints. Skipped when invoked by `hola bootstrap` (HOLA_BOOTSTRAP=1):

--- a/packages/compose/scripts/install.sh
+++ b/packages/compose/scripts/install.sh
@@ -173,8 +173,14 @@ if [[ "$AUTH_MODE" == "authentik" ]]; then
   ldap_token="$(env_get AUTHENTIK_LDAP_OUTPOST_TOKEN | xargs || true)"
   if [[ -z "$ldap_token" ]]; then
     echo "[install] Waiting for the LDAP outpost token (Authentik first boot can take a few minutes)…"
+    # Address the container by its fixed name rather than `docker compose exec`:
+    # install.sh runs in the caller's cwd and, unlike up.sh, doesn't source
+    # _common.sh — so it has neither the compose file paths nor
+    # COMPOSE_PROJECT_NAME. A bare `docker compose` here would infer the project
+    # from the directory name and find nothing whenever the install dir isn't
+    # literally "hola".
     for _ in $(seq 1 60); do
-      ldap_token="$(docker compose exec -T server cat /data/config/ldap-outpost-token 2>/dev/null | tr -d '\r\n' || true)"
+      ldap_token="$(docker exec hola-server cat /data/config/ldap-outpost-token 2>/dev/null | tr -d '\r\n' || true)"
       [[ -n "$ldap_token" ]] && break
       sleep 5
     done

--- a/packages/server/src/__tests__/deployments/auth-provisioning.test.ts
+++ b/packages/server/src/__tests__/deployments/auth-provisioning.test.ts
@@ -149,6 +149,10 @@ class SpyProvisioner implements ProvisionerService {
   async ensureBootstrapAdmin(): Promise<{ created: boolean; recoveryLink?: string }> {
     return { created: false };
   }
+
+  async ensureLdapOutpost(): Promise<{ token: string; baseDn: string }> {
+    return { token: 'spy-ldap-outpost-token', baseDn: 'dc=hola,dc=internal' };
+  }
 }
 
 async function waitForJob(jobs: RealJobService, id: string, timeoutMs = 5000) {

--- a/packages/server/src/__tests__/provisioner/ldap-outpost.test.ts
+++ b/packages/server/src/__tests__/provisioner/ldap-outpost.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Contract tests for automatic LDAP outpost provisioning.
+ *
+ * The `authentik-ldap` container authenticates with an outpost token that only
+ * exists after Authentik is running. Creating the provider + outpost used to be a
+ * manual click-through, and an empty token makes the outpost exit and restart-loop
+ * — so this path is what turns LDAP into a component that comes up on its own.
+ *
+ * Asserts the documented Authentik REST calls against a mocked `fetch`: reuse
+ * before create (so upgrades don't duplicate), the token read via `view_key`, and
+ * that it authenticates with the ADMIN bootstrap token rather than widening the
+ * least-privilege scoped account. No live Authentik.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+
+import { RealAuthentikProvisionerService } from '../../services/core/provisioner';
+import type { AuthConfig } from '../../config/auth';
+
+const BOOTSTRAP_TOKEN = 'admin-bootstrap-token';
+
+const CONFIG: AuthConfig = {
+  mode: 'authentik',
+  authentikUrl: 'http://authentik-server:9000',
+  authentikPublicUrl: 'https://auth.example.com',
+  authentikBootstrapToken: BOOTSTRAP_TOKEN,
+  fetchTimeoutMs: 5000,
+  ldapHost: 'authentik-ldap',
+  ldapPort: '3389',
+  ldapBaseDn: 'dc=hola,dc=internal',
+};
+
+interface RecordedCall {
+  method: string;
+  path: string;
+  search: URLSearchParams;
+  body?: Record<string, unknown>;
+  authorization?: string;
+}
+
+let calls: RecordedCall[] = [];
+let originalFetch: typeof globalThis.fetch;
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+}
+
+/** `existingOutpost` toggles between the fresh-provision and reuse paths. */
+function installFetch(opts: {
+  existingProvider?: boolean;
+  existingOutpost?: { providers: number[] } | null;
+  tokenKey?: string;
+} = {}) {
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = new URL(typeof input === 'string' ? input : input.toString());
+    const method = (init?.method ?? 'GET').toUpperCase();
+    const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : undefined;
+    calls.push({
+      method,
+      path: url.pathname,
+      search: url.searchParams,
+      body,
+      authorization: (init?.headers as Record<string, string> | undefined)?.Authorization,
+    });
+
+    if (method === 'GET' && url.pathname === '/api/v3/providers/ldap/') {
+      return json({ results: opts.existingProvider ? [{ pk: 99 }] : [] });
+    }
+    if (method === 'GET' && url.pathname.startsWith('/api/v3/flows/instances/')) {
+      return json({ pk: 'flow-authorization' });
+    }
+    if (method === 'POST' && url.pathname === '/api/v3/providers/ldap/') {
+      return json({ pk: 99 }, 201);
+    }
+    if (method === 'GET' && url.pathname === '/api/v3/outposts/instances/') {
+      return json({
+        results: opts.existingOutpost
+          ? [{ pk: 'outpost-uuid', token_identifier: 'ak-outpost-id', providers: opts.existingOutpost.providers }]
+          : [],
+      });
+    }
+    if (method === 'POST' && url.pathname === '/api/v3/outposts/instances/') {
+      return json({ pk: 'outpost-uuid', token_identifier: 'ak-outpost-id', providers: [99] }, 201);
+    }
+    if (method === 'PATCH' && url.pathname.startsWith('/api/v3/outposts/instances/')) {
+      return json({ pk: 'outpost-uuid', token_identifier: 'ak-outpost-id' });
+    }
+    if (method === 'GET' && url.pathname === '/api/v3/core/tokens/ak-outpost-id/view_key/') {
+      return json({ key: opts.tokenKey ?? 'outpost-secret-token' });
+    }
+    return json({ detail: `unexpected ${method} ${url.pathname}` }, 500);
+  }) as typeof globalThis.fetch;
+}
+
+function find(method: string, path: string): RecordedCall | undefined {
+  return calls.find((c) => c.method === method && c.path === path);
+}
+
+describe('ensureLdapOutpost', () => {
+  beforeEach(() => {
+    calls = [];
+    originalFetch = globalThis.fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test('provisions provider + outpost and returns the token on a fresh install', async () => {
+    installFetch();
+    const svc = new RealAuthentikProvisionerService(CONFIG);
+
+    const result = await svc.ensureLdapOutpost();
+
+    expect(result.token).toBe('outpost-secret-token');
+    expect(result.baseDn).toBe('dc=hola,dc=internal');
+
+    // Provider carries the configured base DN and a resolved authorization flow.
+    const createProvider = find('POST', '/api/v3/providers/ldap/');
+    expect(createProvider?.body).toMatchObject({
+      name: 'hola-ldap',
+      base_dn: 'dc=hola,dc=internal',
+      authorization_flow: 'flow-authorization',
+    });
+
+    // Outpost is type ldap and bound to that provider.
+    const createOutpost = find('POST', '/api/v3/outposts/instances/');
+    expect(createOutpost?.body).toMatchObject({ name: 'hola-ldap', type: 'ldap', providers: [99] });
+
+    // Token is read back by identifier — Authentik never returns keys on list.
+    expect(find('GET', '/api/v3/core/tokens/ak-outpost-id/view_key/')).toBeDefined();
+  });
+
+  test('reuses an existing provider and outpost instead of duplicating them', async () => {
+    installFetch({ existingProvider: true, existingOutpost: { providers: [99] } });
+    const svc = new RealAuthentikProvisionerService(CONFIG);
+
+    const result = await svc.ensureLdapOutpost();
+
+    expect(result.token).toBe('outpost-secret-token');
+    // Re-running on every upgrade must not create a second provider/outpost.
+    expect(find('POST', '/api/v3/providers/ldap/')).toBeUndefined();
+    expect(find('POST', '/api/v3/outposts/instances/')).toBeUndefined();
+    // Binding already correct, so no needless PATCH either.
+    expect(calls.some((c) => c.method === 'PATCH')).toBe(false);
+  });
+
+  test('re-attaches the provider when an existing outpost lost its binding', async () => {
+    installFetch({ existingProvider: true, existingOutpost: { providers: [] } });
+    const svc = new RealAuthentikProvisionerService(CONFIG);
+
+    await svc.ensureLdapOutpost();
+
+    // Otherwise the outpost would serve an empty directory tree.
+    const patch = calls.find((c) => c.method === 'PATCH' && c.path.startsWith('/api/v3/outposts/instances/'));
+    expect(patch?.body).toMatchObject({ providers: [99] });
+  });
+
+  test('authenticates with the admin bootstrap token, not the scoped account', async () => {
+    installFetch();
+    const svc = new RealAuthentikProvisionerService(CONFIG);
+
+    await svc.ensureLdapOutpost();
+
+    // Reading a token key and creating outposts are broader rights than
+    // day-to-day provisioning; keeping them on the bootstrap token means the
+    // least-privilege scoped account stays exactly as narrow as it already is.
+    expect(calls.length).toBeGreaterThan(0);
+    for (const call of calls) {
+      expect(call.authorization).toBe(`Bearer ${BOOTSTRAP_TOKEN}`);
+    }
+  });
+
+  test('fails clearly when no bootstrap token is configured', async () => {
+    installFetch();
+    const svc = new RealAuthentikProvisionerService({ ...CONFIG, authentikBootstrapToken: undefined });
+
+    await expect(svc.ensureLdapOutpost()).rejects.toThrow(/bootstrap token/i);
+  });
+
+  test('rejects an empty token rather than wiring one that crash-loops the outpost', async () => {
+    installFetch({ tokenKey: '' });
+    const svc = new RealAuthentikProvisionerService(CONFIG);
+
+    // An empty AUTHENTIK_TOKEN is precisely what makes the container exit and
+    // restart forever, so it must never be written to .env as if it succeeded.
+    await expect(svc.ensureLdapOutpost()).rejects.toThrow(/empty LDAP outpost token/i);
+  });
+});

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -78,6 +78,7 @@ import { mapErrorToResponse, asPromoteValidationError } from './middleware/error
 // Phase 3: Authentication imports
 import { createAuthMiddleware, getPrincipal, SESSION_COOKIE } from './middleware/auth';
 import { resolveOidcConfig, setProvisionedOidc } from './config/oidc';
+import { ldapOutpostTokenPath, persistLdapOutpostToken } from './services/auth/ldap-outpost-config';
 import { authConfig } from './config/auth';
 
 
@@ -1977,6 +1978,19 @@ async function initializePlatformAuth(): Promise<void> {
             `=== Hola admin setup: open this one-time link to set your password ===\n${admin.recoveryLink}`,
           );
         }
+      }
+      // Ensure the shared LDAP directory and hand its outpost token to the host.
+      // Separately guarded: LDAP is one component of the stack, and a backend that
+      // can't serve it must not fail (or retry) the dashboard OIDC provisioning
+      // that just succeeded. install.sh picks the token up on this or a later run.
+      try {
+        const ldap = await provisioner.ensureLdapOutpost();
+        persistLdapOutpostToken(ldap.token);
+        logger.info('LDAP outpost ready', { baseDn: ldap.baseDn, path: ldapOutpostTokenPath() });
+      } catch (error) {
+        logger.warn('Could not provision the LDAP outpost; retrying on the next start', {
+          error: error instanceof Error ? error.message : String(error),
+        });
       }
       return;
     } catch (error) {

--- a/packages/server/src/services/auth/ldap-outpost-config.ts
+++ b/packages/server/src/services/auth/ldap-outpost-config.ts
@@ -1,0 +1,60 @@
+/**
+ * Persistence for the shared LDAP outpost's API token.
+ *
+ * The `authentik-ldap` container authenticates with a token that only exists once
+ * Authentik is running and its outpost has been provisioned — so it cannot be in
+ * `.env` at first boot, which is exactly why LDAP used to require a manual
+ * click-through and would restart-loop on an empty token until someone did it.
+ *
+ * The server mints the token during platform-auth startup and writes it here,
+ * under the data root the host shares with the container. install.sh reads it back
+ * out after the stack is up and wires it into `.env`, so install and upgrade both
+ * converge on a working outpost with no operator involvement.
+ *
+ * Mirrors the admin-API-key bootstrap (see api-key-config.ts): mode 0600, the
+ * location is logged but never the secret.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
+
+import { getHolaDataDir } from '../../config/paths';
+import { getLogger } from '../../lib/logger';
+
+const LDAP_TOKEN_PATH = ['config', 'ldap-outpost-token'];
+
+/** Path of the persisted LDAP outpost token under the configured data root. */
+export function ldapOutpostTokenPath(): string {
+  return join(getHolaDataDir(), ...LDAP_TOKEN_PATH);
+}
+
+/**
+ * Persist the outpost token, returning whether it changed. Rewriting an identical
+ * token is skipped so a routine restart doesn't churn the file that install.sh
+ * diffs against `.env`.
+ */
+export function persistLdapOutpostToken(token: string): boolean {
+  const logger = getLogger().child({ service: 'LdapOutpostConfig' });
+  const path = ldapOutpostTokenPath();
+  if (readLdapOutpostToken() === token) return false;
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, token, { mode: 0o600 });
+    logger.info('Persisted LDAP outpost token', { path });
+    return true;
+  } catch (error) {
+    logger.error('Failed to persist the LDAP outpost token', error as Error);
+    return false;
+  }
+}
+
+/** The persisted outpost token, or undefined when it has never been provisioned. */
+export function readLdapOutpostToken(): string | undefined {
+  const path = ldapOutpostTokenPath();
+  if (!existsSync(path)) return undefined;
+  try {
+    return readFileSync(path, 'utf8').trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/server/src/services/core/provisioner.ts
+++ b/packages/server/src/services/core/provisioner.ts
@@ -146,6 +146,21 @@ export interface ProvisionerService extends HealthCheckable {
    * No-op when no admin email is configured.
    */
   ensureBootstrapAdmin(adminGroup: string): Promise<{ created: boolean; recoveryLink?: string }>;
+  /**
+   * Idempotently ensure the platform's shared LDAP directory exists — an LDAP
+   * provider bound to an outpost — and return that outpost's API token.
+   *
+   * The token is what the `authentik-ldap` container authenticates with; without
+   * it the outpost exits immediately and restart-loops. Creating the provider and
+   * outpost used to be a manual one-time click-through in Authentik, which made
+   * LDAP the only part of the stack that didn't come up on its own. Returning the
+   * token here lets install/upgrade wire the container automatically.
+   *
+   * Stable identifiers make this safe to re-run: an existing provider/outpost is
+   * reused and its current token returned, so an upgrade re-syncs a token that was
+   * rotated or lost without disturbing a working directory.
+   */
+  ensureLdapOutpost(): Promise<{ token: string; baseDn: string }>;
   healthCheck(): Promise<ServiceHealth>;
 }
 
@@ -166,6 +181,10 @@ const INVALIDATION_FLOW_SLUG = 'default-provider-invalidation-flow';
 // privilege instead of as the akadmin superuser.
 const PROVISIONER_USERNAME = 'hola-provisioner';
 const PROVISIONER_TOKEN_ID = 'hola-provisioner-token';
+
+// Fixed identifiers for the platform's shared LDAP directory (stable → idempotent).
+const LDAP_PROVIDER_NAME = 'hola-ldap';
+const LDAP_OUTPOST_NAME = 'hola-ldap';
 
 // Global (model-level) permissions the provisioner needs — just enough to manage
 // providers/applications/users/outposts and read flows/scope mappings. NOT superuser.
@@ -1222,6 +1241,109 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
     };
   }
 
+  /**
+   * Ensure the shared LDAP provider + outpost, returning the outpost's token.
+   *
+   * Runs against the ADMIN bootstrap token rather than the scoped provisioning
+   * token: reading a token's key (`view_key`) and creating outposts are broader
+   * rights than day-to-day provisioning needs, and this runs once at startup. That
+   * keeps the least-privilege scoped account exactly as narrow as it already is.
+   */
+  async ensureLdapOutpost(): Promise<{ token: string; baseDn: string }> {
+    const bootstrapToken = this.config.authentikBootstrapToken;
+    if (!bootstrapToken) {
+      throw new ProvisioningError(
+        'Cannot provision the LDAP outpost: no Authentik admin bootstrap token is configured',
+      );
+    }
+    const baseDn = this.config.ldapBaseDn;
+    const providerPk = await this.ensureLdapProvider(bootstrapToken, baseDn);
+    const outpost = await this.ensureLdapOutpostInstance(bootstrapToken, providerPk);
+    const token = await this.readTokenKey(bootstrapToken, outpost.tokenIdentifier);
+    this.logger.info('Ensured LDAP outpost', { providerPk, outpostPk: outpost.pk, baseDn });
+    return { token, baseDn };
+  }
+
+  private async ensureLdapProvider(bootstrapToken: string, baseDn: string): Promise<number> {
+    const existing = await this.request<{ results: Array<{ pk: number }> }>(
+      bootstrapToken,
+      'GET',
+      `/api/v3/providers/ldap/?name=${encodeURIComponent(LDAP_PROVIDER_NAME)}`,
+    );
+    if (existing.results?.[0]?.pk != null) return existing.results[0].pk;
+
+    // The LDAP provider binds against the same authorization flow the OIDC
+    // providers resolve, so a version whose default slug differs still works.
+    const authFlow = await this.resolveFlowPkWith(bootstrapToken, AUTHZ_FLOW_SLUG, 'authorization');
+    const created = await this.request<{ pk: number }>(bootstrapToken, 'POST', '/api/v3/providers/ldap/', {
+      name: LDAP_PROVIDER_NAME,
+      authorization_flow: authFlow,
+      base_dn: baseDn,
+    });
+    return created.pk;
+  }
+
+  private async ensureLdapOutpostInstance(
+    bootstrapToken: string,
+    providerPk: number,
+  ): Promise<{ pk: string; tokenIdentifier: string }> {
+    type Outpost = { pk: string; token_identifier: string; providers?: number[] };
+    const existing = await this.request<{ results: Outpost[] }>(
+      bootstrapToken,
+      'GET',
+      `/api/v3/outposts/instances/?name__iexact=${encodeURIComponent(LDAP_OUTPOST_NAME)}`,
+    );
+    const found = existing.results?.[0];
+    if (found) {
+      // Re-attach the provider if a previous run created the outpost but the
+      // binding was later removed — otherwise the outpost serves an empty tree.
+      if (!found.providers?.includes(providerPk)) {
+        await this.request(bootstrapToken, 'PATCH', `/api/v3/outposts/instances/${found.pk}/`, {
+          providers: [...new Set([...(found.providers ?? []), providerPk])],
+        });
+      }
+      return { pk: found.pk, tokenIdentifier: found.token_identifier };
+    }
+
+    // `docker` would have Authentik spawn its own container via the socket; Hola
+    // runs the outpost itself, so the managed connection stays deliberately unset.
+    const created = await this.request<Outpost>(bootstrapToken, 'POST', '/api/v3/outposts/instances/', {
+      name: LDAP_OUTPOST_NAME,
+      type: 'ldap',
+      providers: [providerPk],
+      config: {},
+    });
+    return { pk: created.pk, tokenIdentifier: created.token_identifier };
+  }
+
+  /** Read a token's secret by identifier (Authentik never returns keys on list). */
+  private async readTokenKey(bootstrapToken: string, identifier: string): Promise<string> {
+    if (!identifier) throw new ProvisioningError('LDAP outpost has no token identifier');
+    const res = await this.request<{ key: string }>(
+      bootstrapToken,
+      'GET',
+      `/api/v3/core/tokens/${encodeURIComponent(identifier)}/view_key/`,
+    );
+    if (!res.key) throw new ProvisioningError('Authentik returned an empty LDAP outpost token');
+    return res.key;
+  }
+
+  /** resolveFlowPk against an explicit token (the scoped one may not exist yet). */
+  private async resolveFlowPkWith(token: string, slug: string, designation: string): Promise<string> {
+    try {
+      const flow = await this.request<{ pk: string }>(token, 'GET', `/api/v3/flows/instances/${encodeURIComponent(slug)}/`);
+      return flow.pk;
+    } catch (error) {
+      const list = await this.request<{ results: Array<{ pk: string }> }>(
+        token,
+        'GET',
+        `/api/v3/flows/instances/?designation=${encodeURIComponent(designation)}&ordering=slug`,
+      );
+      if (list.results?.[0]?.pk) return list.results[0].pk;
+      throw error;
+    }
+  }
+
   /** Grant the bind account directory-search rights. Best-effort: the permission
    *  codename can vary by Authentik version, so a failure is logged, not fatal. */
   private async grantLdapSearch(userPk: number): Promise<void> {
@@ -1615,6 +1737,11 @@ export class MockProvisionerService implements ProvisionerService {
     this.logger.debug('Mock ensureBootstrapAdmin', { adminGroup });
     return { created: false };
   }
+
+  async ensureLdapOutpost(): Promise<{ token: string; baseDn: string }> {
+    this.logger.debug('Mock ensureLdapOutpost');
+    return { token: 'mock-ldap-outpost-token', baseDn: 'dc=hola,dc=internal' };
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -1697,5 +1824,12 @@ export class NoneProvisionerService implements ProvisionerService {
 
   async ensureBootstrapAdmin(): Promise<{ created: boolean; recoveryLink?: string }> {
     return { created: false };
+  }
+
+  /** No auth backend, so there is no directory to serve and nothing to wire. */
+  async ensureLdapOutpost(): Promise<{ token: string; baseDn: string }> {
+    throw new ProvisioningError(
+      'Cannot provision an LDAP outpost without an auth backend (HOLA_AUTH_MODE is not authentik)',
+    );
   }
 }


### PR DESCRIPTION
LDAP was the one part of the stack that didn't come up on its own.

The `authentik-ldap` container authenticates with an outpost token, and creating
that outpost — an LDAP provider, an outpost bound to it, and its token — was a
manual click-through in the Authentik UI. Until someone did it,
`AUTHENTIK_LDAP_OUTPOST_TOKEN` stayed blank, the outpost exited on an empty token,
and `restart: unless-stopped` turned that into an endless restart loop.

#372 responded by moving the service onto its own profile. That stopped *non-LDAP*
installs from crash-looping, but left LDAP itself unusable without manual setup —
and anyone who did enable it still hit the original loop. This provisions it like
every other component instead.

## Server

`ProvisionerService.ensureLdapOutpost()` idempotently ensures the LDAP provider and
outpost and returns the outpost's token, read back via `view_key` (Authentik never
returns keys on list).

- **Idempotent by stable identifier** — re-running reuses what exists, so an upgrade
  re-syncs a token that was rotated or lost without disturbing a working directory.
- **Self-repairing** — an outpost that lost its provider binding is re-attached
  rather than left serving an empty tree.
- **No permission creep** — runs against the ADMIN bootstrap token, since creating
  outposts and reading token keys are broader rights than day-to-day provisioning.
  The least-privilege scoped account stays exactly as narrow as it was.

Startup persists the token under the data root (0600, mirroring the admin-API-key
bootstrap), in its own try/catch so a backend that can't serve LDAP never fails —
or retries — the dashboard OIDC provisioning that just succeeded.

## Compose

The `authentik-ldap` profile stops being an operator switch and becomes a **staging
mechanism**. The token cannot exist on a first `up`, so `install.sh`:

1. holds the service back while the token is blank,
2. brings the stack up,
3. polls the server for the minted token (Authentik first boot can take minutes),
4. writes it to `.env`, activates the profile, and starts the outpost.

Both install and `hola update` run `install.sh`, so both converge on a working
outpost with no operator involvement. `AUTHENTIK_LDAP_OUTPOST_TOKEN` is now
documented as auto-managed.

Compose can't guard this itself: `${VAR:?}` is evaluated *before* profile filtering,
so it would break every install that doesn't run LDAP — which is why the check lives
in `install.sh`, where the profile state is known.

Nothing here is fatal: the rest of the stack is already serving, and a later run
picks the token up.

## Tests

6 new contract tests (`provisioner/ldap-outpost.test.ts`) against a mocked fetch:

- fresh install creates provider + outpost with the configured base DN and returns the token
- re-run reuses both — no duplicate provider/outpost, and no needless PATCH
- an outpost that lost its binding gets the provider re-attached
- every call authenticates with the bootstrap token, not the scoped account
- a missing bootstrap token fails with a clear message
- an empty token is rejected rather than written to `.env` as if it succeeded

I also round-tripped the `install.sh` profile staging across six permutations
(including empty and sole-profile) to confirm no stray commas.

## Verification

`bun run typecheck` · `lint` · `test` · `build` all pass (619 server, 222 web).

**Not yet exercised against a live Authentik.** The REST shapes are covered by
contract tests, but the provider/outpost payloads and `view_key` behaviour deserve a
real run — `bin/vm-catalog-test` on an Authentik VM would do it. Worth doing before
release given this touches first-boot provisioning.

Note: no catalog app declares `auth.mode: native-ldap` today, so this currently
serves custom/self-hosted apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)