### PR TITLE
chore(release): 0.10.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/cli": {
       "name": "@hola/cli",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "bin": {
         "hola": "./bin/hola",
       },
@@ -37,11 +37,11 @@
     },
     "packages/compose": {
       "name": "@hola/compose",
-      "version": "0.9.1",
+      "version": "0.10.0",
     },
     "packages/sdk": {
       "name": "@hola/sdk",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "dependencies": {
         "@hola/shared": "workspace:*",
       },
@@ -55,7 +55,7 @@
     },
     "packages/server": {
       "name": "@hola/server",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "dependencies": {
         "@hola/shared": "workspace:*",
         "jose": "^6.2.3",
@@ -71,7 +71,7 @@
     },
     "packages/shared": {
       "name": "@hola/shared",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "dependencies": {
         "yaml": "^2.9.0",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/cli",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,4 +2,4 @@
 // `hola bootstrap --ref` to the matching release tag (cli-v<version>) so the host
 // pulls the server/web images published for this CLI version. Keep in sync with
 // package.json.
-export const CLI_VERSION = '0.9.1';
+export const CLI_VERSION = '0.10.0';

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/compose",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "description": "Docker Compose stack for Hola (web, server, traefik)",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/sdk",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/server",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hola/shared",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Minor release. **`hola app data push`** is the headline.

## What's in it

- **feat(cli): hola app data push — manifest-declared push targets (#410, closes #409)** — there was no supported way to get a large directory of data *into* an installed app. The only path was raw `scp`/`rsync` into the app's data root, which leaked Hola's on-disk layout into user instructions, quiesced nothing (Calibre-Web holds an open handle on `metadata.db`), and had no wrong-deployment guard. Apps now declare pushable directories in their bundle manifest's `push` block, and `hola app data push` pushes to them over rsync/SSH — a re-push after editing a few files locally sends only the delta.

  The server owns everything layout-aware: it resolves each declared target through `resolveContainedDir` (syntactic, lexical, *and* physical containment — realpath on both sides, so a planted symlink can't smuggle the write), drives stop/start through the normal job lifecycle, and runs any declared `postHook` in the app's own containers. The CLI only moves bytes.

- **feat(web): show the running Hola version in the sidebar (#414)** — shipped in 0.9.1; listed here for anyone upgrading across both releases.

## Catalog side

try-hola/apps#118 adds **Calibre-Web** and try-hola/apps#137 adds the `push` schema plus Calibre-Web's library target (`mode: mirror`, `quiesce: stop`). Both are merged and published — the target is inert until a host is on this release, which is what this release is for.

## Upgrade note

Nothing to do. `push` is opt-in per app; an app that declares no `push` block is unaffected.

## The bump

- `packages/{cli,compose,sdk,server,shared}/package.json` → `0.10.0`
- `packages/cli/src/version.ts` → `CLI_VERSION = '0.10.0'` (pins `hola bootstrap --ref` to `cli-v0.10.0`)
- `bun.lock`

Same file set as the 0.9.0 and 0.9.1 release commits. `typecheck` · `lint` · `test` (655 server + 238 web) · `build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)