### PR TITLE
chore(release): 0.8.2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/cli": {
       "name": "@hola/cli",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "bin": {
         "hola": "./bin/hola",
       },
@@ -37,11 +37,11 @@
     },
     "packages/compose": {
       "name": "@hola/compose",
-      "version": "0.8.1",
+      "version": "0.8.2",
     },
     "packages/sdk": {
       "name": "@hola/sdk",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "dependencies": {
         "@hola/shared": "workspace:*",
       },
@@ -55,7 +55,7 @@
     },
     "packages/server": {
       "name": "@hola/server",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "dependencies": {
         "@hola/shared": "workspace:*",
         "jose": "^6.2.3",
@@ -71,7 +71,7 @@
     },
     "packages/shared": {
       "name": "@hola/shared",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "dependencies": {
         "yaml": "^2.9.0",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.8.1';
+export const CLI_VERSION = '0.8.2';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Patch release cutting the automatic LDAP outpost provisioning from #398.

Bumps `cli`, `compose`, `sdk`, `server`, and `shared` to `0.8.2`, plus
`packages/cli/src/version.ts` and `bun.lock` — the same 7-file footprint as
previous release commits. No functional changes in this PR.

## Included

- **feat(server,compose): provision the LDAP outpost automatically (#398)** — the
  LDAP provider, its outpost, and the outpost token are now provisioned by the
  server against Authentik at startup, and `install.sh` wires the token into the
  container. Previously this was a manual click-through in the Authentik UI, and
  until someone did it the outpost exited on an empty token and restart-looped
  under `restart: unless-stopped`. Provisioning is idempotent, so a token that was
  rotated or lost is re-synced rather than duplicated.

## Upgrade notes

`hola update` performs the wiring — there is no manual step. On an install whose
LDAP was previously restart-looping, the update stops the loop first (the outpost
is held back while the token is blank), brings the stack up, then starts the
outpost once the token has been issued.

`AUTHENTIK_LDAP_OUTPOST_TOKEN` is now auto-managed. Leave it blank unless you point
Hola at an outpost you provision yourself.

Authentik's first boot can take minutes, so the token wait polls for up to five
minutes. If it isn't issued in time the rest of the stack still comes up and the
next run completes the wiring.

## Verification

`bun run typecheck` · `lint` · `test` · `build` all pass locally
(619 server tests, 222 web tests). Built CLI reports `hola, 0.8.2`.

Note: the Authentik REST calls are covered by contract tests against a mocked
fetch, but have **not** been exercised against a live Authentik — this release is
going out so that can be tried on a real install.

After merge, tagging `cli-v0.8.2` triggers `cli-release.yml` to publish the GHCR
images, compose bundle, and CLI binaries, and to move `:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)