### PR TITLE
chore(release): 0.9.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/cli": {
       "name": "@hola/cli",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "bin": {
         "hola": "./bin/hola",
       },
@@ -37,11 +37,11 @@
     },
     "packages/compose": {
       "name": "@hola/compose",
-      "version": "0.9.0",
+      "version": "0.9.1",
     },
     "packages/sdk": {
       "name": "@hola/sdk",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "dependencies": {
         "@hola/shared": "workspace:*",
       },
@@ -55,7 +55,7 @@
     },
     "packages/server": {
       "name": "@hola/server",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "dependencies": {
         "@hola/shared": "workspace:*",
         "jose": "^6.2.3",
@@ -71,7 +71,7 @@
     },
     "packages/shared": {
       "name": "@hola/shared",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "dependencies": {
         "yaml": "^2.9.0",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.9.0';
+export const CLI_VERSION = '0.9.1';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Patch release. One change since [0.9.0](https://github.com/try-hola/hola/releases/tag/cli-v0.9.0):

- **feat(web): show the running Hola version in the sidebar (#414)** — there was no at-a-glance answer to *"what version am I running?"*. The version was already rendered on Settings, but buried in the System card far down a long scrolling page. It now sits at the foot of the sidebar, above **Collapse**, and doubles as a persistent update hint (an amber `Update` label) for after `UpdateAvailableBanner` has been dismissed. It reads the already-cached `/api/system/update-check` rather than `/api/system/status`, so the footer costs no `docker`/`oras` shell-outs.

**Upgrade note:** nothing to do.

## What's in the bump

Versions across the published packages, kept in sync (`web` stays unversioned at `0.0.0`):

- `packages/{cli,compose,sdk,server,shared}/package.json` → `0.9.1`
- `packages/cli/src/version.ts` → `CLI_VERSION = '0.9.1'` (pins `hola bootstrap --ref` to the matching `cli-v0.9.1` release)
- `bun.lock`

Same file set as the 0.9.0 release commit. `typecheck` · `lint` · `test` (627 server + 238 web) · `build` all pass.

Once merged, tagging `cli-v0.9.1` triggers `cli-release.yml`: multi-arch `ghcr.io/try-hola/{server,web}` images (also moving `:latest`, since this is a stable version), the compose bundle tarball, and the standalone CLI binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)