### PR TITLE
chore(release): 0.8.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/cli": {
       "name": "@hola/cli",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "bin": {
         "hola": "./bin/hola",
       },
@@ -37,11 +37,11 @@
     },
     "packages/compose": {
       "name": "@hola/compose",
-      "version": "0.8.2",
+      "version": "0.8.3",
     },
     "packages/sdk": {
       "name": "@hola/sdk",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "dependencies": {
         "@hola/shared": "workspace:*",
       },
@@ -55,7 +55,7 @@
     },
     "packages/server": {
       "name": "@hola/server",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "dependencies": {
         "@hola/shared": "workspace:*",
         "jose": "^6.2.3",
@@ -71,7 +71,7 @@
     },
     "packages/shared": {
       "name": "@hola/shared",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "dependencies": {
         "yaml": "^2.9.0",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.8.2';
+export const CLI_VERSION = '0.8.3';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Patch release fixing the LDAP auto-provisioning shipped in 0.8.2, which never
produced a token against a real Authentik.

Bumps `cli`, `compose`, `sdk`, `server`, and `shared` to `0.8.3`, plus
`packages/cli/src/version.ts` and `bun.lock` — the same 7-file footprint as
previous release commits. No functional changes in this PR.

## Included

- **fix(server): pass invalidation_flow when creating the LDAP provider (#400)** —
  the field is required on Authentik providers from 2024.10 and the LDAP POST
  omitted it, so Authentik returned 400, provisioning threw, and `install.sh`
  polled for its full five minutes before leaving LDAP off. Confirmed against a
  failing host: `Authentik POST /api/v3/providers/ldap/ failed: 400`.

  Also aligns the idempotency lookup with the rest of the service
  (`?name__iexact=`; a bare `?name=` does not narrow Authentik's provider list, so
  a later run could have created a second provider), and logs Authentik's response
  body on failure so the next such rejection names its own field rather than being
  invisible.

## Upgrade notes

`hola update` re-runs the wiring, so an install that came up without LDAP on 0.8.2
converges on this release. No manual step, and nothing to clean up — the 400 meant
no partial provider or outpost was left behind.

## Verification

`bun run typecheck` · `lint` · `test` · `build` all pass locally
(619 server tests, 222 web tests). Built CLI reports `hola, 0.8.3`.

The root cause is confirmed from the failing host's logs. The corrected payload
itself is covered by contract tests against a mocked fetch — a live Authentik run
(`bin/vm-catalog-test` on an Authentik VM) is what would have caught this before
0.8.2 and is worth adding to the release routine.

After merge, tagging `cli-v0.8.3` triggers `cli-release.yml` to publish the GHCR
images, compose bundle, and CLI binaries, and to move `:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)