### PR TITLE
chore(release): 0.8.4

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/cli": {
       "name": "@hola/cli",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "bin": {
         "hola": "./bin/hola",
       },
@@ -37,11 +37,11 @@
     },
     "packages/compose": {
       "name": "@hola/compose",
-      "version": "0.8.3",
+      "version": "0.8.4",
     },
     "packages/sdk": {
       "name": "@hola/sdk",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "dependencies": {
         "@hola/shared": "workspace:*",
       },
@@ -55,7 +55,7 @@
     },
     "packages/server": {
       "name": "@hola/server",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "dependencies": {
         "@hola/shared": "workspace:*",
         "jose": "^6.2.3",
@@ -71,7 +71,7 @@
     },
     "packages/shared": {
       "name": "@hola/shared",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "dependencies": {
         "yaml": "^2.9.0",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.8.3';
+export const CLI_VERSION = '0.8.4';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Patch release completing the LDAP auto-provisioning.

Bumps `cli`, `compose`, `sdk`, `server`, and `shared` to `0.8.4`, plus
`packages/cli/src/version.ts` and `bun.lock`. No functional changes in this PR.

## Included

- **fix(server): back the LDAP provider with an application (#402)** — the 0.8.3
  outpost authenticated and connected its websocket, then panicked with
  `no ldap provider defined` on every start. Authentik only serves an outpost the
  providers that are backed by an application, so the provider was bound to the
  outpost but invisible to it. Now builds the same provider → application → outpost
  chain the forward-auth path already builds, and re-points an application found
  bound to a stale provider.

## Upgrade notes

`hola update` reconciles the existing Authentik objects in place — the provider and
outpost created by 0.8.3 are reused and gain the application they were missing. No
manual cleanup required.

## Verification

`bun run typecheck` · `lint` · `test` · `build` all pass (621 server, 222 web).
Built CLI reports `hola, 0.8.4`. Root cause confirmed from the host's outpost logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)