### PR TITLE
fix(server): pass invalidation_flow when creating the LDAP provider

### DIFF
--- a/packages/server/src/__tests__/provisioner/ldap-outpost.test.ts
+++ b/packages/server/src/__tests__/provisioner/ldap-outpost.test.ts
@@ -67,7 +67,9 @@ function installFetch(opts: {
       return json({ results: opts.existingProvider ? [{ pk: 99 }] : [] });
     }
     if (method === 'GET' && url.pathname.startsWith('/api/v3/flows/instances/')) {
-      return json({ pk: 'flow-authorization' });
+      // Distinct pks per slug so the assertions prove BOTH flows were resolved.
+      const slug = url.pathname.split('/').filter(Boolean).pop() ?? '';
+      return json({ pk: slug.includes('invalidation') ? 'flow-invalidation' : 'flow-authorization' });
     }
     if (method === 'POST' && url.pathname === '/api/v3/providers/ldap/') {
       return json({ pk: 99 }, 201);
@@ -114,13 +116,20 @@ describe('ensureLdapOutpost', () => {
     expect(result.token).toBe('outpost-secret-token');
     expect(result.baseDn).toBe('dc=hola,dc=internal');
 
-    // Provider carries the configured base DN and a resolved authorization flow.
+    // Provider carries the configured base DN and BOTH resolved flows.
+    // invalidation_flow is required on providers from Authentik 2024.10 —
+    // omitting it 400s, which silently leaves the outpost unprovisioned.
     const createProvider = find('POST', '/api/v3/providers/ldap/');
     expect(createProvider?.body).toMatchObject({
       name: 'hola-ldap',
       base_dn: 'dc=hola,dc=internal',
       authorization_flow: 'flow-authorization',
+      invalidation_flow: 'flow-invalidation',
     });
+
+    // Looked up with the same filter every other provider lookup uses; a bare
+    // `?name=` is not a supported filter and would not narrow the list.
+    expect(find('GET', '/api/v3/providers/ldap/')?.search.get('name__iexact')).toBe('hola-ldap');
 
     // Outpost is type ldap and bound to that provider.
     const createOutpost = find('POST', '/api/v3/outposts/instances/');

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1988,8 +1988,13 @@ async function initializePlatformAuth(): Promise<void> {
         persistLdapOutpostToken(ldap.token);
         logger.info('LDAP outpost ready', { baseDn: ldap.baseDn, path: ldapOutpostTokenPath() });
       } catch (error) {
+        // Include Authentik's response body, not just "failed: 400". The status
+        // alone says nothing about WHICH field it rejected, and this runs
+        // unattended during startup — without the body a provisioning failure is
+        // invisible until someone notices LDAP never came up.
         logger.warn('Could not provision the LDAP outpost; retrying on the next start', {
           error: error instanceof Error ? error.message : String(error),
+          detail: (error as { details?: { body?: string } })?.details?.body,
         });
       }
       return;

--- a/packages/server/src/services/core/provisioner.ts
+++ b/packages/server/src/services/core/provisioner.ts
@@ -1268,16 +1268,22 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
     const existing = await this.request<{ results: Array<{ pk: number }> }>(
       bootstrapToken,
       'GET',
-      `/api/v3/providers/ldap/?name=${encodeURIComponent(LDAP_PROVIDER_NAME)}`,
+      `/api/v3/providers/ldap/?name__iexact=${encodeURIComponent(LDAP_PROVIDER_NAME)}`,
     );
     if (existing.results?.[0]?.pk != null) return existing.results[0].pk;
 
-    // The LDAP provider binds against the same authorization flow the OIDC
-    // providers resolve, so a version whose default slug differs still works.
-    const authFlow = await this.resolveFlowPkWith(bootstrapToken, AUTHZ_FLOW_SLUG, 'authorization');
+    // Both flows are resolved by slug with a designation fallback, so a version
+    // whose default slugs differ still works. `invalidation_flow` is REQUIRED on
+    // providers from Authentik 2024.10 — omitting it 400s, which is why every
+    // other provider this service creates (oauth2, proxy) passes it too.
+    const [authFlow, invalidationFlow] = await Promise.all([
+      this.resolveFlowPkWith(bootstrapToken, AUTHZ_FLOW_SLUG, 'authorization'),
+      this.resolveFlowPkWith(bootstrapToken, INVALIDATION_FLOW_SLUG, 'invalidation'),
+    ]);
     const created = await this.request<{ pk: number }>(bootstrapToken, 'POST', '/api/v3/providers/ldap/', {
       name: LDAP_PROVIDER_NAME,
       authorization_flow: authFlow,
+      invalidation_flow: invalidationFlow,
       base_dn: baseDn,
     });
     return created.pk;


### PR DESCRIPTION
The 0.8.2 auto-provisioning never produced a token.

`invalidation_flow` is **required** on Authentik providers from 2024.10, and the
LDAP provider POST omitted it. Authentik 400s → `ensureLdapOutpost` throws → the
token file is never written → `install.sh` polls for its full five minutes and
leaves LDAP off. That matches the reported symptom exactly (stack came up, no LDAP
container, `hola-server` up ~5 minutes = the poll timeout).

Every other provider this service creates already passes it — oauth2 (:515), the
dashboard client (:592), proxy (:699). The LDAP path was the outlier, and the
contract tests didn't catch it because a mocked fetch accepts any payload.

## Also fixed

- **Lookup filter** — `?name=` is not a supported filter on Authentik's provider
  list, so it would not have narrowed the results; `?name__iexact=` is what
  `findProvider` and the outpost lookups use. Left as-is, a later run could create
  a second provider instead of reusing the first.
- **Diagnosability** — the failure log now includes Authentik's response body, not
  just the status. `Authentik POST /api/v3/providers/ldap/ failed: 400` says
  nothing about *which* field was rejected, and this runs unattended at startup —
  which is why this failed invisibly rather than obviously.

## Tests

The existing 6 contract tests now assert the full payload: distinct flow pks per
slug prove both flows resolve, `invalidation_flow` is asserted on the create body,
and the lookup is asserted to use `name__iexact`.

## Verification

`bun run typecheck` · `lint` · `test` · `build` pass (619 server, 222 web).

**Still inferred, not confirmed against a live Authentik.** The 400-on-missing-
invalidation_flow behaviour is established by every other provider in this file
needing it, but the decisive evidence is the server log line from the failing
host. If that log shows a different rejected field, this needs another pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)