### PR TITLE
fix(server): back the LDAP provider with an application

### DIFF
--- a/packages/server/src/__tests__/provisioner/ldap-outpost.test.ts
+++ b/packages/server/src/__tests__/provisioner/ldap-outpost.test.ts
@@ -49,6 +49,7 @@ function json(body: unknown, status = 200): Response {
 function installFetch(opts: {
   existingProvider?: boolean;
   existingOutpost?: { providers: number[] } | null;
+  existingApplication?: { provider: number } | null;
   tokenKey?: string;
 } = {}) {
   globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
@@ -73,6 +74,17 @@ function installFetch(opts: {
     }
     if (method === 'POST' && url.pathname === '/api/v3/providers/ldap/') {
       return json({ pk: 99 }, 201);
+    }
+    if (url.pathname === '/api/v3/core/applications/hola-ldap/') {
+      if (method === 'GET') {
+        return opts.existingApplication
+          ? json({ pk: 'app-uuid', provider: opts.existingApplication.provider })
+          : json({ detail: 'Not found.' }, 404);
+      }
+      if (method === 'PATCH') return json({ pk: 'app-uuid' });
+    }
+    if (method === 'POST' && url.pathname === '/api/v3/core/applications/') {
+      return json({ pk: 'app-uuid', slug: 'hola-ldap' }, 201);
     }
     if (method === 'GET' && url.pathname === '/api/v3/outposts/instances/') {
       return json({
@@ -135,8 +147,44 @@ describe('ensureLdapOutpost', () => {
     const createOutpost = find('POST', '/api/v3/outposts/instances/');
     expect(createOutpost?.body).toMatchObject({ name: 'hola-ldap', type: 'ldap', providers: [99] });
 
+    // The provider MUST be backed by an application. Authentik only serves an
+    // outpost the providers that have one, so without this the outpost starts,
+    // authenticates, and panics with "no ldap provider defined".
+    const createApp = find('POST', '/api/v3/core/applications/');
+    expect(createApp?.body).toMatchObject({ slug: 'hola-ldap', provider: 99 });
+
     // Token is read back by identifier — Authentik never returns keys on list.
     expect(find('GET', '/api/v3/core/tokens/ak-outpost-id/view_key/')).toBeDefined();
+  });
+
+  test('re-points an application left bound to a stale provider', async () => {
+    installFetch({
+      existingProvider: true,
+      existingApplication: { provider: 7 },
+      existingOutpost: { providers: [99] },
+    });
+    const svc = new RealAuthentikProvisionerService(CONFIG);
+
+    await svc.ensureLdapOutpost();
+
+    // Otherwise the outpost keeps serving nothing after the provider is recreated.
+    const patch = calls.find((c) => c.method === 'PATCH' && c.path === '/api/v3/core/applications/hola-ldap/');
+    expect(patch?.body).toMatchObject({ provider: 99 });
+    expect(find('POST', '/api/v3/core/applications/')).toBeUndefined();
+  });
+
+  test('leaves a correctly bound application alone', async () => {
+    installFetch({
+      existingProvider: true,
+      existingApplication: { provider: 99 },
+      existingOutpost: { providers: [99] },
+    });
+    const svc = new RealAuthentikProvisionerService(CONFIG);
+
+    await svc.ensureLdapOutpost();
+
+    expect(calls.some((c) => c.path === '/api/v3/core/applications/hola-ldap/' && c.method === 'PATCH')).toBe(false);
+    expect(find('POST', '/api/v3/core/applications/')).toBeUndefined();
   });
 
   test('reuses an existing provider and outpost instead of duplicating them', async () => {

--- a/packages/server/src/services/core/provisioner.ts
+++ b/packages/server/src/services/core/provisioner.ts
@@ -185,6 +185,8 @@ const PROVISIONER_TOKEN_ID = 'hola-provisioner-token';
 // Fixed identifiers for the platform's shared LDAP directory (stable → idempotent).
 const LDAP_PROVIDER_NAME = 'hola-ldap';
 const LDAP_OUTPOST_NAME = 'hola-ldap';
+const LDAP_APP_SLUG = 'hola-ldap';
+const LDAP_APP_NAME = 'Hola LDAP Directory';
 
 // Global (model-level) permissions the provisioner needs — just enough to manage
 // providers/applications/users/outposts and read flows/scope mappings. NOT superuser.
@@ -1258,6 +1260,12 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
     }
     const baseDn = this.config.ldapBaseDn;
     const providerPk = await this.ensureLdapProvider(bootstrapToken, baseDn);
+    // Authentik only serves an outpost the providers that are backed by an
+    // application, so a provider bound to the outpost but with no application is
+    // invisible to it — the outpost starts, authenticates, then panics with
+    // "no ldap provider defined". Same provider → application → outpost chain the
+    // forward-auth path builds.
+    await this.ensureLdapApplication(bootstrapToken, providerPk);
     const outpost = await this.ensureLdapOutpostInstance(bootstrapToken, providerPk);
     const token = await this.readTokenKey(bootstrapToken, outpost.tokenIdentifier);
     this.logger.info('Ensured LDAP outpost', { providerPk, outpostPk: outpost.pk, baseDn });
@@ -1287,6 +1295,32 @@ export class RealAuthentikProvisionerService implements ProvisionerService {
       base_dn: baseDn,
     });
     return created.pk;
+  }
+
+  /**
+   * Ensure the application that backs the LDAP provider. Applications are
+   * addressed by slug, so a 404 on the lookup is the "doesn't exist yet" signal.
+   * An existing application pointing at a different provider is re-pointed rather
+   * than left stale — otherwise the outpost keeps serving nothing after the
+   * provider is recreated.
+   */
+  private async ensureLdapApplication(bootstrapToken: string, providerPk: number): Promise<void> {
+    const path = `/api/v3/core/applications/${encodeURIComponent(LDAP_APP_SLUG)}/`;
+    try {
+      const app = await this.request<{ provider?: number }>(bootstrapToken, 'GET', path);
+      if (app.provider !== providerPk) {
+        await this.request(bootstrapToken, 'PATCH', path, { provider: providerPk });
+      }
+      return;
+    } catch (error) {
+      const status = error instanceof ProvisioningError ? (error.details as { status?: number })?.status : undefined;
+      if (status !== 404) throw error;
+    }
+    await this.request(bootstrapToken, 'POST', '/api/v3/core/applications/', {
+      name: LDAP_APP_NAME,
+      slug: LDAP_APP_SLUG,
+      provider: providerPk,
+    });
   }
 
   private async ensureLdapOutpostInstance(


### PR DESCRIPTION
The 0.8.3 outpost authenticated fine but panicked on every start:

```
{"event":"Successfully connected websocket","outpost":"fd310a5f-…"}
{"error":"no ldap provider defined","event":"Failed to run server","level":"panic"}
```

That log rules a lot out: the **token is valid**, the websocket connects, and the
outpost exists. What's missing is the provider being *visible* to it.

Authentik only serves an outpost the providers that are backed by an
**application**. A provider bound to the outpost but with no application is
invisible, so the outpost starts, authenticates, finds nothing to serve, and exits
— restart-looping under `restart: unless-stopped`.

## Fix

Build the same provider → application → outpost chain the forward-auth path already
builds — it creates an application for its proxy provider (`provisioner.ts:705`) for
exactly this reason. LDAP was the only path that skipped it.

The application is ensured by slug (a 404 is the "create it" signal) and re-pointed
if found bound to a stale provider, so a recreated provider doesn't silently leave
the outpost serving nothing.

## Deliberately not changed

I did **not** pin the outpost's `config.authentik_host` the way #137 does for the
embedded outpost. That value exists to make *browser* redirects routable for
forward-auth, and LDAP performs none — the outpost connects over the container's own
`AUTHENTIK_HOST`, which the logs confirm works. Copying it here would be
cargo-culting.

## Tests

8 contract tests now (2 new):

- fresh install asserts the application is created and bound to the provider
- an application left bound to a stale provider is re-pointed, not duplicated
- a correctly bound application is left completely alone

## Verification

`bun run typecheck` · `lint` · `test` · `build` pass (621 server, 222 web).

The failure this fixes is confirmed from the host's outpost logs. The corrected
call chain is covered by contract tests against a mocked fetch — which is exactly
the gap that let the previous two attempts through, so a live Authentik run remains
the thing worth adding to the release routine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)