### PR TITLE
feat(web): show the running Hola version in the sidebar

### DIFF
--- a/packages/web/src/__tests__/components/SidebarVersion.test.tsx
+++ b/packages/web/src/__tests__/components/SidebarVersion.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { SidebarVersion } from '../../components/layout/SidebarVersion';
+import type { UpdateCheckResult } from '@hola/shared';
+
+const updateCheck = vi.fn();
+vi.mock('../../utils/api-hybrid', () => ({
+  api: { system: { updateCheck: () => updateCheck() } },
+}));
+
+function renderVersion(isCollapsed = false) {
+  return render(
+    <MemoryRouter>
+      <SidebarVersion isCollapsed={isCollapsed} />
+    </MemoryRouter>,
+  );
+}
+
+function mockResult(result: UpdateCheckResult) {
+  updateCheck.mockResolvedValue(result);
+}
+
+describe('SidebarVersion', () => {
+  beforeEach(() => {
+    updateCheck.mockReset();
+  });
+
+  it('shows the running version and links to settings', async () => {
+    mockResult({ current: '0.9.0', latest: '0.9.0', updateAvailable: false, releaseUrl: null });
+    renderVersion();
+
+    expect(await screen.findByText('v0.9.0')).toBeInTheDocument();
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/settings');
+    expect(link).toHaveAttribute('title', 'Hola v0.9.0');
+    expect(screen.queryByText('Update')).not.toBeInTheDocument();
+  });
+
+  it('flags an available update alongside the running version', async () => {
+    mockResult({
+      current: '0.9.0',
+      latest: '1.0.0',
+      updateAvailable: true,
+      releaseUrl: 'https://example.com/releases/1.0.0',
+    });
+    renderVersion();
+
+    expect(await screen.findByText('v0.9.0')).toBeInTheDocument();
+    expect(screen.getByText('Update')).toBeInTheDocument();
+    expect(screen.getByRole('link')).toHaveAttribute(
+      'title',
+      'Hola v0.9.0 — v1.0.0 is available',
+    );
+  });
+
+  it('drops the "v" prefix and the label when collapsed', async () => {
+    mockResult({ current: '0.9.0', latest: '0.9.0', updateAvailable: false, releaseUrl: null });
+    renderVersion(true);
+
+    expect(await screen.findByText('0.9.0')).toBeInTheDocument();
+    expect(screen.queryByText('v0.9.0')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when the version is unknown', async () => {
+    updateCheck.mockRejectedValue(new Error('offline'));
+    const { container } = renderVersion();
+    await Promise.resolve();
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/packages/web/src/components/layout/Sidebar.tsx
+++ b/packages/web/src/components/layout/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
   PanelLeftClose,
   PanelLeftOpen,
 } from 'lucide-react';
+import { SidebarVersion } from './SidebarVersion';
 
 const navigationItems = [
   { name: 'Apps', path: '/apps', icon: LayoutGrid },
@@ -84,8 +85,9 @@ export const Sidebar: React.FC<SidebarProps> = ({ isCollapsed, onToggleCollapse 
         })}
       </nav>
 
-      {/* Collapse */}
-      <div className="flex-none p-3 border-t border-border-soft">
+      {/* Version + collapse */}
+      <div className="flex-none p-3 border-t border-border-soft flex flex-col gap-px">
+        <SidebarVersion isCollapsed={isCollapsed} />
         <button
           onClick={onToggleCollapse}
           className="w-full flex items-center gap-3 px-[11px] py-[9px] rounded-[9px] cursor-pointer text-text-muted text-[13.5px] hover:bg-surface-2 hover:text-text-strong transition-colors"

--- a/packages/web/src/components/layout/SidebarVersion.tsx
+++ b/packages/web/src/components/layout/SidebarVersion.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { useUpdateCheck } from '../../hooks/useUpdateCheck';
+
+interface SidebarVersionProps {
+  isCollapsed: boolean;
+}
+
+/**
+ * The running Hola version, shown at the foot of the sidebar so an operator can
+ * always tell what's deployed without digging into Settings (which is where the
+ * link goes for the fuller system status).
+ *
+ * The version comes from the update-check endpoint — it reports the running
+ * version alongside the newest release, is cached server-side for an hour, and is
+ * fail-safe when the host is offline (so `current` is still populated). That's a
+ * far cheaper read than /api/system/status, which shells out to docker/oras.
+ */
+export const SidebarVersion: React.FC<SidebarVersionProps> = ({ isCollapsed }) => {
+  const { data } = useUpdateCheck();
+
+  // Nothing to show until the version is known (or if the request failed).
+  if (!data?.current) return null;
+
+  const title = data.updateAvailable && data.latest
+    ? `Hola v${data.current} — v${data.latest} is available`
+    : `Hola v${data.current}`;
+
+  return (
+    <Link
+      to="/settings"
+      title={title}
+      className={`flex items-center gap-2 ${
+        isCollapsed ? 'justify-center px-1' : 'px-[11px]'
+      } py-[7px] rounded-[9px] text-[12px] text-text-muted hover:bg-surface-2 hover:text-text-strong transition-colors`}
+    >
+      {isCollapsed ? (
+        // Icon-rail width is tight: truncate long versions (e.g. "0.9.0-rc.1")
+        // and lean on the tooltip. An available update just tints the text.
+        <span
+          className={`font-mono text-[10px] leading-none truncate ${
+            data.updateAvailable ? 'text-warning' : ''
+          }`}
+        >
+          {data.current}
+        </span>
+      ) : (
+        <>
+          <span className="font-mono truncate">v{data.current}</span>
+          {data.updateAvailable && (
+            <span className="flex-none ml-auto text-[11px] font-medium text-warning">Update</span>
+          )}
+        </>
+      )}
+    </Link>
+  );
+};


### PR DESCRIPTION
## Problem

There's no at-a-glance answer to *"what version am I running?"*. The version **is** already rendered on Settings (`v{systemStatus.version.hola}` in the System card), but it sits far down a long scrolling page — findable only if you already know it's there, which is the opposite of what you need when checking whether a host took an update.

## Change

Adds a version row at the foot of the sidebar, just above **Collapse** — always mounted, always visible.

- **Expanded:** `v0.9.0` in muted mono, linking to `/settings` for the fuller system status.
- **Update available:** an amber `Update` label alongside it — a persistent hint for after `UpdateAvailableBanner` has been dismissed (dismissal is session-only local state, so the banner is easy to lose).
- **Collapsed:** the icon rail is 64px, so the row drops the `v` prefix, tints amber instead of showing the label, and truncates long versions (`0.9.0-rc.1`) to the tooltip.
- Renders nothing when the version is unknown (request failed), same fail-quiet posture as the banner.

## Why `/api/system/update-check` and not `/api/system/status`

Both report the running version, but update-check is the cheap one:

- It's **already fetched** on every app mount by `UpdateAvailableBanner`, so the marginal cost is one server-cached GET.
- It's **cached server-side for an hour** and **fail-safe offline** — a failed GitHub lookup still returns `current`.
- `/api/system/status` shells out to `docker`/`oras` and stats the disk. Far too much work for a footer.

`current` is `HOLA_VERSION` (the image tag the deploy scripts export from the bundle's `VERSION` file), falling back to the server `package.json` for source checkouts — see `getHolaVersion()`. Only the `test` env gets `MockUpdateCheckService`; dev and prod both report the truth.

## Testing

New `SidebarVersion.test.tsx` covers all four states (expanded, update-available, collapsed, unknown-version → renders nothing).

`bun run typecheck` · `lint` · `test` (627 server + 238 web) · `build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)