### PR TITLE
feat(server): capability contract vocabulary — `provides` / `accepts` (#418)

### DIFF
--- a/packages/server/src/__tests__/bundles/catalog-compose-override.test.ts
+++ b/packages/server/src/__tests__/bundles/catalog-compose-override.test.ts
@@ -36,6 +36,11 @@ const MANIFEST = JSON.stringify({
   ingress: { service: 'fixtureapp', port: 80 },
   // #246: this fixture app opts into multiple instances.
   multiInstance: true,
+  // ADR 0004 capability contract roles. `auth@1` is platform-provided (no app can
+  // claim it) and `telemetry@1` is a vocabulary word this build doesn't know —
+  // both must be dropped without rejecting the bundle.
+  provides: ['backup@1', 'auth@1'],
+  accepts: ['backup@1', 'telemetry@1'],
   // #162: an optional Compose profile the operator can enable at install time.
   profiles: [
     { key: 'elasticsearch', label: 'Elasticsearch advanced visibility', default: false },
@@ -126,6 +131,17 @@ describe('RealCatalogService composeOverride (#82)', () => {
     expect(detail.profiles).toEqual([
       { key: 'elasticsearch', label: 'Elasticsearch advanced visibility' },
     ]);
+  });
+
+  test('carries capability contract roles through, dropping unknown and platform-provided refs (ADR 0004)', async () => {
+    const svc = new RealCatalogService();
+    const detail = await svc.getVersionDetail(APP_ID, VERSION);
+
+    // `auth@1` is provided by the platform's Authentik stack, never by a catalog
+    // app; `telemetry@1` is a newer vocabulary word. Both degrade to "not
+    // declared" so a stale server still loads the bundle (ADR 0003 rule).
+    expect(detail.provides).toEqual(['backup@1']);
+    expect(detail.accepts).toEqual(['backup@1']);
   });
 
   test('defaultEnv carries typed-spec fields through and degrades an unknown type without rejecting the bundle (ADR 0003)', async () => {

--- a/packages/server/src/__tests__/bundles/contracts.test.ts
+++ b/packages/server/src/__tests__/bundles/contracts.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Capability contracts (ADR 0004) — the `provides`/`accepts` vocabulary and its
+ * coercion. Mirrors the manifest-auth/manifest-backup coercion tests: anything
+ * malformed or from a newer vocabulary is dropped with a warning, never thrown,
+ * so a sloppy or newer manifest degrades to "fills no role" instead of failing
+ * the bundle load.
+ */
+import { describe, test, expect } from 'bun:test';
+
+import {
+  CONTRACTS,
+  coerceAccepts,
+  coerceProvides,
+  findUndeclaredAcceptorBlocks,
+  formatContractRef,
+  parseContractRef,
+} from '../../services/core/contracts';
+import type { Logger, LogContext } from '../../lib/logger';
+
+/** Captures warn() calls so tests can assert on forward-compat degrade logging. */
+function makeSpyLogger(): { logger: Logger; warnings: Array<{ message: string; context?: LogContext }> } {
+  const warnings: Array<{ message: string; context?: LogContext }> = [];
+  const logger: Logger = {
+    debug: () => {},
+    info: () => {},
+    warn: (message, context) => warnings.push({ message, context }),
+    error: () => {},
+    child: () => logger,
+  };
+  return { logger, warnings };
+}
+
+const ctx = { appId: 'fixtureapp', version: '1.0.0' };
+
+describe('the contract table', () => {
+  test('every entry has a unique id@version ref', () => {
+    const refs = CONTRACTS.map(formatContractRef);
+    expect(new Set(refs).size).toBe(refs.length);
+  });
+
+  test('models the three contracts ADR 0004 names, with their shapes', () => {
+    // The shape is the ADR's load-bearing distinction — broker an operation,
+    // provision a connection. auth was always provisioned; naming it here is what
+    // stops a future contract from being brokered by default.
+    expect(parseContractRef('auth@1')).toMatchObject({ shape: 'provisioned', providerKind: 'platform' });
+    expect(parseContractRef('backup@1')).toMatchObject({ shape: 'brokered', providerKind: 'app' });
+    expect(parseContractRef('push@1')).toMatchObject({ shape: 'brokered', providerKind: 'platform' });
+  });
+});
+
+describe('parseContractRef', () => {
+  test('resolves a known id@version', () => {
+    expect(parseContractRef('backup@1')).toMatchObject({ id: 'backup', version: 1 });
+  });
+
+  test('requires an explicit version — a bare id never resolves', () => {
+    // `backup` alone is ambiguous the moment backup@2 exists; reading it as @1
+    // would drift an old manifest into obligations that changed underneath it.
+    expect(parseContractRef('backup')).toBeUndefined();
+    expect(parseContractRef('backup@')).toBeUndefined();
+    expect(parseContractRef('@1')).toBeUndefined();
+  });
+
+  test('rejects a non-integer or unknown version', () => {
+    expect(parseContractRef('backup@1.5')).toBeUndefined();
+    expect(parseContractRef('backup@x')).toBeUndefined();
+    expect(parseContractRef('backup@2')).toBeUndefined();
+  });
+});
+
+describe('coerceAccepts / coerceProvides', () => {
+  test('returns undefined when absent, empty, or the wrong type', () => {
+    const { logger } = makeSpyLogger();
+    expect(coerceAccepts(undefined, logger, ctx)).toBeUndefined();
+    expect(coerceAccepts([], logger, ctx)).toBeUndefined();
+    expect(coerceAccepts({}, logger, ctx)).toBeUndefined();
+    expect(coerceAccepts(42, logger, ctx)).toBeUndefined();
+  });
+
+  test('accepts a bare string as well as an array, and trims', () => {
+    const { logger } = makeSpyLogger();
+    expect(coerceAccepts('backup@1', logger, ctx)).toEqual(['backup@1']);
+    expect(coerceAccepts(['  backup@1  '], logger, ctx)).toEqual(['backup@1']);
+  });
+
+  test('de-duplicates while preserving declaration order', () => {
+    const { logger } = makeSpyLogger();
+    expect(coerceAccepts(['push@1', 'backup@1', 'push@1'], logger, ctx)).toEqual(['push@1', 'backup@1']);
+  });
+
+  test('drops an unknown contract with a warning instead of failing (forward-compat)', () => {
+    // ADR 0003's rule: the catalog and the server release on separate cadences,
+    // so a stale server meeting a newer vocabulary word must degrade, not brick.
+    const { logger, warnings } = makeSpyLogger();
+    expect(coerceAccepts(['backup@1', 'telemetry@1'], logger, ctx)).toEqual(['backup@1']);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.context).toMatchObject({ ref: 'telemetry@1', role: 'accepts', appId: 'fixtureapp' });
+  });
+
+  test('drops `provides` for a platform-provided contract', () => {
+    // Authentik is deployed by the platform, not installed from the catalog, so
+    // no app can claim to provide auth. Keeping `provides` to mean exactly "this
+    // app performs the capability for others" is what makes the rollup readable.
+    const { logger, warnings } = makeSpyLogger();
+    expect(coerceProvides(['auth@1', 'backup@1'], logger, ctx)).toEqual(['backup@1']);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.context).toMatchObject({ ref: 'auth@1' });
+  });
+
+  test('the same platform contract is still acceptable', () => {
+    const { logger, warnings } = makeSpyLogger();
+    expect(coerceAccepts(['auth@1'], logger, ctx)).toEqual(['auth@1']);
+    expect(warnings).toHaveLength(0);
+  });
+});
+
+describe('findUndeclaredAcceptorBlocks', () => {
+  test('reports a block whose contract is not accepted', () => {
+    // A manifest that predates ADR 0004, or an author who filled in the hooks and
+    // forgot the declaration.
+    expect(findUndeclaredAcceptorBlocks({ backup: { preHook: {} } }, undefined)).toEqual(['backup@1']);
+  });
+
+  test('says nothing when the block and the declaration agree', () => {
+    expect(findUndeclaredAcceptorBlocks({ backup: { preHook: {} } }, ['backup@1'])).toEqual([]);
+  });
+
+  test('does not infer acceptance — accepting without a block is legitimate', () => {
+    // The whole point of the explicit field: a SQLite or flat-file app accepts
+    // backup@1 and needs no hooks at all, and must stay distinguishable from an
+    // app nobody ever considered.
+    expect(findUndeclaredAcceptorBlocks({}, ['backup@1'])).toEqual([]);
+  });
+
+  test('reports each mismatched block independently', () => {
+    expect(findUndeclaredAcceptorBlocks({ backup: {}, push: [], auth: {} }, ['auth@1'])).toEqual([
+      'backup@1',
+      'push@1',
+    ]);
+  });
+});

--- a/packages/server/src/services/core/catalog.ts
+++ b/packages/server/src/services/core/catalog.ts
@@ -30,6 +30,7 @@ import { coerceManifestAuth } from './manifest-auth';
 import { coerceManifestSecurity } from './manifest-security';
 import { coerceManifestProfiles } from './manifest-profiles';
 import { coerceConsumes } from './app-registry';
+import { coerceProvides, coerceAccepts, findUndeclaredAcceptorBlocks } from './contracts';
 import { coerceManifestUpgrade } from './manifest-upgrade';
 import { coerceManifestBackup } from './manifest-backup';
 import { coerceManifestPush } from './manifest-push';
@@ -526,6 +527,8 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
         };
         auth?: unknown;
         consumes?: unknown;
+        provides?: unknown;
+        accepts?: unknown;
         multiInstance?: unknown;
         security?: unknown;
         upgrade?: unknown;
@@ -595,6 +598,18 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
       // so new capability names need no server change (ADR 0002).
       const consumes = coerceConsumes(manifest.consumes);
 
+      // Capability contract roles (ADR 0004): `provides` = this app performs the
+      // capability for others, `accepts` = this app opts in to being a subject of
+      // it. Unknown refs are dropped with a warning (forward-compat), never
+      // fatal. Acceptance is NOT inferred from the presence of the typed block —
+      // an app that needs no hooks must stay distinguishable from one nobody
+      // considered — so a block without its declaration is only reported.
+      const provides = coerceProvides(manifest.provides, this.logger, { appId, version });
+      const accepts = coerceAccepts(manifest.accepts, this.logger, { appId, version });
+      for (const ref of findUndeclaredAcceptorBlocks(manifest as Record<string, unknown>, accepts)) {
+        this.logger.warn('Manifest declares a contract block without accepting the contract', { appId, version, ref });
+      }
+
       // Whether the app opts into multiple instances (#246). Kept absent unless the
       // manifest explicitly sets `true`, so singleton (the default) stays the clean
       // common case in drafts and deployment records.
@@ -634,7 +649,7 @@ export class RealCatalogService implements CatalogService, HealthCheckable {
           ? manifest.ingress.service.trim()
           : undefined;
 
-      return { ...merged, version, composeOverride, auth, consumes, multiInstance, security, upgrade, backup, push, profiles, ingressService } satisfies GetCatalogAppVersionDetailResponse;
+      return { ...merged, version, composeOverride, auth, consumes, provides, accepts, multiInstance, security, upgrade, backup, push, profiles, ingressService } satisfies GetCatalogAppVersionDetailResponse;
     } catch (error) {
       this.logger.warn('Failed to read or parse bundle manifest', { version, error: error instanceof Error ? error.message : String(error) });
       // Keep the underlying reason in the message, not just the cause: a missing

--- a/packages/server/src/services/core/contracts.ts
+++ b/packages/server/src/services/core/contracts.ts
@@ -1,0 +1,216 @@
+/**
+ * Capability contracts (ADR 0004) — the two-sided cross-app integration model.
+ *
+ * ADR 0002 gave the platform a one-sided primitive: an app declares
+ * `consumes: <capability>` and the server grants it something (a read-only mount,
+ * a published feed). That models *app-consumes-platform*. It does not model the
+ * relationship where one app performs a capability **on** another — backup being
+ * the case that forced the issue (#121/#298).
+ *
+ * A **contract** has an id and a version (`backup@1`) and two roles:
+ *
+ * - **provider** — the side that performs the capability (backrest performs backups),
+ *   declared as `provides: ["backup@1"]`;
+ * - **acceptor** — the side that opts in to being a subject of it, declared as
+ *   `accepts: ["backup@1"]`, with an optional typed manifest block carrying the
+ *   details (`backup` → pre/post hooks).
+ *
+ * The contract, not the app, is the coupling point: an acceptor never names
+ * backrest, so replacing the provider is a catalog change rather than a
+ * fleet-wide manifest edit.
+ *
+ * **Acceptance is declared, not derived from the block.** The block says *how* an
+ * app participates; `accepts` says *whether* it does, and they are different
+ * facts — an app that needs no hooks at all (SQLite, flat-file) has to be
+ * distinguishable from an app nobody ever considered, or the "which apps are
+ * covered?" rollup is worthless. See ADR 0004 §2.
+ *
+ * **Contract ids are a closed set defined here, not in the catalog.** A contract
+ * is a promise about *server* behavior; matching two strings does nothing unless
+ * the server implements the middle, so an open vocabulary would let a bundle
+ * claim a capability nothing honors. Unrecognized refs are dropped with a warning
+ * rather than rejected (ADR 0003's forward-compat rule): the catalog and the
+ * server release on separate cadences, and a stale server must not brick an
+ * install.
+ *
+ * This module is Phase 1 (#418) — the vocabulary and its coercion only. Provider
+ * grants + install-time consent (Phase 2), the broker endpoints (Phase 3) and the
+ * API/UI rollup (Phase 4) land on top of this table.
+ */
+
+import type { Logger } from '../../lib/logger';
+
+/**
+ * How a contract's two sides actually exchange (ADR 0004 §5).
+ *
+ * - `brokered` — the provider asks the server and the server acts on acceptors.
+ *   Right for a low-volume operation with a request/response shape (run every
+ *   app's `pg_dump` before a backup). The provider holds no reach into any other
+ *   app, and ordering/retry/failure stay inside the orchestrator.
+ * - `provisioned` — the server wires up a scoped connection and steps out of the
+ *   path. Right for continuous or latency-sensitive traffic, where proxying
+ *   through the orchestrator would make it a data-plane bottleneck. Auth/OIDC
+ *   already works this way (provision an Authentik client, inject env, join
+ *   networks; the app then talks to the IdP directly forever), as does Traefik
+ *   routing.
+ *
+ * The rule: broker if the interaction is an *operation*, provision if it is a
+ * *connection*. Nothing in this phase reads the field — it is recorded now so the
+ * choice is made per contract at design time rather than per call site later.
+ */
+export type ContractShape = 'brokered' | 'provisioned';
+
+/**
+ * Who can fill the provider role.
+ *
+ * - `app` — a catalog app declares `provides` (backrest → `backup@1`).
+ * - `platform` — Hola itself is the provider and no app may claim it. Auth's
+ *   provider is the Authentik stack the platform deploys, not a catalog app;
+ *   `push@1`'s provider is the CLI driving `hola app data push`. An app declaring
+ *   `provides` for one of these is a manifest error, not a capability.
+ */
+export type ContractProviderKind = 'app' | 'platform';
+
+export interface ContractDefinition {
+  /** Contract id — the stable half of a ref (`backup` in `backup@1`). */
+  id: string;
+  /** Contract version — bumped when the acceptor's obligations change. */
+  version: number;
+  shape: ContractShape;
+  providerKind: ContractProviderKind;
+  /**
+   * The manifest block carrying an acceptor's details, when the contract has
+   * one. Absent means acceptance needs no further declaration. Used to warn
+   * about a block declared without the matching `accepts` (see
+   * {@link findUndeclaredAcceptorBlocks}).
+   */
+  acceptorBlock?: string;
+  /** One line, for logs and the future API rollup. */
+  summary: string;
+}
+
+/**
+ * The contract table. Every id the server honors, and nothing else.
+ *
+ * `auth@1` and `push@1` are pre-existing integrations re-labelled by ADR 0004 §8
+ * — their blocks, coercers and runtime behavior are unchanged; naming them as
+ * contracts is what lets one rollup answer "what does this app participate in?"
+ */
+export const CONTRACTS: readonly ContractDefinition[] = [
+  {
+    id: 'auth',
+    version: 1,
+    shape: 'provisioned',
+    providerKind: 'platform',
+    acceptorBlock: 'auth',
+    summary: 'Per-app SSO provisioned at deploy time (native-oidc, forward-auth, native-ldap).',
+  },
+  {
+    id: 'backup',
+    version: 1,
+    shape: 'brokered',
+    providerKind: 'app',
+    acceptorBlock: 'backup',
+    summary: 'Consistent capture of an app\'s data, with optional pre/post hooks around the file capture.',
+  },
+  {
+    id: 'push',
+    version: 1,
+    shape: 'brokered',
+    providerKind: 'platform',
+    acceptorBlock: 'push',
+    summary: 'Bulk data loaded into declared directories under the app\'s data root.',
+  },
+] as const;
+
+/** Canonical ref for a definition (`backup@1`). */
+export function formatContractRef(def: ContractDefinition): string {
+  return `${def.id}@${def.version}`;
+}
+
+/**
+ * Resolve a raw `id@version` ref against the table.
+ *
+ * The version is **required**: `backup` alone is ambiguous the moment `backup@2`
+ * exists, and silently reading it as `@1` would let an old manifest drift into a
+ * contract whose obligations changed underneath it. Manifest CI in the catalog
+ * repo catches the missing `@1` before publish; here it simply doesn't resolve.
+ */
+export function parseContractRef(raw: string): ContractDefinition | undefined {
+  const at = raw.lastIndexOf('@');
+  if (at <= 0 || at === raw.length - 1) return undefined;
+  const id = raw.slice(0, at);
+  const version = Number(raw.slice(at + 1));
+  if (!Number.isInteger(version)) return undefined;
+  return CONTRACTS.find((c) => c.id === id && c.version === version);
+}
+
+type CoerceCtx = { appId?: string; version?: string };
+
+/** Normalize a manifest field that accepts a bare string or an array of them. */
+function asRefList(raw: unknown): string[] {
+  const arr = Array.isArray(raw) ? raw : typeof raw === 'string' ? [raw] : [];
+  return arr.filter((x): x is string => typeof x === 'string' && x.trim().length > 0).map((s) => s.trim());
+}
+
+function coerceRefs(
+  raw: unknown,
+  role: 'provides' | 'accepts',
+  logger: Logger,
+  ctx: CoerceCtx,
+): string[] | undefined {
+  const out: string[] = [];
+
+  for (const ref of asRefList(raw)) {
+    const def = parseContractRef(ref);
+    if (!def) {
+      // Forward-compat (ADR 0003): a newer manifest naming a contract this build
+      // has never heard of degrades to "doesn't participate", never to a failed
+      // catalog load or a blocked install.
+      logger.warn('Dropping unknown capability contract from manifest', { ...ctx, role, ref });
+      continue;
+    }
+    // A platform-provided contract has no app-side provider to claim. Dropping
+    // it (rather than honoring it) keeps `provides` meaning exactly one thing:
+    // this app performs the capability for others.
+    if (role === 'provides' && def.providerKind === 'platform') {
+      logger.warn('Dropping `provides` for a platform-provided contract', { ...ctx, ref });
+      continue;
+    }
+    const canonical = formatContractRef(def);
+    if (!out.includes(canonical)) out.push(canonical);
+  }
+
+  return out.length ? out : undefined;
+}
+
+/** Coerce a manifest `provides` field (string or string[]) to canonical refs. */
+export function coerceProvides(raw: unknown, logger: Logger, ctx: CoerceCtx = {}): string[] | undefined {
+  return coerceRefs(raw, 'provides', logger, ctx);
+}
+
+/** Coerce a manifest `accepts` field (string or string[]) to canonical refs. */
+export function coerceAccepts(raw: unknown, logger: Logger, ctx: CoerceCtx = {}): string[] | undefined {
+  return coerceRefs(raw, 'accepts', logger, ctx);
+}
+
+/**
+ * Contract refs whose acceptor block is present in the manifest while the
+ * contract itself isn't accepted — a manifest that predates ADR 0004 or an author
+ * who filled in the block and forgot the declaration.
+ *
+ * Reported, never repaired: inferring acceptance from the block is exactly the
+ * derivation ADR 0004 §2 rejected, and quietly opting an app into a contract on
+ * its author's behalf is the opposite of what the declaration is for. The
+ * server's job here is to make the discrepancy visible; the catalog's manifest CI
+ * is what fails the build.
+ */
+export function findUndeclaredAcceptorBlocks(
+  manifest: Record<string, unknown>,
+  accepts: string[] | undefined,
+): string[] {
+  const declared = new Set(accepts ?? []);
+  return CONTRACTS.filter(
+    (c) => c.acceptorBlock !== undefined && manifest[c.acceptorBlock] !== undefined && !declared.has(formatContractRef(c)),
+  ).map(formatContractRef);
+}

--- a/packages/server/src/services/core/draft.ts
+++ b/packages/server/src/services/core/draft.ts
@@ -76,6 +76,13 @@ export interface FinalizedManifest {
   // Cross-app capabilities consumed (e.g. `app-registry`); carried so the
   // deploy lifecycle can publish the right feeds without re-reading the bundle.
   consumes?: string[];
+  // Capability contract roles (ADR 0004) carried from the bundle manifest:
+  // `provides` (this app performs the capability for others) drives the
+  // provider's grant + scoped token, `accepts` (this app is a subject of it)
+  // drives what the broker runs. Canonical `id@version` refs, already coerced
+  // against the server's contract table.
+  provides?: string[];
+  accepts?: string[];
   // Whether the app may be installed more than once (#246); carried so
   // createFromDraft can enforce the singleton-by-default guard without re-reading
   // the bundle.
@@ -474,6 +481,8 @@ export class RealDraftService implements DraftService {
         composeOverride,
         auth: defaults.auth,
         consumes: defaults.consumes,
+        provides: defaults.provides,
+        accepts: defaults.accepts,
         multiInstance: defaults.multiInstance,
         security: defaults.security,
         ingressService: defaults.ingressService,
@@ -572,6 +581,8 @@ export class RealDraftService implements DraftService {
         composeOverride,
         auth: detail.auth,
         consumes: detail.consumes,
+        provides: detail.provides,
+        accepts: detail.accepts,
         multiInstance: detail.multiInstance,
         security: detail.security,
         ingressService: detail.ingressService,
@@ -838,6 +849,8 @@ export class RealDraftService implements DraftService {
         composeOverride: draft.composeOverride ?? '',
         auth: draft.auth,
         consumes: draft.consumes,
+        provides: draft.provides,
+        accepts: draft.accepts,
         multiInstance: draft.multiInstance,
         security: draft.security,
         ingressService: draft.ingressService,
@@ -928,7 +941,7 @@ export class RealDraftService implements DraftService {
     };
   }
 
-  async getDraftDefaults(appId: string, version?: string, source?: string): Promise<{ env: AppEnvVar[]; defaults: DraftDefaults; composeOverride: string; auth?: AppAuthConfig; consumes?: string[]; multiInstance?: boolean; security?: AppSecurityConfig; ingressService?: string; upgrade?: AppUpgradeMeta; backup?: AppBackupConfig; push?: AppPushTarget[]; profiles?: AppProfileConfig[]; resolvedVersion?: string }> {
+  async getDraftDefaults(appId: string, version?: string, source?: string): Promise<{ env: AppEnvVar[]; defaults: DraftDefaults; composeOverride: string; auth?: AppAuthConfig; consumes?: string[]; provides?: string[]; accepts?: string[]; multiInstance?: boolean; security?: AppSecurityConfig; ingressService?: string; upgrade?: AppUpgradeMeta; backup?: AppBackupConfig; push?: AppPushTarget[]; profiles?: AppProfileConfig[]; resolvedVersion?: string }> {
     try {
       const versionDetail = await this.catalogService.getVersionDetail(appId, version || 'latest', source);
       return {
@@ -937,6 +950,8 @@ export class RealDraftService implements DraftService {
         composeOverride: versionDetail.composeOverride ?? '',
         auth: versionDetail.auth,
         consumes: versionDetail.consumes,
+        provides: versionDetail.provides,
+        accepts: versionDetail.accepts,
         multiInstance: versionDetail.multiInstance,
         security: versionDetail.security,
         ingressService: versionDetail.ingressService,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -839,6 +839,15 @@ export type GetCatalogAppVersionDetailResponse = {
   // (e.g. `app-registry`). The server writes the corresponding feed into the
   // app's data root on app-set change; rendering is a bundle bolt-on (ADR 0002).
   consumes?: string[];
+  // Capability contracts the app fills a role in, declared in its bundle
+  // manifest (ADR 0004). `provides` is the performing side (backrest performs
+  // `backup@1`); `accepts` is the subject side (a database-backed app accepts
+  // `backup@1`, exposing its pre/post hooks in the `backup` block). Both are
+  // canonical `id@version` refs against the server's closed contract table;
+  // unknown refs are dropped at coercion time. Absent ⇒ fills no role, which is
+  // reported as "not covered" rather than assumed fine.
+  provides?: string[];
+  accepts?: string[];
   // Whether the app may be installed more than once, declared in its bundle
   // manifest (#246). Absent/false ⇒ singleton (the default): the server rejects a
   // second install unless the operator opts in per-install. `true` (e.g. a browser
@@ -1057,6 +1066,12 @@ export type Draft = {
   // Cross-app capabilities consumed (e.g. `app-registry`), seeded from the bundle
   // manifest and carried through finalize (ADR 0002).
   consumes?: string[];
+  // Capability contract roles (ADR 0004) seeded from the bundle manifest and
+  // carried through finalize (read-only; not user-editable), so the deploy
+  // lifecycle can grant a provider's privilege and broker acceptors' hooks
+  // without re-reading the bundle.
+  provides?: string[];
+  accepts?: string[];
   // Whether the app may be installed more than once (#246), seeded from the bundle
   // manifest and carried through finalize (read-only; not user-editable). Drives
   // the server's singleton-by-default guard at create time.


### PR DESCRIPTION
Phase 1 of #418 (ADR 0004, #419): the vocabulary only. Nothing reads these fields yet, so **no behavior changes** — provider grants + install consent (Phase 2), the broker endpoints (Phase 3) and the API/UI rollup (Phase 4) land on top of this table.

## Why

`consumes` (ADR 0002) models app-consumes-*platform*: the server grants a primitive or publishes a feed. It cannot express one app performing a capability *on* another — which is why the #121 backup hooks have a provider (backrest), acceptors (four Postgres-backed apps), and nothing connecting them. This adds the missing axis.

## What

**`packages/server/src/services/core/contracts.ts`** — the closed contract table (`auth@1`, `backup@1`, `push@1`: the three integrations that grew this shape independently) plus `coerceProvides` / `coerceAccepts`, modelled on `coerceConsumes`. Ids are server-defined because a contract is a promise about server behavior; matching two strings does nothing unless the server implements the middle.

Each entry records its `shape` — `brokered` (an operation: the provider asks, the server acts on acceptors) vs `provisioned` (a connection: the server wires it and steps out, as auth/OIDC and Traefik already do). Nothing reads it in this phase. It's recorded now because that's what forces the choice at design time instead of letting a future contract default to brokering — the mistake that would have mis-shaped `container-logs` (#245).

Three coercion rules, each earning its place:

- **Unknown refs drop with a warning**, never a throw — ADR 0003's forward-compat rule. The catalog and the server release separately; a stale server meeting a newer vocabulary word must degrade, not brick an install.
- **`provides` for a platform-provided contract drops.** Authentik is deployed by the platform and `push@1`'s provider is the CLI, so no app can claim either. Keeps `provides` meaning exactly one thing: this app performs the capability for others.
- **The version in a ref is required.** `backup` alone is ambiguous the moment `backup@2` exists, and silently reading it as `@1` would drift an old manifest into obligations that changed underneath it.

**Acceptance is declared, never inferred from the typed block.** The block says *how* an app participates; `accepts` says *whether* it does. An app that needs no hooks at all (SQLite, flat-file) must stay distinguishable from one nobody ever considered — otherwise the coverage rollup, the whole reason immich's missing hooks went unnoticed, is worthless. `findUndeclaredAcceptorBlocks` reports a block without its declaration and deliberately does not repair it.

**Carry-through**: catalog version detail → draft → finalized manifest, alongside `consumes`. The finalize checksum is unaffected — `stableStringify` drops undefined keys, so a manifest declaring neither field hashes exactly as before.

## Tests

`__tests__/bundles/contracts.test.ts` (15 tests) covers the table, ref parsing, both drop rules, dedupe/order, and the "does not infer acceptance" case. The existing `catalog-compose-override` fixture gained a `provides`/`accepts` block carrying one valid ref plus one platform-provided and one unknown ref, asserting end-to-end that both are dropped without failing the bundle load.

`bun run typecheck` · `lint` · `test` (671 server + 238 web) · `build` all green.

## Companion

try-hola/apps#140 adds `provides`/`accepts` to the manifest schema + authoring docs. No app manifest declares them yet — that's Phase 5, together with immich's missing hooks and the CI check that a declared contract is actually satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)