### PR TITLE
docs(adr): 0004 capability contracts — a `provides` role alongside `consumes`

### DIFF
--- a/docs/adr/0004-capability-contracts.md
+++ b/docs/adr/0004-capability-contracts.md
@@ -1,0 +1,196 @@
+# ADR 0004: Capability contracts — a `provides` role alongside `consumes`
+
+- **Status:** Proposed (August 2026)
+- **Context:** ADR 0002 defined cross-app integration one-directionally: an app declares
+  `consumes: <capability>` and the server reconciles a generic primitive. Since then the
+  *other* half of several integrations has appeared as one-off manifest blocks (`auth`,
+  `backup`, `push`), with nothing naming the relationship between the two sides. This ADR
+  names it. Design only — no behavior ships with this ADR.
+
+## Context
+
+ADR 0002's `consumes` is not app-to-app at all: it is **app-consumes-platform**. The server
+grants a privileged primitive (`apps-data`, a read-only mount of every app's data root) or
+publishes a feed (`app-registry`, `registry.json` written into the consumer's data root).
+Backrest and Homepage are consumers of Hola, not of each other. That model works and is not
+changed here.
+
+But backup — the integration ADR 0002 named as Phase 2 — turned out to need a second side.
+A file-level restic snapshot of a running Postgres is crash-consistent, not
+transaction-consistent, so #121 added a manifest `backup` block: `preHook`/`postHook`
+exec-form commands the server runs in the app's own containers around a capture. Four
+catalog apps declare it today (`paperless-ngx`, `mealie`, `guacamole`, `postiz`); `immich`,
+the most restore-fragile of them, does not.
+
+That block is a genuine second role — "this app supports being backed up consistently" — and
+today it is invisible as such:
+
+- The **provider** side is nowhere. `backrest` declares `consumes: apps-data` and nothing
+  else. "Backrest is the backup app" lives in prose in this ADR series and in #160, not in
+  any data structure, so nothing can ask "is a backup provider installed?"
+- The **participant** side is not named. The `backup` block is one of three unrelated-looking
+  manifest blocks (`services/core/manifest-backup.ts`, `manifest-push.ts`, the `auth` block)
+  with its own coercer and no shared vocabulary. Nothing can answer "which installed apps
+  support consistent backup, and which are silently getting crash-consistent copies?"
+- The two halves are **not connected**. `RealDeploymentService.capturePreUpgradeSnapshot`
+  (`deployment.ts:1637`) runs the hooks for the server's *own* pre-upgrade snapshot. Backrest
+  runs restic on its own schedule inside its own container, and the server is not in that
+  loop — so the hooks never run for a scheduled backup (#298). The primitive exists, has a
+  caller, and still doesn't do the job it was written for.
+
+The same shape has now recurred three times independently — `auth` (this app supports SSO in
+mode X), `backup` (this app supports consistent snapshots), `push` (#409: this app accepts
+bulk data at these paths). Each was discovered separately and modelled separately. A fourth
+(`container-logs`, #245) is queued. The model is real; it has just never been named.
+
+## Decision
+
+### 1. A *contract* is a named, versioned integration with two roles
+
+A **capability contract** has an id and a version (`backup@1`) and defines two sides:
+
+- a **provider** — the app that performs the capability (backrest performs backups);
+- **participants** — apps that expose whatever the contract requires of a subject
+  (a `pg_dump` pre-hook, an OIDC setup command, a pushable directory).
+
+The contract, not the app, is the coupling point. A participant never names backrest; it
+declares that it satisfies `backup@1`. Swapping the provider (restic → Kopia → a
+server-native engine) is a catalog change, not a fleet-wide manifest edit.
+
+This is a **separate axis from `consumes`**, not a replacement for it. `consumes` is "the
+server grants me a privileged primitive"; a contract is "I speak this protocol." Conflating
+them into one `capabilities: []` list was rejected (below) precisely because it would blur a
+security boundary with a naming convention.
+
+### 2. Manifests gain exactly one new field: `provides`
+
+```jsonc
+// backrest manifest.json
+"consumes": "apps-data",      // unchanged: the privileged grant
+"provides": ["backup@1"]      // new: the role it fills
+```
+
+**Participation is derived, not declared.** An app supports `backup@1` because it has a valid
+`backup` block — there is no second `supports: ["backup@1"]` field to keep in sync with it.
+This is the same reasoning ADR 0003 used to extend `defaultEnv` in place rather than add a
+parallel `paramSpec`: two structures describing one fact drift, and the block is already the
+natural unit the coercer and the hook runner operate on. The server derives the participant
+list from the finalized manifests it already reads.
+
+So the manifest surface added by this ADR is one optional string-or-array field. Every
+existing manifest keeps working untouched, and only provider apps (today: one) change.
+
+### 3. The server owns a contract registry; contracts are server-defined, not open
+
+A new module (`packages/server/src/services/core/contracts.ts`) holds the canonical table.
+Each entry declares:
+
+| field | meaning |
+| --- | --- |
+| `id` / `version` | `backup`, `1` |
+| `requires` | primitives a provider must already hold (`backup@1` → `apps-data`) |
+| `participantBlock` | manifest block + coercer that constitutes support (`backup` → `coerceManifestBackup`) |
+| `broker` | what the server does when the provider asks (run `preHook` for every participant, …) |
+
+Contract ids are a **closed set defined in server code**, like the `consumes` primitives.
+The catalog cannot invent a contract, because a contract is a promise about server behavior.
+Forward-compat follows ADR 0003's rule: a `provides` entry this build doesn't recognize is
+**dropped with a logged warning**, never a hard failure — the catalog and the server release
+on separate cadences, and a stale server must not brick an install.
+
+### 4. `provides` grants nothing; it is checked against `consumes`
+
+Declaring `provides: backup@1` does **not** cause the server to inject `apps-data`. A
+manifest that provides a contract without the primitives the contract `requires` is rejected
+at catalog-coercion time (the `provides` entry is dropped, with a warning). Privilege stays
+where ADR 0002 put it: an explicit, auditable `consumes` declaration reviewed when the bundle
+is published. `provides` is a role label over privilege already granted, never a way to
+acquire it — otherwise a contract definition becomes a second, less visible privilege
+channel.
+
+### 5. The server brokers; apps still never talk to each other
+
+ADR 0002's security boundary holds unchanged: **the provider asks the server, the server acts
+on participants.** A provider never learns which apps exist, never gets a token for another
+app, never execs into another app's containers.
+
+Concretely, for `backup@1`, the provider gets two authenticated endpoints scoped to its own
+deployment:
+
+```
+POST /api/contracts/backup/prepare    → server runs every participant's preHook
+POST /api/contracts/backup/finalize   → server runs every participant's postHook
+```
+
+Backrest wires them into its own `onBackupStart` / `onBackupEnd` hooks — a bundle bolt-on,
+exactly the ADR 0002 pattern, with the app-specific glue in the bundle and the generic
+primitive in the server. This is #298's Option A, generalized: the hook runner
+(`capturePreUpgradeSnapshot`'s inner block, lifted out) gets a second caller instead of a
+second implementation, and `preHook` failure semantics (fail-closed vs. warn-and-continue)
+are decided per call site as they are today.
+
+The provider's credential is a **contract-scoped token** minted for that deployment when it
+is installed with `provides`, carrying only the capability for its own contract endpoints —
+not an admin key, and not usable for anything else in the API. It reuses the existing
+scoped-token machinery the server already uses to self-bootstrap against Authentik.
+
+### 6. Roles are visible in the API and the UI
+
+The server exposes, per deployment, `contracts: { provides: [...], supports: [...] }`, and a
+platform-level rollup: for each contract, who provides it and which installed apps
+participate. That makes the thing that is invisible today legible:
+
+- "No backup provider installed" is answerable, so the stubbed Backups page (#160) has real
+  content before any backup engine exists.
+- "Immich does not support `backup@1`" becomes a visible gap in the dashboard rather than a
+  fact buried in an issue comment — which is the actual reason it has stayed unfixed.
+
+This also settles #160's open question in favor of **Option A**: the Backups page is a view
+over the installed provider (plus the participant rollup), not a second backup engine
+competing with it. Hola brokers; it does not back up.
+
+### 7. Existing blocks are re-labelled, not rewritten
+
+`auth`, `backup` and `push` become the participant blocks of `auth@1`, `backup@1` and
+`push@1`. Their shapes, coercers and runtime behavior are unchanged — this ADR names what
+they already are and gives the next one somewhere to land. `app-registry` and `apps-data`
+stay primitives under `consumes`; `container-logs` (#245) lands there too, with a possible
+`logs@1` contract later if a collector ever needs a participant side (e.g. per-app log
+format declarations).
+
+### Rejected alternatives
+
+- **One flat `capabilities: []` list** covering both grants and contracts. Rejected: a
+  privileged server grant and a protocol label have different review requirements, and
+  merging them makes it impossible to see at a glance which apps hold cross-app privilege.
+- **Naming the provider in the participant manifest** (`"backupProvider": "backrest"`).
+  Rejected: couples every stateful app to one catalog app's identity and makes replacing the
+  provider an N-manifest migration. The contract exists to be the only shared name.
+- **Direct provider→participant execution** (give backrest the ability to exec hooks itself).
+  Rejected for the same reason ADR 0002 rejected an app-to-app notification bus: it hands a
+  container credentials and reach into other apps' containers, and moves ordering, retry and
+  failure handling outside Hola's control. Brokering costs one HTTP round trip and keeps the
+  whole thing inside the orchestrator.
+- **Catalog-defined contracts** (arbitrary ids matched between manifests, server stays out of
+  it). Rejected: a contract is a promise about *server* behavior — matching two strings does
+  nothing unless the server implements the broker. Open ids would let a bundle claim a
+  capability nothing honors.
+- **A redundant `supports` field** alongside the participant block. Rejected per ADR 0003's
+  two-structures-drift argument; derive it.
+
+## Consequences
+
+- One new optional manifest field (`provides`) and one new server module (the contract
+  table + broker routes). No existing manifest, draft, or deployment record changes shape;
+  `FinalizedManifest` gains an optional `provides?: string[]` beside `consumes?: string[]`.
+- #121's hook runner gets its second consumer, closing #298 without a bespoke backrest
+  endpoint. The hook logic lifts out of `capturePreUpgradeSnapshot` into a shared runner with
+  two callers (pre-upgrade snapshot; contract broker).
+- #160's architectural question is answered (Option A), and the Backups page has something
+  true to render before an engine exists.
+- The catalog gains a reason and a place to fix the `immich` hook gap, and manifest CI can
+  warn when an app runs a database with no `backup@1` participation.
+- Future integrations (monitoring, AV scanning, status pages, log collection) get a shape to
+  follow instead of a fourth bespoke block — which is the whole point.
+- The security envelope is unchanged: privilege still comes only from `consumes`, still
+  read-only, still gated on an explicit manifest declaration reviewed at publish time.

--- a/docs/adr/0004-capability-contracts.md
+++ b/docs/adr/0004-capability-contracts.md
@@ -1,19 +1,19 @@
-# ADR 0004: Capability contracts — a `provides` role alongside `consumes`
+# ADR 0004: Capability contracts — `provides` / `accepts`
 
 - **Status:** Proposed (August 2026)
 - **Context:** ADR 0002 defined cross-app integration one-directionally: an app declares
   `consumes: <capability>` and the server reconciles a generic primitive. Since then the
   *other* half of several integrations has appeared as one-off manifest blocks (`auth`,
   `backup`, `push`), with nothing naming the relationship between the two sides. This ADR
-  names it. Design only — no behavior ships with this ADR.
+  names it, and names the two shapes a contract can take. Design only — no behavior ships
+  with this ADR.
 
 ## Context
 
 ADR 0002's `consumes` is not app-to-app at all: it is **app-consumes-platform**. The server
 grants a privileged primitive (`apps-data`, a read-only mount of every app's data root) or
 publishes a feed (`app-registry`, `registry.json` written into the consumer's data root).
-Backrest and Homepage are consumers of Hola, not of each other. That model works and is not
-changed here.
+Backrest and Homepage are consumers of Hola, not of each other.
 
 But backup — the integration ADR 0002 named as Phase 2 — turned out to need a second side.
 A file-level restic snapshot of a running Postgres is crash-consistent, not
@@ -22,8 +22,8 @@ exec-form commands the server runs in the app's own containers around a capture.
 catalog apps declare it today (`paperless-ngx`, `mealie`, `guacamole`, `postiz`); `immich`,
 the most restore-fragile of them, does not.
 
-That block is a genuine second role — "this app supports being backed up consistently" — and
-today it is invisible as such:
+That block is a genuine second role — "this app can be backed up consistently" — and today
+it is invisible as such:
 
 - The **provider** side is nowhere. `backrest` declares `consumes: apps-data` and nothing
   else. "Backrest is the backup app" lives in prose in this ADR series and in #160, not in
@@ -50,35 +50,54 @@ bulk data at these paths). Each was discovered separately and modelled separatel
 A **capability contract** has an id and a version (`backup@1`) and defines two sides:
 
 - a **provider** — the app that performs the capability (backrest performs backups);
-- **participants** — apps that expose whatever the contract requires of a subject
-  (a `pg_dump` pre-hook, an OIDC setup command, a pushable directory).
+- **acceptors** — apps that opt in to being a subject of it, exposing whatever the contract
+  requires (a `pg_dump` pre-hook, an OIDC setup command, a pushable directory).
 
-The contract, not the app, is the coupling point. A participant never names backrest; it
-declares that it satisfies `backup@1`. Swapping the provider (restic → Kopia → a
-server-native engine) is a catalog change, not a fleet-wide manifest edit.
+The contract, not the app, is the coupling point. An acceptor never names backrest; it
+declares that it accepts `backup@1`. Swapping the provider (restic → Kopia → a server-native
+engine) is a catalog change, not a fleet-wide manifest edit.
 
 This is a **separate axis from `consumes`**, not a replacement for it. `consumes` is "the
-server grants me a privileged primitive"; a contract is "I speak this protocol." Conflating
-them into one `capabilities: []` list was rejected (below) precisely because it would blur a
-security boundary with a naming convention.
+server grants me a platform primitive"; a contract is "I fill a role in a two-sided
+integration." Conflating them into one `capabilities: []` list was rejected (below): a
+privileged grant and a role declaration have different review requirements.
 
-### 2. Manifests gain exactly one new field: `provides`
+### 2. Both roles are declared explicitly in the manifest
 
 ```jsonc
 // backrest manifest.json
-"consumes": "apps-data",      // unchanged: the privileged grant
-"provides": ["backup@1"]      // new: the role it fills
+"provides": ["backup@1"]
+
+// paperless-ngx manifest.json
+"accepts": ["backup@1"],
+"backup": { "preHook": { … }, "postHook": { … } }   // unchanged: *how* it participates
 ```
 
-**Participation is derived, not declared.** An app supports `backup@1` because it has a valid
-`backup` block — there is no second `supports: ["backup@1"]` field to keep in sync with it.
-This is the same reasoning ADR 0003 used to extend `defaultEnv` in place rather than add a
-parallel `paramSpec`: two structures describing one fact drift, and the block is already the
-natural unit the coercer and the hook runner operate on. The server derives the participant
-list from the finalized manifests it already reads.
+An earlier draft of this ADR derived acceptance from the presence of the typed block — no
+`accepts` field, on the grounds that two structures describing one fact drift (ADR 0003's
+argument for extending `defaultEnv` in place). **That was wrong, for a reason specific to
+this axis:** the block and the acceptance are *not* the same fact.
 
-So the manifest surface added by this ADR is one optional string-or-array field. Every
-existing manifest keeps working untouched, and only provider apps (today: one) change.
+- The block says **how** an app participates. Acceptance says **whether** it does.
+- Plenty of apps accept `backup@1` and need **no hooks at all** — a SQLite or flat-file app
+  is fine with a crash-consistent file copy. Under derived acceptance those apps are
+  indistinguishable from apps nobody ever considered, because both have no `backup` block.
+  The "which apps are covered?" view — the entire reason the Immich gap stayed invisible —
+  would still be unanswerable.
+- Acceptance is an **assertion by the bundle author**: "I have thought about backup for this
+  app, and this manifest makes it safe." That is a claim worth writing down and reviewing,
+  and it is worth being able to *withhold* — an app whose data can't be captured safely at
+  all should be able to stay silent, and be reported as uncovered rather than assumed fine.
+
+So a contract's participant requirements are checked **against the declaration**: `accepts:
+["backup@1"]` on an app whose compose runs a database image, with no `backup` block, is a
+manifest-CI error in try-hola/apps. The server's own check is narrower (a declared block must
+be well-formed); publish-time CI is where "you accepted this and didn't do the work" is
+caught, because only the catalog repo can see the compose and the manifest together.
+
+Manifests therefore gain two optional fields, `provides` and `accepts`. Existing manifests
+keep working — an app that declares neither is simply reported as filling no role, which is
+the honest answer.
 
 ### 3. The server owns a contract registry; contracts are server-defined, not open
 
@@ -88,109 +107,188 @@ Each entry declares:
 | field | meaning |
 | --- | --- |
 | `id` / `version` | `backup`, `1` |
-| `requires` | primitives a provider must already hold (`backup@1` → `apps-data`) |
-| `participantBlock` | manifest block + coercer that constitutes support (`backup` → `coerceManifestBackup`) |
-| `broker` | what the server does when the provider asks (run `preHook` for every participant, …) |
+| `shape` | `brokered` or `provisioned` (§5) |
+| `providerGrant` | what the server injects for the provider (`backup@1` → the read-only apps-data mount) |
+| `acceptorBlock` | manifest block that carries the acceptor's details, if any (`backup` → `coerceManifestBackup`) |
+| `broker` | for brokered contracts: what the server does when the provider asks |
+| `unavailable` | what the provider must do when the server can't be reached (§6) |
 
 Contract ids are a **closed set defined in server code**, like the `consumes` primitives.
-The catalog cannot invent a contract, because a contract is a promise about server behavior.
-Forward-compat follows ADR 0003's rule: a `provides` entry this build doesn't recognize is
+The catalog cannot invent a contract, because a contract is a promise about server behavior —
+matching two strings does nothing unless the server implements the middle. Forward-compat
+follows ADR 0003's rule: a `provides`/`accepts` entry this build doesn't recognize is
 **dropped with a logged warning**, never a hard failure — the catalog and the server release
 on separate cadences, and a stale server must not brick an install.
 
-### 4. `provides` grants nothing; it is checked against `consumes`
+### 4. Privilege attaches to the provider role, gated by operator consent at install
 
-Declaring `provides: backup@1` does **not** cause the server to inject `apps-data`. A
-manifest that provides a contract without the primitives the contract `requires` is rejected
-at catalog-coercion time (the `provides` entry is dropped, with a warning). Privilege stays
-where ADR 0002 put it: an explicit, auditable `consumes` declaration reviewed when the bundle
-is published. `provides` is a role label over privilege already granted, never a way to
-acquire it — otherwise a contract definition becomes a second, less visible privilege
-channel.
+A provider needs privilege the contract defines — `backup@1`'s provider needs read access to
+every app's data. Two ways to grant it:
 
-### 5. The server brokers; apps still never talk to each other
+- **(a)** keep the separate `consumes: apps-data` declaration and require the two to agree;
+- **(b)** derive the grant from the contract definition and gate it on **explicit operator
+  consent at install time**.
 
-ADR 0002's security boundary holds unchanged: **the provider asks the server, the server acts
-on participants.** A provider never learns which apps exist, never gets a token for another
-app, never execs into another app's containers.
+We choose **(b)**. Under (a) the privilege is visible only in a manifest line reviewed once,
+at publish time, by whoever merged the bundle — the operator installing it sees nothing. It
+also lets the two declarations disagree, which is a check to write and a failure mode to
+explain. Under (b) there is one source of truth (the contract says what its provider gets),
+and the person who actually bears the risk is asked.
 
-Concretely, for `backup@1`, the provider gets two authenticated endpoints scoped to its own
-deployment:
+Hola already has the mechanism: the `security` block surfaces elevated container permissions
+for explicit consent in the install wizard (`AppSecurityConfig`). Installing an app that
+declares `provides: backup@1` shows the same kind of consent step — *"Backrest will be able
+to read the data of every installed app"* — and the grant is injected only on acceptance.
+This is the "operator approval flow for privileged capabilities" ADR 0002 deferred.
+
+Consequently `apps-data` stops being an independently declarable primitive. It becomes the
+provider grant of `backup@1` (and, later, of whatever other contract needs it), which is the
+only context in which handing an app every app's data was ever justifiable. `app-registry`
+stays a plain `consumes` primitive: it is a published feed, not a two-sided integration, and
+nothing provides it but the platform.
+
+### 5. Two shapes: broker the control plane, provision the data plane
+
+**Not every contract should route through the server.** Brokering — the provider asks Hola,
+Hola acts on acceptors — is right when the exchange is a low-volume command or event with a
+request/response shape. It is wrong when the exchange is continuous or latency-sensitive:
+log streaming, metrics scraping, an app calling another app's API in a loop. Proxying that
+through the orchestrator makes Hola a bottleneck and a single point of failure for traffic it
+has no reason to see.
+
+Hola already implements both shapes; only one of them has ever been written down:
+
+| | **Brokered** | **Provisioned** |
+| --- | --- | --- |
+| Server's role | executes on the acceptor's behalf, per request | sets up a scoped connection, then steps out |
+| Traffic | control plane, bursty, low volume | data plane, continuous |
+| Credentials held by apps | none | scoped, server-issued, revoked on uninstall |
+| Existing example | #121 hooks around the pre-upgrade snapshot | **auth/OIDC** — provision an Authentik client, inject env, join networks; the app then talks to the IdP directly forever. Also Traefik routing. |
+| This ADR's example | `backup@1` | a future `database@1`, `smtp@1`, `object-store@1`, `logs@1` |
+
+The rule: **broker if the interaction is an operation; provision if it is a connection.** A
+contract declares its shape in the registry (§3), and the choice is made per contract at
+design time, not per call.
+
+What holds in **both** shapes is the actual invariant, and it is the one thing this ADR
+refuses to relax:
+
+> **No app ever gets ambient reach into another app.** Every cross-app access is explicit
+> (declared in a manifest), scoped (to one contract, one peer, one direction), server-issued,
+> and revoked on uninstall.
+
+Brokering is one way to honor that invariant; provisioning is another. Naming both is what
+keeps the model from constraining future integrations — a Postgres-as-a-service or an SMTP
+relay contract falls out as a provisioned contract rather than needing an exception. ADR
+0002's rejection of an *app-to-app notification bus* stands unchanged: what is rejected is
+apps discovering and calling each other on their own initiative, not the server deliberately
+wiring two apps together.
+
+### 6. Brokered contracts inherit the server's availability, and must say what that means
+
+For `backup@1`, the provider gets endpoints scoped to its own deployment:
 
 ```
-POST /api/contracts/backup/prepare    → server runs every participant's preHook
-POST /api/contracts/backup/finalize   → server runs every participant's postHook
+POST /api/contracts/backup/prepare    → server runs every acceptor's preHook
+POST /api/contracts/backup/finalize   → server runs every acceptor's postHook
 ```
 
 Backrest wires them into its own `onBackupStart` / `onBackupEnd` hooks — a bundle bolt-on,
-exactly the ADR 0002 pattern, with the app-specific glue in the bundle and the generic
-primitive in the server. This is #298's Option A, generalized: the hook runner
-(`capturePreUpgradeSnapshot`'s inner block, lifted out) gets a second caller instead of a
-second implementation, and `preHook` failure semantics (fail-closed vs. warn-and-continue)
-are decided per call site as they are today.
+the ADR 0002 pattern, with app-specific glue in the bundle and the generic primitive in the
+server. This is #298's Option A, generalized: the hook runner (lifted out of
+`capturePreUpgradeSnapshot`) gets a second caller instead of a second implementation.
 
-The provider's credential is a **contract-scoped token** minted for that deployment when it
-is installed with `provides`, carrying only the capability for its own contract endpoints —
-not an admin key, and not usable for anything else in the API. It reuses the existing
-scoped-token machinery the server already uses to self-bootstrap against Authentik.
+Which means a brokered backup is only as available as the server. If Hola is down, mid-
+upgrade, or slow when Backrest's cron fires, the hooks don't run. Each brokered contract must
+therefore declare its `unavailable` behavior; for `backup@1` it is **fail-closed** — skip the
+snapshot and surface it, rather than silently capturing inconsistent files, because a backup
+believed good and isn't is worse than a backup known missing.
 
-### 6. Roles are visible in the API and the UI
+Long-running acceptor work (a large `pg_dump`) must not be bounded by an HTTP request:
+`prepare` enqueues through the existing job system and returns a handle the provider polls,
+with a per-contract timeout after which `finalize` runs regardless.
 
-The server exposes, per deployment, `contracts: { provides: [...], supports: [...] }`, and a
-platform-level rollup: for each contract, who provides it and which installed apps
-participate. That makes the thing that is invisible today legible:
+The provider's credential is a **contract-scoped token** minted for that deployment at
+install, carrying only the capability for its own contract endpoints — not an admin key, not
+usable elsewhere in the API. It reuses the scoped-token machinery the server already uses to
+self-bootstrap against Authentik, and is revoked when the app is uninstalled.
+
+### 7. Roles are visible in the API and the UI
+
+The server exposes, per deployment, `contracts: { provides: [...], accepts: [...] }`, and a
+platform-level rollup: for each contract, who provides it and which installed apps accept it.
+That makes the thing that is invisible today legible:
 
 - "No backup provider installed" is answerable, so the stubbed Backups page (#160) has real
   content before any backup engine exists.
-- "Immich does not support `backup@1`" becomes a visible gap in the dashboard rather than a
+- "Immich does not accept `backup@1`" becomes a visible gap in the dashboard rather than a
   fact buried in an issue comment — which is the actual reason it has stayed unfixed.
 
 This also settles #160's open question in favor of **Option A**: the Backups page is a view
-over the installed provider (plus the participant rollup), not a second backup engine
-competing with it. Hola brokers; it does not back up.
+over the installed provider plus the acceptor rollup, not a second backup engine competing
+with it. Hola brokers; it does not back up.
 
-### 7. Existing blocks are re-labelled, not rewritten
+### 8. Existing blocks are re-labelled; backrest is re-cut
 
-`auth`, `backup` and `push` become the participant blocks of `auth@1`, `backup@1` and
-`push@1`. Their shapes, coercers and runtime behavior are unchanged — this ADR names what
-they already are and gives the next one somewhere to land. `app-registry` and `apps-data`
-stay primitives under `consumes`; `container-logs` (#245) lands there too, with a possible
-`logs@1` contract later if a collector ever needs a participant side (e.g. per-app log
-format declarations).
+`auth`, `backup` and `push` become the acceptor blocks of `auth@1`, `backup@1` and `push@1` —
+shapes, coercers and runtime behavior unchanged. What changes is that each acceptor now also
+declares the contract, and `auth@1` is documented as **provisioned** (it always was).
+
+`backrest` is re-cut rather than preserved: it drops `consumes: apps-data`, gains
+`provides: ["backup@1"]`, gains the contract-scoped token and the `onBackupStart` bolt-on, and
+its apps-data mount now arrives as the contract's provider grant behind an install-time
+consent step. Since `apps-data` ceases to be independently declarable, the server must
+tolerate an already-installed backrest whose stored manifest still declares it (treat a bare
+`consumes: apps-data` as `provides: backup@1` for one release, warn, and drop the shim after).
+
+`container-logs` (#245) is re-examined under §5 before it is built: a collector scraping every
+container continuously is a **provisioned** contract, not a brokered one — the server grants
+the log source and stays out of the stream.
 
 ### Rejected alternatives
 
-- **One flat `capabilities: []` list** covering both grants and contracts. Rejected: a
-  privileged server grant and a protocol label have different review requirements, and
-  merging them makes it impossible to see at a glance which apps hold cross-app privilege.
-- **Naming the provider in the participant manifest** (`"backupProvider": "backrest"`).
-  Rejected: couples every stateful app to one catalog app's identity and makes replacing the
-  provider an N-manifest migration. The contract exists to be the only shared name.
-- **Direct provider→participant execution** (give backrest the ability to exec hooks itself).
-  Rejected for the same reason ADR 0002 rejected an app-to-app notification bus: it hands a
-  container credentials and reach into other apps' containers, and moves ordering, retry and
-  failure handling outside Hola's control. Brokering costs one HTTP round trip and keeps the
-  whole thing inside the orchestrator.
-- **Catalog-defined contracts** (arbitrary ids matched between manifests, server stays out of
-  it). Rejected: a contract is a promise about *server* behavior — matching two strings does
-  nothing unless the server implements the broker. Open ids would let a bundle claim a
-  capability nothing honors.
-- **A redundant `supports` field** alongside the participant block. Rejected per ADR 0003's
-  two-structures-drift argument; derive it.
+- **One flat `capabilities: []` list** covering both grants and roles. Rejected: a privileged
+  server grant and a role declaration have different review requirements, and merging them
+  makes it impossible to see at a glance which apps hold cross-app privilege.
+- **Derived acceptance** (no `accepts` field; infer it from the typed block). Rejected in §2:
+  it cannot distinguish "reviewed, needs no hooks" from "nobody looked," which is exactly the
+  question the model exists to answer.
+- **Naming the provider in the acceptor manifest** (`"backupProvider": "backrest"`). Rejected:
+  couples every stateful app to one catalog app's identity and makes replacing the provider an
+  N-manifest migration. The contract exists to be the only shared name.
+- **Brokering everything**, as a universal rule. Rejected in §5: it turns the orchestrator into
+  a data-plane proxy for contracts that are continuous rather than transactional, and it
+  contradicts how auth already works.
+- **Direct provider→acceptor execution** (give backrest the ability to exec hooks itself).
+  Rejected for the reason ADR 0002 rejected an app-to-app bus: it hands a container reach into
+  other apps' containers and moves ordering, retry and failure handling outside Hola's control.
+- **Catalog-defined contracts** (arbitrary ids matched between manifests, server stays out).
+  Rejected: a contract is a promise about *server* behavior; open ids would let a bundle claim
+  a capability nothing honors.
 
 ## Consequences
 
-- One new optional manifest field (`provides`) and one new server module (the contract
-  table + broker routes). No existing manifest, draft, or deployment record changes shape;
-  `FinalizedManifest` gains an optional `provides?: string[]` beside `consumes?: string[]`.
+- Two new optional manifest fields (`provides`, `accepts`) and one new server module (the
+  contract table + broker routes). `FinalizedManifest` gains `provides?: string[]` and
+  `accepts?: string[]` beside `consumes?: string[]`.
+- **Manifest churn is expected and wanted**: every app that participates in a contract states
+  it. That is the point — the declaration is the reviewable artifact, and the rollup is only
+  as trustworthy as the fact that silence means "not covered."
+- `apps-data` is no longer independently declarable; it becomes `backup@1`'s provider grant
+  behind install-time operator consent, with a one-release compatibility shim for installed
+  backrest deployments.
 - #121's hook runner gets its second consumer, closing #298 without a bespoke backrest
   endpoint. The hook logic lifts out of `capturePreUpgradeSnapshot` into a shared runner with
-  two callers (pre-upgrade snapshot; contract broker).
+  two callers (pre-upgrade snapshot; contract broker), plus job-backed execution for long hooks.
 - #160's architectural question is answered (Option A), and the Backups page has something
   true to render before an engine exists.
-- The catalog gains a reason and a place to fix the `immich` hook gap, and manifest CI can
-  warn when an app runs a database with no `backup@1` participation.
-- Future integrations (monitoring, AV scanning, status pages, log collection) get a shape to
-  follow instead of a fourth bespoke block — which is the whole point.
-- The security envelope is unchanged: privilege still comes only from `consumes`, still
-  read-only, still gated on an explicit manifest declaration reviewed at publish time.
+- The catalog gains a reason and a place to fix the `immich` gap, and manifest CI gains a real
+  check: accepts a contract without meeting its requirements → error; runs a database and
+  accepts nothing → warning.
+- **Cost, accepted:** a new contract requires a server release, so the catalog cannot add one
+  on its own. That is the price of the server being the only thing that can honor a promise
+  about cross-app behavior. It bounds how fast the vocabulary can grow, not how fast apps can
+  adopt existing contracts.
+- The security envelope tightens rather than loosens: privilege is now tied to a named role,
+  disclosed to the operator at install, and revoked on uninstall — instead of an invisible
+  manifest line reviewed once at publish time.


### PR DESCRIPTION
Design doc only — no code, no behavior change.

## Why

ADR 0002 defined cross-app integration one-directionally: an app declares `consumes: <capability>` and the server reconciles a generic primitive. That's really *app-consumes-platform* — backrest and Homepage consume Hola, not each other.

The other half of the relationship has since shown up three times as unrelated-looking one-off manifest blocks — `auth`, `backup` (#121), `push` (#409) — each with its own coercer and no shared vocabulary. A fourth (#245) is queued. The model is real; it has just never been named, and that has costs today:

- **The provider side doesn't exist as data.** "Backrest is the backup app" lives in prose, so nothing can ask "is a backup provider installed?"
- **The halves aren't connected.** `capturePreUpgradeSnapshot` (`deployment.ts:1637`) runs the #121 hooks for the server's own snapshot; backrest runs restic on its own schedule with the server out of the loop, so scheduled DB backups are still crash-consistent (#298). The primitive exists, has a caller, and still doesn't do the job it was written for.
- **Coverage is invisible.** `paperless-ngx`, `mealie`, `guacamole`, `postiz` declare hooks; `immich` — the most restore-fragile — doesn't, and nothing surfaces that.

## What the ADR decides

- A **capability contract** has an id and version (`backup@1`) and two roles: a **provider** and **acceptors**. The contract, not the app, is the coupling point — an acceptor never names backrest, so swapping restic for something else is a catalog change rather than a fleet-wide manifest edit.
- **Both roles are declared explicitly**: `provides` and `accepts`. The typed block (`backup`) says *how* an app participates; `accepts` says *whether* it does. Those are different facts — an app needing no hooks at all (SQLite, flat-file) has to be distinguishable from an app nobody considered, or the coverage view is worthless. Manifest churn here is the point: the declaration is the reviewable artifact.
- Contracts are a **closed set defined in server code** — a contract is a promise about server behavior, so the catalog can't invent one. Unknown ids drop with a warning (ADR 0003 forward-compat rule).
- **Privilege attaches to the provider role and is disclosed to the operator at install**, reusing the `security` block's consent pattern — ADR 0002's deferred operator-approval flow. `apps-data` stops being independently declarable and becomes `backup@1`'s provider grant; backrest is re-cut, with a one-release shim for installed deployments.
- **Two shapes: broker the control plane, provision the data plane.** Brokering fits a low-volume operation; it's wrong for continuous traffic (log streaming, metrics), which would make the orchestrator a data-plane proxy. Hola already does both — auth/OIDC and Traefik routing are provisioned, not brokered — but only brokering had been written down. The invariant across both: **no app ever gets ambient reach into another** — every access explicit, scoped, server-issued, revoked on uninstall.
- Roles become visible in the API/UI, which settles #160 in favor of Option A (the Backups page is a view over the installed provider, not a second engine).

## Costs, named and accepted

- A new contract needs a server release; the catalog can't add one alone. That bounds how fast the *vocabulary* grows, not how fast apps adopt existing contracts.
- A brokered contract inherits the server's availability. If Hola is down when Backrest's cron fires, the hooks don't run — so `backup@1` is **fail-closed**: skip the snapshot and surface it, rather than silently capturing inconsistent files.

Rejected alternatives are recorded in the ADR: one flat `capabilities: []` list, derived acceptance, naming the provider in the acceptor manifest, brokering everything as a universal rule, direct provider→acceptor execution, and catalog-defined contracts.

## Follow-up

Implementation is tracked in #418 (5 phases; Phase 3 closes #298, Phase 4 unblocks #160). Nothing in this PR changes behavior — merging it commits to the vocabulary, not to a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
