### PR TITLE
feat(web,server,cli): catalog-source registry consent — preview, edit, and a one-click fix

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -118,6 +118,31 @@ hola install <appId>
 The install-by-ref escape hatch (`hola install <ociRef>`) has no source, so it
 still needs either `--registry-cred` or the baseline allowlist to cover the ref.
 
+##### Fixing `REF_NOT_ALLOWED` after the fact
+
+A source added *without* `allowRegistries` fails every install from it with a 403:
+
+```
+REF_NOT_ALLOWED: ghcr.io/myorg/hola-cms:0.1.13 is not covered by the registry
+allowlist (ghcr.io/try-hola/*).
+```
+
+The source doesn't need recreating — patch it in place:
+
+```bash
+hola source update myorg --allow-registry ghcr.io/myorg/*
+```
+
+`source update` is a patch: an omitted flag leaves that field alone,
+`--allow-registry` replaces the stored glob list, and `--clear-allow-registry`
+empties it back to the baseline. In the dashboard the same fix is offered on the
+failure itself ("Allow `ghcr.io/myorg/*` for …", which grants it and retries the
+install), or by editing the source under **Settings → Catalog Sources**.
+
+Prefer the narrowest glob that covers the package — `ghcr.io/myorg/*`, not
+`ghcr.io/*` — so consenting to one publisher doesn't consent to every other
+namespace on that registry.
+
 Through the web dashboard (or the SDK/CLI against the API), an app moves through:
 
 ```

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -115,6 +115,12 @@ hola refresh    # web UI refresh button hits the same force-refresh endpoint
 hola install <appId>
 ```
 
+You don't have to know the glob up front. Adding a source in the dashboard reads
+the catalog first and lists the registries its apps actually publish from, with
+a tick box per registry — grant them there and the source works from its first
+install. `hola source add` without `--allow-registry` prints the same finding as
+a note, including the `source update` line that grants it.
+
 The install-by-ref escape hatch (`hola install <ociRef>`) has no source, so it
 still needs either `--registry-cred` or the baseline allowlist to cover the ref.
 

--- a/packages/cli/src/__tests__/source.test.ts
+++ b/packages/cli/src/__tests__/source.test.ts
@@ -16,11 +16,80 @@ function makeSdk(updated: Partial<CatalogSourceRecord> = {}) {
       update: vi.fn(async () => ({ ...RECORD, ...updated })),
       list: vi.fn(async () => ({ items: [RECORD] })),
       remove: vi.fn(async () => ({ success: true })),
+      preview: vi.fn(async () => ({
+        appCount: 3,
+        appsWithoutRefs: 0,
+        registries: [
+          { glob: 'ghcr.io/pofallon/*', appCount: 2, covered: false },
+          { glob: 'ghcr.io/try-hola/*', appCount: 1, covered: true },
+        ],
+      })),
     },
   };
 }
 
 const asSdk = (s: ReturnType<typeof makeSdk>) => ({ sdk: s as unknown as HolaSdk, args: [] as string[] });
+
+describe('source add registry warning', () => {
+  let logs: string[];
+  beforeEach(() => {
+    process.exitCode = 0;
+    logs = [];
+    vi.spyOn(console, 'log').mockImplementation((m?: unknown) => { logs.push(String(m)); });
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => { vi.restoreAllMocks(); process.exitCode = 0; });
+
+  it('warns when the new source cannot pull anything, naming the exact fix', async () => {
+    const sdk = makeSdk();
+    await runSource('add', { url: 'https://example.test/catalog.json' }, { ...asSdk(sdk), args: ['pofallon'] });
+
+    const out = logs.join('\n');
+    expect(out).toContain("Added catalog source 'pofallon'");
+    expect(out).toContain('ghcr.io/pofallon/* (2 apps)');
+    // The already-covered baseline registry isn't presented as a problem.
+    expect(out).not.toContain('ghcr.io/try-hola/*');
+    expect(out).toContain('hola source update pofallon --allow-registry ghcr.io/pofallon/*');
+    // Advisory only — the source WAS added.
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('stays quiet when the operator already granted the registries', async () => {
+    const sdk = makeSdk();
+    await runSource('add', { url: 'https://example.test/catalog.json', allowRegistry: 'ghcr.io/pofallon/*' }, { ...asSdk(sdk), args: ['pofallon'] });
+
+    expect(sdk.catalogSources.preview).not.toHaveBeenCalled();
+    expect(logs.join('\n')).not.toMatch(/REF_NOT_ALLOWED/);
+  });
+
+  it('stays quiet when every registry is already covered by the baseline', async () => {
+    const sdk = makeSdk();
+    sdk.catalogSources.preview.mockResolvedValueOnce({
+      appCount: 1, appsWithoutRefs: 0, registries: [{ glob: 'ghcr.io/try-hola/*', appCount: 1, covered: true }],
+    });
+    await runSource('add', { url: 'https://example.test/catalog.json' }, { ...asSdk(sdk), args: ['pofallon'] });
+
+    expect(logs.join('\n')).not.toMatch(/REF_NOT_ALLOWED/);
+  });
+
+  it('an unreadable catalog degrades to a generic hint, never a failed add', async () => {
+    const sdk = makeSdk();
+    sdk.catalogSources.preview.mockRejectedValueOnce(new Error('CATALOG_UNREACHABLE'));
+    await runSource('add', { url: 'https://down.test/catalog.json' }, { ...asSdk(sdk), args: ['pofallon'] });
+
+    expect(logs.join('\n')).toContain("Added catalog source 'pofallon'");
+    expect(logs.join('\n')).toContain('could not read https://down.test/catalog.json');
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('--json stays machine-readable: no advisory prose in the output', async () => {
+    const sdk = makeSdk();
+    await runSource('add', { url: 'https://example.test/catalog.json', json: true }, { ...asSdk(sdk), args: ['pofallon'] });
+
+    expect(() => JSON.parse(logs.join('\n'))).not.toThrow();
+    expect(sdk.catalogSources.preview).not.toHaveBeenCalled();
+  });
+});
 
 describe('source update', () => {
   let logs: string[];

--- a/packages/cli/src/__tests__/source.test.ts
+++ b/packages/cli/src/__tests__/source.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { runSource } from '../commands/source/source';
+import type { HolaSdk } from '@hola/sdk';
+import type { CatalogSourceRecord } from '@hola/shared';
+
+const RECORD: CatalogSourceRecord = {
+  id: 'pofallon', name: 'Pofallon apps', type: 'index-url',
+  url: 'https://example.test/catalog.json', trust: 'custom', enabled: true,
+};
+
+function makeSdk(updated: Partial<CatalogSourceRecord> = {}) {
+  return {
+    catalogSources: {
+      add: vi.fn(async () => RECORD),
+      update: vi.fn(async () => ({ ...RECORD, ...updated })),
+      list: vi.fn(async () => ({ items: [RECORD] })),
+      remove: vi.fn(async () => ({ success: true })),
+    },
+  };
+}
+
+const asSdk = (s: ReturnType<typeof makeSdk>) => ({ sdk: s as unknown as HolaSdk, args: [] as string[] });
+
+describe('source update', () => {
+  let logs: string[];
+  let errs: string[];
+  beforeEach(() => {
+    process.exitCode = 0;
+    logs = []; errs = [];
+    vi.spyOn(console, 'log').mockImplementation((m?: unknown) => { logs.push(String(m)); });
+    vi.spyOn(console, 'error').mockImplementation((m?: unknown) => { errs.push(String(m)); });
+  });
+  afterEach(() => { vi.restoreAllMocks(); process.exitCode = 0; });
+
+  it('adds allowRegistries to an existing source — the REF_NOT_ALLOWED fix, no re-add', async () => {
+    const sdk = makeSdk({ allowRegistries: ['ghcr.io/pofallon/*'] });
+    await runSource('update', { allowRegistry: 'ghcr.io/pofallon/*' }, { ...asSdk(sdk), args: ['pofallon'] });
+
+    expect(sdk.catalogSources.update).toHaveBeenCalledWith('pofallon', { allowRegistries: ['ghcr.io/pofallon/*'] });
+    // Nothing else is touched: a patch must not silently rewrite url/name/auth.
+    expect(sdk.catalogSources.add).not.toHaveBeenCalled();
+    expect(logs.join('\n')).toContain('allow: ghcr.io/pofallon/*');
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('accepts repeated and comma-separated globs, as `source add` does', async () => {
+    const sdk = makeSdk();
+    await runSource('update', { allowRegistry: ['ghcr.io/a/*', 'ghcr.io/b/*,ghcr.io/c/*'] }, { ...asSdk(sdk), args: ['pofallon'] });
+
+    expect(sdk.catalogSources.update).toHaveBeenCalledWith('pofallon', {
+      allowRegistries: ['ghcr.io/a/*', 'ghcr.io/b/*', 'ghcr.io/c/*'],
+    });
+  });
+
+  it('clears the allowlist only when asked explicitly', async () => {
+    const sdk = makeSdk();
+    await runSource('update', { clearAllowRegistry: true }, { ...asSdk(sdk), args: ['pofallon'] });
+    expect(sdk.catalogSources.update).toHaveBeenCalledWith('pofallon', { allowRegistries: [] });
+  });
+
+  it('sends only the flags given — an omitted field is left alone', async () => {
+    const sdk = makeSdk();
+    await runSource('update', { name: 'Renamed' }, { ...asSdk(sdk), args: ['pofallon'] });
+    expect(sdk.catalogSources.update).toHaveBeenCalledWith('pofallon', { name: 'Renamed' });
+  });
+
+  it('refuses a no-op patch rather than sending an empty body', async () => {
+    const sdk = makeSdk();
+    await runSource('update', {}, { ...asSdk(sdk), args: ['pofallon'] });
+
+    expect(sdk.catalogSources.update).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+    expect(errs.join('\n')).toMatch(/nothing to change/i);
+  });
+
+  it('rejects half a credential and contradictory enable/disable', async () => {
+    const sdk = makeSdk();
+    await runSource('update', { registry: 'ghcr.io' }, { ...asSdk(sdk), args: ['pofallon'] });
+    expect(process.exitCode).toBe(1);
+    expect(errs.join('\n')).toMatch(/must be provided together/i);
+
+    process.exitCode = 0;
+    await runSource('update', { enable: true, disable: true }, { ...asSdk(sdk), args: ['pofallon'] });
+    expect(process.exitCode).toBe(1);
+    expect(errs.join('\n')).toMatch(/mutually exclusive/i);
+
+    expect(sdk.catalogSources.update).not.toHaveBeenCalled();
+  });
+
+  it('requires a source id', async () => {
+    const sdk = makeSdk();
+    await runSource('update', { name: 'x' }, asSdk(sdk));
+    expect(sdk.catalogSources.update).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('surfaces a server rejection (e.g. a malformed glob) instead of claiming success', async () => {
+    const sdk = makeSdk();
+    sdk.catalogSources.update.mockRejectedValueOnce(new Error('HTTP 400: SOURCE_ALLOW_REGISTRY_INVALID: ghcr io/x/*'));
+    await runSource('update', { allowRegistry: 'ghcr io/x/*' }, { ...asSdk(sdk), args: ['pofallon'] });
+
+    expect(process.exitCode).toBe(1);
+    expect(errs.join('\n')).toContain('SOURCE_ALLOW_REGISTRY_INVALID');
+    expect(logs.join('\n')).not.toMatch(/Updated catalog source/);
+  });
+});

--- a/packages/cli/src/commands/source/source.ts
+++ b/packages/cli/src/commands/source/source.ts
@@ -1,5 +1,5 @@
 import { HolaSdk } from '@hola/sdk';
-import type { CatalogSourceRecord } from '@hola/shared';
+import type { CatalogSourceRecord, UpdateCatalogSourceRequest } from '@hola/shared';
 
 export interface SourceOptions {
   id?: string;
@@ -16,14 +16,33 @@ export interface SourceOptions {
    * baseline `HOLA_REGISTRY_ALLOWLIST`.
    */
   allowRegistry?: string[] | string;
+  /** `update` only: empty the allowlist (omitting `--allow-registry` leaves it). */
+  clearAllowRegistry?: boolean;
+  /** `update` only: toggle whether the source's apps are aggregated. */
+  enable?: boolean;
+  disable?: boolean;
   json?: boolean;
 }
 
 /**
- * Manage catalog sources (`add | list | rm`) — the Homebrew-tap model. A source
- * is a catalog.json (same schema as the public catalog) hosted elsewhere,
+ * Flatten `--allow-registry` into a clean glob list. mri may pass repeated flags
+ * as an array, or comma-separated inside a single flag.
+ */
+function parseAllowRegistries(input: string[] | string | undefined): string[] {
+  return (Array.isArray(input) ? input : input ? [input] : [])
+    .flatMap((s) => s.split(','))
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Manage catalog sources (`add | list | update | rm`) — the Homebrew-tap model. A
+ * source is a catalog.json (same schema as the public catalog) hosted elsewhere,
  * optionally with a stored registry credential for private packages. The built-in
- * `hola` source is always present and can't be removed.
+ * `hola` source is always present and can't be removed or patched.
+ *
+ * `update` exists chiefly so `allowRegistries` can be fixed after a
+ * `REF_NOT_ALLOWED` pull without deleting and re-adding the source.
  */
 export async function runSource(
   action: string,
@@ -48,12 +67,7 @@ export async function runSource(
           return;
         }
         const auth = opts.registry && opts.cred ? { registry: opts.registry, credentialRef: opts.cred } : undefined;
-        // mri may pass repeated --allow-registry flags as an array, or comma-
-        // separated in a single flag. Flatten both into a clean glob list.
-        const allowRegistries = (Array.isArray(opts.allowRegistry) ? opts.allowRegistry : opts.allowRegistry ? [opts.allowRegistry] : [])
-          .flatMap((s) => s.split(','))
-          .map((s) => s.trim())
-          .filter(Boolean);
+        const allowRegistries = parseAllowRegistries(opts.allowRegistry);
         const record = await sdk.catalogSources.add({ id, name: opts.name ?? id, url: opts.url, auth, allowRegistries: allowRegistries.length > 0 ? allowRegistries : undefined });
         if (opts.json) console.log(JSON.stringify(record, null, 2));
         else {
@@ -75,6 +89,48 @@ export async function runSource(
         }
         return;
       }
+      case 'update': {
+        const id = opts.id ?? positional[0];
+        if (!id) { console.error('source update requires a source id'); process.exitCode = 1; return; }
+        if ((opts.registry && !opts.cred) || (!opts.registry && opts.cred)) {
+          console.error('source update: --registry and --cred must be provided together');
+          process.exitCode = 1;
+          return;
+        }
+        if (opts.enable && opts.disable) {
+          console.error('source update: --enable and --disable are mutually exclusive');
+          process.exitCode = 1;
+          return;
+        }
+        const allowRegistries = parseAllowRegistries(opts.allowRegistry);
+        // A patch: an omitted field is left alone. `--allow-registry` REPLACES the
+        // stored list (so a glob can be corrected, not just appended to), and
+        // `--clear-allow-registry` empties it back to the server baseline.
+        const patch: UpdateCatalogSourceRequest = {
+          ...(opts.name ? { name: opts.name } : {}),
+          ...(opts.url ? { url: opts.url } : {}),
+          ...(opts.registry && opts.cred ? { auth: { registry: opts.registry, credentialRef: opts.cred } } : {}),
+          ...(opts.clearAllowRegistry ? { allowRegistries: [] } : allowRegistries.length > 0 ? { allowRegistries } : {}),
+          ...(opts.enable ? { enabled: true } : opts.disable ? { enabled: false } : {}),
+        };
+        if (Object.keys(patch).length === 0) {
+          console.error('source update: nothing to change (pass --name, --url, --registry + --cred, --allow-registry, --clear-allow-registry, --enable or --disable)');
+          process.exitCode = 1;
+          return;
+        }
+        const record = await sdk.catalogSources.update(id, patch);
+        if (opts.json) console.log(JSON.stringify(record, null, 2));
+        else {
+          const allows = record.allowRegistries ?? [];
+          const tail = [
+            record.auth ? `auth: ${record.auth.credentialRef}` : '',
+            allows.length > 0 ? `allow: ${allows.join(', ')}` : 'allow: (baseline only)',
+            record.enabled ? '' : 'disabled',
+          ].filter(Boolean).join(' · ');
+          console.log(`Updated catalog source '${record.id}' → ${record.url} (${tail}).`);
+        }
+        return;
+      }
       case 'rm':
       case 'remove': {
         const id = opts.id ?? positional[0];
@@ -84,7 +140,7 @@ export async function runSource(
         return;
       }
       default:
-        console.error(`Unknown action '${action}'. Use: add | list | rm`);
+        console.error(`Unknown action '${action}'. Use: add | list | update | rm`);
         process.exitCode = 1;
     }
   } catch (err) {

--- a/packages/cli/src/commands/source/source.ts
+++ b/packages/cli/src/commands/source/source.ts
@@ -36,6 +36,31 @@ function parseAllowRegistries(input: string[] | string | undefined): string[] {
 }
 
 /**
+ * After adding a source with no `allowRegistries`, probe its catalog and name any
+ * registry its apps publish from that the server won't pull from yet — with the
+ * `source update` line that fixes it. Best-effort: an unreachable or non-catalog
+ * URL is reported as a hint, never as a failure of the add that already happened.
+ */
+async function warnUngrantedRegistries(sdk: HolaSdk, id: string, url: string): Promise<void> {
+  try {
+    const { registries } = await sdk.catalogSources.preview(url);
+    const ungranted = registries.filter(r => !r.covered);
+    if (ungranted.length === 0) return;
+    const globs = ungranted.map(r => r.glob);
+    console.log('');
+    console.log(`Note: apps in this catalog publish from ${ungranted.map(r => `${r.glob} (${r.appCount} app${r.appCount === 1 ? '' : 's'})`).join(', ')},`);
+    console.log('which this source is not allowed to pull from yet. Installs will fail with');
+    console.log('REF_NOT_ALLOWED until you allow it:');
+    console.log(`  hola source update ${id} ${globs.map(g => `--allow-registry ${g}`).join(' ')}`);
+  } catch {
+    console.log('');
+    console.log(`Note: could not read ${url} to check which registries it publishes from.`);
+    console.log('If installs fail with REF_NOT_ALLOWED, allow the registry with:');
+    console.log(`  hola source update ${id} --allow-registry <host>/<namespace>/*`);
+  }
+}
+
+/**
  * Manage catalog sources (`add | list | update | rm`) — the Homebrew-tap model. A
  * source is a catalog.json (same schema as the public catalog) hosted elsewhere,
  * optionally with a stored registry credential for private packages. The built-in
@@ -76,6 +101,12 @@ export async function runSource(
             allowRegistries.length > 0 ? `allow: ${allowRegistries.join(', ')}` : '',
           ].filter(Boolean).join(' · ');
           console.log(`Added catalog source '${record.id}' → ${record.url}${tail ? ` (${tail})` : ''}.`);
+          // A source added with no consent looks fine and then fails every
+          // install with REF_NOT_ALLOWED. Say so NOW, naming the exact fix,
+          // rather than letting it surface as a 403 at install time. Advisory
+          // only: the add already succeeded, and a probe failure is not the
+          // operator's problem to solve right now.
+          if (allowRegistries.length === 0) await warnUngrantedRegistries(sdk, record.id, opts.url);
         }
         return;
       }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -117,11 +117,12 @@ prog
 // source — manage catalog sources (the Homebrew-tap model)
 prog
   .command('source <action> [id]')
-  .describe('Manage catalog sources: add | list | rm')
+  .describe('Manage catalog sources: add | list | update | rm')
   .example('source add acme --url https://raw.githubusercontent.com/acme/hola-apps/main/catalog.json')
   .example('source add acme --url <catalog.json> --registry ghcr.io --cred acme')
   .example('source add acme --url <catalog.json> --allow-registry ghcr.io/acme/*')
   .example('source list')
+  .example('source update acme --allow-registry ghcr.io/acme/*')
   .example('source rm acme')
   .option('--id', 'Source id (alternative to the positional id)')
   .option('--name', 'Human-readable source name')
@@ -129,6 +130,11 @@ prog
   .option('--registry', 'Registry host for private packages (with --cred)')
   .option('--cred', 'Stored registry credential id (with --registry)')
   .option('--allow-registry', 'Registry glob to permit for this source (repeatable or comma-separated; e.g. ghcr.io/acme/*)')
+  // update-only: `--clear-allow-registry` is how you empty the list, since an
+  // omitted --allow-registry means "leave it alone" (a patch, not a replace).
+  .option('--clear-allow-registry', 'On update: clear this source\'s allowed registries', false)
+  .option('--enable', 'On update: re-enable a disabled source', false)
+  .option('--disable', 'On update: stop aggregating this source\'s apps', false)
   .option('--json', 'Print raw JSON output', false)
   .action(async (action, id, opts) => {
     const { runSource } = await load(import('./commands/source/source'));

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -23,6 +23,7 @@ import {
   InstallFromRefRequest, InstallFromRefResponse,
   // Catalog sources (multi-catalog Slice 2)
   CatalogSourceRecord, AddCatalogSourceRequest, UpdateCatalogSourceRequest, ListCatalogSourcesResponse,
+  PreviewCatalogSourceRequest, PreviewCatalogSourceResponse,
   RefreshCatalogResponse,
   // Job types
   DeleteJobsRequest, DeleteJobsResponse,
@@ -117,6 +118,10 @@ export class HolaSdk {
     update: (id: string, data: UpdateCatalogSourceRequest) =>
       this.patch<CatalogSourceRecord>(API.catalogSources.byId(id), data),
     remove: (id: string) => this.delete<{ success: boolean }>(API.catalogSources.byId(id)),
+    // Probe a catalog.json before adding it: what apps it lists and which
+    // registries they publish from. Stores nothing.
+    preview: (url: string) =>
+      this.post<PreviewCatalogSourceResponse>(API.catalogSources.preview, { url } satisfies PreviewCatalogSourceRequest),
   };
 
   // Registry credentials for private OCI pulls. The token is write-only: `add`

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -22,7 +22,7 @@ import {
   RegistryCredentialRecord, AddRegistryCredentialRequest, ListRegistryCredentialsResponse,
   InstallFromRefRequest, InstallFromRefResponse,
   // Catalog sources (multi-catalog Slice 2)
-  CatalogSourceRecord, AddCatalogSourceRequest, ListCatalogSourcesResponse,
+  CatalogSourceRecord, AddCatalogSourceRequest, UpdateCatalogSourceRequest, ListCatalogSourcesResponse,
   RefreshCatalogResponse,
   // Job types
   DeleteJobsRequest, DeleteJobsResponse,
@@ -112,6 +112,10 @@ export class HolaSdk {
   catalogSources = {
     list: () => this.get<ListCatalogSourcesResponse>(API.catalogSources.base),
     add: (data: AddCatalogSourceRequest) => this.post<CatalogSourceRecord>(API.catalogSources.base, data),
+    // Patch a source in place — chiefly to add `allowRegistries` after a
+    // REF_NOT_ALLOWED pull, without deleting and re-adding the source.
+    update: (id: string, data: UpdateCatalogSourceRequest) =>
+      this.patch<CatalogSourceRecord>(API.catalogSources.byId(id), data),
     remove: (id: string) => this.delete<{ success: boolean }>(API.catalogSources.byId(id)),
   };
 

--- a/packages/server/src/__tests__/bundles/auth-pull.test.ts
+++ b/packages/server/src/__tests__/bundles/auth-pull.test.ts
@@ -3,7 +3,9 @@ import { mkdtemp, rm } from 'fs/promises';
 import { readFileSync, statSync, mkdirSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { suggestRegistryGlob } from '@hola/shared';
 import { RealBundleService, bundleCacheKey, type CommandRunner } from '../../services/core/bundles';
+import { BundleError } from '../../middleware/error-mapping';
 
 describe('bundleCacheKey (cross-source collision guard)', () => {
   test('the built-in hola source keeps the bare appId; others are namespaced', () => {
@@ -99,6 +101,54 @@ describe('RealBundleService authenticated pull', () => {
       credentials: { registry: 'registry.example.com', username: 'u', password: 'p' },
     });
     expect(ok.localPath).toBe(join(base, 'acme__app', '1.0'));
+  });
+
+  test('REF_NOT_ALLOWED carries the fix as structured details', async () => {
+    // The web install wizard offers "allow this registry" straight from the
+    // failure, so the remedy has to travel as DATA. If it only existed in the
+    // prose message, the client would be back to regexing English.
+    const base = await makeCache();
+    const svc = new RealBundleService(base, async () => ({ stdout: '', stderr: '' }));
+
+    let err: unknown;
+    try {
+      await svc.ensurePulled({ appId: 'cms', version: '0.1.13', source: 'pofallon', ociRef: 'ghcr.io/pofallon/hola-get2know-cms:0.1.13' });
+    } catch (e) { err = e; }
+
+    expect(err).toBeInstanceOf(BundleError);
+    expect((err as BundleError).status).toBe(403);
+    expect((err as BundleError).details).toEqual({
+      ref: 'ghcr.io/pofallon/hola-get2know-cms:0.1.13',
+      suggestedGlob: 'ghcr.io/pofallon/*',
+      allowed: ['ghcr.io/try-hola/*'],
+    });
+  });
+
+  test('the suggested glob is narrow, submittable, and actually unblocks the ref', async () => {
+    // Namespace-scoped, never bare-host: allowing one publisher's package must
+    // not silently allow every other org on the same registry.
+    expect(suggestRegistryGlob('ghcr.io/pofallon/hola-get2know-cms:0.1.13')).toBe('ghcr.io/pofallon/*');
+    expect(suggestRegistryGlob('ghcr.io/acme/app@sha256:abc')).toBe('ghcr.io/acme/*');
+    // A namespace-less ref has no org to scope to — the host is as narrow as it gets.
+    expect(suggestRegistryGlob('registry.example.com/app:1')).toBe('registry.example.com/*');
+
+    // End to end: feeding the suggestion back as a source consent unblocks the pull.
+    const base = await makeCache();
+    const svc = new RealBundleService(base, async () => ({ stdout: '', stderr: '' }));
+    const ref = 'ghcr.io/pofallon/hola-get2know-cms:0.1.13';
+    const ok = await svc.ensurePulled({
+      appId: 'cms', version: '0.1.13', source: 'pofallon', ociRef: ref,
+      extraAllowlist: [suggestRegistryGlob(ref)],
+    });
+    expect(ok.localPath).toBe(join(base, 'pofallon__cms', '0.1.13'));
+
+    // ...and does NOT unblock a different namespace on the same registry.
+    await expect(
+      svc.ensurePulled({
+        appId: 'other', version: '1.0', source: 'pofallon', ociRef: 'ghcr.io/someone-else/app:1.0',
+        extraAllowlist: [suggestRegistryGlob(ref)],
+      }),
+    ).rejects.toThrow('REF_NOT_ALLOWED');
   });
 });
 

--- a/packages/server/src/__tests__/catalog/catalog-preview.test.ts
+++ b/packages/server/src/__tests__/catalog/catalog-preview.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Previewing a catalog.json before adding it as a source.
+ *
+ * The point is consent from real data: a source added without `allowRegistries`
+ * looks fine until the first install dies with REF_NOT_ALLOWED, so the preview
+ * reports the registries the catalog's own OCI refs point at and lets the
+ * operator grant them up front. It doubles as URL validation — the fetcher casts
+ * parsed JSON straight to a catalog shape, so a wrong URL would otherwise be
+ * discovered as a mysteriously empty source.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { RealCatalogService } from '../../services/core/catalog';
+
+const CATALOG = {
+  apps: [
+    // Two apps, same namespace → one glob, counted by APPS not versions.
+    { id: 'cms', name: 'CMS', versions: [
+      { version: '1.0.0', refs: { oci: 'ghcr.io/acme/cms:1.0.0' } },
+      { version: '1.1.0', refs: { oci: 'ghcr.io/acme/cms:1.1.0' } },
+    ] },
+    { id: 'wiki', name: 'Wiki', versions: [{ version: '2.0.0', refs: { oci: 'ghcr.io/acme/wiki:2.0.0' } }] },
+    // A different namespace on the same registry — must stay a separate consent.
+    { id: 'tool', name: 'Tool', versions: [{ version: '1.0.0', refs: { oci: 'ghcr.io/othervendor/tool:1.0.0' } }] },
+    // Already covered by the default baseline (ghcr.io/try-hola/*).
+    { id: 'builtin', name: 'Builtin', versions: [{ version: '1.0.0', refs: { oci: 'ghcr.io/try-hola/builtin:1.0.0' } }] },
+    // No installable package at all.
+    { id: 'refless', name: 'Refless', versions: [{ version: '0.1.0' }] },
+  ],
+};
+
+const okResponse = (body: unknown, status = 200) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  headers: { get: () => null },
+  json: async () => body,
+});
+
+describe('RealCatalogService.previewSource', () => {
+  const realFetch = globalThis.fetch;
+  let served: unknown = CATALOG;
+  let status = 200;
+  let calls: string[] = [];
+
+  beforeEach(() => {
+    served = CATALOG; status = 200; calls = [];
+    globalThis.fetch = (async (input: unknown) => {
+      calls.push(String(input));
+      if (status === 0) throw new Error('network unreachable');
+      return okResponse(served, status);
+    }) as unknown as typeof fetch;
+  });
+  afterEach(() => { globalThis.fetch = realFetch; });
+
+  test('reports each publishing namespace, counted by apps, with baseline coverage marked', async () => {
+    const res = await new RealCatalogService().previewSource('https://acme.test/catalog.json');
+
+    expect(res.appCount).toBe(5);
+    expect(res.appsWithoutRefs).toBe(1);
+    // Most-used namespace first; every glob is namespace-scoped, never a bare host.
+    expect(res.registries).toEqual([
+      { glob: 'ghcr.io/acme/*', appCount: 2, covered: false },
+      { glob: 'ghcr.io/othervendor/*', appCount: 1, covered: false },
+      // Baseline already permits this one, so it needs no per-source grant.
+      { glob: 'ghcr.io/try-hola/*', appCount: 1, covered: true },
+    ]);
+  });
+
+  test('a URL that is not a catalog fails loudly instead of previewing as empty', async () => {
+    // The fetcher does no schema validation, so without this check an HTML page
+    // or someone's repo root would "succeed" and be added as a silent no-op source.
+    served = { message: 'not a catalog' };
+    await expect(new RealCatalogService().previewSource('https://acme.test/README.md'))
+      .rejects.toThrow('CATALOG_MALFORMED');
+
+    served = CATALOG; status = 404;
+    await expect(new RealCatalogService().previewSource('https://acme.test/missing.json'))
+      .rejects.toThrow('CATALOG_UNREACHABLE');
+
+    status = 0;
+    await expect(new RealCatalogService().previewSource('https://down.test/catalog.json'))
+      .rejects.toThrow('CATALOG_UNREACHABLE');
+  });
+
+  test('an empty catalog previews as empty rather than failing', async () => {
+    served = { apps: [] };
+    const res = await new RealCatalogService().previewSource('https://acme.test/catalog.json');
+    expect(res).toEqual({ appCount: 0, registries: [], appsWithoutRefs: 0 });
+  });
+
+  test('always hits the URL — a preview is never served from the source cache', async () => {
+    // The URL isn't a source yet, and re-probing an edited URL must reflect what
+    // is there NOW, not what a shared 24h cache last saw.
+    const svc = new RealCatalogService();
+    await svc.previewSource('https://acme.test/catalog.json');
+    served = { apps: [{ id: 'new', name: 'New', versions: [{ version: '1.0.0', refs: { oci: 'ghcr.io/changed/new:1.0.0' } }] }] };
+    const second = await svc.previewSource('https://acme.test/catalog.json');
+
+    expect(calls).toHaveLength(2);
+    expect(second.registries).toEqual([{ glob: 'ghcr.io/changed/*', appCount: 1, covered: false }]);
+  });
+});

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -53,6 +53,7 @@ import {
   type InstallFromRefResponse,
   type AddCatalogSourceRequest,
   type UpdateCatalogSourceRequest,
+  type PreviewCatalogSourceRequest,
   type ListCatalogSourcesResponse,
   type RefreshCatalogResponse,
   type GetSubdomainAvailabilityResponse,
@@ -577,6 +578,24 @@ async function route(url: URL, req: Request): Promise<Response> {
       const status = message === 'SOURCE_ID_EXISTS' ? 409 : 400;
       logger.warn('Failed to add catalog source', { error: message });
       return json({ error: { code: 'SOURCE_ADD_FAILED', message } }, { status });
+    }
+  }
+
+  // Probe a catalog.json before it's added: reports the registries its apps
+  // publish from so the operator grants consent from real data. Read-only —
+  // nothing is stored, and it MUST be matched before the `/:id` regex below.
+  if (pathname === API.catalogSources.preview && req.method === 'POST') {
+    try {
+      const body = (await req.json().catch(() => ({}))) as Partial<PreviewCatalogSourceRequest>;
+      if (!body.url || typeof body.url !== 'string') {
+        return json({ error: { code: 'SOURCE_URL_INVALID', message: 'url is required' } }, { status: 400 });
+      }
+      return json(await getServices().catalog.previewSource(body.url));
+    } catch (error) {
+      logger.warn('Catalog source preview failed', { error: error instanceof Error ? error.message : String(error) });
+      // Typed BundleErrors carry their own status (502 unreachable, 422 malformed)
+      // and message — the operator needs the real reason to fix the URL.
+      return errorResponse(req, error);
     }
   }
 

--- a/packages/server/src/services/core/bundles.ts
+++ b/packages/server/src/services/core/bundles.ts
@@ -385,7 +385,13 @@ function registryHost(registry: string): string {
   return registry.trim().split('/')[0];
 }
 
-function matchesAllowlist(pattern: string, ref: string): boolean {
+/**
+ * Does an allowlist pattern permit a ref? Exported so the catalog-source preview
+ * can report which of a catalog's registries the baseline already covers using
+ * the SAME matcher that gates the pull — a second implementation would be free
+ * to drift into telling the operator a ref is allowed when it isn't.
+ */
+export function matchesAllowlist(pattern: string, ref: string): boolean {
   // Convert simple glob like ghcr.io/org/* to regex start match
   const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\\\*/g, '.*');
   const re = new RegExp('^' + escaped + '(?:$|[:/])');

--- a/packages/server/src/services/core/bundles.ts
+++ b/packages/server/src/services/core/bundles.ts
@@ -3,6 +3,7 @@ import { promisify } from 'util';
 import { mkdirSync, existsSync, rmSync, statSync, mkdtempSync, writeFileSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import { suggestRegistryGlob, type RefNotAllowedDetails } from '@hola/shared';
 import { getLogger } from '../../lib/logger';
 import { getHolaDataDir } from '../../config/paths';
 import type { ServiceHealth, HealthCheckable } from './types';
@@ -321,7 +322,17 @@ export class RealBundleService implements BundleService, HealthCheckable {
         'REF_NOT_ALLOWED',
         `REF_NOT_ALLOWED: ${ref} is not covered by the registry allowlist (${allowed.join(', ') || 'empty'}). ` +
           `Add the registry to this catalog source's allowRegistries, or to HOLA_REGISTRY_ALLOWLIST.`,
-        { status: 403 },
+        // Structured detail so a client can OFFER the fix rather than restate the
+        // message: `suggestedGlob` is exactly what a caller would PATCH into the
+        // source's `allowRegistries`. Clients must not regex the prose message.
+        {
+          status: 403,
+          details: {
+            ref,
+            suggestedGlob: suggestRegistryGlob(ref),
+            allowed,
+          } satisfies RefNotAllowedDetails,
+        },
       );
     }
   }

--- a/packages/server/src/services/core/catalog.ts
+++ b/packages/server/src/services/core/catalog.ts
@@ -4,6 +4,7 @@ import { getLogger } from '../../lib/logger';
 import type { Logger } from '../../lib/logger';
 import type { ServiceHealth, HealthCheckable } from './types';
 import type { PullCredentials, BundleService } from './bundles';
+import { matchesAllowlist } from './bundles';
 import { catalogConfig } from '../../config/catalog';
 import { parseComposeDefaults, mergeDefaults } from './compose-parser';
 import type {
@@ -20,7 +21,9 @@ import type {
   ParamType,
   ParamGenerate,
   ParamEnumOption,
+  PreviewCatalogSourceResponse,
 } from '@hola/shared';
+import { suggestRegistryGlob } from '@hola/shared';
 import type { CatalogSourceService } from './catalog-sources';
 import type { RegistryCredentialService } from './registry-credentials';
 import { coerceManifestAuth } from './manifest-auth';
@@ -214,6 +217,13 @@ export interface CatalogService {
   getVersionDetailByRef(ociRef: string, credentials?: PullCredentials): Promise<GetCatalogAppVersionDetailResponse & { appId: string }>;
   /** Per-source outcome, so one bad source doesn't silently mask the others. */
   refresh(force?: boolean): Promise<Array<{ id: string; name: string; ok: boolean; error?: string }>>;
+  /**
+   * Probe a catalog.json without storing anything: what apps it lists and which
+   * registries they publish bundles from. Lets the operator grant registry
+   * consent from the catalog's own contents at add time, instead of discovering
+   * a missing `allowRegistries` as a REF_NOT_ALLOWED install failure later.
+   */
+  previewSource(url: string): Promise<PreviewCatalogSourceResponse>;
 }
 
 /**
@@ -640,6 +650,60 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
     });
   }
 
+  async previewSource(url: string): Promise<PreviewCatalogSourceResponse> {
+    // A THROWAWAY fetcher: a preview must not seed (or be served by) the shared
+    // per-source cache — the URL isn't a source yet, and a stale hit would report
+    // a different catalog than the one about to be added.
+    let data: RemoteCatalog;
+    try {
+      data = await new SourceCatalog(url).ensureLoaded();
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new BundleError('CATALOG_UNREACHABLE', `CATALOG_UNREACHABLE: ${url}: ${detail}`, { status: 502 });
+    }
+
+    // The fetcher casts the parsed JSON straight to RemoteCatalog without
+    // checking it, so a non-catalog URL (an HTML page, someone's repo root)
+    // parses "fine" and only fails much later. Preview is the one place that can
+    // tell the operator now, while they're still looking at the URL field.
+    if (!data || !Array.isArray(data.apps)) {
+      throw new BundleError(
+        'CATALOG_MALFORMED',
+        `CATALOG_MALFORMED: ${url} did not return a catalog.json (no "apps" array).`,
+        { status: 422 },
+      );
+    }
+
+    // Count DISTINCT APPS per registry, not versions: "12 apps" is the number an
+    // operator can reason about, where "137 versions" is noise.
+    const appsByGlob = new Map<string, Set<string>>();
+    let appsWithoutRefs = 0;
+    for (const app of data.apps) {
+      const refs = (app.versions ?? []).map(v => v.refs?.oci).filter((r): r is string => Boolean(r));
+      if (refs.length === 0) { appsWithoutRefs++; continue; }
+      for (const ref of refs) {
+        const glob = suggestRegistryGlob(ref);
+        const seen = appsByGlob.get(glob) ?? new Set<string>();
+        seen.add(app.id);
+        appsByGlob.set(glob, seen);
+      }
+    }
+
+    const registries = [...appsByGlob.entries()]
+      .map(([glob, apps]) => ({
+        glob,
+        appCount: apps.size,
+        // Report coverage with the same matcher that gates the pull, against a
+        // representative ref for the glob — never a second opinion about what the
+        // allowlist permits.
+        covered: catalogConfig.registryAllowlist.some(p => matchesAllowlist(p, glob.replace(/\*$/, 'probe'))),
+      }))
+      .sort((a, b) => b.appCount - a.appCount || a.glob.localeCompare(b.glob));
+
+    this.logger.info('Catalog source previewed', { url, appCount: data.apps.length, registries: registries.map(r => r.glob) });
+    return { appCount: data.apps.length, registries, appsWithoutRefs };
+  }
+
   private mapApp(app: RemoteCatalog['apps'][number], source: CatalogSourceRecord): CatalogApp {
     return {
       id: app.id,
@@ -683,4 +747,7 @@ export class MockCatalogService implements CatalogService {
     throw new BundleUnavailableError('VERSION_NOT_FOUND', 'VERSION_NOT_FOUND');
   }
   async refresh(): Promise<Array<{ id: string; name: string; ok: boolean; error?: string }>> { return []; }
+  async previewSource(): Promise<PreviewCatalogSourceResponse> {
+    return { appCount: 0, registries: [], appsWithoutRefs: 0 };
+  }
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -37,6 +37,11 @@ export const API = {
   catalogSources: {
     base: '/api/catalog-sources',
     byId: (id: string) => `/api/catalog-sources/${id}`,
+    // Probe a catalog.json before adding it: reports the registries its apps
+    // actually publish from, so the operator grants consent from real data
+    // rather than guessing a glob. Reserved id — `byId('preview')` can't collide
+    // because preview is POST-only and matched first.
+    preview: '/api/catalog-sources/preview',
   },
 
   drafts: {
@@ -596,6 +601,46 @@ export function suggestRegistryGlob(ociRef: string): string {
   const namespace = segments.length >= 3 ? segments[1] : undefined;
   return namespace ? `${host}/${namespace}/*` : `${host}/*`;
 }
+
+/**
+ * Probe a catalog.json before adding it as a source. Read-only: nothing is
+ * stored, so this is safe to call on every keystroke-settled URL.
+ */
+export type PreviewCatalogSourceRequest = {
+  url: string;
+};
+
+/** One registry namespace a previewed catalog's apps publish bundles from. */
+export type CatalogSourcePreviewRegistry = {
+  /** The glob that would permit it — see `suggestRegistryGlob`. */
+  glob: string;
+  /** How many of the catalog's apps publish under it (for "12 apps" context). */
+  appCount: number;
+  /**
+   * True when the server's baseline `HOLA_REGISTRY_ALLOWLIST` already covers it,
+   * so no per-source consent is needed. The UI shows these as already-allowed
+   * rather than asking for a grant that would be a no-op.
+   */
+  covered: boolean;
+};
+
+/**
+ * What a catalog.json turned out to contain. Doubles as URL validation: a
+ * catalog that can't be fetched or parsed fails the request outright rather than
+ * being discovered later as a silently empty source.
+ */
+export type PreviewCatalogSourceResponse = {
+  /** Apps listed in the catalog. */
+  appCount: number;
+  /** Distinct publishing registries, most-used first. */
+  registries: CatalogSourcePreviewRegistry[];
+  /**
+   * Apps whose versions carry no OCI ref at all. They can't be installed from a
+   * bundle, so no registry consent would help them — surfaced so a catalog that
+   * previews as "0 registries" isn't mistaken for a broken probe.
+   */
+  appsWithoutRefs: number;
+};
 
 export type ListCatalogSourcesResponse = {
   items: CatalogSourceRecord[];

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -555,6 +555,48 @@ export type UpdateCatalogSourceRequest = {
   enabled?: boolean;
 };
 
+/**
+ * `details` on a `REF_NOT_ALLOWED` (403) error. The pull was blocked because the
+ * bundle's registry isn't covered by the effective allowlist.
+ *
+ * Carried as structured data so a client can OFFER the fix — PATCH
+ * `suggestedGlob` into the owning source's `allowRegistries` — instead of asking
+ * the operator to re-read the prose message and retype it. Clients must read
+ * these fields rather than regex the message, which is free to change.
+ */
+export type RefNotAllowedDetails = {
+  /** The blocked OCI reference, e.g. `ghcr.io/acme/hola-cms:0.1.13`. */
+  ref: string;
+  /**
+   * The narrowest glob that would permit `ref` — the registry host plus the
+   * publishing namespace (e.g. `ghcr.io/acme/*`). Valid input for a source's
+   * `allowRegistries` or the `HOLA_REGISTRY_ALLOWLIST` baseline.
+   */
+  suggestedGlob: string;
+  /** The effective allowlist that rejected the ref (baseline + any consents). */
+  allowed: string[];
+};
+
+/**
+ * Narrowest allowlist glob covering an OCI ref: the host plus the publishing
+ * namespace, so allowing one app doesn't silently allow an unrelated org on the
+ * same registry. `ghcr.io/acme/hola-cms:0.1.13` → `ghcr.io/acme/*`; a
+ * namespace-less ref (`registry.example.com/app:1`) → `registry.example.com/*`.
+ *
+ * Output is deliberately restricted to the `host/…/*` shape the server's glob
+ * validator accepts, so a suggestion is always directly submittable.
+ */
+export function suggestRegistryGlob(ociRef: string): string {
+  // Drop any digest/tag before splitting: a tag can't contain `/`, but a digest
+  // (`@sha256:…`) must not be mistaken for a path segment.
+  const withoutDigest = ociRef.split('@')[0];
+  const segments = withoutDigest.split('/').filter(Boolean);
+  const host = segments[0] ?? '';
+  // host + namespace when the ref has one (host/ns/name), else just the host.
+  const namespace = segments.length >= 3 ? segments[1] : undefined;
+  return namespace ? `${host}/${namespace}/*` : `${host}/*`;
+}
+
 export type ListCatalogSourcesResponse = {
   items: CatalogSourceRecord[];
 };

--- a/packages/web/src/__tests__/pages/InstallWizard.refNotAllowed.test.tsx
+++ b/packages/web/src/__tests__/pages/InstallWizard.refNotAllowed.test.tsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import type { CreateDraftResponse, RefNotAllowedDetails } from '@hola/shared';
+import { globalCache } from '../../utils/cache';
+
+/**
+ * Installing from a custom catalog source whose registry isn't allowlisted fails
+ * with REF_NOT_ALLOWED (403). The operator's fix — granting that source the
+ * registry — is one PATCH away, so the wizard offers it as a button instead of
+ * printing a message and leaving them to find Settings (which, before the edit
+ * form existed, couldn't even do it without deleting and re-adding the source).
+ */
+const draftId = 'draft-refnotallowed';
+
+const DETAILS: RefNotAllowedDetails = {
+  ref: 'ghcr.io/pofallon/hola-get2know-cms:0.1.13',
+  suggestedGlob: 'ghcr.io/pofallon/*',
+  allowed: ['ghcr.io/try-hola/*'],
+};
+
+/** The 403 as the API layer surfaces it: message for display, code/details to act on. */
+function refNotAllowedError() {
+  return Object.assign(new Error(`REF_NOT_ALLOWED: ${DETAILS.ref} is not covered by the registry allowlist (ghcr.io/try-hola/*).`), {
+    code: 'REF_NOT_ALLOWED',
+    details: DETAILS,
+    statusCode: 403,
+  });
+}
+
+const okDraft = (): CreateDraftResponse => ({
+  draftId,
+  app: { id: 'get2know-cms', name: 'get2know CMS', icon: '📝' },
+  systemEnv: [],
+  appEnv: [],
+  defaults: { ports: [], volumes: [] },
+});
+
+const draftsApi = {
+  create: vi.fn(async (): Promise<CreateDraftResponse> => { throw refNotAllowedError(); }),
+  byId: vi.fn(async () => ({ draftId, appId: 'get2know-cms', version: '0.1.13', systemOverrides: {}, appEnv: [], ports: [] })),
+  update: vi.fn(async () => ({ ok: true as const })),
+  remove: vi.fn(async () => ({ ok: true as const })),
+};
+
+const catalogSources = {
+  list: vi.fn(async () => ({
+    items: [
+      { id: 'hola', name: 'hola', type: 'index-url' as const, url: '', trust: 'verified' as const, enabled: true },
+      // Already carries one consent — the fix must ADD to it, not replace it.
+      { id: 'pofallon', name: 'pofallon', type: 'index-url' as const, url: 'https://example.test/catalog.json', trust: 'custom' as const, enabled: true, allowRegistries: ['ghcr.io/other/*'] },
+    ],
+  })),
+  update: vi.fn(async () => ({ id: 'pofallon', name: 'pofallon', type: 'index-url' as const, url: 'https://example.test/catalog.json', trust: 'custom' as const, enabled: true })),
+};
+
+vi.mock('../../utils/api-hybrid', () => ({
+  api: {
+    drafts: draftsApi,
+    catalogSources,
+    deployments: {
+      create: vi.fn(),
+      subdomainAvailable: vi.fn(async (subdomain: string) => ({ subdomain, host: `${subdomain}.local.hola`, available: true })),
+    },
+  },
+}));
+
+const { InstallWizard } = await import('../../pages/InstallWizard');
+
+function renderWizard(search = '?source=pofallon') {
+  return render(
+    <MemoryRouter initialEntries={[`/install/get2know-cms${search}`]}>
+      <Routes>
+        <Route path="/install/:appId" element={<InstallWizard />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  globalCache.clear();
+  vi.clearAllMocks();
+  draftsApi.create.mockImplementation(async () => { throw refNotAllowedError(); });
+});
+
+afterEach(() => cleanup());
+
+describe('InstallWizard REF_NOT_ALLOWED recovery', () => {
+  it('offers the exact fix and applies it as an additional grant, then retries the install', async () => {
+    renderWizard();
+
+    await waitFor(() => expect(screen.getByText('Registry not allowed')).toBeInTheDocument());
+    // The suggestion names the registry to be granted — not the raw ref.
+    const allow = await screen.findByRole('button', { name: /allow ghcr\.io\/pofallon\/\* for/i });
+
+    // The next attempt succeeds, as it would once the source is patched.
+    draftsApi.create.mockImplementation(async () => okDraft());
+    fireEvent.click(allow);
+
+    await waitFor(() => expect(catalogSources.update).toHaveBeenCalled());
+    const [sourceId, patch] = catalogSources.update.mock.calls[0] as [string, { allowRegistries: string[] }];
+    expect(sourceId).toBe('pofallon');
+    // Merged with the source's existing consent — patching must never revoke it.
+    expect([...patch.allowRegistries].sort()).toEqual(['ghcr.io/other/*', 'ghcr.io/pofallon/*']);
+
+    // The install resumes on its own: no reload, no re-navigating the catalog.
+    await waitFor(() => expect(draftsApi.create).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.queryByText('Registry not allowed')).not.toBeInTheDocument());
+  });
+
+  it('does not offer to patch a source that has none to patch (install-by-ref)', async () => {
+    // `/install/ref?ref=…` has no stored source record, so the only remedy is the
+    // server-wide baseline — say so instead of dangling an unusable button.
+    renderWizard('?ref=ghcr.io/pofallon/hola-get2know-cms:0.1.13');
+
+    await waitFor(() => expect(screen.getByText('Registry not allowed')).toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: /allow .* for/i })).not.toBeInTheDocument();
+    expect(screen.getByText(/HOLA_REGISTRY_ALLOWLIST/)).toBeInTheDocument();
+    expect(catalogSources.update).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the plain message when the server sends no usable details', async () => {
+    // An older server sends the same code with no payload. Offering to grant
+    // `undefined` would be worse than saying nothing.
+    draftsApi.create.mockImplementation(async () => {
+      throw Object.assign(new Error('REF_NOT_ALLOWED: blocked'), { code: 'REF_NOT_ALLOWED', statusCode: 403 });
+    });
+    renderWizard();
+
+    await waitFor(() => expect(screen.getByText('REF_NOT_ALLOWED: blocked')).toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: /allow/i })).not.toBeInTheDocument();
+    expect(screen.queryByText('Registry not allowed')).not.toBeInTheDocument();
+  });
+
+  it('does not hammer the server: a failed draft is attempted once until the operator retries', async () => {
+    renderWizard();
+
+    await waitFor(() => expect(screen.getByText('Registry not allowed')).toBeInTheDocument());
+    // Settle: the effect re-runs on every render, so a missing guard shows up here.
+    await new Promise(r => setTimeout(r, 50));
+    expect(draftsApi.create).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole('button', { name: /try again/i }));
+    await waitFor(() => expect(draftsApi.create).toHaveBeenCalledTimes(2));
+  });
+});

--- a/packages/web/src/__tests__/pages/Settings.catalogSources.test.tsx
+++ b/packages/web/src/__tests__/pages/Settings.catalogSources.test.tsx
@@ -15,11 +15,21 @@ const SOURCES: CatalogSourceRecord[] = [
   { id: 'pofallon', name: 'Pofallon apps', type: 'index-url', url: 'https://example.test/catalog.json', trust: 'custom', enabled: true },
 ];
 
+const PREVIEW = {
+  appCount: 4,
+  appsWithoutRefs: 1,
+  registries: [
+    { glob: 'ghcr.io/pofallon/*', appCount: 2, covered: false },
+    { glob: 'ghcr.io/try-hola/*', appCount: 1, covered: true },
+  ],
+};
+
 const catalogSources = {
   list: vi.fn(async () => ({ items: SOURCES })),
   add: vi.fn(async () => SOURCES[1]),
   update: vi.fn(async () => SOURCES[1]),
   remove: vi.fn(async () => ({ success: true })),
+  preview: vi.fn(async () => PREVIEW),
 };
 
 const registryCredentials = {
@@ -32,8 +42,17 @@ const { CatalogSourcesCard } = await import('../../pages/Settings');
 
 const renderCard = () => render(<CatalogSourcesCard inputClass="input" labelClass="label" />);
 
-beforeEach(() => vi.clearAllMocks());
+beforeEach(() => {
+  vi.clearAllMocks();
+  catalogSources.preview.mockResolvedValue(PREVIEW);
+});
 afterEach(() => cleanup());
+
+/** Fill the URL field and wait out the preview debounce. */
+async function typeUrlAndPreview(url = 'https://example.test/catalog.json') {
+  fireEvent.change(screen.getByPlaceholderText(/raw\.githubusercontent\.com/), { target: { value: url } });
+  await waitFor(() => expect(catalogSources.preview).toHaveBeenCalledWith(url), { timeout: 2000 });
+}
 
 describe('Settings → Catalog Sources editing', () => {
   it('patches an existing source in place rather than recreating it', async () => {
@@ -87,6 +106,75 @@ describe('Settings → Catalog Sources editing', () => {
 
     expect(screen.queryByLabelText('Edit hola')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Remove hola')).not.toBeInTheDocument();
+  });
+
+  it('probes the URL and grants only the registries the operator ticks', async () => {
+    renderCard();
+    await waitFor(() => expect(screen.getByText('pofallon')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: /add source/i }));
+
+    // Nothing is probed until the URL looks like one — no request per keystroke.
+    fireEvent.change(screen.getByPlaceholderText(/raw\.githubusercontent\.com/), { target: { value: 'not-a-url' } });
+    expect(catalogSources.preview).not.toHaveBeenCalled();
+
+    await typeUrlAndPreview();
+
+    // The catalog's own contents, with app counts for context.
+    await waitFor(() => expect(screen.getByText(/4 apps/)).toBeInTheDocument());
+    expect(screen.getByText('ghcr.io/pofallon/*')).toBeInTheDocument();
+    expect(screen.getByText(/1 app list(s)? no installable package/)).toBeInTheDocument();
+
+    // Consent is opt-IN: discovered registries start unticked, so nothing is
+    // granted by merely pasting a URL.
+    const grantable = screen.getByLabelText('Allow ghcr.io/pofallon/*') as HTMLInputElement;
+    expect(grantable.checked).toBe(false);
+    // A registry the server baseline already covers is shown, not asked for.
+    const covered = screen.getByLabelText('Allow ghcr.io/try-hola/*') as HTMLInputElement;
+    expect(covered.checked).toBe(true);
+    expect(covered.disabled).toBe(true);
+
+    fireEvent.click(grantable);
+    expect((screen.getByPlaceholderText('ghcr.io/myorg/*') as HTMLInputElement).value).toBe('ghcr.io/pofallon/*');
+
+    fireEvent.change(screen.getByPlaceholderText('acme'), { target: { value: 'acme' } });
+    fireEvent.click(screen.getByRole('button', { name: /^add source$/i }));
+
+    await waitFor(() => expect(catalogSources.add).toHaveBeenCalled());
+    // Only the ticked one — never the already-covered baseline registry.
+    expect(catalogSources.add.mock.calls[0][0]).toMatchObject({ allowRegistries: ['ghcr.io/pofallon/*'] });
+  });
+
+  it('unticking a registry withdraws it from the grant', async () => {
+    renderCard();
+    await waitFor(() => expect(screen.getByText('pofallon')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: /add source/i }));
+    await typeUrlAndPreview();
+
+    const box = await screen.findByLabelText('Allow ghcr.io/pofallon/*');
+    fireEvent.click(box);
+    fireEvent.click(box);
+    expect((screen.getByPlaceholderText('ghcr.io/myorg/*') as HTMLInputElement).value).toBe('');
+  });
+
+  it('reports a URL that is not a usable catalog instead of silently adding it', async () => {
+    catalogSources.preview.mockRejectedValue(new Error('CATALOG_MALFORMED: did not return a catalog.json (no "apps" array).'));
+    renderCard();
+    await waitFor(() => expect(screen.getByText('pofallon')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: /add source/i }));
+    await typeUrlAndPreview('https://example.test/README.md');
+
+    await waitFor(() => expect(screen.getByText(/did not return a catalog\.json/)).toBeInTheDocument());
+    // Advisory, not a gate: adding is still allowed (a catalog may be published later).
+    expect(screen.getByRole('button', { name: /^add source$/i })).not.toBeDisabled();
+  });
+
+  it('previews on edit too, so an existing source can be checked against its catalog', async () => {
+    renderCard();
+    await waitFor(() => expect(screen.getByText('pofallon')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByLabelText('Edit pofallon'));
+    await waitFor(() => expect(catalogSources.preview).toHaveBeenCalledWith('https://example.test/catalog.json'), { timeout: 2000 });
+    await waitFor(() => expect(screen.getByText('ghcr.io/pofallon/*')).toBeInTheDocument());
   });
 
   it('still adds a new source, with the id editable and no source id preselected', async () => {

--- a/packages/web/src/__tests__/pages/Settings.catalogSources.test.tsx
+++ b/packages/web/src/__tests__/pages/Settings.catalogSources.test.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import type { CatalogSourceRecord } from '@hola/shared';
+
+/**
+ * A catalog source added without `allowRegistries` blocks every install from it
+ * with REF_NOT_ALLOWED. The server has always supported PATCHing one in place;
+ * until the edit form existed, the UI's only route was remove-and-re-add — which
+ * loses the source's other settings and is a strange thing to ask of an operator
+ * following an error message that says "add the registry to this source".
+ */
+const SOURCES: CatalogSourceRecord[] = [
+  { id: 'hola', name: 'hola', type: 'index-url', url: 'https://raw.githubusercontent.com/try-hola/apps/main/catalog.json', trust: 'verified', enabled: true },
+  { id: 'pofallon', name: 'Pofallon apps', type: 'index-url', url: 'https://example.test/catalog.json', trust: 'custom', enabled: true },
+];
+
+const catalogSources = {
+  list: vi.fn(async () => ({ items: SOURCES })),
+  add: vi.fn(async () => SOURCES[1]),
+  update: vi.fn(async () => SOURCES[1]),
+  remove: vi.fn(async () => ({ success: true })),
+};
+
+const registryCredentials = {
+  list: vi.fn(async () => ({ items: [{ id: 'acme-bot', registry: 'ghcr.io', username: 'bot' }] })),
+};
+
+vi.mock('../../utils/api-hybrid', () => ({ api: { catalogSources, registryCredentials } }));
+
+const { CatalogSourcesCard } = await import('../../pages/Settings');
+
+const renderCard = () => render(<CatalogSourcesCard inputClass="input" labelClass="label" />);
+
+beforeEach(() => vi.clearAllMocks());
+afterEach(() => cleanup());
+
+describe('Settings → Catalog Sources editing', () => {
+  it('patches an existing source in place rather than recreating it', async () => {
+    renderCard();
+    await waitFor(() => expect(screen.getByText('pofallon')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByLabelText('Edit pofallon'));
+
+    // The form opens prefilled, and the id — the record key — is not editable.
+    const idInput = screen.getByPlaceholderText('acme') as HTMLInputElement;
+    expect(idInput.value).toBe('pofallon');
+    expect(idInput.readOnly).toBe(true);
+    expect((screen.getByPlaceholderText(/raw\.githubusercontent\.com/) as HTMLInputElement).value).toBe('https://example.test/catalog.json');
+
+    fireEvent.change(screen.getByPlaceholderText('ghcr.io/myorg/*'), {
+      target: { value: 'ghcr.io/pofallon/*, ghcr.io/pofallon-labs/*' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => expect(catalogSources.update).toHaveBeenCalled());
+    expect(catalogSources.add).not.toHaveBeenCalled();
+    expect(catalogSources.remove).not.toHaveBeenCalled();
+
+    const [id, patch] = catalogSources.update.mock.calls[0] as [string, { allowRegistries: string[]; url: string; name: string }];
+    expect(id).toBe('pofallon');
+    // Comma-separated input is split and trimmed, matching the server's parser.
+    expect(patch.allowRegistries).toEqual(['ghcr.io/pofallon/*', 'ghcr.io/pofallon-labs/*']);
+    // Untouched fields are sent as they were, so saving one field can't blank another.
+    expect(patch.url).toBe('https://example.test/catalog.json');
+    expect(patch.name).toBe('Pofallon apps');
+  });
+
+  it('clearing the globs box clears the allowlist (an empty array, not "unchanged")', async () => {
+    catalogSources.list.mockResolvedValueOnce({
+      items: [{ ...SOURCES[1], allowRegistries: ['ghcr.io/pofallon/*'] }],
+    });
+    renderCard();
+    await waitFor(() => expect(screen.getByText(/allows: ghcr\.io\/pofallon\/\*/)).toBeInTheDocument());
+
+    fireEvent.click(screen.getByLabelText('Edit pofallon'));
+    fireEvent.change(screen.getByPlaceholderText('ghcr.io/myorg/*'), { target: { value: '  ' } });
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => expect(catalogSources.update).toHaveBeenCalled());
+    expect((catalogSources.update.mock.calls[0][1] as { allowRegistries: string[] }).allowRegistries).toEqual([]);
+  });
+
+  it('offers no edit for the built-in source, which has no stored record to patch', async () => {
+    renderCard();
+    await waitFor(() => expect(screen.getByText('hola')).toBeInTheDocument());
+
+    expect(screen.queryByLabelText('Edit hola')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Remove hola')).not.toBeInTheDocument();
+  });
+
+  it('still adds a new source, with the id editable and no source id preselected', async () => {
+    renderCard();
+    await waitFor(() => expect(screen.getByText('pofallon')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /add source/i }));
+    const idInput = screen.getByPlaceholderText('acme') as HTMLInputElement;
+    expect(idInput.value).toBe('');
+    expect(idInput.readOnly).toBe(false);
+
+    fireEvent.change(idInput, { target: { value: 'acme' } });
+    fireEvent.change(screen.getByPlaceholderText(/raw\.githubusercontent\.com/), { target: { value: 'https://acme.test/catalog.json' } });
+    fireEvent.click(screen.getByRole('button', { name: /^add source$/i }));
+
+    await waitFor(() => expect(catalogSources.add).toHaveBeenCalled());
+    expect(catalogSources.update).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/hooks/useDraftApi.ts
+++ b/packages/web/src/hooks/useDraftApi.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 import { api } from '../utils/api-hybrid'; // Use hybrid API
 import { globalCache } from '../utils/cache';
+import type { EnhancedError } from '../utils/error-enhanced';
 import type { 
   CreateDraftRequest, 
   CreateDraftResponse, 
@@ -15,34 +16,46 @@ export function useCreateDraft() {
     data: CreateDraftResponse | null;
     loading: boolean;
     error: string | null;
+    // The server's machine-readable failure code + payload, kept alongside the
+    // display message so the wizard can offer a fix for the failures that have
+    // one (e.g. REF_NOT_ALLOWED → allow the registry on the catalog source).
+    errorCode: string | null;
+    errorDetails: unknown;
   }>({
     data: null,
     loading: false,
     error: null,
+    errorCode: null,
+    errorDetails: null,
   });
 
   const createDraft = React.useCallback(async (request: CreateDraftRequest) => {
-    setState(prev => ({ ...prev, loading: true, error: null }));
-    
+    setState(prev => ({ ...prev, loading: true, error: null, errorCode: null, errorDetails: null }));
+
     try {
       const result = await api.drafts.create(request) as CreateDraftResponse;
-      
+
       // Cache the result for immediate retrieval
       const cacheKey = `draft-${result.draftId}`;
       globalCache.set(cacheKey, { data: result, timestamp: Date.now() });
-      
+
       setState({
         data: result,
         loading: false,
         error: null,
+        errorCode: null,
+        errorDetails: null,
       });
-      
+
       return result;
     } catch (error) {
+      const enhanced = error as Partial<EnhancedError>;
       setState({
         data: null,
         loading: false,
         error: error instanceof Error ? error.message : 'Failed to create draft',
+        errorCode: typeof enhanced?.code === 'string' ? enhanced.code : null,
+        errorDetails: enhanced?.details ?? null,
       });
       throw error;
     }

--- a/packages/web/src/pages/InstallWizard.tsx
+++ b/packages/web/src/pages/InstallWizard.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
-import { ChevronRight, ChevronDown, Check, Upload, X, Plus, AlertTriangle, Eye, EyeOff, RotateCw, FileText, Code, Download, Wand2 } from 'lucide-react';
+import { ChevronRight, ChevronDown, Check, Upload, X, Plus, AlertTriangle, Eye, EyeOff, RotateCw, FileText, Code, Download, Wand2, ShieldCheck } from 'lucide-react';
 import { AppIcon } from '../components/ui/AppIcon';
 import { ParamField } from '../components/ui/fields/ParamField';
 import type {
@@ -12,6 +12,7 @@ import type {
   AppSecurityConfig,
   AppProfileConfig,
   GetSubdomainAvailabilityResponse,
+  RefNotAllowedDetails,
 } from '@hola/shared';
 import { slugifySubdomain } from '@hola/shared';
 import { validateParams, generateSecretValue, isEffectivelyRequired } from '@hola/shared/param-validate';
@@ -50,6 +51,113 @@ function elevatedPermissionRisk(type: AppSecurityConfig['elevated'][number]['typ
       return 'Relaxes this container’s security hardening.';
   }
 }
+
+/** Sources whose `allowRegistries` can't be patched: the built-in catalog and the
+ * synthetic install-by-ref pseudo-source (neither is a stored record). */
+const UNPATCHABLE_SOURCES = new Set(['hola', 'ref', '(ref)']);
+
+/**
+ * Narrow an error payload to REF_NOT_ALLOWED details. A server older than the
+ * structured-details change sends the same code with no payload, so the shape is
+ * checked rather than assumed — without it the panel would offer to grant
+ * `undefined`. Failing the check just falls back to the plain error message.
+ */
+function asRefNotAllowed(code: string | null, details: unknown): RefNotAllowedDetails | null {
+  if (code !== 'REF_NOT_ALLOWED' || typeof details !== 'object' || details === null) return null;
+  const d = details as Partial<RefNotAllowedDetails>;
+  return typeof d.suggestedGlob === 'string' && d.suggestedGlob.length > 0
+    ? (d as RefNotAllowedDetails)
+    : null;
+}
+
+/**
+ * Draft-creation failure banner. Most failures are just reported, but the ones
+ * with a known remedy get a button that applies it — today that's
+ * `REF_NOT_ALLOWED`, where the fix is to add the blocked registry to the owning
+ * catalog source's `allowRegistries` (an explicit grant of pull consent, which is
+ * why it's a click and not something the server does for itself).
+ */
+const DraftErrorPanel: React.FC<{
+  message: string;
+  code: string | null;
+  details: unknown;
+  source?: string;
+  onRetry: () => void;
+}> = ({ message, code, details, source, onRetry }) => {
+  const [busy, setBusy] = useState(false);
+  const [fixErr, setFixErr] = useState<string | null>(null);
+
+  const refDetails = asRefNotAllowed(code, details);
+  const suggestedGlob = refDetails?.suggestedGlob;
+  // Only a stored custom source can be granted the registry; the built-in catalog
+  // and by-ref installs have no record to patch (see UNPATCHABLE_SOURCES).
+  const canAllow = Boolean(suggestedGlob && source && !UNPATCHABLE_SOURCES.has(source));
+
+  const allowRegistry = async () => {
+    if (!suggestedGlob || !source) return;
+    setBusy(true); setFixErr(null);
+    try {
+      // Merge, never replace: this is an additional grant, and clobbering an
+      // existing allowlist would silently revoke consent the operator gave before.
+      const { items } = await api.catalogSources.list();
+      const existing = items.find(s => s.id === source)?.allowRegistries ?? [];
+      await api.catalogSources.update(source, {
+        allowRegistries: Array.from(new Set([...existing, suggestedGlob])),
+      });
+      onRetry();
+    } catch (e) {
+      setFixErr(e instanceof Error ? e.message : 'Failed to update the catalog source');
+    } finally { setBusy(false); }
+  };
+
+  return (
+    <div className="bg-danger-weak border border-danger/20 text-danger rounded-card p-4 text-sm mt-4">
+      <div className="flex items-start gap-3">
+        <AlertTriangle className="w-5 h-5 flex-none mt-0.5" />
+        <div className="min-w-0 flex-1">
+          <div className="font-semibold">{refDetails ? 'Registry not allowed' : 'Error'}</div>
+          <div className="text-text-muted mt-1 break-words">{message}</div>
+
+          {refDetails && !canAllow && (
+            <div className="text-text-muted mt-2">
+              This package came from a source Hola can’t grant registries for. Add{' '}
+              <code className="text-text-strong">{suggestedGlob}</code> to <code>HOLA_REGISTRY_ALLOWLIST</code> on the server and restart it.
+            </div>
+          )}
+
+          {fixErr && <div className="text-danger mt-2">{fixErr}</div>}
+
+          <div className="flex flex-wrap items-center gap-2 mt-3">
+            {canAllow && (
+              <button
+                onClick={allowRegistry}
+                disabled={busy}
+                className="bg-primary text-primary-contrast px-3 py-1.5 rounded-lg text-[13px] font-medium hover:bg-primary/90 transition-colors disabled:opacity-50 flex items-center gap-2"
+              >
+                <ShieldCheck className="w-4 h-4" />
+                Allow <code className="font-mono">{suggestedGlob}</code> for “{source}”
+              </button>
+            )}
+            <button
+              onClick={onRetry}
+              disabled={busy}
+              className="px-3 py-1.5 rounded-lg text-[13px] font-medium text-text-muted hover:text-text-strong transition-colors disabled:opacity-50 flex items-center gap-2"
+            >
+              <RotateCw className="w-4 h-4" /> Try again
+            </button>
+          </div>
+
+          {canAllow && (
+            <p className="text-[12px] text-text-muted mt-2">
+              Grants the “{source}” catalog source permission to pull packages from{' '}
+              <code>{suggestedGlob}</code>. You can change this later in Settings → Catalog Sources.
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
 
 export const InstallWizard: React.FC = () => {
   const { appId } = useParams();
@@ -165,6 +273,8 @@ export const InstallWizard: React.FC = () => {
   // draft is created exactly once (without it, the in-flight window before
   // `data` is set races dozens of duplicate createDraft calls).
   const creatingDraftRef = React.useRef(false);
+  // Bumped to ask for one more attempt after a failure (see `retryDraft`).
+  const [draftAttempt, setDraftAttempt] = useState(0);
   useEffect(() => {
     if ((!appId && !ociRef) || createDraftHook.data || creatingDraftRef.current) return;
     creatingDraftRef.current = true;
@@ -213,13 +323,26 @@ export const InstallWizard: React.FC = () => {
         }
 
       } catch (err) {
-        creatingDraftRef.current = false; // allow a retry on failure
+        // Deliberately leave the guard SET. This effect re-runs on every render
+        // (the hook object is a fresh reference each time) and the failure itself
+        // sets error state, so clearing the guard here spun the wizard into an
+        // unbounded retry loop against a request that keeps failing. Retrying is
+        // now explicit — see `retryDraft`, which the error banner drives.
         console.error('Failed to create draft:', err);
       }
     };
 
     initializeDraft();
-  }, [appId, ociRef, credentialRef, source, createDraftHook]); // Include the whole hook object
+    // `draftAttempt` is the explicit retry signal; the hook object is included
+    // as-is (it's a new reference each render, so the ref guard above — not this
+    // list — is what keeps the draft created exactly once).
+  }, [appId, ociRef, credentialRef, source, draftAttempt, createDraftHook]);
+
+  /** Re-run draft creation after a failure the operator has just fixed. */
+  const retryDraft = React.useCallback(() => {
+    creatingDraftRef.current = false;
+    setDraftAttempt(n => n + 1);
+  }, []);
 
   // Seed the instance name from the catalog display name once the draft resolves
   // (until the user edits it) — so a normal install keeps the app's own name/host.
@@ -1560,15 +1683,13 @@ services:
 
       {/* Error State */}
       {error && !draftId && (
-        <div className="bg-danger-weak border border-danger/20 text-danger rounded-card p-4 text-sm mt-4">
-          <div className="flex items-start gap-3">
-            <AlertTriangle className="w-5 h-5 flex-none mt-0.5" />
-            <div>
-              <div className="font-semibold">Error</div>
-              <div className="text-text-muted mt-1">{error}</div>
-            </div>
-          </div>
-        </div>
+        <DraftErrorPanel
+          message={error}
+          code={createDraftHook.errorCode}
+          details={createDraftHook.errorDetails}
+          source={source}
+          onRetry={retryDraft}
+        />
       )}
 
       {/* Wizard Content - only show when draft is ready */}

--- a/packages/web/src/pages/Settings.tsx
+++ b/packages/web/src/pages/Settings.tsx
@@ -10,7 +10,8 @@ import {
   Wifi,
   WifiOff,
   AlertTriangle,
-  Activity
+  Activity,
+  Pencil
 } from 'lucide-react';
 import type {
   SystemEnvVar,
@@ -135,10 +136,13 @@ const RegistryCredentialsCard: React.FC<{ inputClass: string; labelClass: string
  * stored registry credential for private packages. The built-in `hola` source is
  * always present (verified) and can't be removed.
  */
-const CatalogSourcesCard: React.FC<{ inputClass: string; labelClass: string }> = ({ inputClass, labelClass }) => {
+export const CatalogSourcesCard: React.FC<{ inputClass: string; labelClass: string }> = ({ inputClass, labelClass }) => {
   const [items, setItems] = useState<CatalogSourceRecord[]>([]);
   const [creds, setCreds] = useState<RegistryCredentialRecord[]>([]);
-  const [adding, setAdding] = useState(false);
+  // The open form, if any: `add` for a new source, or the id of the source being
+  // edited. Editing exists chiefly so `allowRegistries` can be fixed after a
+  // REF_NOT_ALLOWED install failure without deleting and re-adding the source.
+  const [form, setForm] = useState<'add' | { editing: string } | null>(null);
   const [id, setId] = useState('');
   const [name, setName] = useState('');
   const [url, setUrl] = useState('');
@@ -149,40 +153,75 @@ const CatalogSourcesCard: React.FC<{ inputClass: string; labelClass: string }> =
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
+  const editingId = form && form !== 'add' ? form.editing : null;
+
   const refresh = React.useCallback(() => {
     api.catalogSources.list().then(r => setItems(r.items)).catch(() => setItems([]));
     api.registryCredentials.list().then(r => setCreds(r.items)).catch(() => setCreds([]));
   }, []);
   React.useEffect(() => { refresh(); }, [refresh]);
 
-  const add = async () => {
-    if (!id.trim() || !url.trim()) { setErr('id and url are required.'); return; }
+  const closeForm = () => {
+    setId(''); setName(''); setUrl(''); setCredentialRef(''); setAllowRegistries('');
+    setForm(null); setErr(null);
+  };
+
+  const openAdd = () => { closeForm(); setForm('add'); };
+
+  const openEdit = (s: CatalogSourceRecord) => {
+    setId(s.id);
+    setName(s.name === s.id ? '' : s.name);
+    setUrl(s.url);
+    setCredentialRef(s.auth?.credentialRef ?? '');
+    setAllowRegistries((s.allowRegistries ?? []).join(', '));
+    setForm({ editing: s.id });
+    setErr(null);
+  };
+
+  const save = async () => {
+    if (!editingId && !id.trim()) { setErr('id and url are required.'); return; }
+    if (!url.trim()) { setErr('id and url are required.'); return; }
     setBusy(true); setErr(null);
     try {
       // Pair the credential with the registry host derived from the credential record.
       const cred = creds.find(c => c.id === credentialRef);
-      const auth = cred ? { registry: cred.registry, credentialRef: cred.id } : undefined;
       // Server accepts comma-separated globs in a single string; no client-side
       // validation beyond non-empty trimming — the server rejects malformed
       // globs with SOURCE_ALLOW_REGISTRY_INVALID and surfaces the message.
       const globs = allowRegistries.split(',').map(s => s.trim()).filter(Boolean);
-      await api.catalogSources.add({
-        id: id.trim(),
-        name: name.trim() || id.trim(),
-        url: url.trim(),
-        auth,
-        allowRegistries: globs.length > 0 ? globs : undefined,
-      });
-      setId(''); setName(''); setUrl(''); setCredentialRef(''); setAllowRegistries(''); setAdding(false);
+      if (editingId) {
+        // Every field is sent, so the form is authoritative: clearing the
+        // credential select or the globs box clears them on the record (`null` /
+        // `[]` are the documented "clear this" values).
+        await api.catalogSources.update(editingId, {
+          name: name.trim() || editingId,
+          url: url.trim(),
+          auth: cred ? { registry: cred.registry, credentialRef: cred.id } : null,
+          allowRegistries: globs,
+        });
+      } else {
+        await api.catalogSources.add({
+          id: id.trim(),
+          name: name.trim() || id.trim(),
+          url: url.trim(),
+          auth: cred ? { registry: cred.registry, credentialRef: cred.id } : undefined,
+          allowRegistries: globs.length > 0 ? globs : undefined,
+        });
+      }
+      closeForm();
       refresh();
     } catch (e) {
-      setErr(e instanceof Error ? e.message : 'Failed to add source');
+      setErr(e instanceof Error ? e.message : `Failed to ${editingId ? 'update' : 'add'} source`);
     } finally { setBusy(false); }
   };
 
   const remove = async (sourceId: string) => {
     setBusy(true); setErr(null);
-    try { await api.catalogSources.remove(sourceId); refresh(); }
+    try {
+      await api.catalogSources.remove(sourceId);
+      if (editingId === sourceId) closeForm();
+      refresh();
+    }
     catch (e) { setErr(e instanceof Error ? e.message : 'Failed to remove source'); }
     finally { setBusy(false); }
   };
@@ -215,19 +254,32 @@ const CatalogSourcesCard: React.FC<{ inputClass: string; labelClass: string }> =
               )}
             </div>
             {s.id !== 'hola' && (
-              <button onClick={() => remove(s.id)} disabled={busy} className="text-text-muted hover:text-danger transition-colors disabled:opacity-50 flex-none ml-2" aria-label={`Remove ${s.id}`}>
-                <X className="w-4 h-4" />
-              </button>
+              <div className="flex items-center gap-1 flex-none ml-2">
+                <button onClick={() => openEdit(s)} disabled={busy} className="text-text-muted hover:text-text-strong transition-colors disabled:opacity-50" aria-label={`Edit ${s.id}`}>
+                  <Pencil className="w-4 h-4" />
+                </button>
+                <button onClick={() => remove(s.id)} disabled={busy} className="text-text-muted hover:text-danger transition-colors disabled:opacity-50" aria-label={`Remove ${s.id}`}>
+                  <X className="w-4 h-4" />
+                </button>
+              </div>
             )}
           </div>
         ))}
       </div>
 
-      {adding ? (
+      {form ? (
         <div className="grid grid-cols-2 gap-3">
           <div>
             <div className={labelClass}>Source id</div>
-            <input value={id} onChange={(e) => setId(e.target.value)} placeholder="acme" className={inputClass} />
+            {/* The id is the record key — patching it would be a different source. */}
+            <input
+              value={id}
+              onChange={(e) => setId(e.target.value)}
+              placeholder="acme"
+              readOnly={Boolean(editingId)}
+              aria-readonly={Boolean(editingId)}
+              className={`${inputClass}${editingId ? ' opacity-60 cursor-not-allowed' : ''}`}
+            />
           </div>
           <div>
             <div className={labelClass}>Name (optional)</div>
@@ -257,14 +309,14 @@ const CatalogSourcesCard: React.FC<{ inputClass: string; labelClass: string }> =
             </p>
           </div>
           <div className="col-span-2 flex items-center gap-2">
-            <button onClick={add} disabled={busy} className="bg-primary text-primary-contrast px-4 py-2 rounded-lg text-[13px] font-medium hover:bg-primary/90 transition-colors disabled:opacity-50 flex items-center gap-2">
-              <Save className="w-4 h-4" /> Add source
+            <button onClick={save} disabled={busy} className="bg-primary text-primary-contrast px-4 py-2 rounded-lg text-[13px] font-medium hover:bg-primary/90 transition-colors disabled:opacity-50 flex items-center gap-2">
+              <Save className="w-4 h-4" /> {editingId ? 'Save changes' : 'Add source'}
             </button>
-            <button onClick={() => { setAdding(false); setErr(null); }} className="px-4 py-2 rounded-lg text-[13px] text-text-muted hover:text-text-strong transition-colors">Cancel</button>
+            <button onClick={closeForm} className="px-4 py-2 rounded-lg text-[13px] text-text-muted hover:text-text-strong transition-colors">Cancel</button>
           </div>
         </div>
       ) : (
-        <button onClick={() => setAdding(true)} className="flex items-center gap-2 text-[13px] font-medium text-primary hover:opacity-80 transition-opacity">
+        <button onClick={openAdd} className="flex items-center gap-2 text-[13px] font-medium text-primary hover:opacity-80 transition-opacity">
           <Plus className="w-4 h-4" /> Add source
         </button>
       )}

--- a/packages/web/src/pages/Settings.tsx
+++ b/packages/web/src/pages/Settings.tsx
@@ -11,13 +11,15 @@ import {
   WifiOff,
   AlertTriangle,
   Activity,
-  Pencil
+  Pencil,
+  RotateCw
 } from 'lucide-react';
 import type {
   SystemEnvVar,
   GetBackupSettingsResponse,
   RegistryCredentialRecord,
-  CatalogSourceRecord
+  CatalogSourceRecord,
+  PreviewCatalogSourceResponse
 } from '@hola/shared';
 import { useSettingsApi } from '../hooks/useSettingsApi';
 import { useBackupSettingsApi } from '../hooks/useSettingsApi';
@@ -152,8 +154,46 @@ export const CatalogSourcesCard: React.FC<{ inputClass: string; labelClass: stri
   const [allowRegistries, setAllowRegistries] = useState('');
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+  // What the catalog at `url` actually contains, probed as the operator types it.
+  // `null` while idle/in-flight; `error` when the URL isn't a usable catalog.
+  const [preview, setPreview] = useState<PreviewCatalogSourceResponse | null>(null);
+  const [previewing, setPreviewing] = useState(false);
+  const [previewErr, setPreviewErr] = useState<string | null>(null);
 
   const editingId = form && form !== 'add' ? form.editing : null;
+
+  /** The globs box, parsed the way the server parses it. */
+  const globList = React.useMemo(
+    () => allowRegistries.split(',').map(s => s.trim()).filter(Boolean),
+    [allowRegistries],
+  );
+
+  const toggleGlob = (glob: string) => {
+    setAllowRegistries(
+      globList.includes(glob)
+        ? globList.filter(g => g !== glob).join(', ')
+        : [...globList, glob].join(', '),
+    );
+  };
+
+  // Probe the URL as it settles. Debounced because it's a real network fetch on
+  // the server's side; nothing is stored, so probing an in-progress URL is safe.
+  React.useEffect(() => {
+    const candidate = url.trim();
+    if (!form || !/^https?:\/\/\S+$/.test(candidate)) {
+      setPreview(null); setPreviewErr(null); setPreviewing(false);
+      return;
+    }
+    let cancelled = false;
+    setPreviewing(true); setPreviewErr(null);
+    const t = setTimeout(() => {
+      api.catalogSources.preview(candidate)
+        .then(res => { if (!cancelled) { setPreview(res); setPreviewErr(null); } })
+        .catch(e => { if (!cancelled) { setPreview(null); setPreviewErr(e instanceof Error ? e.message : 'Could not read this catalog'); } })
+        .finally(() => { if (!cancelled) setPreviewing(false); });
+    }, 600);
+    return () => { cancelled = true; clearTimeout(t); setPreviewing(false); };
+  }, [url, form]);
 
   const refresh = React.useCallback(() => {
     api.catalogSources.list().then(r => setItems(r.items)).catch(() => setItems([]));
@@ -164,6 +204,7 @@ export const CatalogSourcesCard: React.FC<{ inputClass: string; labelClass: stri
   const closeForm = () => {
     setId(''); setName(''); setUrl(''); setCredentialRef(''); setAllowRegistries('');
     setForm(null); setErr(null);
+    setPreview(null); setPreviewErr(null);
   };
 
   const openAdd = () => { closeForm(); setForm('add'); };
@@ -288,6 +329,67 @@ export const CatalogSourcesCard: React.FC<{ inputClass: string; labelClass: stri
           <div className="col-span-2">
             <div className={labelClass}>Catalog URL</div>
             <input value={url} onChange={(e) => setUrl(e.target.value)} placeholder="https://raw.githubusercontent.com/acme/hola-apps/main/catalog.json" className={inputClass} />
+
+            {/* What the URL actually returned. The registries come from the
+                catalog's own OCI refs, so the operator grants consent from real
+                data instead of guessing a glob — and a bad URL is caught here
+                rather than as an empty source (or a failed install) later. */}
+            {previewing && (
+              <p className="text-[12px] text-text-muted mt-2 flex items-center gap-1.5">
+                <RotateCw className="w-3 h-3 animate-spin" /> Reading catalog…
+              </p>
+            )}
+            {previewErr && !previewing && (
+              <p className="text-[12px] text-warning mt-2 flex items-start gap-1.5">
+                <AlertTriangle className="w-3.5 h-3.5 flex-none mt-px" />
+                <span>{previewErr}</span>
+              </p>
+            )}
+            {preview && !previewing && (
+              <div className="mt-2 bg-surface-0 border border-border rounded-lg p-3">
+                <div className="text-[12.5px] text-text-strong">
+                  {preview.appCount} app{preview.appCount === 1 ? '' : 's'}
+                  {preview.registries.length > 0 && <>, published from:</>}
+                </div>
+                {preview.registries.length === 0 ? (
+                  <p className="text-[12px] text-text-muted mt-1">
+                    {preview.appsWithoutRefs > 0
+                      ? 'No app in this catalog points at an installable package yet, so no registry access is needed.'
+                      : 'This catalog lists no apps yet.'}
+                  </p>
+                ) : (
+                  <div className="flex flex-col gap-1.5 mt-2">
+                    {preview.registries.map(r => (
+                      <label key={r.glob} className={`flex items-center gap-2 text-[12.5px] ${r.covered ? 'text-text-muted' : 'text-text-strong cursor-pointer'}`}>
+                        <input
+                          type="checkbox"
+                          // Already covered by the server baseline: granting it
+                          // per-source would be a no-op, so it's shown, not asked.
+                          checked={r.covered || globList.includes(r.glob)}
+                          disabled={r.covered}
+                          onChange={() => toggleGlob(r.glob)}
+                          aria-label={`Allow ${r.glob}`}
+                        />
+                        <code>{r.glob}</code>
+                        <span className="text-text-muted">
+                          ({r.appCount} app{r.appCount === 1 ? '' : 's'}{r.covered ? ', already allowed' : ''})
+                        </span>
+                      </label>
+                    ))}
+                  </div>
+                )}
+                {preview.registries.some(r => !r.covered) && (
+                  <p className="text-[12px] text-text-muted mt-2">
+                    Ticking a registry lets this source pull packages from it. Leave it unticked and installs from those apps will fail until you allow it.
+                  </p>
+                )}
+                {preview.appsWithoutRefs > 0 && preview.registries.length > 0 && (
+                  <p className="text-[12px] text-text-muted mt-1">
+                    {preview.appsWithoutRefs} app{preview.appsWithoutRefs === 1 ? '' : 's'} list no installable package.
+                  </p>
+                )}
+              </div>
+            )}
           </div>
           <div className="col-span-2">
             <div className={labelClass}>Registry credential (for private packages)</div>

--- a/packages/web/src/utils/error-enhanced.ts
+++ b/packages/web/src/utils/error-enhanced.ts
@@ -29,6 +29,14 @@ export interface EnhancedError extends Error {
   statusCode?: number;
   timestamp: number;
   suggestion?: string;
+  /**
+   * The server's machine-readable `error.code` and `error.details`, preserved
+   * verbatim. Callers that can OFFER a fix (e.g. REF_NOT_ALLOWED → PATCH the
+   * source's allowRegistries) discriminate on these rather than regexing the
+   * human-facing message, which is free to change.
+   */
+  code?: string;
+  details?: unknown;
 }
 
 // Retry configuration with exponential backoff
@@ -175,14 +183,22 @@ export function createEnhancedError(
   return enhancedError;
 }
 
-// Enhanced error message extraction with better parsing
-export async function toEnhancedErrorMessage(res: Response): Promise<string> {
+/**
+ * Parse an error response body once, returning both the human-facing message and
+ * the server's machine-readable `code`/`details`. The body is a stream that can
+ * only be read once, so callers that want both must go through here.
+ */
+export async function parseErrorBody(
+  res: Response
+): Promise<{ message: string; code?: string; details?: unknown }> {
   try {
     const data = (await res.json()) as Partial<ErrorResponse> | unknown;
-    
+
     // Try to extract detailed error message
     let serverMessage = '';
-    
+    let code: string | undefined;
+    let details: unknown;
+
     if (typeof data === 'object' && data !== null) {
       // Check for nested error structure
       if ('error' in data) {
@@ -191,6 +207,12 @@ export async function toEnhancedErrorMessage(res: Response): Promise<string> {
           if ('message' in errorObj && typeof (errorObj as { message?: unknown }).message === 'string') {
             serverMessage = (errorObj as { message: string }).message;
           }
+          if ('code' in errorObj && typeof (errorObj as { code?: unknown }).code === 'string') {
+            code = (errorObj as { code: string }).code;
+          }
+          // Preserve `details` verbatim for callers that act on it (the
+          // validation-issue flattening below only shapes the MESSAGE).
+          if ('details' in errorObj) details = (errorObj as { details?: unknown }).details;
           // Check for validation errors. The server sends these either as a
           // bare `details` array or, for DraftValidationError (the finalize /
           // promote / deployment-config 422s), as `details: { issues: [...] }`.
@@ -226,18 +248,23 @@ export async function toEnhancedErrorMessage(res: Response): Promise<string> {
 
     // Return server message if available and meaningful
     if (serverMessage && serverMessage.trim().length > 0) {
-      return serverMessage;
+      return { message: serverMessage, code, details };
     }
 
     // Fallback to status-based message
     const errorType = classifyError(res);
-    return ERROR_MESSAGES[errorType].message;
-    
+    return { message: ERROR_MESSAGES[errorType].message, code, details };
+
   } catch {
     // If JSON parsing fails, use status-based message
     const errorType = classifyError(res);
-    return ERROR_MESSAGES[errorType].message;
+    return { message: ERROR_MESSAGES[errorType].message };
   }
+}
+
+// Enhanced error message extraction with better parsing
+export async function toEnhancedErrorMessage(res: Response): Promise<string> {
+  return (await parseErrorBody(res)).message;
 }
 
 // Calculate delay for exponential backoff with jitter
@@ -271,9 +298,11 @@ export async function enhancedFetch(
       const response = await fetch(input, init);
       
       if (!response.ok) {
-        const errorMessage = await toEnhancedErrorMessage(response);
-        const error = new Error(errorMessage);
-        throw createEnhancedError(error, response);
+        // Read the body once: the message for display, plus code/details so a
+        // caller can act on the failure (see EnhancedError.code).
+        const { message, code, details } = await parseErrorBody(response);
+        const error = new Error(message);
+        throw Object.assign(createEnhancedError(error, response), { code, details });
       }
       
       return response;

--- a/packages/web/src/utils/sdk-adapter.ts
+++ b/packages/web/src/utils/sdk-adapter.ts
@@ -13,6 +13,7 @@ import type {
   InstallFromRefRequest, InstallFromRefResponse,
   // Catalog sources (multi-catalog Slice 2)
   AddCatalogSourceRequest, UpdateCatalogSourceRequest, ListCatalogSourcesResponse, CatalogSourceRecord,
+  PreviewCatalogSourceResponse,
   // Draft types  
   CreateDraftRequest, CreateDraftResponse, GetDraftResponse, 
   PatchDraftRequest, PatchDraftResponse, ValidateDraftResponse, FinalizeDraftResponse,
@@ -379,6 +380,9 @@ export class SdkAdapter {
       globalCache.deleteByPattern(/^api:.*\/catalog/);
       return res;
     },
+    // Read-only probe: stores nothing, so it neither invalidates nor is cached
+    // (the operator editing a URL expects each probe to actually hit the URL).
+    preview: (url: string): Promise<PreviewCatalogSourceResponse> => this.sdk.catalogSources.preview(url),
   };
 
   // Drafts (Install Wizard) with cache invalidation

--- a/packages/web/src/utils/sdk-adapter.ts
+++ b/packages/web/src/utils/sdk-adapter.ts
@@ -12,7 +12,7 @@ import type {
   AddRegistryCredentialRequest, ListRegistryCredentialsResponse, RegistryCredentialRecord,
   InstallFromRefRequest, InstallFromRefResponse,
   // Catalog sources (multi-catalog Slice 2)
-  AddCatalogSourceRequest, ListCatalogSourcesResponse, CatalogSourceRecord,
+  AddCatalogSourceRequest, UpdateCatalogSourceRequest, ListCatalogSourcesResponse, CatalogSourceRecord,
   // Draft types  
   CreateDraftRequest, CreateDraftResponse, GetDraftResponse, 
   PatchDraftRequest, PatchDraftResponse, ValidateDraftResponse, FinalizeDraftResponse,
@@ -363,6 +363,12 @@ export class SdkAdapter {
       this.getWithCache('/api/catalog-sources', () => this.sdk.catalogSources.list()),
     add: async (data: AddCatalogSourceRequest): Promise<CatalogSourceRecord> => {
       const res = await this.sdk.catalogSources.add(data);
+      globalCache.deleteByPattern(/^api:.*\/catalog-sources/);
+      globalCache.deleteByPattern(/^api:.*\/catalog/);
+      return res;
+    },
+    update: async (id: string, data: UpdateCatalogSourceRequest): Promise<CatalogSourceRecord> => {
+      const res = await this.sdk.catalogSources.update(id, data);
       globalCache.deleteByPattern(/^api:.*\/catalog-sources/);
       globalCache.deleteByPattern(/^api:.*\/catalog/);
       return res;


### PR DESCRIPTION
Installing from a custom catalog source failed with a 403 the product couldn't fix:

```
REF_NOT_ALLOWED: ghcr.io/pofallon/hola-get2know-cms:0.1.13 is not covered by the
registry allowlist (ghcr.io/try-hola/*). Add the registry to this catalog
source's allowRegistries, or to HOLA_REGISTRY_ALLOWLIST.
```

The message names the remedy, but `allowRegistries` could only be set when the
source was first added — and only as free text the operator had to know in
advance. `PATCH /api/catalog-sources/:id` existed for exactly this and had no
callers, so "add the registry to this source" meant delete it and re-add it.

Three changes, from the failure back to its root.

## 1. Don't land there: preview the catalog at add time

`POST /api/catalog-sources/preview` fetches a `catalog.json` and reports the
registries its apps' OCI refs actually point at, counted by app, each flagged
with whether the server baseline already covers it. Settings probes the URL as it
settles and lists what it found with a tick box per registry.

Deriving the glob from the catalog URL was the other option and is wrong: it only
holds for GitHub+GHCR, and silently prefilling a consent field defeats the point
of having one. The catalog itself knows the answer, so consent comes from real
data. **Boxes start unticked** — pasting a URL grants nothing.

It doubles as URL validation. The fetcher casts parsed JSON straight to a catalog
shape, so an HTML page or a repo root previously "succeeded" and became a silently
empty source; that now fails as `CATALOG_MALFORMED` / `CATALOG_UNREACHABLE` while
the operator is still looking at the field.

`hola source add` without `--allow-registry` prints the same finding as a note,
with the `source update` line that grants it.

## 2. Sources are editable

- `catalogSources.update` in the SDK and web adapter.
- Settings gets a per-source edit form (id read-only — it's the record key).
- `hola source update <id>` — a patch: an omitted flag leaves that field alone,
  `--allow-registry` replaces the glob list, `--clear-allow-registry` empties it,
  `--enable`/`--disable` toggle aggregation.

## 3. The failure carries its own fix

`REF_NOT_ALLOWED` now carries `{ ref, suggestedGlob, allowed }` as structured
details, and the web error layer preserves the server's `code`/`details` on
`EnhancedError` instead of flattening every failure to a message string. The
install wizard's banner offers **"Allow `ghcr.io/…/*` for <source>"**, which
merges the grant into the source's allowlist (never replaces it) and retries in
place.

`suggestedGlob` is namespace-scoped — `ghcr.io/acme/*`, never `ghcr.io/*` — so
allowing one publisher doesn't allow every other org on that registry.
Install-by-ref and the built-in source have no record to patch, so they get the
`HOLA_REGISTRY_ALLOWLIST` hint rather than a dead button, and a server that sends
the code without details falls back to the plain message.

`matchesAllowlist` is exported and reused for the preview's `covered` flag: a
second implementation would be free to drift into telling an operator a ref is
allowed when the pull gate disagrees.

## Incidental fix: unbounded draft-creation retry loop

Making the error banner stable surfaced a real bug. The draft-creation effect
re-runs on every render (the hook object is a fresh reference each time) and
cleared its own guard on failure, so a failing install re-POSTed continuously —
**49 calls in 50ms** with the old line restored under test. The guard now stays
set and retrying is explicit.

## Testing

`bun run typecheck` · `lint` · `build` clean.

- **Server** — preview reports namespaces counted by app with baseline coverage
  marked, rejects a non-catalog URL, never serves a preview from the source
  cache; the 403 carries its details, and the suggested glob unblocks its own ref
  but *not* a sibling namespace.
- **Web** — 4 wizard tests (offer + merge + retry, no-record case,
  missing-details fallback, no-hammering) and 8 Settings tests (probe + opt-in
  grant, unticking withdraws, bad URL reported, preview on edit, patch not
  re-add, clearing, built-in has no edit, add still works).
- **CLI** — 13 tests across `source update` and the add-time warning.

Two failures in `deployments/pre-upgrade-snapshot` are pre-existing on `main`
(verified by stashing and re-running there) and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)