### PR TITLE
chore(release): 0.9.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/cli": {
       "name": "@hola/cli",
-      "version": "0.8.4",
+      "version": "0.9.0",
       "bin": {
         "hola": "./bin/hola",
       },
@@ -37,11 +37,11 @@
     },
     "packages/compose": {
       "name": "@hola/compose",
-      "version": "0.8.4",
+      "version": "0.9.0",
     },
     "packages/sdk": {
       "name": "@hola/sdk",
-      "version": "0.8.4",
+      "version": "0.9.0",
       "dependencies": {
         "@hola/shared": "workspace:*",
       },
@@ -55,7 +55,7 @@
     },
     "packages/server": {
       "name": "@hola/server",
-      "version": "0.8.4",
+      "version": "0.9.0",
       "dependencies": {
         "@hola/shared": "workspace:*",
         "jose": "^6.2.3",
@@ -71,7 +71,7 @@
     },
     "packages/shared": {
       "name": "@hola/shared",
-      "version": "0.8.4",
+      "version": "0.9.0",
       "dependencies": {
         "yaml": "^2.9.0",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.8.4';
+export const CLI_VERSION = '0.9.0';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Minor release. Catalog-source registry consent is now something the product can
do, end to end.

- **feat(web,server,cli): catalog-source registry consent — preview, edit, and a
  one-click fix (#404)** — adding a custom catalog source asked for
  `allowRegistries` as free text the operator had to know in advance, and getting
  it wrong (or omitting it) failed every install from that source with a 403
  whose stated remedy the UI couldn't apply.
  - Adding a source now reads the catalog first and lists the registries its apps
    actually publish from, with a tick box each (unticked by default — pasting a
    URL grants nothing). It doubles as URL validation: a non-catalog URL is
    caught at the field instead of becoming a silently empty source.
  - Sources are editable — in Settings, and via `hola source update`. The
    server's PATCH endpoint existed for exactly this and had no callers.
  - A `REF_NOT_ALLOWED` install failure now carries its own fix and offers
    "Allow `<registry>` for `<source>`", which grants it and retries in place.
  - Also caught an unbounded retry loop: a failed draft creation re-POSTed
    continuously (49 calls in 50ms under test) instead of stopping at the error.

Version bump only — no code changes in this PR.

**Upgrade note:** nothing to do. A source added before this release that fails
with `REF_NOT_ALLOWED` can now be fixed from the failure itself, or under
Settings → Catalog Sources — no delete-and-re-add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)